### PR TITLE
Lazy load fronts

### DIFF
--- a/projects/Mallard/src/components/front/front.tsx
+++ b/projects/Mallard/src/components/front/front.tsx
@@ -99,7 +99,8 @@ const Wrapper: FunctionComponent<{
 
 export const Front: FunctionComponent<{
     front: string
-}> = ({ front }) => {
+    viewIsTransitioning: boolean
+}> = ({ front, viewIsTransitioning }) => {
     const [scrollX] = useState(() => new Animated.Value(0))
     const scrollViewRef = useRef<AnimatedScrollViewRef | undefined>()
 
@@ -114,7 +115,9 @@ export const Front: FunctionComponent<{
 
     const color = 'green'
     const pages = Object.keys(frontData.collections).length
-    const collections = Object.entries(frontData.collections)
+    const collections = viewIsTransitioning
+        ? Object.entries(frontData.collections).slice(0, 1)
+        : Object.entries(frontData.collections)
 
     return (
         <Wrapper

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { ScrollView, StyleSheet } from 'react-native'
 import { MonoTextBlock } from '../components/styled-text'
-import { NavigationScreenProp } from 'react-navigation'
+import { NavigationScreenProp, NavigationEvents } from 'react-navigation'
 
 import { container } from '../theme/styles'
 import { Front } from '../components/front/front'
@@ -21,18 +21,33 @@ const IssueScreen = ({
     const issue: Issue = navigation.getParam('issue', { date: -1 })
     const issueDate = useMemo(() => renderIssueDate(issue.date), [issue.date])
 
+    /* 
+    we don't wanna render a massive tree at once 
+    as the navigator is trying to push the screen bc this
+    delays the tap response 
+
+    we can pass this prop to identify if we wanna render 
+    just the 'above the fold' content or the whole shebang
+    */
+    const [viewIsTransitioning, setViewIsTransitioning] = useState(true)
+
     return (
         <ScrollView
             style={styles.container}
             contentContainerStyle={styles.contentContainer}
         >
+            <NavigationEvents
+                onDidFocus={() => {
+                    setViewIsTransitioning(false)
+                }}
+            />
             <MonoTextBlock>
                 This is a IssueScreen for issue {issueDate.weekday} -{' '}
                 {issueDate.date}
             </MonoTextBlock>
 
-            <Front front="cities" />
-            <Front front="best-awards" />
+            <Front {...{ viewIsTransitioning }} front="cities" />
+            <Front {...{ viewIsTransitioning }} front="best-awards" />
         </ScrollView>
     )
 }


### PR DESCRIPTION
## Why are you doing this?
instantiating react components is expensive and `react-navigation` waits until the whole view is ready before showing it. This PR allows us to do a two-pass render by only showing the stuff that's on screen during the page transition and then bringing everything else right after