### PR TITLE
Remove alert from clearLocalCache

### DIFF
--- a/projects/Mallard/src/hooks/use-fetch.ts
+++ b/projects/Mallard/src/hooks/use-fetch.ts
@@ -4,7 +4,6 @@ import { useSettings } from './use-settings'
 let naiveCache: { [url: string]: any } = {}
 
 export const clearLocalCache = () => {
-    alert(`deleting ${Object.keys(naiveCache).length} entries`)
     for (let url in naiveCache) {
         delete naiveCache[url]
         console.log(`deleted ${url}`)


### PR DESCRIPTION
## Why are you doing this?

The existence of this `alert` call is breaking the build. From what I've gathered, the `hooks/` directory should not contain any `react-native`-specific constructs, so I'm going to remove it altogether.
