### PR TITLE
Serve articledata from fronts

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -12,7 +12,7 @@ import { FileSystemProvider } from './hooks/use-fs'
 
 useScreens()
 
-const navigationPersistenceKey = __DEV__ ? 'nav-1560178658566-' : null
+const navigationPersistenceKey = __DEV__ ? 'nav-dfdsf' : null
 
 export default class App extends React.Component<{}, {}> {
     /**

--- a/projects/Mallard/src/components/front/card-group.tsx
+++ b/projects/Mallard/src/components/front/card-group.tsx
@@ -79,12 +79,7 @@ const CardGroupWithAppearance = ({
                     ]}
                     key={i}
                 >
-                    <SmallCard
-                        style={styles.unit}
-                        path={story.path}
-                        kicker={story.kicker}
-                        headline={story.headline}
-                    />
+                    <SmallCard style={styles.unit} article={story} />
                     {i < trimmed.length - 1 && (
                         <Multiline
                             color={appearance.backgrounds.borderColor}

--- a/projects/Mallard/src/components/front/card-group.tsx
+++ b/projects/Mallard/src/components/front/card-group.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../theme/appearance'
 import { SmallCard } from './cards'
 import { color } from '../../theme/color'
-import { ArticleFromTheCollectionsAtm } from '../../common'
+import { FrontArticle } from '../../common'
 
 const styles = StyleSheet.create({
     root: {
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 
 interface PropTypes {
     style: StyleProp<{}>
-    articles: ArticleFromTheCollectionsAtm[]
+    articles: FrontArticle[]
     length?: number
     translate: Animated.AnimatedInterpolation
 }
@@ -81,9 +81,9 @@ const CardGroupWithAppearance = ({
                 >
                     <SmallCard
                         style={styles.unit}
-                        path={story}
-                        kicker="Kicker"
-                        headline={story}
+                        path={story.path}
+                        kicker={story.kicker}
+                        headline={story.headline}
                     />
                     {i < trimmed.length - 1 && (
                         <Multiline

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -7,7 +7,6 @@ import { HeadlineCardText, HeadlineKickerText } from '../styled-text'
 
 import { useArticleAppearance } from '../../theme/appearance'
 import { FrontArticle } from '../../common'
-import { ArticleParams } from '../../screens/article-screen'
 
 const styles = StyleSheet.create({
     root: {
@@ -24,13 +23,9 @@ interface SmallCardProps {
     style: StyleProp<ViewStyle>
     article: FrontArticle
 }
-type InjectedProps = NavigationInjectedProps<ArticleParams>
+type InjectedProps = NavigationInjectedProps<{}>
 const SmallCard = withNavigation(
-    ({
-        style,
-        article,
-        navigation,
-    }: SmallCardProps & Partial<InjectedProps>) => {
+    ({ style, article, navigation }: SmallCardProps & InjectedProps) => {
         const { appearance } = useArticleAppearance()
         if (navigation == null) {
             throw new Error('No navigation present in cards.')
@@ -39,7 +34,10 @@ const SmallCard = withNavigation(
             <View style={style}>
                 <Highlight
                     onPress={() => {
-                        navigation.navigate('Article', { article: article })
+                        navigation.navigate('Article', {
+                            article: article,
+                            path: article.path,
+                        })
                     }}
                 >
                     <View

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -6,6 +6,7 @@ import { Highlight } from '../highlight'
 import { HeadlineCardText, HeadlineKickerText } from '../styled-text'
 
 import { useArticleAppearance } from '../../theme/appearance'
+import { Params } from '../../navigation'
 
 const styles = StyleSheet.create({
     root: {
@@ -25,7 +26,7 @@ const SmallCard = withNavigation(
         kicker,
         path,
         navigation,
-    }: NavigationInjectedProps & {
+    }: NavigationInjectedProps<Params> & {
         style: StyleProp<ViewStyle>
         headline: string
         kicker: string

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -7,6 +7,7 @@ import { HeadlineCardText, HeadlineKickerText } from '../styled-text'
 
 import { useArticleAppearance } from '../../theme/appearance'
 import { Params } from '../../navigation'
+import { FrontArticle } from '../../common'
 
 const styles = StyleSheet.create({
     root: {
@@ -22,21 +23,17 @@ const styles = StyleSheet.create({
 const SmallCard = withNavigation(
     ({
         style,
-        headline,
-        kicker,
-        path,
+        article,
         navigation,
     }: NavigationInjectedProps<Params> & {
         style: StyleProp<ViewStyle>
-        headline: string
-        kicker: string
-        path: string
+        article: FrontArticle
     }) => {
         const { appearance } = useArticleAppearance()
         return (
             <View style={style}>
                 <Highlight
-                    onPress={() => navigation.navigate('Article', { path })}
+                    onPress={() => navigation.navigate('Article', article)}
                 >
                     <View
                         style={[
@@ -49,12 +46,12 @@ const SmallCard = withNavigation(
                         <HeadlineKickerText
                             style={[appearance.text, appearance.kicker]}
                         >
-                            {kicker}
+                            {article.kicker}
                         </HeadlineKickerText>
                         <HeadlineCardText
                             style={[appearance.text, appearance.headline]}
                         >
-                            {headline}
+                            {article.headline}
                         </HeadlineCardText>
                     </View>
                 </Highlight>

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -63,6 +63,6 @@ const SmallCard = withNavigation(
             </View>
         )
     },
-) //Dirty type casting unti useNavigation hooks are stable
+)
 
 export { SmallCard }

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -33,7 +33,7 @@ const SmallCard = withNavigation(
     }: SmallCardProps & Partial<InjectedProps>) => {
         const { appearance } = useArticleAppearance()
         if (navigation == null) {
-            throw new Error('No navigation presetn in cards.')
+            throw new Error('No navigation present in cards.')
         }
         return (
             <View style={style}>

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -25,9 +25,16 @@ interface SmallCardProps {
     article: FrontArticle
 }
 type InjectedProps = NavigationInjectedProps<Params>
-const InjectedSmallCard = withNavigation(
-    ({ style, article, navigation }: SmallCardProps & InjectedProps) => {
+const SmallCard = withNavigation(
+    ({
+        style,
+        article,
+        navigation,
+    }: SmallCardProps & Partial<InjectedProps>) => {
         const { appearance } = useArticleAppearance()
+        if (navigation == null) {
+            throw new Error('No navigation presetn in cards.')
+        }
         return (
             <View style={style}>
                 <Highlight
@@ -60,9 +67,5 @@ const InjectedSmallCard = withNavigation(
         )
     },
 ) //Dirty type casting unti useNavigation hooks are stable
-
-const SmallCard = (InjectedSmallCard as unknown) as React.FunctionComponent<
-    SmallCardProps
->
 
 export { SmallCard }

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -7,7 +7,7 @@ import { HeadlineCardText, HeadlineKickerText } from '../styled-text'
 
 import { useArticleAppearance } from '../../theme/appearance'
 import { FrontArticle } from '../../common'
-import { Params } from '../../screens/article-screen'
+import { ArticleParams } from '../../screens/article-screen'
 
 const styles = StyleSheet.create({
     root: {
@@ -24,7 +24,7 @@ interface SmallCardProps {
     style: StyleProp<ViewStyle>
     article: FrontArticle
 }
-type InjectedProps = NavigationInjectedProps<Params>
+type InjectedProps = NavigationInjectedProps<ArticleParams>
 const SmallCard = withNavigation(
     ({
         style,
@@ -39,7 +39,6 @@ const SmallCard = withNavigation(
             <View style={style}>
                 <Highlight
                     onPress={() => {
-                        console.log(article)
                         navigation.navigate('Article', { article: article })
                     }}
                 >

--- a/projects/Mallard/src/components/front/cards.tsx
+++ b/projects/Mallard/src/components/front/cards.tsx
@@ -6,8 +6,8 @@ import { Highlight } from '../highlight'
 import { HeadlineCardText, HeadlineKickerText } from '../styled-text'
 
 import { useArticleAppearance } from '../../theme/appearance'
-import { Params } from '../../navigation'
 import { FrontArticle } from '../../common'
+import { Params } from '../../screens/article-screen'
 
 const styles = StyleSheet.create({
     root: {
@@ -20,20 +20,21 @@ const styles = StyleSheet.create({
         flexBasis: '100%',
     },
 })
-const SmallCard = withNavigation(
-    ({
-        style,
-        article,
-        navigation,
-    }: NavigationInjectedProps<Params> & {
-        style: StyleProp<ViewStyle>
-        article: FrontArticle
-    }) => {
+interface SmallCardProps {
+    style: StyleProp<ViewStyle>
+    article: FrontArticle
+}
+type InjectedProps = NavigationInjectedProps<Params>
+const InjectedSmallCard = withNavigation(
+    ({ style, article, navigation }: SmallCardProps & InjectedProps) => {
         const { appearance } = useArticleAppearance()
         return (
             <View style={style}>
                 <Highlight
-                    onPress={() => navigation.navigate('Article', article)}
+                    onPress={() => {
+                        console.log(article)
+                        navigation.navigate('Article', { article: article })
+                    }}
                 >
                     <View
                         style={[
@@ -58,6 +59,10 @@ const SmallCard = withNavigation(
             </View>
         )
     },
-)
+) //Dirty type casting unti useNavigation hooks are stable
+
+const SmallCard = (InjectedSmallCard as unknown) as React.FunctionComponent<
+    SmallCardProps
+>
 
 export { SmallCard }

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -8,9 +8,7 @@ import { ApiScreen } from '../screens/settings/api-screen'
 import { color } from '../theme/color'
 import { Animated, Easing } from 'react-native'
 import { FrontArticle } from '../common'
-export interface Params {
-    article: FrontArticle
-}
+
 export const RootNavigator = createAppContainer(
     createStackNavigator(
         {

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -7,7 +7,10 @@ import { DownloadScreen } from '../screens/settings/download-screen'
 import { ApiScreen } from '../screens/settings/api-screen'
 import { color } from '../theme/color'
 import { Animated, Easing } from 'react-native'
-
+import { FrontArticle } from '../common'
+export interface Params {
+    article: FrontArticle
+}
 export const RootNavigator = createAppContainer(
     createStackNavigator(
         {

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -18,16 +18,15 @@ const useArticleResponse = (path: string) =>
         `content/${path}`,
         article => article.title != null,
     )
-export interface Params {
+export interface ArticleParams {
     article: FrontArticle
 }
 export const ArticleScreen = ({
     navigation,
 }: {
-    navigation: NavigationScreenProp<{}, Params>
+    navigation: NavigationScreenProp<{}, ArticleParams>
 }) => {
     const frontArticle = navigation.getParam('article')
-    console.log(frontArticle)
     const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
     const articleResponse = useArticleResponse(frontArticle.path)

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -18,18 +18,21 @@ const useArticleResponse = (path: string) =>
         `content/${path}`,
         article => article.title != null,
     )
-export interface ArticleParams {
-    article: FrontArticle
-}
+
 export const ArticleScreen = ({
     navigation,
 }: {
-    navigation: NavigationScreenProp<{}, ArticleParams>
+    navigation: NavigationScreenProp<{}>
 }) => {
-    const frontArticle = navigation.getParam('article')
+    const frontArticle = navigation.getParam('article') as
+        | FrontArticle
+        | undefined
+
+    const path =
+        (frontArticle && frontArticle.path) || navigation.getParam('path')
     const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
-    const articleResponse = useArticleResponse(frontArticle.path)
+    const articleResponse = useArticleResponse(path)
 
     return articleResponse({
         error: ({ message }) => (
@@ -46,13 +49,13 @@ export const ArticleScreen = ({
         ),
         pending: () => (
             <Article
-                kicker={frontArticle.kicker}
-                headline={frontArticle.headline}
-                byline={frontArticle.byline}
+                kicker={(frontArticle && frontArticle.kicker) || ''}
+                headline={(frontArticle && frontArticle.headline) || ''}
+                byline={(frontArticle && frontArticle.byline) || ''}
                 standfirst=""
             />
         ),
-        success: ({ standfirst, imageURL, elements }) => {
+        success: ({ standfirst, title, byline, imageURL, elements }) => {
             return (
                 <>
                     <View
@@ -93,11 +96,17 @@ export const ArticleScreen = ({
                     >
                         <Article
                             article={elements}
-                            kicker={frontArticle.kicker}
-                            headline={frontArticle.headline}
-                            byline={frontArticle.byline}
+                            kicker={(frontArticle && frontArticle.kicker) || ''}
+                            headline={
+                                (frontArticle && frontArticle.headline) || title
+                            }
+                            byline={
+                                (frontArticle && frontArticle.byline) || byline
+                            }
                             standfirst={standfirst}
-                            image={imageURL || frontArticle.image}
+                            image={
+                                imageURL || (frontArticle && frontArticle.image)
+                            }
                         />
                     </WithArticleAppearance>
                 </>

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -29,7 +29,7 @@ export const ArticleScreen = ({
         | undefined
 
     const path =
-        (frontArticle && frontArticle.path) || navigation.getParam('path')
+        navigation.getParam('path')
     const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
     const articleResponse = useArticleResponse(path)

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -12,6 +12,7 @@ import { View, TouchableOpacity, Text, Button } from 'react-native'
 import { metrics } from '../theme/spacing'
 import { UiBodyCopy } from '../components/styled-text'
 import { FlexCenter } from '../components/layout/flex-center'
+import { Params } from '../navigation'
 
 const useArticleResponse = (path: string) =>
     useEndpointResponse<ArticleType>(
@@ -24,11 +25,11 @@ export const ArticleScreen = ({
 }: {
     navigation: NavigationScreenProp<{}, Params>
 }) => {
-    const pathFromUrl = navigation.getParam('path', '')
-    const titleFromUrl = navigation.getParam('title', 'Loading')
+    const frontArticle = navigation.getParam('article')
+
     const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
-    const articleResponse = useArticleResponse(pathFromUrl)
+    const articleResponse = useArticleResponse(frontArticle.path)
 
     return articleResponse({
         error: ({ message }) => (
@@ -45,13 +46,13 @@ export const ArticleScreen = ({
         ),
         pending: () => (
             <Article
-                kicker={'Kicker 🥾'}
-                headline={titleFromUrl}
-                byline={'Byliney McPerson'}
-                standfirst={`Is this delicious smoky dip the ultimate aubergine recipe – and which side of the great tahini divide are you on?`}
+                kicker={frontArticle.kicker}
+                headline={frontArticle.headline}
+                byline={frontArticle.byline}
+                standfirst=""
             />
         ),
-        success: ({ title, imageURL, elements }) => {
+        success: ({ standfirst, imageURL, elements }) => {
             return (
                 <>
                     <View
@@ -92,11 +93,11 @@ export const ArticleScreen = ({
                     >
                         <Article
                             article={elements}
-                            kicker={'Kicker 🥾'}
-                            headline={title}
-                            byline={'Byliney McPerson'}
-                            standfirst={`Is this delicious smoky dip the ultimate aubergine recipe – and which side of the great tahini divide are you on?`}
-                            image={imageURL}
+                            kicker={frontArticle.kicker}
+                            headline={frontArticle.headline}
+                            byline={frontArticle.byline}
+                            standfirst={standfirst}
+                            image={imageURL || frontArticle.image}
                         />
                     </WithArticleAppearance>
                 </>

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -22,7 +22,7 @@ const useArticleResponse = (path: string) =>
 export const ArticleScreen = ({
     navigation,
 }: {
-    navigation: NavigationScreenProp<{}>
+    navigation: NavigationScreenProp<{}, Params>
 }) => {
     const pathFromUrl = navigation.getParam('path', '')
     const titleFromUrl = navigation.getParam('title', 'Loading')

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -7,26 +7,27 @@ import {
     articleAppearances,
 } from '../theme/appearance'
 import { Article } from '../components/article'
-import { Article as ArticleType } from '../common'
+import { Article as ArticleType, FrontArticle } from '../common'
 import { View, TouchableOpacity, Text, Button } from 'react-native'
 import { metrics } from '../theme/spacing'
 import { UiBodyCopy } from '../components/styled-text'
 import { FlexCenter } from '../components/layout/flex-center'
-import { Params } from '../navigation'
 
 const useArticleResponse = (path: string) =>
     useEndpointResponse<ArticleType>(
         `content/${path}`,
         article => article.title != null,
     )
-
+export interface Params {
+    article: FrontArticle
+}
 export const ArticleScreen = ({
     navigation,
 }: {
     navigation: NavigationScreenProp<{}, Params>
 }) => {
     const frontArticle = navigation.getParam('article')
-
+    console.log(frontArticle)
     const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
     const articleResponse = useArticleResponse(frontArticle.path)

--- a/projects/backend/common.ts
+++ b/projects/backend/common.ts
@@ -3,6 +3,7 @@
 
 export interface Article {
     title: string
+    byline: string
     standfirst: string
     imageURL?: string
     elements: BlockElement[]

--- a/projects/backend/common.ts
+++ b/projects/backend/common.ts
@@ -1,12 +1,10 @@
 // This file is symlinked into both backend and Mallard.
 // Be careful.
 
-export type ArticleFromTheCollectionsAtm = string
-export interface ArticleFundamentals {
+export interface Article {
     title: string
+    standfirst: string
     imageURL?: string
-}
-export interface Article extends ArticleFundamentals {
     elements: BlockElement[]
 }
 
@@ -20,6 +18,7 @@ export interface FrontArticle {
     headline: string
     kicker: string
     image: string
+    byline: string
 }
 export interface CollectionArticles {
     id: string

--- a/projects/backend/common.ts
+++ b/projects/backend/common.ts
@@ -15,11 +15,16 @@ export interface Issue {
     date: number
     fronts: string[]
 }
-
+export interface FrontArticle {
+    path: string
+    headline: string
+    kicker: string
+    image: string
+}
 export interface CollectionArticles {
     id: string
     name: string
-    articles: string[]
+    articles: FrontArticle[]
 }
 export interface Collection {
     displayName: string
@@ -40,7 +45,7 @@ export interface Collection {
     hideShowMore?: boolean
     platform?: unknown
     frontsToolSettings?: unknown
-    articles?: string[]
+    articles?: FrontArticle[]
 }
 
 export interface Front {

--- a/projects/backend/controllers/article.ts
+++ b/projects/backend/controllers/article.ts
@@ -25,6 +25,12 @@ export const getArticle = async (path: string): Promise<Article> => {
     const data = ItemResponseCodec.decode(input)
     const title = data && data.content && data.content.webTitle
     if (title == null) throw new Error('Title was undefined!')
+    const standfirst =
+        data &&
+        data.content &&
+        data.content.fields &&
+        data.content.fields.standfirst
+    if (standfirst == null) throw new Error('Standfirst was undefined!')
 
     const image =
         data &&
@@ -50,6 +56,7 @@ export const getArticle = async (path: string): Promise<Article> => {
 
     return {
         title,
+        standfirst,
         imageURL,
         elements,
     }

--- a/projects/backend/controllers/article.ts
+++ b/projects/backend/controllers/article.ts
@@ -54,7 +54,16 @@ export const getArticle = async (path: string): Promise<Article> => {
     const elements = body && (await Promise.all(body.map(elementParser)))
     if (elements == null) throw new Error('Elements was undefined!')
 
+    const byline =
+        data &&
+        data.content &&
+        data.content.fields &&
+        data.content.fields.byline
+
+    if (byline == null) throw new Error('Byline was undefined!')
+
     return {
+        byline,
         title,
         standfirst,
         imageURL,

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -18,7 +18,17 @@ export const getCollection = async (
         return {
             id,
             name: collection.displayName,
-            articles: collection.live.map(_ => _.id),
+            articles: collection.live.map(article => {
+                const meta = article.meta as ArticleFragmentRootMeta
+                return {
+                    path: article.id,
+                    headline: meta.headline || 'THIS ARTICLE LACKS A HEADLINE',
+                    kicker: meta.customKicker || 'no custom kicker',
+                    image:
+                        meta.imageSrc ||
+                        'https://i.guim.co.uk/img/media/7c71ec6e4bc73ab01384e94b02efe16df054bb73/0_51_3600_2160/master/3600.jpg?width=1900&quality=45&auto=format&fit=max&dpr=2&s=5b33424cbebbad93a8001c62a701a64d',
+                }
+            }),
         }
     } catch {
         console.log('OH NO', id)
@@ -84,6 +94,48 @@ interface CollectionFromResponse {
     metadata?: { type: string }[]
     uneditable?: boolean
 }
+interface ArticleFragmentRootMeta {
+    group?: string
+    headline?: string
+    trailText?: string
+    byline?: string
+    customKicker?: string
+    href?: string
+    imageSrc?: string
+    imageSrcThumb?: string
+    imageSrcWidth?: string
+    imageSrcHeight?: string
+    imageSrcOrigin?: string
+    imageCutoutSrc?: string
+    imageCutoutSrcWidth?: string
+    imageCutoutSrcHeight?: string
+    imageCutoutSrcOrigin?: string
+    isBreaking?: boolean
+    isBoosted?: boolean
+    showLivePlayable?: boolean
+    showMainVideo?: boolean
+    showBoostedHeadline?: boolean
+    showQuotedHeadline?: boolean
+    showByline?: boolean
+    imageCutoutReplace?: boolean
+    imageReplace?: boolean
+    imageHide?: boolean
+    showKickerTag?: boolean
+    showKickerSection?: boolean
+    showKickerCustom?: boolean
+    snapUri?: string
+    snapType?: string
+    snapCss?: string
+    imageSlideshowReplace?: boolean
+    slideshow?: Array<{
+        src?: string
+        thumb?: string
+        width?: string
+        height?: string
+        origin?: string
+    }>
+}
+
 interface NestedArticleFragmentRootFields {
     id: string
     frontPublicationDate: number

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -27,6 +27,7 @@ export const getCollection = async (
                     image:
                         meta.imageSrc ||
                         'https://i.guim.co.uk/img/media/7c71ec6e4bc73ab01384e94b02efe16df054bb73/0_51_3600_2160/master/3600.jpg?width=1900&quality=45&auto=format&fit=max&dpr=2&s=5b33424cbebbad93a8001c62a701a64d',
+                    byline: meta.byline || 'no byline set',
                 }
             }),
         }


### PR DESCRIPTION
## Why are you doing this?
Populate the cards and prepopulate the articles when data is present. Otherwise stub until we can discuss with tools.
 https://trello.com/c/s9nKCTmR/174-consume-templated-editions-model-from-front-tools

This makes navigation potentially undefined until we find a better way of handling it while retaining the type data on the NavigationProps.

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborare
-->
