### PR TITLE
Article barebones

### DIFF
--- a/projects/pwa/package.json
+++ b/projects/pwa/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.4.3",
-    "@guardian/pasteup": "^1.0.0-alpha.7",
+    "@guardian/pasteup": "^1.0.0-alpha.8",
     "@reach/router": "^1.2.1",
     "@svgr/webpack": "4.1.0",
     "@types/jest": "24.0.11",

--- a/projects/pwa/src/@types/index.d.ts
+++ b/projects/pwa/src/@types/index.d.ts
@@ -1,2 +1,8 @@
 declare module '@guardian/pasteup/palette';
+declare module '@guardian/pasteup/typography';
 declare module 'emotion-reset';
+
+interface CAPIElement {
+    _type: string;
+    html: string;
+}

--- a/projects/pwa/src/component/Elements.tsx
+++ b/projects/pwa/src/component/Elements.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { css } from 'emotion';
+import { Text } from './elements/Text';
+
+const clear = css`
+    clear: both;
+`;
+
+export const Elements: React.FC<{
+    elements: CAPIElement[];
+}> = ({
+    elements,
+}) => {
+    const output = elements.map((element, i) => {
+        switch (element._type) {
+            case 'model.dotcomrendering.pageElements.TextBlockElement':
+                return <Text key={i} html={element.html} />;
+            default:
+                return null;
+        }
+    });
+
+    return (
+        <>
+            {output}
+            <div className={clear} />
+        </>
+    );
+};

--- a/projects/pwa/src/component/elements/Text.tsx
+++ b/projects/pwa/src/component/elements/Text.tsx
@@ -3,13 +3,15 @@ import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { body } from '@guardian/pasteup/typography';
 
+import { metrics } from '../../helper/styles';
+
 // tslint:disable:react-no-dangerous-html
 export const textStyle = css`
     strong {
         font-weight: 700;
     }
     p {
-        padding: 0 0 12px;
+        padding: 0 0 ${metrics.baseline}px;
         ${body(2)};
         font-weight: 300;
         word-wrap: break-word;

--- a/projects/pwa/src/component/elements/Text.tsx
+++ b/projects/pwa/src/component/elements/Text.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { css } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
+import { body } from '@guardian/pasteup/typography';
+
+// tslint:disable:react-no-dangerous-html
+export const textStyle = css`
+    strong {
+        font-weight: 700;
+    }
+    p {
+        padding: 0 0 12px;
+        ${body(2)};
+        font-weight: 300;
+        word-wrap: break-word;
+        color: ${palette.neutral[7]};
+    }
+    a {
+        color: ${palette.news.main};
+        text-decoration: none;
+        border-bottom: 1px solid ${palette.neutral[86]};
+        :hover {
+            border-bottom: 1px solid ${palette.news.main};
+        }
+    }
+    ${body(3)};
+`;
+
+export const Text: React.FC<{
+    html: string;
+}> = ({ html }) => (
+    <span
+        className={textStyle}
+        dangerouslySetInnerHTML={{
+            __html: html,
+        }}
+    />
+);

--- a/projects/pwa/src/fixtures/article.ts
+++ b/projects/pwa/src/fixtures/article.ts
@@ -1,0 +1,3018 @@
+export const data = {
+    page: {
+        content: {
+            headline:
+                "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+            standfirst:
+                '<p><strong>Exclusive:</strong> Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans</p>',
+            main:
+                '<figure class="element element-image" data-media-id="c0c1beb4b6c6889b095fbb4aef36009222420d65"> <img src="https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg" alt="The Palace Theatre, London, showing Harry Potter and the Cursed Child" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. </span> <span class="element-image__credit">Photograph: Kirsty Wigglesworth/AP</span> </figcaption> </figure>',
+            body:
+                '<p>Touts who use computer software to <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-beat-adele-take-that-hamilton">harvest concert tickets in bulk</a> and resell them at vast mark-ups face unlimited fines as part of a crackdown on highly profitable resale sites such as Viagogo, StubHub and GetMeIn.</p> <p>The Department of Culture, Media and Sport will announce a package of measures to curb the growing power of the so-called “secondary ticketing” industry, which now regularly offers tickets at huge mark-ups, even before they are available to the general public.</p> <p>Proposals will include a new criminal offence for the use of “bots” – <a href="https://www.theguardian.com/money/2016/may/21/ticket-touts-powerful-software-assist-widely-available">software that helps touts bypass limits</a> on the number of tickets one person can buy.</p> <p>National Trading Standards will also be handed a ringfenced pot of money to fund efforts to stop fans being ripped off or shut out of the most in-demand events.</p> <p>The government is taking action following outrage that face-value tickets to see <a href="https://www.theguardian.com/music/2016/dec/02/adele-tickets-appear-online-for-9000-despite-singers-efforts-to-stop-touts">artists such as Adele</a> and Ed Sheeran are selling out in minutes, only to appear for thousands of pounds on resale websites such as <a href="https://www.theguardian.com/business/2016/sep/23/what-we-know-about-ticket-reseller-viagogo">Viagogo</a>, StubHub and GetMeIn moments later.</p> <p>These websites make money by allowing touts, as well as genuine fans, to resell tickets in return for a cut of anything up to 25% of the sale price.</p> <p>As well as criminalising bots, ministers at DCMS will accept in full the recommendations of a <a href="https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement">review by Professor Michael Waterson</a>, who <a href="https://www.gov.uk/government/publications/consumer-protection-measures-applying-to-ticket-resale-waterson-review">published proposals</a> to tackle rogue ticket traders last year.</p> <p>These include demanding that ticket firms to step up their own efforts to prevent the use of bots and to report any attacks on their systems by touts trying to harvest tickets.</p> <p>While primary ticket firms such as Ticketmaster say they are doing their utmost to stop bot users, the company also owns secondary sites, such as GetMeIn and Seatwave, which have <a href="https://www.theguardian.com/money/2016/jul/16/bands-fans-declare-war-online-ticket-touts">close relationships with major touts</a> and take a cut of their profits.</p> <p>Ministers will also propose stronger enforcement of consumer rights laws, amid concern that tickets are being sold with no information about the seat location or the name of the seller, in contravention of the Consumer Rights Act 2015.</p> <p>Efforts to step up scrutiny of firms’ adherence to consumer laws is also aimed at sites that sell tickets whose terms and conditions specifically ban resale, meaning fans are turned away at the door.</p> <p>Labour MP Sharon Hodgson, a long-time campaigner for ticket reform, welcomed measures she said would address a “broken and parasitic market”. </p> <p>“These measures will ensure that fans are protected, but there still remains work to do to make sure that these measures are enforced properly so touts do not circumvent them as this is going to very soon be the law of the land.”</p> <p>The DCMS proposals will be informed by an <a href="https://www.theguardian.com/business/2016/dec/19/ticket-resale-websites-run-risk-of-fines-cma-launches-investigation-competition-and-markets-authority">ongoing review by the Competition and Market Authority</a> into secondary ticketing firms’ compliance with the law.</p> <p>Ticket resale sites will face even harsher measures if they do not prove that they are taking sufficient steps to address the power of touts, the Guardian understands.</p> <p>Theresa May <a href="https://www.theguardian.com/money/2017/mar/01/viagogo-ticket-rip-off-parliament-theresa-may-promises-crackdown">promised to take action on ticket resale</a> at Prime Minister’s Questions after Nigel Adams MP urged her to help “ensure genuine fans are not fleeced by <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">ticket touts and rogues</a>”.</p> <p>Increased scrutiny of secondary ticketing follows revelations in the Guardian about the actions of well-known ticket resale sites and the <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">touts who have used them to build multi-million pound businesses</a> by harvesting tickets in bulk.</p> <p>Viagogo, which is based in Switzerland but has a large office in Cannon Street, London, was recently <a href="https://www.theguardian.com/money/2017/feb/17/viagogo-condemned-ed-sheeran-cancer-benefit-concert-tickets-teenage-cancer-trust">accused of “moral repugnance”</a> for seeking to profit from the resale of tickets for an Ed Sheeran gig at the Royal Albert Hall in aid of the Teenage Cancer Trust.</p> <p>Ticketmaster, which owns resale sites GetMeIn and Seatwave, has also come under the spotlight after it emerged that a <a href="https://www.theguardian.com/business/2017/feb/22/convicted-fraudsters-sell-ed-sheeran-tickets-through-ticketmaster">man previously convicted of a £2m ticket fraud</a> was using the sites to sell thousands of pounds’ worth of tickets.<br></p> <p>The identities of some of the UK’s most powerful touts were revealed last year after a whistleblower passed the Guardian information revealing the vast rewards on offer to those with a grip on access to the UK’s most popular events.</p> <p>Many have since <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-investigations-competition-hmrc">rebranded their companies</a> amid mounting outrage about their business models.</p> <p>While music concerts have proved the most lucrative targets for touts, high-profile theatre productions such as <a href="https://www.theguardian.com/stage/2017/jan/16/hamilton-west-end-tickets-found-on-resale-sites-viagogo-despite-anti-tout-measures">critically acclaimed hip-hop musical Hamilton</a>, as well as <a href="https://www.theguardian.com/stage/2016/aug/13/harry-potter-cursed-child-ticket-resale-prices">Harry Potter and the Cursed Child</a>, have also been targeted.</p>',
+            blocks: {
+                main: {
+                    bodyHtml:
+                        '<figure class="element element-image" data-media-id="c0c1beb4b6c6889b095fbb4aef36009222420d65"> <img src="https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg" alt="The Palace Theatre, London, showing Harry Potter and the Cursed Child" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. </span> <span class="element-image__credit">Photograph: Kirsty Wigglesworth/AP</span> </figcaption> </figure>',
+                    elements: [
+                        {
+                            media: {
+                                allImages: [
+                                    {
+                                        index: 0,
+                                        fields: {
+                                            height: '1200',
+                                            width: '2000',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/2000.jpg',
+                                    },
+                                    {
+                                        index: 1,
+                                        fields: {
+                                            height: '600',
+                                            width: '1000',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg',
+                                    },
+                                    {
+                                        index: 2,
+                                        fields: {
+                                            height: '300',
+                                            width: '500',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/500.jpg',
+                                    },
+                                    {
+                                        index: 3,
+                                        fields: {
+                                            height: '84',
+                                            width: '140',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/140.jpg',
+                                    },
+                                    {
+                                        index: 4,
+                                        fields: {
+                                            height: '3009',
+                                            width: '5015',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/5015.jpg',
+                                    },
+                                    {
+                                        index: 5,
+                                        fields: {
+                                            isMaster: 'true',
+                                            height: '3009',
+                                            width: '5015',
+                                        },
+                                        mediaType: 'Image',
+                                        mimeType: 'image/jpeg',
+                                        url:
+                                            'http://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg',
+                                    },
+                                ],
+                            },
+                            data: {
+                                copyright:
+                                    'Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu',
+                                alt:
+                                    'The Palace Theatre, London, showing Harry Potter and the Cursed Child',
+                                caption:
+                                    'Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. ',
+                                credit: 'Photograph: Kirsty Wigglesworth/AP',
+                            },
+                            displayCredit: true,
+                            role: 'inline',
+                            imageSources: [
+                                {
+                                    weighting: 'inline',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                                            width: 620,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                                            width: 605,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                                            width: 445,
+                                        },
+                                    ],
+                                },
+                                {
+                                    weighting: 'thumbnail',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=140&quality=85&auto=format&fit=max&s=47fa9641d01f7b562c1407c999bd9da0',
+                                            width: 140,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=120&quality=85&auto=format&fit=max&s=0aec1c40ad08585352196ba9cbbe712e',
+                                            width: 120,
+                                        },
+                                    ],
+                                },
+                                {
+                                    weighting: 'supporting',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=380&quality=85&auto=format&fit=max&s=6bf99684d34d7e640b42e77de94d2369',
+                                            width: 380,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=300&quality=85&auto=format&fit=max&s=4e8c8811000fc54bea72dedd69ab13d6',
+                                            width: 300,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                                            width: 620,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                                            width: 605,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                                            width: 445,
+                                        },
+                                    ],
+                                },
+                                {
+                                    weighting: 'showcase',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=860&quality=85&auto=format&fit=max&s=16f69557a812fa0f97f386567be954d6',
+                                            width: 860,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=780&quality=85&auto=format&fit=max&s=ce247f6cf701cb7c91cc6243a0b52bbe',
+                                            width: 780,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                                            width: 620,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                                            width: 605,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                                            width: 445,
+                                        },
+                                    ],
+                                },
+                                {
+                                    weighting: 'halfwidth',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                                            width: 620,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                                            width: 605,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                                            width: 445,
+                                        },
+                                    ],
+                                },
+                                {
+                                    weighting: 'immersive',
+                                    srcSet: [
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                                            width: 620,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                                            width: 605,
+                                        },
+                                        {
+                                            src:
+                                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                                            width: 445,
+                                        },
+                                    ],
+                                },
+                            ],
+                            _type:
+                                'model.dotcomrendering.pageElements.ImageBlockElement',
+                        },
+                    ],
+                },
+                body: [
+                    {
+                        bodyHtml:
+                            '<p>Touts who use computer software to <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-beat-adele-take-that-hamilton">harvest concert tickets in bulk</a> and resell them at vast mark-ups face unlimited fines as part of a crackdown on highly profitable resale sites such as Viagogo, StubHub and GetMeIn.</p> <p>The Department of Culture, Media and Sport will announce a package of measures to curb the growing power of the so-called “secondary ticketing” industry, which now regularly offers tickets at huge mark-ups, even before they are available to the general public.</p> <p>Proposals will include a new criminal offence for the use of “bots” – <a href="https://www.theguardian.com/money/2016/may/21/ticket-touts-powerful-software-assist-widely-available">software that helps touts bypass limits</a> on the number of tickets one person can buy.</p> <p>National Trading Standards will also be handed a ringfenced pot of money to fund efforts to stop fans being ripped off or shut out of the most in-demand events.</p> <p>The government is taking action following outrage that face-value tickets to see <a href="https://www.theguardian.com/music/2016/dec/02/adele-tickets-appear-online-for-9000-despite-singers-efforts-to-stop-touts">artists such as Adele</a> and Ed Sheeran are selling out in minutes, only to appear for thousands of pounds on resale websites such as <a href="https://www.theguardian.com/business/2016/sep/23/what-we-know-about-ticket-reseller-viagogo">Viagogo</a>, StubHub and GetMeIn moments later.</p> <p>These websites make money by allowing touts, as well as genuine fans, to resell tickets in return for a cut of anything up to 25% of the sale price.</p> <p>As well as criminalising bots, ministers at DCMS will accept in full the recommendations of a <a href="https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement">review by Professor Michael Waterson</a>, who <a href="https://www.gov.uk/government/publications/consumer-protection-measures-applying-to-ticket-resale-waterson-review">published proposals</a> to tackle rogue ticket traders last year.</p> <p>These include demanding that ticket firms to step up their own efforts to prevent the use of bots and to report any attacks on their systems by touts trying to harvest tickets.</p> <p>While primary ticket firms such as Ticketmaster say they are doing their utmost to stop bot users, the company also owns secondary sites, such as GetMeIn and Seatwave, which have <a href="https://www.theguardian.com/money/2016/jul/16/bands-fans-declare-war-online-ticket-touts">close relationships with major touts</a> and take a cut of their profits.</p> <p>Ministers will also propose stronger enforcement of consumer rights laws, amid concern that tickets are being sold with no information about the seat location or the name of the seller, in contravention of the Consumer Rights Act 2015.</p> <p>Efforts to step up scrutiny of firms’ adherence to consumer laws is also aimed at sites that sell tickets whose terms and conditions specifically ban resale, meaning fans are turned away at the door.</p> <p>Labour MP Sharon Hodgson, a long-time campaigner for ticket reform, welcomed measures she said would address a “broken and parasitic market”. </p> <p>“These measures will ensure that fans are protected, but there still remains work to do to make sure that these measures are enforced properly so touts do not circumvent them as this is going to very soon be the law of the land.”</p> <p>The DCMS proposals will be informed by an <a href="https://www.theguardian.com/business/2016/dec/19/ticket-resale-websites-run-risk-of-fines-cma-launches-investigation-competition-and-markets-authority">ongoing review by the Competition and Market Authority</a> into secondary ticketing firms’ compliance with the law.</p> <p>Ticket resale sites will face even harsher measures if they do not prove that they are taking sufficient steps to address the power of touts, the Guardian understands.</p> <p>Theresa May <a href="https://www.theguardian.com/money/2017/mar/01/viagogo-ticket-rip-off-parliament-theresa-may-promises-crackdown">promised to take action on ticket resale</a> at Prime Minister’s Questions after Nigel Adams MP urged her to help “ensure genuine fans are not fleeced by <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">ticket touts and rogues</a>”.</p> <p>Increased scrutiny of secondary ticketing follows revelations in the Guardian about the actions of well-known ticket resale sites and the <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">touts who have used them to build multi-million pound businesses</a> by harvesting tickets in bulk.</p> <p>Viagogo, which is based in Switzerland but has a large office in Cannon Street, London, was recently <a href="https://www.theguardian.com/money/2017/feb/17/viagogo-condemned-ed-sheeran-cancer-benefit-concert-tickets-teenage-cancer-trust">accused of “moral repugnance”</a> for seeking to profit from the resale of tickets for an Ed Sheeran gig at the Royal Albert Hall in aid of the Teenage Cancer Trust.</p> <p>Ticketmaster, which owns resale sites GetMeIn and Seatwave, has also come under the spotlight after it emerged that a <a href="https://www.theguardian.com/business/2017/feb/22/convicted-fraudsters-sell-ed-sheeran-tickets-through-ticketmaster">man previously convicted of a £2m ticket fraud</a> was using the sites to sell thousands of pounds’ worth of tickets.<br></p> <p>The identities of some of the UK’s most powerful touts were revealed last year after a whistleblower passed the Guardian information revealing the vast rewards on offer to those with a grip on access to the UK’s most popular events.</p> <p>Many have since <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-investigations-competition-hmrc">rebranded their companies</a> amid mounting outrage about their business models.</p> <p>While music concerts have proved the most lucrative targets for touts, high-profile theatre productions such as <a href="https://www.theguardian.com/stage/2017/jan/16/hamilton-west-end-tickets-found-on-resale-sites-viagogo-despite-anti-tout-measures">critically acclaimed hip-hop musical Hamilton</a>, as well as <a href="https://www.theguardian.com/stage/2016/aug/13/harry-potter-cursed-child-ticket-resale-prices">Harry Potter and the Cursed Child</a>, have also been targeted.</p>',
+                        elements: [
+                            {
+                                html:
+                                    '<p>Touts who use computer software to <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-beat-adele-take-that-hamilton">harvest concert tickets in bulk</a> and resell them at vast mark-ups face unlimited fines as part of a crackdown on highly profitable resale sites such as Viagogo, StubHub and GetMeIn.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>The Department of Culture, Media and Sport will announce a package of measures to curb the growing power of the so-called “secondary ticketing” industry, which now regularly offers tickets at huge mark-ups, even before they are available to the general public.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Proposals will include a new criminal offence for the use of “bots” – <a href="https://www.theguardian.com/money/2016/may/21/ticket-touts-powerful-software-assist-widely-available">software that helps touts bypass limits</a> on the number of tickets one person can buy.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>National Trading Standards will also be handed a ringfenced pot of money to fund efforts to stop fans being ripped off or shut out of the most in-demand events.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>The government is taking action following outrage that face-value tickets to see <a href="https://www.theguardian.com/music/2016/dec/02/adele-tickets-appear-online-for-9000-despite-singers-efforts-to-stop-touts">artists such as Adele</a> and Ed Sheeran are selling out in minutes, only to appear for thousands of pounds on resale websites such as <a href="https://www.theguardian.com/business/2016/sep/23/what-we-know-about-ticket-reseller-viagogo">Viagogo</a>, StubHub and GetMeIn moments later.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>These websites make money by allowing touts, as well as genuine fans, to resell tickets in return for a cut of anything up to 25% of the sale price.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>As well as criminalising bots, ministers at DCMS will accept in full the recommendations of a <a href="https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement">review by Professor Michael Waterson</a>, who <a href="https://www.gov.uk/government/publications/consumer-protection-measures-applying-to-ticket-resale-waterson-review">published proposals</a> to tackle rogue ticket traders last year.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>These include demanding that ticket firms to step up their own efforts to prevent the use of bots and to report any attacks on their systems by touts trying to harvest tickets.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>While primary ticket firms such as Ticketmaster say they are doing their utmost to stop bot users, the company also owns secondary sites, such as GetMeIn and Seatwave, which have <a href="https://www.theguardian.com/money/2016/jul/16/bands-fans-declare-war-online-ticket-touts">close relationships with major touts</a> and take a cut of their profits.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Ministers will also propose stronger enforcement of consumer rights laws, amid concern that tickets are being sold with no information about the seat location or the name of the seller, in contravention of the Consumer Rights Act 2015.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Efforts to step up scrutiny of firms’ adherence to consumer laws is also aimed at sites that sell tickets whose terms and conditions specifically ban resale, meaning fans are turned away at the door.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Labour MP Sharon Hodgson, a long-time campaigner for ticket reform, welcomed measures she said would address a “broken and parasitic market”. </p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>“These measures will ensure that fans are protected, but there still remains work to do to make sure that these measures are enforced properly so touts do not circumvent them as this is going to very soon be the law of the land.”</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>The DCMS proposals will be informed by an <a href="https://www.theguardian.com/business/2016/dec/19/ticket-resale-websites-run-risk-of-fines-cma-launches-investigation-competition-and-markets-authority">ongoing review by the Competition and Market Authority</a> into secondary ticketing firms’ compliance with the law.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Ticket resale sites will face even harsher measures if they do not prove that they are taking sufficient steps to address the power of touts, the Guardian understands.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Theresa May <a href="https://www.theguardian.com/money/2017/mar/01/viagogo-ticket-rip-off-parliament-theresa-may-promises-crackdown">promised to take action on ticket resale</a> at Prime Minister’s Questions after Nigel Adams MP urged her to help “ensure genuine fans are not fleeced by <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">ticket touts and rogues</a>”.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Increased scrutiny of secondary ticketing follows revelations in the Guardian about the actions of well-known ticket resale sites and the <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">touts who have used them to build multi-million pound businesses</a> by harvesting tickets in bulk.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Viagogo, which is based in Switzerland but has a large office in Cannon Street, London, was recently <a href="https://www.theguardian.com/money/2017/feb/17/viagogo-condemned-ed-sheeran-cancer-benefit-concert-tickets-teenage-cancer-trust">accused of “moral repugnance”</a> for seeking to profit from the resale of tickets for an Ed Sheeran gig at the Royal Albert Hall in aid of the Teenage Cancer Trust.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Ticketmaster, which owns resale sites GetMeIn and Seatwave, has also come under the spotlight after it emerged that a <a href="https://www.theguardian.com/business/2017/feb/22/convicted-fraudsters-sell-ed-sheeran-tickets-through-ticketmaster">man previously convicted of a £2m ticket fraud</a> was using the sites to sell thousands of pounds’ worth of tickets.<br></p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>The identities of some of the UK’s most powerful touts were revealed last year after a whistleblower passed the Guardian information revealing the vast rewards on offer to those with a grip on access to the UK’s most popular events.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>Many have since <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-investigations-competition-hmrc">rebranded their companies</a> amid mounting outrage about their business models.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                            {
+                                html:
+                                    '<p>While music concerts have proved the most lucrative targets for touts, high-profile theatre productions such as <a href="https://www.theguardian.com/stage/2017/jan/16/hamilton-west-end-tickets-found-on-resale-sites-viagogo-despite-anti-tout-measures">critically acclaimed hip-hop musical Hamilton</a>, as well as <a href="https://www.theguardian.com/stage/2016/aug/13/harry-potter-cursed-child-ticket-resale-prices">Harry Potter and the Cursed Child</a>, have also been targeted.</p>',
+                                _type:
+                                    'model.dotcomrendering.pageElements.TextBlockElement',
+                            },
+                        ],
+                    },
+                ],
+            },
+            byline: 'Rob Davies',
+            trailText:
+                'Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans',
+        },
+        tags: {
+            authorIds: 'profile/rob-davies',
+            toneIds:
+                'money/ticket-prices,money/consumer-affairs,money/money,technology/internet,money/viagogo',
+            keywordIds: 'tone/news',
+            commissioningDesks: 'uk-business',
+            all: [
+                {
+                    properties: {
+                        id: 'money/ticket-prices',
+                        tagType: 'Keyword',
+                        webTitle: 'Ticket prices',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'money/consumer-affairs',
+                        tagType: 'Keyword',
+                        webTitle: 'Consumer affairs',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'money/money',
+                        tagType: 'Keyword',
+                        webTitle: 'Money',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'technology/internet',
+                        tagType: 'Keyword',
+                        webTitle: 'Internet',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'type/article',
+                        tagType: 'Type',
+                        webTitle: 'Article',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'tone/news',
+                        tagType: 'Tone',
+                        webTitle: 'News',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'money/viagogo',
+                        tagType: 'Keyword',
+                        webTitle: 'Viagogo',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'profile/rob-davies',
+                        tagType: 'Contributor',
+                        webTitle: 'Rob Davies',
+                        twitterHandle: 'ByRobDavies',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'publication/theguardian',
+                        tagType: 'Publication',
+                        webTitle: 'The Guardian',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'theguardian/mainsection',
+                        tagType: 'NewspaperBook',
+                        webTitle: 'Main section',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'theguardian/mainsection/topstories',
+                        tagType: 'NewspaperBookSection',
+                        webTitle: 'Top stories',
+                    },
+                },
+                {
+                    properties: {
+                        id: 'tracking/commissioningdesk/uk-business',
+                        tagType: 'Tracking',
+                        webTitle: 'UK Business',
+                    },
+                },
+            ],
+        },
+        author: 'Rob Davies',
+        pageId:
+            'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        pillar: 'Lifestyle',
+        webPublicationDate: 1489173305000,
+        webPublicationDateDisplay: 'Sat 11 Mar 2017 19.15 GMT',
+        section: 'money',
+        sectionLabel: 'Ticket prices',
+        sectionUrl: 'money/ticket-prices',
+        webTitle:
+            "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+        contentId:
+            'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        editionId: 'UK',
+        edition: 'UK edition',
+        contentType: 'Article',
+        subMetaLinks: {
+            sectionLabels: [
+                {
+                    link: '/money/ticket-prices',
+                    text: 'Ticket prices',
+                    dataLinkName: 'article section',
+                },
+            ],
+            keywords: [
+                {
+                    link: '/money/consumer-affairs',
+                    text: 'Consumer affairs',
+                    dataLinkName: 'keyword: money/consumer-affairs',
+                },
+                {
+                    link: '/technology/internet',
+                    text: 'Internet',
+                    dataLinkName: 'keyword: technology/internet',
+                },
+                {
+                    link: '/money/viagogo',
+                    text: 'Viagogo',
+                    dataLinkName: 'keyword: money/viagogo',
+                },
+                {
+                    link: '/tone/news',
+                    text: 'news',
+                    dataLinkName: 'tone: news',
+                },
+            ],
+        },
+        webURL:
+            'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        commercial: {
+            editionCommercialProperties: {
+                UK: {
+                    adTargeting: [
+                        {
+                            name: 'edition',
+                            value: 'uk',
+                        },
+                        {
+                            name: 'url',
+                            value:
+                                '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                        },
+                        {
+                            name: 'tn',
+                            value: ['news'],
+                        },
+                        {
+                            name: 'sh',
+                            value: 'https://gu.com/p/64ak8',
+                        },
+                        {
+                            name: 'su',
+                            value: ['0'],
+                        },
+                        {
+                            name: 'co',
+                            value: ['rob-davies'],
+                        },
+                        {
+                            name: 'ct',
+                            value: 'article',
+                        },
+                        {
+                            name: 'p',
+                            value: 'ng',
+                        },
+                        {
+                            name: 'k',
+                            value: [
+                                'ticket-prices',
+                                'consumer-affairs',
+                                'internet',
+                                'viagogo',
+                                'money',
+                            ],
+                        },
+                    ],
+                },
+                US: {
+                    adTargeting: [
+                        {
+                            name: 'url',
+                            value:
+                                '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                        },
+                        {
+                            name: 'tn',
+                            value: ['news'],
+                        },
+                        {
+                            name: 'sh',
+                            value: 'https://gu.com/p/64ak8',
+                        },
+                        {
+                            name: 'su',
+                            value: ['0'],
+                        },
+                        {
+                            name: 'co',
+                            value: ['rob-davies'],
+                        },
+                        {
+                            name: 'ct',
+                            value: 'article',
+                        },
+                        {
+                            name: 'p',
+                            value: 'ng',
+                        },
+                        {
+                            name: 'edition',
+                            value: 'us',
+                        },
+                        {
+                            name: 'k',
+                            value: [
+                                'ticket-prices',
+                                'consumer-affairs',
+                                'internet',
+                                'viagogo',
+                                'money',
+                            ],
+                        },
+                    ],
+                },
+                AU: {
+                    adTargeting: [
+                        {
+                            name: 'url',
+                            value:
+                                '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                        },
+                        {
+                            name: 'tn',
+                            value: ['news'],
+                        },
+                        {
+                            name: 'sh',
+                            value: 'https://gu.com/p/64ak8',
+                        },
+                        {
+                            name: 'su',
+                            value: ['0'],
+                        },
+                        {
+                            name: 'co',
+                            value: ['rob-davies'],
+                        },
+                        {
+                            name: 'ct',
+                            value: 'article',
+                        },
+                        {
+                            name: 'p',
+                            value: 'ng',
+                        },
+                        {
+                            name: 'k',
+                            value: [
+                                'ticket-prices',
+                                'consumer-affairs',
+                                'internet',
+                                'viagogo',
+                                'money',
+                            ],
+                        },
+                        {
+                            name: 'edition',
+                            value: 'au',
+                        },
+                    ],
+                },
+                INT: {
+                    adTargeting: [
+                        {
+                            name: 'url',
+                            value:
+                                '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                        },
+                        {
+                            name: 'tn',
+                            value: ['news'],
+                        },
+                        {
+                            name: 'edition',
+                            value: 'int',
+                        },
+                        {
+                            name: 'sh',
+                            value: 'https://gu.com/p/64ak8',
+                        },
+                        {
+                            name: 'su',
+                            value: ['0'],
+                        },
+                        {
+                            name: 'co',
+                            value: ['rob-davies'],
+                        },
+                        {
+                            name: 'ct',
+                            value: 'article',
+                        },
+                        {
+                            name: 'p',
+                            value: 'ng',
+                        },
+                        {
+                            name: 'k',
+                            value: [
+                                'ticket-prices',
+                                'consumer-affairs',
+                                'internet',
+                                'viagogo',
+                                'money',
+                            ],
+                        },
+                    ],
+                },
+            },
+            prebidIndexSites: [
+                {
+                    bp: 'D',
+                    id: 208236,
+                },
+                {
+                    bp: 'M',
+                    id: 213509,
+                },
+                {
+                    bp: 'T',
+                    id: 215444,
+                },
+            ],
+            commercialProperties: {
+                editionBrandings: [
+                    {
+                        edition: {
+                            id: 'UK',
+                        },
+                    },
+                    {
+                        edition: {
+                            id: 'US',
+                        },
+                    },
+                    {
+                        edition: {
+                            id: 'AU',
+                        },
+                    },
+                    {
+                        edition: {
+                            id: 'INT',
+                        },
+                    },
+                ],
+                editionAdTargetings: [
+                    {
+                        edition: {
+                            id: 'UK',
+                        },
+                        paramSet: [
+                            {
+                                name: 'edition',
+                                value: 'uk',
+                            },
+                            {
+                                name: 'url',
+                                value:
+                                    '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                            },
+                            {
+                                name: 'tn',
+                                value: ['news'],
+                            },
+                            {
+                                name: 'sh',
+                                value: 'https://gu.com/p/64ak8',
+                            },
+                            {
+                                name: 'su',
+                                value: ['0'],
+                            },
+                            {
+                                name: 'co',
+                                value: ['rob-davies'],
+                            },
+                            {
+                                name: 'ct',
+                                value: 'article',
+                            },
+                            {
+                                name: 'p',
+                                value: 'ng',
+                            },
+                            {
+                                name: 'k',
+                                value: [
+                                    'ticket-prices',
+                                    'consumer-affairs',
+                                    'internet',
+                                    'viagogo',
+                                    'money',
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        edition: {
+                            id: 'US',
+                        },
+                        paramSet: [
+                            {
+                                name: 'url',
+                                value:
+                                    '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                            },
+                            {
+                                name: 'tn',
+                                value: ['news'],
+                            },
+                            {
+                                name: 'sh',
+                                value: 'https://gu.com/p/64ak8',
+                            },
+                            {
+                                name: 'su',
+                                value: ['0'],
+                            },
+                            {
+                                name: 'co',
+                                value: ['rob-davies'],
+                            },
+                            {
+                                name: 'ct',
+                                value: 'article',
+                            },
+                            {
+                                name: 'p',
+                                value: 'ng',
+                            },
+                            {
+                                name: 'edition',
+                                value: 'us',
+                            },
+                            {
+                                name: 'k',
+                                value: [
+                                    'ticket-prices',
+                                    'consumer-affairs',
+                                    'internet',
+                                    'viagogo',
+                                    'money',
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        edition: {
+                            id: 'AU',
+                        },
+                        paramSet: [
+                            {
+                                name: 'url',
+                                value:
+                                    '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                            },
+                            {
+                                name: 'tn',
+                                value: ['news'],
+                            },
+                            {
+                                name: 'sh',
+                                value: 'https://gu.com/p/64ak8',
+                            },
+                            {
+                                name: 'su',
+                                value: ['0'],
+                            },
+                            {
+                                name: 'co',
+                                value: ['rob-davies'],
+                            },
+                            {
+                                name: 'ct',
+                                value: 'article',
+                            },
+                            {
+                                name: 'p',
+                                value: 'ng',
+                            },
+                            {
+                                name: 'k',
+                                value: [
+                                    'ticket-prices',
+                                    'consumer-affairs',
+                                    'internet',
+                                    'viagogo',
+                                    'money',
+                                ],
+                            },
+                            {
+                                name: 'edition',
+                                value: 'au',
+                            },
+                        ],
+                    },
+                    {
+                        edition: {
+                            id: 'INT',
+                        },
+                        paramSet: [
+                            {
+                                name: 'url',
+                                value:
+                                    '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                            },
+                            {
+                                name: 'tn',
+                                value: ['news'],
+                            },
+                            {
+                                name: 'edition',
+                                value: 'int',
+                            },
+                            {
+                                name: 'sh',
+                                value: 'https://gu.com/p/64ak8',
+                            },
+                            {
+                                name: 'su',
+                                value: ['0'],
+                            },
+                            {
+                                name: 'co',
+                                value: ['rob-davies'],
+                            },
+                            {
+                                name: 'ct',
+                                value: 'article',
+                            },
+                            {
+                                name: 'p',
+                                value: 'ng',
+                            },
+                            {
+                                name: 'k',
+                                value: [
+                                    'ticket-prices',
+                                    'consumer-affairs',
+                                    'internet',
+                                    'viagogo',
+                                    'money',
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                prebidIndexSites: [
+                    {
+                        bp: 'D',
+                        id: 208236,
+                    },
+                    {
+                        bp: 'M',
+                        id: 213509,
+                    },
+                    {
+                        bp: 'T',
+                        id: 215444,
+                    },
+                ],
+            },
+        },
+        meta: {
+            isImmersive: false,
+            isHosted: false,
+            shouldHideAds: true,
+            hasStoryPackage: true,
+            hasRelated: true,
+            isCommentable: false,
+            linkedData: [
+                {
+                    '@type': 'NewsArticle',
+                    '@context': 'https://schema.org',
+                    '@id':
+                        'https://amp.theguardian.commoney/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    publisher: {
+                        '@type': 'Organization',
+                        '@context': 'https://schema.org',
+                        '@id': 'https://www.theguardian.com#publisher',
+                        name: 'The Guardian',
+                        url: 'https://www.theguardian.com/',
+                        logo: {
+                            '@type': 'ImageObject',
+                            url:
+                                'https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png',
+                            width: 190,
+                            height: 60,
+                        },
+                        sameAs: [
+                            'https://www.facebook.com/theguardian',
+                            'https://twitter.com/guardian',
+                            'https://www.youtube.com/user/TheGuardian',
+                        ],
+                    },
+                    isAccessibleForFree: true,
+                    isPartOf: {
+                        '@type': ['CreativeWork', 'Product'],
+                        name: 'The Guardian',
+                        productID: 'theguardian.com:basic',
+                    },
+                    image: [
+                        'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=1200&quality=85&auto=format&fit=max&s=81c451031902977f730a5ce8889745f3',
+                        'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=900&quality=85&auto=format&fit=max&s=4bc0fff8555ac350f33d81703e0ac7f4',
+                        'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&quality=85&auto=format&fit=max&s=c52c6ee4e127be64398a289551edcbfa',
+                    ],
+                    author: [
+                        {
+                            '@type': 'Person',
+                            name: 'Rob Davies',
+                            sameAs:
+                                'https://www.theguardian.com/profile/rob-davies',
+                        },
+                    ],
+                    datePublished: '2017-03-11T06:15:05.000+11:00',
+                    headline:
+                        "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+                    dateModified: '2017-11-28T14:55:02.000+11:00',
+                    mainEntityOfPage:
+                        'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+                {
+                    '@type': 'WebPage',
+                    '@context': 'https://schema.org',
+                    '@id':
+                        'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    potentialAction: {
+                        '@type': 'ViewAction',
+                        target:
+                            'android-app://com.guardian/https/www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    },
+                },
+            ],
+        },
+    },
+    site: {
+        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        guardianBaseURL: 'https://www.theguardian.com',
+        sentryHost: 'app.getsentry.com/35463',
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        switches: {
+            abCommercialCmpCustomise: true,
+            prebidAppnexusUkRow: true,
+            prebidTrustx: true,
+            scAdFreeBanner: true,
+            enableSentryReporting: true,
+            lazyLoadContainers: true,
+            adFreeStrictExpiryEnforcement: false,
+            remarketing: true,
+            emailSignupLabNotes: true,
+            registerWithPhone: false,
+            lotame: true,
+            targeting: true,
+            emailInlineInFooter: true,
+            prebidPangaea: true,
+            adomik: true,
+            facebookTrackingPixel: true,
+            serviceWorkerEnabled: false,
+            iasAdTargeting: true,
+            extendedMostPopular: true,
+            prebidAnalytics: true,
+            idEmailSignInUpsell: false,
+            doubleclickYoutubeAdFree: true,
+            imrWorldwide: true,
+            membershipEngagementBannerBlockUs: false,
+            prebidAppnexusInvcode: true,
+            subscribeWithGoogle: false,
+            prebidAppnexus: true,
+            enableDiscussionSwitch: true,
+            enableConsentManagementService: true,
+            prebidXaxis: true,
+            oldTlsSupportDeprecation: true,
+            abContributionsEpicAskFourEarning: true,
+            discussionAllPageSize: true,
+            emailSignupEuRef: true,
+            prebidUserSync: true,
+            audioOnwardJourneySwitch: true,
+            breakingNews: true,
+            externalVideoEmbeds: true,
+            simpleReach: true,
+            emailInArticleOutbrain: true,
+            carrotTrafficDriver: true,
+            geoMostPopular: true,
+            abFebruaryMomentBannerThankYou: false,
+            weAreHiring: true,
+            relatedContent: true,
+            thirdPartyEmbedTracking: true,
+            commercialPageViewAnalytics: true,
+            prebidAdYouLike: true,
+            membershipEngagementBanner: true,
+            mostViewedFronts: true,
+            googleSearch: true,
+            membershipEngagementBannerBlockAu: false,
+            outbrain: true,
+            commercial: true,
+            plistaForOutbrainAu: true,
+            prebidSonobi: true,
+            membershipEngagementBannerBlockUk: false,
+            idProfileNavigation: true,
+            discussionAllowAnonymousRecommendsSwitch: false,
+            scrollDepth: true,
+            krux: true,
+            kruxVideoTracking: false,
+            epicTestsFromGoogleDocs: true,
+            youtubeRelatedVideos: true,
+            webFonts: true,
+            abFebruaryMomentBannerCopy: true,
+            prebidImproveDigital: true,
+            abCommercialPrebidSafeframe: true,
+            ophan: true,
+            abAcquisitionsEpicAlwaysAskIfTagged: true,
+            crosswordSvgThumbnails: true,
+            weather: true,
+            commercialOutbrainNewids: true,
+            hostedVideoAutoplay: true,
+            emailInArticleGtoday: true,
+            engagementBannerTestsFromGoogleDocs: false,
+            prebidS2sozone: true,
+            abAdblockAsk: true,
+            prebidPubmatic: true,
+            serverShareCounts: true,
+            autoRefresh: true,
+            enhanceTweets: true,
+            prebidIndexExchange: true,
+            prebidOpenx: true,
+            tourismAustralia: true,
+            emailInArticle: true,
+            idCookieRefresh: true,
+            sharingComments: true,
+            discussionPageSize: true,
+            smartAppBanner: true,
+            boostGaUserTimingFidelity: false,
+            historyTags: true,
+            videojs: true,
+            surveys: true,
+            abCommercialAdVerification: false,
+            inizio: true,
+        },
+        beaconUrl: '//phar.gu-web.net',
+        subscribeWithGoogleApiUrl: 'https://swg.theguardian.com',
+        nav: {
+            currentUrl: '/money',
+            pillars: [
+                {
+                    title: 'News',
+                    url: '/',
+                    longTitle: 'Headlines',
+                    iconName: 'home',
+                    children: [
+                        {
+                            title: 'UK',
+                            url: '/uk-news',
+                            longTitle: 'UK news',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'UK politics',
+                                    url: '/politics',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Education',
+                                    url: '/education',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [
+                                        {
+                                            title: 'Schools',
+                                            url: '/education/schools',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Teachers',
+                                            url: '/teacher-network',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Universities',
+                                            url: '/education/universities',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Students',
+                                            url: '/education/students',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                    ],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Media',
+                                    url: '/media',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Society',
+                                    url: '/society',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Law',
+                                    url: '/law',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Scotland',
+                                    url: '/uk/scotland',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Wales',
+                                    url: '/uk/wales',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Northern Ireland',
+                                    url: '/uk/northernireland',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'World',
+                            url: '/world',
+                            longTitle: 'World news',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Europe',
+                                    url: '/world/europe-news',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'US',
+                                    url: '/us-news',
+                                    longTitle: 'US news',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Americas',
+                                    url: '/world/americas',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Asia',
+                                    url: '/world/asia',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Australia',
+                                    url: '/australia-news',
+                                    longTitle: 'Australia news',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Middle East',
+                                    url: '/world/middleeast',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Africa',
+                                    url: '/world/africa',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Inequality',
+                                    url: '/inequality',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Cities',
+                                    url: '/cities',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Global development',
+                                    url: '/global-development',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Business',
+                            url: '/business',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Economics',
+                                    url: '/business/economics',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Banking',
+                                    url: '/business/banking',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Money',
+                                    url: '/money',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [
+                                        {
+                                            title: 'Property',
+                                            url: '/money/property',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Pensions',
+                                            url: '/money/pensions',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Savings',
+                                            url: '/money/savings',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Borrowing',
+                                            url: '/money/debt',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                        {
+                                            title: 'Careers',
+                                            url: '/money/work-and-careers',
+                                            longTitle: '',
+                                            iconName: '',
+                                            children: [],
+                                            classList: [],
+                                        },
+                                    ],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Markets',
+                                    url: '/business/stock-markets',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Project Syndicate',
+                                    url:
+                                        '/business/series/project-syndicate-economists',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'B2B',
+                                    url: '/business-to-business',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Football',
+                            url: '/football',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Live scores',
+                                    url: '/football/live',
+                                    longTitle: 'football/live',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Tables',
+                                    url: '/football/tables',
+                                    longTitle: 'football/tables',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Fixtures',
+                                    url: '/football/fixtures',
+                                    longTitle: 'football/fixtures',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Results',
+                                    url: '/football/results',
+                                    longTitle: 'football/results',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Competitions',
+                                    url: '/football/competitions',
+                                    longTitle: 'football/competitions',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Clubs',
+                                    url: '/football/teams',
+                                    longTitle: 'football/teams',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'World Cup 2019',
+                                    url: '/football/womens-world-cup-2019',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'UK politics',
+                            url: '/politics',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Environment',
+                            url: '/environment',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Climate change',
+                                    url: '/environment/climate-change',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Wildlife',
+                                    url: '/environment/wildlife',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Energy',
+                                    url: '/environment/energy',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Pollution',
+                                    url: '/environment/pollution',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Education',
+                            url: '/education',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Schools',
+                                    url: '/education/schools',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Teachers',
+                                    url: '/teacher-network',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Universities',
+                                    url: '/education/universities',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Students',
+                                    url: '/education/students',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Society',
+                            url: '/society',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Science',
+                            url: '/science',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Tech',
+                            url: '/technology',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Global development',
+                            url: '/global-development',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cities',
+                            url: '/cities',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Obituaries',
+                            url: '/tone/obituaries',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Opinion',
+                    url: '/commentisfree',
+                    longTitle: 'Opinion home',
+                    iconName: 'home',
+                    children: [
+                        {
+                            title: 'The Guardian view',
+                            url: '/profile/editorial',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Columnists',
+                            url: '/index/contributors',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cartoons',
+                            url: '/cartoons/archive',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Opinion videos',
+                            url: '/commentisfree/series/comment-is-free-weekly',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Letters',
+                            url: '/tone/letters',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Sport',
+                    url: '/sport',
+                    longTitle: 'Sport home',
+                    iconName: 'home',
+                    children: [
+                        {
+                            title: 'Football',
+                            url: '/football',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Live scores',
+                                    url: '/football/live',
+                                    longTitle: 'football/live',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Tables',
+                                    url: '/football/tables',
+                                    longTitle: 'football/tables',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Fixtures',
+                                    url: '/football/fixtures',
+                                    longTitle: 'football/fixtures',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Results',
+                                    url: '/football/results',
+                                    longTitle: 'football/results',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Competitions',
+                                    url: '/football/competitions',
+                                    longTitle: 'football/competitions',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Clubs',
+                                    url: '/football/teams',
+                                    longTitle: 'football/teams',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'World Cup 2019',
+                                    url: '/football/womens-world-cup-2019',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Rugby union',
+                            url: '/sport/rugby-union',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cricket',
+                            url: '/sport/cricket',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Tennis',
+                            url: '/sport/tennis',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cycling',
+                            url: '/sport/cycling',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'F1',
+                            url: '/sport/formulaone',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Golf',
+                            url: '/sport/golf',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Boxing',
+                            url: '/sport/boxing',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Rugby league',
+                            url: '/sport/rugbyleague',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Racing',
+                            url: '/sport/horse-racing',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'US sports',
+                            url: '/sport/us-sport',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Culture',
+                    url: '/culture',
+                    longTitle: 'Culture home',
+                    iconName: 'home',
+                    children: [
+                        {
+                            title: 'Film',
+                            url: '/film',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Music',
+                            url: '/music',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'TV & radio',
+                            url: '/tv-and-radio',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Books',
+                            url: '/books',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Art & design',
+                            url: '/artanddesign',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Stage',
+                            url: '/stage',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Games',
+                            url: '/games',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Classical',
+                            url: '/music/classicalmusicandopera',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Lifestyle',
+                    url: '/lifeandstyle',
+                    longTitle: 'Lifestyle home',
+                    iconName: 'home',
+                    children: [
+                        {
+                            title: 'Fashion',
+                            url: '/fashion',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Food',
+                            url: '/food',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Recipes',
+                            url: '/tone/recipes',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Travel',
+                            url: '/travel',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'UK',
+                                    url: '/travel/uk',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Europe',
+                                    url: '/travel/europe',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'US',
+                                    url: '/travel/usa',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Health & fitness',
+                            url: '/lifeandstyle/health-and-wellbeing',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Women',
+                            url: '/lifeandstyle/women',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Men',
+                            url: '/lifeandstyle/men',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Love & sex',
+                            url: '/lifeandstyle/love-and-sex',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Beauty',
+                            url: '/fashion/beauty',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Home & garden',
+                            url: '/lifeandstyle/home-and-garden',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Money',
+                            url: '/money',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Property',
+                                    url: '/money/property',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Pensions',
+                                    url: '/money/pensions',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Savings',
+                                    url: '/money/savings',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Borrowing',
+                                    url: '/money/debt',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Careers',
+                                    url: '/money/work-and-careers',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cars',
+                            url: '/technology/motoring',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+            ],
+            otherLinks: [
+                {
+                    title: 'The Guardian app',
+                    url:
+                        'https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Video',
+                    url: '/video',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Podcasts',
+                    url: '/podcasts',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Pictures',
+                    url: '/inpictures',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Newsletters',
+                    url: '/email-newsletters',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: "Today's paper",
+                    url: '/theguardian',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Obituaries',
+                            url: '/tone/obituaries',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'G2',
+                            url: '/theguardian/g2',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Weekend',
+                            url: '/theguardian/weekend',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'The Guide',
+                            url: '/theguardian/theguide',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Saturday review',
+                            url: '/theguardian/guardianreview',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Inside the Guardian',
+                    url: 'https://www.theguardian.com/membership',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'The Observer',
+                    url: '/observer',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Comment',
+                            url: '/theobserver/news/comment',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'The New Review',
+                            url: '/theobserver/new-review',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Observer Magazine',
+                            url: '/theobserver/magazine',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Guardian Weekly',
+                    url:
+                        'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Professional networks',
+                    url: '/guardian-professional',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Crosswords',
+                    url: '/crosswords',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Blog',
+                            url: '/crosswords/crossword-blog',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Editor',
+                            url: '/crosswords/series/crossword-editor-update',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Quick',
+                            url: '/crosswords/series/quick',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Cryptic',
+                            url: '/crosswords/series/cryptic',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Prize',
+                            url: '/crosswords/series/prize',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Weekend',
+                            url: '/crosswords/series/weekend-crossword',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Quiptic',
+                            url: '/crosswords/series/quiptic',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Genius',
+                            url: '/crosswords/series/genius',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Speedy',
+                            url: '/crosswords/series/speedy',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Everyman',
+                            url: '/crosswords/series/everyman',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Azed',
+                            url: '/crosswords/series/azed',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Guardian Masterclasses',
+                    url: '/guardian-masterclasses',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Journalism',
+                            url: '/guardian-masterclasses/journalism',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Digital',
+                            url: '/guardian-masterclasses/digital',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Business',
+                            url: '/guardian-masterclasses/business',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Creative writing',
+                            url:
+                                '/guardian-masterclasses/writing-and-publishing',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Wellbeing & Culture',
+                            url: '/guardian-masterclasses/culture',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Bespoke training',
+                            url: '/guardian-masterclasses/corporate-training',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Calendar',
+                            url: '/guardian-masterclasses/calendar',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+            ],
+            brandExtensions: [
+                {
+                    title: 'Search jobs',
+                    url:
+                        'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Dating',
+                    url:
+                        'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Holidays',
+                    url:
+                        'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Masterclasses',
+                    url:
+                        'https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Digital Archive',
+                    url: 'https://theguardian.newspapers.com',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Patrons',
+                    url:
+                        'https://patrons.theguardian.com/?INTCMP=header_patrons',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Discount Codes',
+                    url:
+                        'https://discountcode.theguardian.com/uk?INTCMP=guardian_header',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+            currentNavLink: {
+                title: 'Money',
+                url: '/money',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Property',
+                        url: '/money/property',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Pensions',
+                        url: '/money/pensions',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Savings',
+                        url: '/money/savings',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Borrowing',
+                        url: '/money/debt',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Careers',
+                        url: '/money/work-and-careers',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            currentParent: {
+                title: 'Lifestyle',
+                url: '/lifeandstyle',
+                longTitle: 'Lifestyle home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Fashion',
+                        url: '/fashion',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Food',
+                        url: '/food',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Recipes',
+                        url: '/tone/recipes',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Travel',
+                        url: '/travel',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK',
+                                url: '/travel/uk',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Europe',
+                                url: '/travel/europe',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/travel/usa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Health & fitness',
+                        url: '/lifeandstyle/health-and-wellbeing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Women',
+                        url: '/lifeandstyle/women',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Men',
+                        url: '/lifeandstyle/men',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Love & sex',
+                        url: '/lifeandstyle/love-and-sex',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Beauty',
+                        url: '/fashion/beauty',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Home & garden',
+                        url: '/lifeandstyle/home-and-garden',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Money',
+                        url: '/money',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Property',
+                                url: '/money/property',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pensions',
+                                url: '/money/pensions',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Savings',
+                                url: '/money/savings',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Borrowing',
+                                url: '/money/debt',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Careers',
+                                url: '/money/work-and-careers',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cars',
+                        url: '/technology/motoring',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            currentPillar: {
+                title: 'Lifestyle',
+                url: '/lifeandstyle',
+                longTitle: 'Lifestyle home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Fashion',
+                        url: '/fashion',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Food',
+                        url: '/food',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Recipes',
+                        url: '/tone/recipes',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Travel',
+                        url: '/travel',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK',
+                                url: '/travel/uk',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Europe',
+                                url: '/travel/europe',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/travel/usa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Health & fitness',
+                        url: '/lifeandstyle/health-and-wellbeing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Women',
+                        url: '/lifeandstyle/women',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Men',
+                        url: '/lifeandstyle/men',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Love & sex',
+                        url: '/lifeandstyle/love-and-sex',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Beauty',
+                        url: '/fashion/beauty',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Home & garden',
+                        url: '/lifeandstyle/home-and-garden',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Money',
+                        url: '/money',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Property',
+                                url: '/money/property',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pensions',
+                                url: '/money/pensions',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Savings',
+                                url: '/money/savings',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Borrowing',
+                                url: '/money/debt',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Careers',
+                                url: '/money/work-and-careers',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cars',
+                        url: '/technology/motoring',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            subNavSections: {
+                parent: {
+                    title: 'Money',
+                    url: '/money',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Property',
+                            url: '/money/property',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Pensions',
+                            url: '/money/pensions',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Savings',
+                            url: '/money/savings',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Borrowing',
+                            url: '/money/debt',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Careers',
+                            url: '/money/work-and-careers',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                links: [
+                    {
+                        title: 'Property',
+                        url: '/money/property',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Pensions',
+                        url: '/money/pensions',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Savings',
+                        url: '/money/savings',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Borrowing',
+                        url: '/money/debt',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Careers',
+                        url: '/money/work-and-careers',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+            },
+        },
+        readerRevenueLinks: {
+            header: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_contribute"%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_subscribe"%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support"%7D',
+            },
+            footer: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support_contribute"%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support_subscribe"%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
+            },
+            sideMenu: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support_contribute"%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support_subscribe"%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support"%7D',
+            },
+            ampHeader: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_contribute"%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_subscribe"%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"amp_header_support"%7D',
+            },
+            ampFooter: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"amp_footer_support_contribute"%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"amp_footer_support_subscribe"%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
+            },
+        },
+        commercialUrl:
+            'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
+    },
+    version: 2,
+};

--- a/projects/pwa/src/hooks/useArticle.ts
+++ b/projects/pwa/src/hooks/useArticle.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react';
 
+// TODO: replace with call to backend!
+import { data as articleData } from '../fixtures/article';
+
 type Article = {
-	title: string;
-	content: string;
+	headline: string;
+	body: string;
 };
 
 type AsyncReturnable<Returnable> = Returnable | null;
@@ -12,8 +15,8 @@ const useArticle = (front: string, id: string): AsyncReturnable<Article> => {
 	useEffect(() => {
 		setTimeout(() => {
 			setState({
-				title: `Article about ${id}`,
-				content: `this is article ${id} in front ${front}`,
+				headline: articleData.page.content.headline,
+				body: articleData.page.content.body,
 			});
 		}, 200);
 	}, [front, id]);

--- a/projects/pwa/src/hooks/useArticle.ts
+++ b/projects/pwa/src/hooks/useArticle.ts
@@ -5,7 +5,7 @@ import { data as articleData } from '../fixtures/article';
 
 type Article = {
 	headline: string;
-	body: string;
+	elements: CAPIElement[];
 };
 
 type AsyncReturnable<Returnable> = Returnable | null;
@@ -16,7 +16,7 @@ const useArticle = (front: string, id: string): AsyncReturnable<Article> => {
 		setTimeout(() => {
 			setState({
 				headline: articleData.page.content.headline,
-				body: articleData.page.content.body,
+				elements: articleData.page.content.blocks.body[0].elements,
 			});
 		}, 200);
 	}, [front, id]);

--- a/projects/pwa/src/react-app-env.d.ts
+++ b/projects/pwa/src/react-app-env.d.ts
@@ -47,18 +47,3 @@ declare module '*.svg' {
   const src: string;
   export default src;
 }
-
-declare module '*.module.css' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
-declare module '*.module.sass' {
-  const classes: { [key: string]: string };
-  export default classes;
-}

--- a/projects/pwa/src/route/Article.tsx
+++ b/projects/pwa/src/route/Article.tsx
@@ -3,6 +3,7 @@ import useArticle from '../hooks/useArticle';
 import Header from '../component/Header';
 import { urlBuilder } from '../helper/urlBuilder';
 import Content from '../component/Content';
+import { Elements } from '../component/Elements';
 
 export interface ArticleProps {
     product: string;
@@ -25,8 +26,7 @@ const Article = ({ product, issue, front, article }: ArticleProps) => {
             </Header>
             <Content>
                 {content ? (
-                    <div dangerouslySetInnerHTML={{ __html: content.body }}>
-                    </div>
+                    <Elements elements={content.elements}/>
                 ) : (
                     <div>loading</div>
                 )}

--- a/projects/pwa/src/route/Article.tsx
+++ b/projects/pwa/src/route/Article.tsx
@@ -21,19 +21,11 @@ const Article = ({ product, issue, front, article }: ArticleProps) => {
                     url: urlBuilder({ product, issue, front }),
                 }}
             >
-                {content ? content.title : 'loading'}
+                {content ? content.headline : 'loading'}
             </Header>
             <Content>
                 {content ? (
-                    <div>
-                        <p>{content.content}</p>
-                        <ul>
-                            {[product, issue, front, article].map(
-                                (thing, index) => (
-                                    <li key={index}>{thing}</li>
-                                ),
-                            )}
-                        </ul>
+                    <div dangerouslySetInnerHTML={{ __html: content.body }}>
                     </div>
                 ) : (
                     <div>loading</div>

--- a/projects/pwa/yarn.lock
+++ b/projects/pwa/yarn.lock
@@ -856,10 +856,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
-"@guardian/pasteup@^1.0.0-alpha.7":
-  version "1.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.7.tgz#680656b92632006d736d0378ae19f8c6943769c8"
-  integrity sha512-WSa3gnRYxciFas3QYhtTk8unvj5N9K5IB61LL1CP3bVCJ2euXR13xRRHafI/Vy1dnrDwPa80SaE+apTcwipvpA==
+"@guardian/pasteup@^1.0.0-alpha.8":
+  version "1.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.8.tgz#340cc86207523adc71b5b6cb1d6693e3afeab217"
+  integrity sha512-ojTYoCRQxUx6axiwCLX26JKGmIah/MJix6AiPGIplQ/DiO4oJXS6RUC+HfYIEZC8V1g3woqXzmVF2lgCfDtyIA==
 
 "@jest/console@^24.7.1":
   version "24.7.1"


### PR DESCRIPTION
- upgrades pasteup to grab typography tokens
- adds article data fixture (copy-pasted from [dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/master/fixtures/article.ts))
- implements an Elements renderer (only text elements are currently supported)
- some super simple styling, yo (don't judge... well, judge a little bit)
- tangential: delete some more CSS Modules boilerplate

We can improve styling if the general approach here is 👌 

![Screenshot 2019-04-25 at 17 05 53](https://user-images.githubusercontent.com/5931528/56750969-caf26680-677c-11e9-95ea-c45b6a19a61f.png)
