### PR TITLE
Article webview

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -138,6 +138,7 @@ android {
 }
 
 dependencies {
+    implementation project(':react-native-webview')
     implementation project(':react-native-zip-archive')
     implementation project(':react-native-svg')
     implementation project(':@react-native-community_async-storage')

--- a/projects/Mallard/android/app/src/main/java/com/mallard/MainApplication.java
+++ b/projects/Mallard/android/app/src/main/java/com/mallard/MainApplication.java
@@ -3,6 +3,7 @@ package com.mallard;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.rnziparchive.RNZipArchivePackage;
 import com.horcrux.svg.SvgPackage;
 import com.reactnativecommunity.asyncstorage.AsyncStoragePackage;
@@ -29,6 +30,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNCWebViewPackage(),
             new RNZipArchivePackage(),
             new SvgPackage(),
             new AsyncStoragePackage(),

--- a/projects/Mallard/android/settings.gradle
+++ b/projects/Mallard/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'Mallard'
+include ':react-native-webview'
+project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 include ':react-native-zip-archive'
 project(':react-native-zip-archive').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-zip-archive/android')
 include ':react-native-svg'

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		E9885E433EE84C1585CED823 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FE20416D3D243E5A4320927 /* libz.tbd */; };
 		3141A00B48124CDEB222AE8C /* GuardianTextEgyptian-Reg.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 74288DBD9D3848588CDA9778 /* GuardianTextEgyptian-Reg.ttf */; };
 		F4F556D931AA48DAB9FF3F92 /* GuardianTextEgyptian-RegIt.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8B79D2F0496E4B54B5A15981 /* GuardianTextEgyptian-RegIt.ttf */; };
+		2795FFC912F745B79C95E324 /* libRNCWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3FAFC61256B42E39F76C701 /* libRNCWebView.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -447,6 +448,8 @@
 		74288DBD9D3848588CDA9778 /* GuardianTextEgyptian-Reg.ttf */ = {isa = PBXFileReference; name = "GuardianTextEgyptian-Reg.ttf"; path = "../src/assets/fonts/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-Reg.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		8A107111D4A24C5AACD6E2A0 /* GuardianTextEgyptian-RegularIt.ttf */ = {isa = PBXFileReference; name = "GuardianTextEgyptian-RegularIt.ttf"; path = "../src/assets/fonts/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-RegularIt.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		8B79D2F0496E4B54B5A15981 /* GuardianTextEgyptian-RegIt.ttf */ = {isa = PBXFileReference; name = "GuardianTextEgyptian-RegIt.ttf"; path = "../src/assets/fonts/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-RegIt.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		853A3F573E72498B91AA0E6E /* RNCWebView.xcodeproj */ = {isa = PBXFileReference; name = "RNCWebView.xcodeproj"; path = "../node_modules/react-native-webview/ios/RNCWebView.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		B3FAFC61256B42E39F76C701 /* libRNCWebView.a */ = {isa = PBXFileReference; name = "libRNCWebView.a"; path = "libRNCWebView.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -482,6 +485,7 @@
 				F799A66568FF47AE853CD184 /* libRNSVG.a in Frameworks */,
 				3A140BAAF8A54BCD80E527EA /* libRNZipArchive.a in Frameworks */,
 				E9885E433EE84C1585CED823 /* libz.tbd in Frameworks */,
+				2795FFC912F745B79C95E324 /* libRNCWebView.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -681,6 +685,7 @@
 				6771A18BDD144402A066FE1C /* RNCAsyncStorage.xcodeproj */,
 				9827A6EFCE7D481C850944C7 /* RNSVG.xcodeproj */,
 				197CB28C99C64D45B992B609 /* RNZipArchive.xcodeproj */,
+				853A3F573E72498B91AA0E6E /* RNCWebView.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1447,12 +1452,14 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = MallardTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1486,12 +1493,14 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = MallardTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1526,6 +1535,7 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = Mallard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1555,6 +1565,7 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = Mallard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1590,11 +1601,13 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1636,11 +1649,13 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1681,11 +1696,13 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -1726,11 +1743,13 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/async-storage/ios",
 					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-zip-archive/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-webview/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -12,7 +12,8 @@
         "validate": "cd ../.. && yarn validate-mallard",
         "fix": "cd ../.. && yarn fix-mallard",
         "build-android-debug": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
-        "build-ios-debug": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios"
+        "build-ios-debug": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
+        "rn-link": "react-native link"
     },
     "rnpm": {
         "assets": [
@@ -26,6 +27,7 @@
         "react-native": "0.59.3",
         "react-native-gesture-handler": "^1.2.1",
         "react-native-svg": "^9.4.0",
+        "react-native-webview": "^5.11.0",
         "react-native-zip-archive": "^4.0.1",
         "react-navigation": "3.9.1",
         "react-navigation-fluid-transitions": "^0.3.2",

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
-import { View, Text, StyleSheet } from 'react-native'
+import React, { useState } from 'react'
+import { View, Text, StyleSheet, Alert, PixelRatio } from 'react-native'
 import { NavigationScreenProp } from 'react-navigation'
+import { WebView } from 'react-native-webview'
 import { color } from '../../theme/color'
 import { metrics } from '../../theme/spacing'
 import { SlideCard } from '../layout/slide-card'
@@ -37,6 +38,26 @@ const styles = StyleSheet.create({
     },
 })
 
+const render = (article) => {
+    return `
+    <html>
+    <head></head>
+    <body>
+      ${article
+            .filter(el => el.type === 0)
+            .map(el => (
+                el.textTypeData.html
+            )).join('')}
+      <script>
+        setTimeout(function() {
+            window.ReactNativeWebView.postMessage(document.body.getBoundingClientRect().height)
+        }, 0)
+      </script>
+    </body>
+    </html>
+    `
+}
+
 const Article = ({
     navigation,
     article,
@@ -51,6 +72,8 @@ const Article = ({
 } & ArticleHeaderPropTypes &
     StandfirstPropTypes) => {
     const { appearance, name: appearanceName } = useArticleAppearance()
+    const html = render(article)
+    const [height, setHeight] = useState(500)
     return (
         <SlideCard
             headerStyle={[
@@ -68,18 +91,24 @@ const Article = ({
                 {appearanceName === 'longread' ? (
                     <LongReadHeader {...{ headline, image, kicker }} />
                 ) : (
-                    <NewsHeader {...{ headline, image, kicker }} />
-                )}
+                        <NewsHeader {...{ headline, image, kicker }} />
+                    )}
                 <Standfirst {...{ byline, standfirst }} />
 
                 <View style={{ backgroundColor: color.background, flex: 1 }}>
-                    {article
+                    <WebView originWhitelist={['*']}
+                        source={{ html: html }}
+                        onMessage={event => {
+                            setHeight(parseInt(event.nativeEvent.data) / PixelRatio.get())
+                        }}
+                        style={{ flex: 1, height: height }} />
+                    {/* {article
                         .filter(el => el.type === 0)
                         .map((el, index) => (
                             <View style={styles.block} key={index}>
                                 <Text>{el.textTypeData.html}</Text>
                             </View>
-                        ))}
+                        ))} */}
                 </View>
             </View>
         </SlideCard>

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { View, Text, StyleSheet, Alert, PixelRatio } from 'react-native'
+import { View, StyleSheet, PixelRatio } from 'react-native'
 import { NavigationScreenProp } from 'react-navigation'
 import { WebView } from 'react-native-webview'
 import { color } from '../../theme/color'
@@ -106,13 +106,6 @@ const Article = ({
                         }}
                         style={{ flex: 1, height: height }}
                     />
-                    {/* {article
-                        .filter(el => el.type === 0)
-                        .map((el, index) => (
-                            <View style={styles.block} key={index}>
-                                <Text>{el.textTypeData.html}</Text>
-                            </View>
-                        ))} */}
                 </View>
             </View>
         </SlideCard>

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -38,16 +38,15 @@ const styles = StyleSheet.create({
     },
 })
 
-const render = (article) => {
+const render = article => {
     return `
     <html>
     <head></head>
     <body>
       ${article
-            .filter(el => el.type === 0)
-            .map(el => (
-                el.textTypeData.html
-            )).join('')}
+          .filter(el => el.type === 0)
+          .map(el => el.textTypeData.html)
+          .join('')}
       <script>
         setTimeout(function() {
             window.ReactNativeWebView.postMessage(document.body.getBoundingClientRect().height)
@@ -91,17 +90,22 @@ const Article = ({
                 {appearanceName === 'longread' ? (
                     <LongReadHeader {...{ headline, image, kicker }} />
                 ) : (
-                        <NewsHeader {...{ headline, image, kicker }} />
-                    )}
+                    <NewsHeader {...{ headline, image, kicker }} />
+                )}
                 <Standfirst {...{ byline, standfirst }} />
 
                 <View style={{ backgroundColor: color.background, flex: 1 }}>
-                    <WebView originWhitelist={['*']}
+                    <WebView
+                        originWhitelist={['*']}
                         source={{ html: html }}
                         onMessage={event => {
-                            setHeight(parseInt(event.nativeEvent.data) / PixelRatio.get())
+                            setHeight(
+                                parseInt(event.nativeEvent.data) /
+                                    PixelRatio.get(),
+                            )
                         }}
-                        style={{ flex: 1, height: height }} />
+                        style={{ flex: 1, height: height }}
+                    />
                     {/* {article
                         .filter(el => el.type === 0)
                         .map((el, index) => (

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -44,13 +44,13 @@ const render = article => {
     <head></head>
     <body>
       ${article
-          .filter(el => el.type === 0)
-          .map(el => el.textTypeData.html)
-          .join('')}
+            .filter(el => el.type === 0)
+            .map(el => el.textTypeData.html)
+            .join('')}
       <script>
-        setTimeout(function() {
+        window.requestAnimationFrame(function() {
             window.ReactNativeWebView.postMessage(document.body.getBoundingClientRect().height)
-        }, 0)
+        })
       </script>
     </body>
     </html>
@@ -90,8 +90,8 @@ const Article = ({
                 {appearanceName === 'longread' ? (
                     <LongReadHeader {...{ headline, image, kicker }} />
                 ) : (
-                    <NewsHeader {...{ headline, image, kicker }} />
-                )}
+                        <NewsHeader {...{ headline, image, kicker }} />
+                    )}
                 <Standfirst {...{ byline, standfirst }} />
 
                 <View style={{ backgroundColor: color.background, flex: 1 }}>
@@ -101,7 +101,7 @@ const Article = ({
                         onMessage={event => {
                             setHeight(
                                 parseInt(event.nativeEvent.data) /
-                                    PixelRatio.get(),
+                                PixelRatio.get(),
                             )
                         }}
                         style={{ flex: 1, height: height }}

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -44,9 +44,9 @@ const render = article => {
     <head></head>
     <body>
       ${article
-            .filter(el => el.type === 0)
-            .map(el => el.textTypeData.html)
-            .join('')}
+          .filter(el => el.type === 0)
+          .map(el => el.textTypeData.html)
+          .join('')}
       <script>
         window.requestAnimationFrame(function() {
             window.ReactNativeWebView.postMessage(document.body.getBoundingClientRect().height)
@@ -90,8 +90,8 @@ const Article = ({
                 {appearanceName === 'longread' ? (
                     <LongReadHeader {...{ headline, image, kicker }} />
                 ) : (
-                        <NewsHeader {...{ headline, image, kicker }} />
-                    )}
+                    <NewsHeader {...{ headline, image, kicker }} />
+                )}
                 <Standfirst {...{ byline, standfirst }} />
 
                 <View style={{ backgroundColor: color.background, flex: 1 }}>
@@ -101,7 +101,7 @@ const Article = ({
                         onMessage={event => {
                             setHeight(
                                 parseInt(event.nativeEvent.data) /
-                                PixelRatio.get(),
+                                    PixelRatio.get(),
                             )
                         }}
                         style={{ flex: 1, height: height }}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2036,7 +2036,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -2789,7 +2789,7 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -5037,6 +5037,14 @@ react-native-tab-view@^1.2.0, react-native-tab-view@^1.3.4:
   integrity sha512-Bke8KkDcDhvB/z0AS7MnQKMD2p6Kwfc1rSKlMOvg9CC5CnClQ2QEnhPSbwegKDYhUkBI92iH/BYy7hNSm5kbUQ==
   dependencies:
     prop-types "^15.6.1"
+
+react-native-webview@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.11.0.tgz#7b1eeac7f3ea3a6f7bab3eefc10b272f0a008603"
+  integrity sha512-8hqq7Gr5tP6seWUJ5G1qmSmSo53hljhXIkZT09SX07pfAw1pbEoIMg7uYvZGk7BVkYiwIO4nkyg+M501E8CL8g==
+  dependencies:
+    escape-string-regexp "1.0.5"
+    invariant "2.2.4"
 
 react-native-zip-archive@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Why are you doing this?

Block data from CAPI contains HTML, so we need to bust articles out of the native layer into a Webview.

[**Trello Card**](https://trello.com/c/2esfv0D9/104-display-article-basic-news-articles-for-each-pillars)

## Changes

* install `react-native-webview`
* Inject HTML from CAPI directly into webview

## Screenshots

![Screenshot 2019-06-04 at 17 47 13](https://user-images.githubusercontent.com/5931528/58897695-cf515e00-86f0-11e9-9b8e-a7c0b9086f8b.png)

