### PR TITLE
Improve iOS beta pipeline

### DIFF
--- a/projects/Mallard/Makefile
+++ b/projects/Mallard/Makefile
@@ -1,14 +1,14 @@
 debug-android:
 	mkdir -p android/app/src/main/assets
-	yarn build-android-debug
+	yarn bundle-android
 	cd android && ./gradlew assembleDebug && cd ..
 	cp android/app/build/outputs/apk/debug/app-debug.apk .
 
 debug-ios:
-	yarn build-ios-debug
+	yarn bundle-ios
 	xcodebuild archive -allowProvisioningUpdates -project ios/Mallard.xcodeproj -configuration Debug -scheme Mallard -derivedDataPath ./ -archivePath "./Mallard.xcarchive" > build.log
 	xcodebuild -exportArchive -allowProvisioningUpdates -exportOptionsPlist ExportOptions.plist -archivePath "./Mallard.xcarchive" -exportPath ./ >> build.log
 
 beta-ios:
-	yarn build-ios-debug
+	yarn bundle-ios
 	cd ios && fastlane beta

--- a/projects/Mallard/ios/fastlane/Fastfile
+++ b/projects/Mallard/ios/fastlane/Fastfile
@@ -20,6 +20,8 @@ platform :ios do
   lane :beta do
     increment_build_number(xcodeproj: "Mallard.xcodeproj")
     build_app(scheme: "Mallard")
-    upload_to_testflight
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true
+    )
   end
 end

--- a/projects/Mallard/ios/fastlane/Fastfile
+++ b/projects/Mallard/ios/fastlane/Fastfile
@@ -18,8 +18,13 @@ default_platform(:ios)
 platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :beta do
-    increment_build_number(xcodeproj: "Mallard.xcodeproj")
-    build_app(scheme: "Mallard")
+    increment_build_number(
+      xcodeproj: "Mallard.xcodeproj",
+      build_number: latest_testflight_build_number + 1
+    )
+    build_app(
+      scheme: "Mallard"
+    )
     upload_to_testflight(
       skip_waiting_for_build_processing: true
     )

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -11,8 +11,8 @@
         "run-ios": "react-native run-ios",
         "validate": "cd ../.. && yarn validate-mallard",
         "fix": "cd ../.. && yarn fix-mallard",
-        "build-android-debug": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
-        "build-ios-debug": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
+        "bundle-android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
+        "bundle-ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
         "rn-link": "react-native link"
     },
     "rnpm": {


### PR DESCRIPTION
## Why are you doing this?

The iOS beta release process is currently missing a few steps. This fills in some gaps and improves some naming.

[**Trello Card ->**](https://trello.com/c/vsA7DzZB/182-editions-build-pipeline-ios)

## Changes

* improved names of yarn scripts
* automatically increment beta build version, so we don't have to keep it up to date in git
* prevent CI from waiting for app to process in TestFlight, to save 5 minutes of waiting on the TeamCity build agent

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborare
-->
