### PR TITLE
Clean up settings

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -1,9 +1,38 @@
 import { AsyncStorage } from 'react-native'
-
 export interface Settings {
     apiUrl: string
+    hasLiveDevMenu: boolean
 }
 
+/* 
+we can only store strings to memory 
+so we need to convert them
+*/
+const [TRUE, FALSE] = ['TRUE', 'FALSE']
+type UnsanitizedSetting = Settings[keyof Settings]
+const sanitize = (value: UnsanitizedSetting): string => {
+    if (value === true) {
+        value = TRUE
+    }
+    if (value === false) {
+        value = FALSE
+    }
+    return value
+}
+const unsanitize = (value: string): UnsanitizedSetting => {
+    if (value === TRUE) {
+        return true
+    }
+    if (value === FALSE) {
+        return false
+    }
+    return value
+}
+
+/*
+Default settings.
+This is a bit of a mess
+*/
 export const backends = [
     {
         title: 'PROD',
@@ -19,15 +48,23 @@ export const backends = [
 
 export const defaultSettings: Settings = {
     apiUrl: backends[0].value,
+    hasLiveDevMenu: false,
 }
 
-const getSetting = (setting: keyof Settings) =>
+/* 
+getters & setters
+*/
+export const getSetting = (setting: keyof Settings) =>
     AsyncStorage.getItem('@Setting_' + setting).then(item => {
-        if (item) return item
-        else return defaultSettings[setting]
+        if (!item) {
+            return defaultSettings[setting]
+        }
+        return unsanitize(item)
     })
-const storeSetting = (setting: keyof Settings, value: string) => {
-    return AsyncStorage.setItem('@Setting_' + setting, value)
-}
 
-export { getSetting, storeSetting }
+export const storeSetting = (
+    setting: keyof Settings,
+    value: string | boolean,
+) => {
+    return AsyncStorage.setItem('@Setting_' + setting, sanitize(value))
+}

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -8,25 +8,19 @@ export interface Settings {
 we can only store strings to memory 
 so we need to convert them
 */
-const [TRUE, FALSE] = ['TRUE', 'FALSE']
 type UnsanitizedSetting = Settings[keyof Settings]
 const sanitize = (value: UnsanitizedSetting): string => {
-    if (value === true) {
-        value = TRUE
-    }
-    if (value === false) {
-        value = FALSE
+    if (typeof value !== 'string') {
+        return JSON.stringify(value)
     }
     return value
 }
 const unsanitize = (value: string): UnsanitizedSetting => {
-    if (value === TRUE) {
-        return true
+    try {
+        return JSON.parse(value)
+    } catch {
+        return value
     }
-    if (value === FALSE) {
-        return false
-    }
-    return value
 }
 
 /*

--- a/projects/Mallard/src/hooks/use-settings.tsx
+++ b/projects/Mallard/src/hooks/use-settings.tsx
@@ -9,13 +9,13 @@ import {
 
 type SettingsFromContext = [
     Settings,
-    (setting: keyof Settings, value: string) => void
+    (setting: keyof Settings, value: Settings[keyof Settings]) => void
 ]
 
 const useStoredSettings = (): SettingsFromContext => {
     const [state, setState] = useState(defaultSettings)
-    const setSetting = (setting: keyof Settings, value: string) => {
-        setState({ [setting]: value })
+    const setSetting = (setting: keyof Settings, value: string | boolean) => {
+        setState(settings => ({ ...settings, [setting]: value }))
         storeSetting(setting, value)
     }
     useEffect(() => {

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -14,7 +14,7 @@ import { NavigationScreenProp } from 'react-navigation'
 import { container } from '../theme/styles'
 import { useSettings } from '../hooks/use-settings'
 import { clearLocalCache } from '../hooks/use-fetch'
-import { MonoTextBlock } from '../components/styled-text'
+import { MonoTextBlock, UiBodyCopy } from '../components/styled-text'
 import { Highlight } from '../components/highlight'
 
 const styles = StyleSheet.create({
@@ -26,7 +26,9 @@ const SettingsScreen = ({
 }: {
     navigation: NavigationScreenProp<{}>
 }) => {
-    const [{ apiUrl, hasLiveDevMenu }, setSetting] = useSettings()
+    const [settings, setSetting] = useSettings()
+    const { apiUrl, hasLiveDevMenu } = settings
+
     return (
         <ScrollView style={styles.container}>
             <ListHeading>About this app</ListHeading>
@@ -127,6 +129,17 @@ const SettingsScreen = ({
                                 },
                             },
                         ]}
+                    />
+                    <ListHeading>Your settings</ListHeading>
+                    <List
+                        onPress={() => {}}
+                        data={Object.entries(settings).map(
+                            ([title, explainer]) => ({
+                                key: title,
+                                title,
+                                explainer: explainer + '',
+                            }),
+                        )}
                     />
                 </>
             )}

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { ScrollView, StyleSheet } from 'react-native'
+import { ScrollView, StyleSheet, Text, Dimensions, View } from 'react-native'
 
-import { List } from '../components/lists/list'
+import { List, ListHeading } from '../components/lists/list'
 import { NavigationScreenProp } from 'react-navigation'
 import { container } from '../theme/styles'
 import { useSettings } from '../hooks/use-settings'
 import { clearLocalCache } from '../hooks/use-fetch'
+import { MonoTextBlock } from '../components/styled-text'
+import { Highlight } from '../components/highlight'
 
 const styles = StyleSheet.create({
     container,
@@ -16,38 +18,90 @@ const SettingsScreen = ({
 }: {
     navigation: NavigationScreenProp<{}>
 }) => {
-    const [{ apiUrl }] = useSettings()
+    const [{ apiUrl, hasLiveDevMenu }, setSetting] = useSettings()
     return (
         <ScrollView style={styles.container}>
-            <List
-                onPress={({ to }) => navigation.navigate(to)}
-                data={[
-                    {
-                        key: 'Downloads',
-                        title: 'Manage issues',
-                        data: { to: 'Downloads' },
-                    },
-                    {
-                        key: 'Endpoints',
-                        title: 'API Endpoint',
-                        explainer: apiUrl,
-                        data: { to: 'Endpoints' },
-                    },
-                ]}
-            />
-            <List
-                onPress={() => {
-                    clearLocalCache()
-                }}
-                data={[
-                    {
-                        key: 'Clear local cache',
-                        title: 'Clear local cache',
-                        explainer: 'You can also cmd-r',
-                        data: {},
-                    },
-                ]}
-            />
+            <ListHeading>About this app</ListHeading>
+            <MonoTextBlock>
+                Thanks for helping us test the Editions app beta! your feedback
+                will be invaluable to the final product.
+            </MonoTextBlock>
+            <MonoTextBlock>
+                Come back soon to see relevant settings.
+            </MonoTextBlock>
+            {!hasLiveDevMenu ? (
+                <>
+                    <View style={{ height: Dimensions.get('window').height }} />
+                    <Highlight
+                        style={{ alignItems: 'center' }}
+                        onPress={() => {
+                            setSetting('hasLiveDevMenu', true)
+                        }}
+                    >
+                        <Text
+                            style={{
+                                textAlign: 'center',
+                                padding: 40,
+                            }}
+                        >
+                            🦆
+                        </Text>
+                    </Highlight>
+                </>
+            ) : (
+                <>
+                    <ListHeading>💣 DEVELOPER ZONE 💣</ListHeading>
+                    <MonoTextBlock>
+                        Only wander here if you know what you are doing!!
+                    </MonoTextBlock>
+                    <List
+                        onPress={({ onPress }) => onPress()}
+                        data={[
+                            {
+                                key: 'Downloads',
+                                title: 'Manage issues',
+                                data: {
+                                    onPress: () => {
+                                        navigation.navigate('Downloads')
+                                    },
+                                },
+                            },
+                            {
+                                key: 'Endpoints',
+                                title: 'API Endpoint',
+                                explainer: apiUrl,
+                                data: {
+                                    onPress: () => {
+                                        navigation.navigate('Endpoints')
+                                    },
+                                },
+                            },
+                            {
+                                key: 'Clear cache',
+                                title: 'Clear local cache',
+                                explainer:
+                                    'You can also cmd-r or quit and reopen',
+                                data: {
+                                    onPress: () => {
+                                        clearLocalCache()
+                                    },
+                                },
+                            },
+                            {
+                                key: 'Hide this menu',
+                                title: 'Hide this menu',
+                                explainer:
+                                    'Scroll down and tap the duck to bring it back',
+                                data: {
+                                    onPress: () => {
+                                        setSetting('hasLiveDevMenu', false)
+                                    },
+                                },
+                            },
+                        ]}
+                    />
+                </>
+            )}
         </ScrollView>
     )
 }

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { ScrollView, StyleSheet, Text, Dimensions, View } from 'react-native'
+import {
+    ScrollView,
+    StyleSheet,
+    Text,
+    Dimensions,
+    View,
+    AsyncStorage,
+    Alert,
+} from 'react-native'
 
 import { List, ListHeading } from '../components/lists/list'
 import { NavigationScreenProp } from 'react-navigation'
@@ -77,13 +85,33 @@ const SettingsScreen = ({
                                 },
                             },
                             {
-                                key: 'Clear cache',
-                                title: 'Clear local cache',
-                                explainer:
-                                    'You can also cmd-r or quit and reopen',
+                                key: 'Clear caches',
+                                title: 'Clear caches',
                                 data: {
                                     onPress: () => {
-                                        clearLocalCache()
+                                        Alert.alert(
+                                            'Clear caches',
+                                            'You sure?',
+                                            [
+                                                {
+                                                    text: 'Delete fetch cache',
+                                                    onPress: () => {
+                                                        clearLocalCache()
+                                                    },
+                                                },
+                                                {
+                                                    text: 'Delete EVERYTHING',
+                                                    onPress: () => {
+                                                        AsyncStorage.clear()
+                                                    },
+                                                },
+                                                {
+                                                    style: 'cancel',
+                                                    text: `No don't do it`,
+                                                },
+                                            ],
+                                            { cancelable: false },
+                                        )
                                     },
                                 },
                             },

--- a/projects/Mallard/src/screens/settings/api-screen.tsx
+++ b/projects/Mallard/src/screens/settings/api-screen.tsx
@@ -9,7 +9,7 @@ import { NavigationScreenProp } from 'react-navigation'
 import { TextInput } from 'react-native-gesture-handler'
 import { color } from '../../theme/color'
 import { metrics } from '../../theme/spacing'
-import { backends } from '../../helpers/settings'
+import { backends, defaultSettings } from '../../helpers/settings'
 
 const styles = StyleSheet.create({
     container,
@@ -17,7 +17,12 @@ const styles = StyleSheet.create({
 
 const ApiState = () => {
     const [{ apiUrl }] = useSettings()
-    return <MonoTextBlock>API backend pointing to {apiUrl}</MonoTextBlock>
+    if (apiUrl === defaultSettings.apiUrl) return null
+    return (
+        <MonoTextBlock>
+            API backend pointing to {apiUrl}. This is not PROD!
+        </MonoTextBlock>
+    )
 }
 
 const ApiScreen = ({


### PR DESCRIPTION
## Why are you doing this?
Just like most drawers in my closet, our settings menu is chock full of scary internal things that nobody else needs or wants to know about. This PR hides all of that

<img width="483" alt="Screenshot 2019-06-14 at 16 18 23" src="https://user-images.githubusercontent.com/11539094/59520288-830cd780-8ec1-11e9-93a9-4541309a97be.png">

If you do wanna get to the settings (you can just scroll down enough and tap the duck emoji. This will unlock the danger zone. This is a bit overengineered but I'll admit it was fun.

<img width="483" alt="Screenshot 2019-06-14 at 16 29 33" src="https://user-images.githubusercontent.com/11539094/59520346-a5065a00-8ec1-11e9-8dde-457ab168b6d2.png">
<img width="483" alt="Screenshot 2019-06-14 at 16 18 17" src="https://user-images.githubusercontent.com/11539094/59520353-a8014a80-8ec1-11e9-8c0f-678e63c687b9.png">


## Changes

We can only store strings to local storage so there's some basic type conversion (JSON <3) going on in the background