### PR TITLE
Lint for hooks, use absolute paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint', 'prettier'],
+    plugins: ['@typescript-eslint', 'prettier', 'react-hooks'],
     extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:react/recommended',
@@ -13,6 +13,8 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': 'off',
         'react/prop-types': 'off',
         '@typescript-eslint/no-object-literal-type-assertion': 'warn',
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
     },
     overrides: [
         {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^4.2.0",
         "eslint-plugin-prettier": "^3.0.1",
         "eslint-plugin-react": "^7.13.0",
+        "eslint-plugin-react-hooks": "^1.6.0",
         "prettier": "^1.17.0",
         "typescript": "^3.4.5"
     },

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -6,9 +6,9 @@ import React from 'react'
 import { useScreens } from 'react-native-screens'
 import { StatusBar, View } from 'react-native'
 
-import { RootNavigator } from './navigation'
-import { SettingsProvider } from './hooks/use-settings'
-import { FileSystemProvider } from './hooks/use-fs'
+import { RootNavigator } from 'src/navigation'
+import { SettingsProvider } from 'src/hooks/use-settings'
+import { FileSystemProvider } from 'src/hooks/use-fs'
 
 useScreens()
 

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -2,10 +2,9 @@ import React, { useState, useMemo } from 'react'
 import { View, StyleSheet, Dimensions, Linking } from 'react-native'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
 import { WebView } from 'react-native-webview'
-import { color } from '../../theme/color'
-import { metrics } from '../../theme/spacing'
-import { SlideCard } from '../layout/slide-card'
-import { useArticleAppearance } from '../../theme/appearance'
+import { color } from 'src/theme/color'
+import { metrics } from 'src/theme/spacing'
+import { useArticleAppearance } from 'src/theme/appearance'
 import {
     LongReadHeader,
     NewsHeader,
@@ -15,7 +14,7 @@ import {
     Standfirst,
     PropTypes as StandfirstPropTypes,
 } from './article-standfirst'
-import { BlockElement } from '../../common'
+import { BlockElement } from 'src/common'
 import { render } from './html/render'
 
 /*

--- a/projects/Mallard/src/package.json
+++ b/projects/Mallard/src/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "src",
+    "@notes": "metro bundler will resolve absolute imports that start from a package.json's name. this is a teeny hack that 'names' the src folder as src, effectively tricking Metro bundler into loading stuff from it while making the imports look like an absolute path.",
+    "@more notes": "Just to explain, if the name here was 'banana', something like `import Article from 'banana/components/article'` would work.",
+    "@even more notes": "Why name it src then? Well, vs code and eslint don't know about this convention in metro bundler but they know about other more standard ways of doing absolute resolution so using the folder name lets them work with no config"
+}

--- a/projects/Mallard/src/package.json
+++ b/projects/Mallard/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "src",
-    "@notes": "metro bundler will resolve absolute imports that start from a package.json's name. this is a teeny hack that 'names' the src folder as src, effectively tricking Metro bundler into loading stuff from it while making the imports look like an absolute path.",
+    "@notes": "metro bundler treats absolute imports as names in package.json. Kinda like monorepos. We are doing a teeny hack that 'names' the src folder as src, effectively tricking Metro bundler into loading stuff from it while making the imports look like an absolute path.",
     "@more notes": "Just to explain, if the name here was 'banana', something like `import Article from 'banana/components/article'` would work.",
     "@even more notes": "Why name it src then? Well, vs code and eslint don't know about this convention in metro bundler but they know about other more standard ways of doing absolute resolution so using the folder name lets them work with no config"
 }

--- a/projects/Mallard/tsconfig.json
+++ b/projects/Mallard/tsconfig.json
@@ -9,7 +9,8 @@
         "moduleResolution": "node",
         "noEmit": true,
         "strict": true,
-        "target": "esnext"
+        "target": "esnext",
+        "baseUrl": "."
     },
     "exclude": [
         "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,11 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"


### PR DESCRIPTION
## Why are you doing this?

these are super handy for `useEffect` and such