### PR TITLE
Photo cards V1

### DIFF
--- a/projects/Mallard/src/components/front/card-group.tsx
+++ b/projects/Mallard/src/components/front/card-group.tsx
@@ -71,7 +71,7 @@ const ThreeStoryCardGroup = ({ articles, translate }: PropTypes) => {
                 size={Size.hero}
             />
             <RowWithTwoArticles
-                index={0}
+                index={1}
                 isLastChild={true}
                 translate={translate}
                 articles={[articles[0], articles[1]]}

--- a/projects/Mallard/src/components/front/card-group.tsx
+++ b/projects/Mallard/src/components/front/card-group.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo, ReactNode } from 'react'
-import { StyleSheet, StyleProp, Animated, View } from 'react-native'
-import { Multiline } from '../multiline'
+import React, { ReactNode } from 'react'
+import { StyleSheet, StyleProp, Animated } from 'react-native'
 import { metrics } from '../../theme/spacing'
 
 import {
@@ -8,10 +7,9 @@ import {
     useArticleAppearance,
     ArticleAppearance,
 } from '../../theme/appearance'
-import { SmallCard } from './card-group/card'
 import { color } from '../../theme/color'
 import { FrontArticle } from '../../common'
-import { RowWithArticle, RowWithTwoArticles } from './card-group/row'
+import { RowWithArticle, RowWithTwoArticles, Size } from './card-group/row'
 
 const styles = StyleSheet.create({
     root: {
@@ -44,9 +42,10 @@ const AnyStoryCardGroup = ({ articles, translate }: PropTypes) => {
                 <RowWithArticle
                     index={index}
                     key={index}
-                    isLastChild={index === articles.length}
+                    isLastChild={index === articles.length - 1}
                     translate={translate}
                     article={article}
+                    size={Size.row}
                 />
             ))}
         </>
@@ -69,12 +68,14 @@ const ThreeStoryCardGroup = ({ articles, translate }: PropTypes) => {
                 isLastChild={false}
                 translate={translate}
                 articles={[articles[0], articles[1]]}
+                size={Size.fourth}
             />
             <RowWithArticle
                 index={0}
-                isLastChild={false}
+                isLastChild={true}
                 translate={translate}
                 article={articles[2]}
+                size={Size.hero}
             />
         </>
     )

--- a/projects/Mallard/src/components/front/card-group.tsx
+++ b/projects/Mallard/src/components/front/card-group.tsx
@@ -58,24 +58,24 @@ const ThreeStoryCardGroup = ({ articles, translate }: PropTypes) => {
     stuff than expected we fall back to using 
     a flexible container rather than crash
     */
-    if (articles.length < 3)
+    if (articles.length !== 3)
         return <AnyStoryCardGroup {...{ articles, translate }} />
 
     return (
         <>
-            <RowWithTwoArticles
+            <RowWithArticle
                 index={0}
                 isLastChild={false}
                 translate={translate}
-                articles={[articles[0], articles[1]]}
-                size={Size.fourth}
+                article={articles[2]}
+                size={Size.hero}
             />
-            <RowWithArticle
+            <RowWithTwoArticles
                 index={0}
                 isLastChild={true}
                 translate={translate}
-                article={articles[2]}
-                size={Size.hero}
+                articles={[articles[0], articles[1]]}
+                size={Size.third}
             />
         </>
     )

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -87,7 +87,7 @@ const CoverCard = ({ style, article, path }: PropTypes) => {
                 <Image
                     style={coverStyles.cover}
                     source={{
-                        uri: 'https://placekitten.com/200/200',
+                        uri: article.image,
                     }}
                 />
                 <TextBlock
@@ -101,29 +101,31 @@ const CoverCard = ({ style, article, path }: PropTypes) => {
     )
 }
 
-const smallStyles = StyleSheet.create({
+const imageStyles = StyleSheet.create({
     image: {
         width: '100%',
         flex: 1,
     },
 })
 
-const SmallCard = ({ style, article, path }: PropTypes) => {
-    /* gotta derive these from appearance+size */
-    const textBlockAppearance = 'default'
+const ImageCard = ({ style, article, path }: PropTypes) => {
     return (
         <CardTappable {...{ style, article, path }}>
             <Image
-                style={smallStyles.image}
+                style={imageStyles.image}
                 source={{
-                    uri: 'https://placekitten.com/200/200',
+                    uri: article.image,
                 }}
             />
-            <TextBlock
-                kicker={article.kicker}
-                headline={article.headline}
-                textBlockAppearance={textBlockAppearance}
-            />
+            <TextBlock kicker={article.kicker} headline={article.headline} />
+        </CardTappable>
+    )
+}
+
+const SmallCard = ({ style, article, path }: PropTypes) => {
+    return (
+        <CardTappable {...{ style, article, path }}>
+            <TextBlock kicker={article.kicker} headline={article.headline} />
         </CardTappable>
     )
 }
@@ -132,6 +134,8 @@ const Card = ({ size, ...props }: { size: Size } & PropTypes) => {
     /* this chooses the card type for us based on ummm MAGIC? */
     return size >= Size.hero ? (
         <CoverCard {...props} />
+    ) : size >= Size.half ? (
+        <ImageCard {...props} />
     ) : (
         <SmallCard {...props} />
     )

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -128,7 +128,7 @@ const ImageCard = ({ style, article, path }: PropTypes) => {
                 }}
             />
             <TextBlock
-                style={style.textBlock}
+                style={imageStyles.textBlock}
                 kicker={article.kicker}
                 headline={article.headline}
             />

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -1,13 +1,13 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { View, StyleSheet, StyleProp, ViewStyle, Image } from 'react-native'
 import { metrics } from '../../../theme/spacing'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
 import { Highlight } from '../../highlight'
-import { HeadlineCardText, HeadlineKickerText } from '../../styled-text'
 
 import { useArticleAppearance } from '../../../theme/appearance'
 import { FrontArticle } from '../../../common'
-import { color } from 'src/theme/color'
+
+import { TextBlock } from './text-block'
 
 const styles = StyleSheet.create({
     root: {
@@ -27,85 +27,6 @@ interface PropTypes {
     path: FrontArticle['path']
 }
 
-type TextBlockAppearance = 'default' | 'highlight' | 'pillarColor'
-
-const textBlockStyles = {
-    root: {
-        paddingBottom: metrics.vertical,
-        paddingTop: metrics.vertical / 3,
-    },
-    rootWithHighlight: {
-        backgroundColor: color.palette.highlight.main,
-        paddingHorizontal: metrics.horizontal / 2,
-    },
-    contrastText: {
-        color: color.palette.neutral[100],
-    },
-    headline: {
-        color: color.dimText,
-    },
-}
-
-const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
-    const { appearance } = useArticleAppearance()
-    switch (textBlockAppearance) {
-        case 'highlight':
-            return {
-                rootStyle: [
-                    textBlockStyles.root,
-                    textBlockStyles.rootWithHighlight,
-                ],
-                kickerStyle: null,
-                headlineStyle: textBlockStyles.headline,
-            }
-        case 'pillarColor':
-            return {
-                rootStyle: [
-                    textBlockStyles.root,
-                    textBlockStyles.rootWithHighlight,
-                    appearance.contrastCardBackgrounds,
-                ],
-                kickerStyle: textBlockStyles.contrastText,
-                headlineStyle: textBlockStyles.contrastText,
-            }
-        default:
-            return {
-                rootStyle: textBlockStyles.root,
-                kickerStyle: [appearance.text, appearance.kicker],
-                headlineStyle: [
-                    textBlockStyles.headline,
-                    appearance.text,
-                    appearance.kicker,
-                ],
-            }
-    }
-}
-
-const TextBlock = ({
-    kicker,
-    headline,
-    appearance,
-}: {
-    kicker: string
-    headline: string
-    appearance: TextBlockAppearance
-}) => {
-    const { rootStyle, kickerStyle, headlineStyle } = useTextBlockStyles(
-        appearance,
-    )
-
-    return (
-        <View style={rootStyle}>
-            <HeadlineKickerText style={kickerStyle}>
-                Kick {kicker}
-            </HeadlineKickerText>
-            <HeadlineCardText style={headlineStyle}>
-                headline {headline}
-            </HeadlineCardText>
-        </View>
-    )
-}
-
 const SmallCard = withNavigation(
     ({
         style,
@@ -114,7 +35,6 @@ const SmallCard = withNavigation(
         navigation,
     }: PropTypes & NavigationInjectedProps<{}>) => {
         const { appearance } = useArticleAppearance()
-        const blockAppearance = 'highlight'
         return (
             <View style={style}>
                 <Highlight
@@ -145,7 +65,7 @@ const SmallCard = withNavigation(
                         <TextBlock
                             kicker={article.kicker}
                             headline={article.headline}
-                            appearance={'pillarColor'}
+                            textBlockAppearance={'pillarColor'}
                         />
                     </View>
                 </Highlight>

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { View, StyleSheet, StyleProp, ViewStyle, Image } from 'react-native'
 import { metrics } from '../../../theme/spacing'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
@@ -7,6 +7,7 @@ import { HeadlineCardText, HeadlineKickerText } from '../../styled-text'
 
 import { useArticleAppearance } from '../../../theme/appearance'
 import { FrontArticle } from '../../../common'
+import { color } from 'src/theme/color'
 
 const styles = StyleSheet.create({
     root: {
@@ -26,6 +27,85 @@ interface PropTypes {
     path: FrontArticle['path']
 }
 
+type TextBlockAppearance = 'default' | 'highlight' | 'pillarColor'
+
+const textBlockStyles = {
+    root: {
+        paddingBottom: metrics.vertical,
+        paddingTop: metrics.vertical / 3,
+    },
+    rootWithHighlight: {
+        backgroundColor: color.palette.highlight.main,
+        paddingHorizontal: metrics.horizontal / 2,
+    },
+    contrastText: {
+        color: color.palette.neutral[100],
+    },
+    headline: {
+        color: color.dimText,
+    },
+}
+
+const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
+    const { appearance } = useArticleAppearance()
+    switch (textBlockAppearance) {
+        case 'highlight':
+            return {
+                rootStyle: [
+                    textBlockStyles.root,
+                    textBlockStyles.rootWithHighlight,
+                ],
+                kickerStyle: null,
+                headlineStyle: textBlockStyles.headline,
+            }
+        case 'pillarColor':
+            return {
+                rootStyle: [
+                    textBlockStyles.root,
+                    textBlockStyles.rootWithHighlight,
+                    appearance.contrastCardBackgrounds,
+                ],
+                kickerStyle: textBlockStyles.contrastText,
+                headlineStyle: textBlockStyles.contrastText,
+            }
+        default:
+            return {
+                rootStyle: textBlockStyles.root,
+                kickerStyle: [appearance.text, appearance.kicker],
+                headlineStyle: [
+                    textBlockStyles.headline,
+                    appearance.text,
+                    appearance.kicker,
+                ],
+            }
+    }
+}
+
+const TextBlock = ({
+    kicker,
+    headline,
+    appearance,
+}: {
+    kicker: string
+    headline: string
+    appearance: TextBlockAppearance
+}) => {
+    const { rootStyle, kickerStyle, headlineStyle } = useTextBlockStyles(
+        appearance,
+    )
+
+    return (
+        <View style={rootStyle}>
+            <HeadlineKickerText style={kickerStyle}>
+                Kick {kicker}
+            </HeadlineKickerText>
+            <HeadlineCardText style={headlineStyle}>
+                headline {headline}
+            </HeadlineCardText>
+        </View>
+    )
+}
+
 const SmallCard = withNavigation(
     ({
         style,
@@ -34,7 +114,7 @@ const SmallCard = withNavigation(
         navigation,
     }: PropTypes & NavigationInjectedProps<{}>) => {
         const { appearance } = useArticleAppearance()
-
+        const blockAppearance = 'highlight'
         return (
             <View style={style}>
                 <Highlight
@@ -54,28 +134,19 @@ const SmallCard = withNavigation(
                         ]}
                     >
                         <Image
-                            accessibilityLabel={'Loading content'}
                             style={{
                                 width: '100%',
                                 flex: 1,
-                                marginBottom: metrics.vertical / 2,
                             }}
                             source={{
                                 uri: 'https://placekitten.com/200/200',
                             }}
                         />
-                        <View>
-                            <HeadlineKickerText
-                                style={[appearance.text, appearance.kicker]}
-                            >
-                                Kick {article.kicker}
-                            </HeadlineKickerText>
-                            <HeadlineCardText
-                                style={[appearance.text, appearance.headline]}
-                            >
-                                headline {article.headline}
-                            </HeadlineCardText>
-                        </View>
+                        <TextBlock
+                            kicker={article.kicker}
+                            headline={article.headline}
+                            appearance={'pillarColor'}
+                        />
                     </View>
                 </Highlight>
             </View>

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native'
+import { View, StyleSheet, StyleProp, ViewStyle, Image } from 'react-native'
 import { metrics } from '../../../theme/spacing'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
 import { Highlight } from '../../highlight'
@@ -10,7 +10,7 @@ import { FrontArticle } from '../../../common'
 
 const styles = StyleSheet.create({
     root: {
-        padding: metrics.horizontal,
+        padding: metrics.horizontal / 2,
         paddingVertical: metrics.vertical / 2,
     },
     elastic: {
@@ -34,6 +34,7 @@ const SmallCard = withNavigation(
         navigation,
     }: PropTypes & NavigationInjectedProps<{}>) => {
         const { appearance } = useArticleAppearance()
+
         return (
             <View style={style}>
                 <Highlight
@@ -52,16 +53,29 @@ const SmallCard = withNavigation(
                             appearance.cardBackgrounds,
                         ]}
                     >
-                        <HeadlineKickerText
-                            style={[appearance.text, appearance.kicker]}
-                        >
-                            {article.kicker}
-                        </HeadlineKickerText>
-                        <HeadlineCardText
-                            style={[appearance.text, appearance.headline]}
-                        >
-                            {article.headline}
-                        </HeadlineCardText>
+                        <Image
+                            accessibilityLabel={'Loading content'}
+                            style={{
+                                width: '100%',
+                                flex: 1,
+                                marginBottom: metrics.vertical / 2,
+                            }}
+                            source={{
+                                uri: 'https://placekitten.com/200/200',
+                            }}
+                        />
+                        <View>
+                            <HeadlineKickerText
+                                style={[appearance.text, appearance.kicker]}
+                            >
+                                Kick {article.kicker}
+                            </HeadlineKickerText>
+                            <HeadlineCardText
+                                style={[appearance.text, appearance.headline]}
+                            >
+                                headline {article.headline}
+                            </HeadlineCardText>
+                        </View>
                     </View>
                 </Highlight>
             </View>

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -83,6 +83,7 @@ const coverStyles = StyleSheet.create({
         bottom: 0,
         left: 0,
         top: '50%',
+        paddingTop: metrics.vertical / 3,
     },
 })
 
@@ -112,6 +113,9 @@ const imageStyles = StyleSheet.create({
         width: '100%',
         flex: 1,
     },
+    textBlock: {
+        paddingTop: metrics.vertical / 3,
+    },
 })
 
 const ImageCard = ({ style, article, path }: PropTypes) => {
@@ -123,7 +127,11 @@ const ImageCard = ({ style, article, path }: PropTypes) => {
                     uri: article.image,
                 }}
             />
-            <TextBlock kicker={article.kicker} headline={article.headline} />
+            <TextBlock
+                style={style.textBlock}
+                kicker={article.kicker}
+                headline={article.headline}
+            />
         </CardTappable>
     )
 }

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -27,6 +27,8 @@ interface PropTypes {
     path: FrontArticle['path']
 }
 
+type ImageComposition = 'default' | 'cover'
+
 const SmallCard = withNavigation(
     ({
         style,
@@ -35,6 +37,9 @@ const SmallCard = withNavigation(
         navigation,
     }: PropTypes & NavigationInjectedProps<{}>) => {
         const { appearance } = useArticleAppearance()
+        /* gotta derive these from appearance+size */
+        const textBlockAppearance = 'pillarColor'
+        const imageComposition: ImageComposition = 'cover'
         return (
             <View style={style}>
                 <Highlight
@@ -53,20 +58,48 @@ const SmallCard = withNavigation(
                             appearance.cardBackgrounds,
                         ]}
                     >
-                        <Image
-                            style={{
-                                width: '100%',
-                                flex: 1,
-                            }}
-                            source={{
-                                uri: 'https://placekitten.com/200/200',
-                            }}
-                        />
-                        <TextBlock
-                            kicker={article.kicker}
-                            headline={article.headline}
-                            textBlockAppearance={'pillarColor'}
-                        />
+                        {imageComposition === 'cover' ? (
+                            <View style={{ width: '100%', height: '100%' }}>
+                                <Image
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        flex: 1,
+                                    }}
+                                    source={{
+                                        uri: 'https://placekitten.com/200/200',
+                                    }}
+                                />
+                                <TextBlock
+                                    kicker={article.kicker}
+                                    headline={article.headline}
+                                    textBlockAppearance={textBlockAppearance}
+                                    style={{
+                                        width: '50%',
+                                        position: 'absolute',
+                                        bottom: 0,
+                                        left: 0,
+                                    }}
+                                />
+                            </View>
+                        ) : (
+                            <>
+                                <Image
+                                    style={{
+                                        width: '100%',
+                                        flex: 1,
+                                    }}
+                                    source={{
+                                        uri: 'https://placekitten.com/200/200',
+                                    }}
+                                />
+                                <TextBlock
+                                    kicker={article.kicker}
+                                    headline={article.headline}
+                                    textBlockAppearance={textBlockAppearance}
+                                />
+                            </>
+                        )}
                     </View>
                 </Highlight>
             </View>

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -77,7 +77,13 @@ const coverStyles = StyleSheet.create({
         height: '100%',
         flex: 1,
     },
-    text: { width: '50%', position: 'absolute', bottom: 0, left: 0 },
+    text: {
+        width: '50%',
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        top: '50%',
+    },
 })
 
 const CoverCard = ({ style, article, path }: PropTypes) => {

--- a/projects/Mallard/src/components/front/card-group/card.tsx
+++ b/projects/Mallard/src/components/front/card-group/card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { View, StyleSheet, StyleProp, ViewStyle, Image } from 'react-native'
 import { metrics } from '../../../theme/spacing'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
@@ -8,18 +8,7 @@ import { useArticleAppearance } from '../../../theme/appearance'
 import { FrontArticle } from '../../../common'
 
 import { TextBlock } from './text-block'
-
-const styles = StyleSheet.create({
-    root: {
-        padding: metrics.horizontal / 2,
-        paddingVertical: metrics.vertical / 2,
-    },
-    elastic: {
-        flexGrow: 1,
-        flexShrink: 0,
-        flexBasis: '100%',
-    },
-})
+import { Size } from './row'
 
 interface PropTypes {
     style: StyleProp<ViewStyle>
@@ -27,19 +16,32 @@ interface PropTypes {
     path: FrontArticle['path']
 }
 
-type ImageComposition = 'default' | 'cover'
+/*
+TAPPABLE
+This just wraps every card to make it tappable
+*/
+const tappableStyles = StyleSheet.create({
+    root: {
+        padding: metrics.horizontal / 2,
+        paddingVertical: metrics.vertical / 2,
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: '100%',
+    },
+})
 
-const SmallCard = withNavigation(
+const CardTappable = withNavigation(
     ({
+        children,
         style,
         article,
         path,
         navigation,
-    }: PropTypes & NavigationInjectedProps<{}>) => {
+    }: {
+        children: ReactNode
+    } & PropTypes &
+        NavigationInjectedProps) => {
         const { appearance } = useArticleAppearance()
-        /* gotta derive these from appearance+size */
-        const textBlockAppearance = 'pillarColor'
-        const imageComposition: ImageComposition = 'cover'
         return (
             <View style={style}>
                 <Highlight
@@ -52,54 +54,12 @@ const SmallCard = withNavigation(
                 >
                     <View
                         style={[
-                            styles.elastic,
-                            styles.root,
+                            tappableStyles.root,
                             appearance.backgrounds,
                             appearance.cardBackgrounds,
                         ]}
                     >
-                        {imageComposition === 'cover' ? (
-                            <View style={{ width: '100%', height: '100%' }}>
-                                <Image
-                                    style={{
-                                        width: '100%',
-                                        height: '100%',
-                                        flex: 1,
-                                    }}
-                                    source={{
-                                        uri: 'https://placekitten.com/200/200',
-                                    }}
-                                />
-                                <TextBlock
-                                    kicker={article.kicker}
-                                    headline={article.headline}
-                                    textBlockAppearance={textBlockAppearance}
-                                    style={{
-                                        width: '50%',
-                                        position: 'absolute',
-                                        bottom: 0,
-                                        left: 0,
-                                    }}
-                                />
-                            </View>
-                        ) : (
-                            <>
-                                <Image
-                                    style={{
-                                        width: '100%',
-                                        flex: 1,
-                                    }}
-                                    source={{
-                                        uri: 'https://placekitten.com/200/200',
-                                    }}
-                                />
-                                <TextBlock
-                                    kicker={article.kicker}
-                                    headline={article.headline}
-                                    textBlockAppearance={textBlockAppearance}
-                                />
-                            </>
-                        )}
+                        {children}
                     </View>
                 </Highlight>
             </View>
@@ -107,4 +67,73 @@ const SmallCard = withNavigation(
     },
 )
 
-export { SmallCard }
+/*
+COVER CARD
+Text over image. To use in lifestyle & art heros
+*/
+const coverStyles = StyleSheet.create({
+    cover: {
+        width: '100%',
+        height: '100%',
+        flex: 1,
+    },
+    text: { width: '50%', position: 'absolute', bottom: 0, left: 0 },
+})
+
+const CoverCard = ({ style, article, path }: PropTypes) => {
+    return (
+        <CardTappable {...{ style, article, path }}>
+            <View style={coverStyles.cover}>
+                <Image
+                    style={coverStyles.cover}
+                    source={{
+                        uri: 'https://placekitten.com/200/200',
+                    }}
+                />
+                <TextBlock
+                    kicker={article.kicker}
+                    headline={article.headline}
+                    textBlockAppearance={'pillarColor'}
+                    style={coverStyles.text}
+                />
+            </View>
+        </CardTappable>
+    )
+}
+
+const smallStyles = StyleSheet.create({
+    image: {
+        width: '100%',
+        flex: 1,
+    },
+})
+
+const SmallCard = ({ style, article, path }: PropTypes) => {
+    /* gotta derive these from appearance+size */
+    const textBlockAppearance = 'default'
+    return (
+        <CardTappable {...{ style, article, path }}>
+            <Image
+                style={smallStyles.image}
+                source={{
+                    uri: 'https://placekitten.com/200/200',
+                }}
+            />
+            <TextBlock
+                kicker={article.kicker}
+                headline={article.headline}
+                textBlockAppearance={textBlockAppearance}
+            />
+        </CardTappable>
+    )
+}
+
+const Card = ({ size, ...props }: { size: Size } & PropTypes) => {
+    /* this chooses the card type for us based on ummm MAGIC? */
+    return size >= Size.hero ? (
+        <CoverCard {...props} />
+    ) : (
+        <SmallCard {...props} />
+    )
+}
+export { Card }

--- a/projects/Mallard/src/components/front/card-group/row.tsx
+++ b/projects/Mallard/src/components/front/card-group/row.tsx
@@ -4,9 +4,18 @@ import { Multiline } from '../../multiline'
 import { metrics } from '../../../theme/spacing'
 
 import { useArticleAppearance } from '../../../theme/appearance'
-import { SmallCard } from './../card-group/card'
+import { Card } from './../card-group/card'
 import { FrontArticle } from '../../../common'
 import { PropTypes as CardGroupPropTypes } from '../card-group'
+
+export enum Size {
+    row,
+    fourth,
+    third,
+    half,
+    hero,
+    superhero,
+}
 
 const styles = StyleSheet.create({
     row: {
@@ -88,12 +97,19 @@ shows 1 article
 */
 const RowWithArticle = ({
     article,
+    size,
     ...rowProps
 }: {
+    size: Size
     article: FrontArticle
 } & RowPropTypes) => (
     <Row {...rowProps}>
-        <SmallCard style={styles.card} path={article.path} article={article} />
+        <Card
+            style={styles.card}
+            path={article.path}
+            article={article}
+            size={size}
+        />
     </Row>
 )
 
@@ -105,8 +121,10 @@ then it eats them up
 */
 const RowWithTwoArticles = ({
     articles,
+    size,
     ...rowProps
 }: {
+    size: Size
     articles: [FrontArticle, FrontArticle]
 } & RowPropTypes) => {
     const { appearance } = useArticleAppearance()
@@ -117,16 +135,19 @@ const RowWithTwoArticles = ({
     we fall back to 1 article
     */
     if (!articles[1])
-        return <RowWithArticle {...rowProps} article={articles[0]} />
+        return (
+            <RowWithArticle {...rowProps} {...{ size }} article={articles[0]} />
+        )
     return (
         <Row {...rowProps}>
             <View style={styles.doubleRow}>
-                <SmallCard
+                <Card
                     style={[styles.card]}
                     path={articles[0].path}
                     article={articles[0]}
+                    size={size}
                 />
-                <SmallCard
+                <Card
                     style={[
                         styles.card,
                         styles.rightCard,
@@ -136,6 +157,7 @@ const RowWithTwoArticles = ({
                     ]}
                     path={articles[1].path}
                     article={articles[1]}
+                    size={size}
                 />
             </View>
         </Row>

--- a/projects/Mallard/src/components/front/card-group/row.tsx
+++ b/projects/Mallard/src/components/front/card-group/row.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 import { StyleSheet, Animated, View } from 'react-native'
 import { Multiline } from '../../multiline'
 import { metrics } from '../../../theme/spacing'
@@ -10,7 +10,6 @@ import { PropTypes as CardGroupPropTypes } from '../card-group'
 
 export enum Size {
     row,
-    fourth,
     third,
     half,
     hero,
@@ -19,7 +18,6 @@ export enum Size {
 
 const styles = StyleSheet.create({
     row: {
-        flexBasis: 0,
         flexGrow: 1,
         flexDirection: 'column',
         alignItems: 'stretch',
@@ -45,6 +43,19 @@ interface RowPropTypes {
     translate: CardGroupPropTypes['translate']
     isLastChild: boolean
     index: number
+    size: Size
+}
+
+const getHeightForSize = (size: Size): string => {
+    const heights = {
+        [Size.row]: 'auto',
+        [Size.third]: `${(2 / 6) * 100}%`,
+        [Size.half]: '50%',
+        [Size.hero]: `${(4 / 6) * 100}%`,
+        [Size.superhero]: 'auto',
+    }
+
+    return heights[size]
 }
 
 /*
@@ -55,14 +66,17 @@ const Row = ({
     translate,
     isLastChild,
     index,
+    size,
 }: {
     children: ReactNode
 } & RowPropTypes) => {
     const { appearance } = useArticleAppearance()
+    const height = useMemo(() => getHeightForSize(size), [size])
     return (
         <Animated.View
             style={[
                 styles.row,
+                { height },
                 {
                     transform: [
                         {
@@ -97,10 +111,8 @@ shows 1 article
 */
 const RowWithArticle = ({
     article,
-    size,
     ...rowProps
 }: {
-    size: Size
     article: FrontArticle
 } & RowPropTypes) => (
     <Row {...rowProps}>
@@ -108,7 +120,7 @@ const RowWithArticle = ({
             style={styles.card}
             path={article.path}
             article={article}
-            size={size}
+            size={rowProps.size}
         />
     </Row>
 )
@@ -121,10 +133,8 @@ then it eats them up
 */
 const RowWithTwoArticles = ({
     articles,
-    size,
     ...rowProps
 }: {
-    size: Size
     articles: [FrontArticle, FrontArticle]
 } & RowPropTypes) => {
     const { appearance } = useArticleAppearance()
@@ -135,9 +145,7 @@ const RowWithTwoArticles = ({
     we fall back to 1 article
     */
     if (!articles[1])
-        return (
-            <RowWithArticle {...rowProps} {...{ size }} article={articles[0]} />
-        )
+        return <RowWithArticle {...rowProps} article={articles[0]} />
     return (
         <Row {...rowProps}>
             <View style={styles.doubleRow}>
@@ -145,7 +153,7 @@ const RowWithTwoArticles = ({
                     style={[styles.card]}
                     path={articles[0].path}
                     article={articles[0]}
-                    size={size}
+                    size={rowProps.size}
                 />
                 <Card
                     style={[
@@ -157,7 +165,7 @@ const RowWithTwoArticles = ({
                     ]}
                     path={articles[1].path}
                     article={articles[1]}
-                    size={size}
+                    size={rowProps.size}
                 />
             </View>
         </Row>

--- a/projects/Mallard/src/components/front/card-group/text-block.tsx
+++ b/projects/Mallard/src/components/front/card-group/text-block.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View } from 'react-native'
+import { View, ViewStyle, StyleProp } from 'react-native'
 import { metrics } from '../../../theme/spacing'
 import { HeadlineCardText, HeadlineKickerText } from '../../styled-text'
 
@@ -61,17 +61,19 @@ const TextBlock = ({
     kicker,
     headline,
     textBlockAppearance,
+    style,
 }: {
     kicker: string
     headline: string
     textBlockAppearance: TextBlockAppearance
+    style?: StyleProp<ViewStyle>
 }) => {
     const { rootStyle, kickerStyle, headlineStyle } = useTextBlockStyles(
         textBlockAppearance,
     )
 
     return (
-        <View style={rootStyle}>
+        <View style={[rootStyle, style]}>
             <HeadlineKickerText style={kickerStyle}>
                 Kick {kicker}
             </HeadlineKickerText>

--- a/projects/Mallard/src/components/front/card-group/text-block.tsx
+++ b/projects/Mallard/src/components/front/card-group/text-block.tsx
@@ -11,7 +11,6 @@ type TextBlockAppearance = 'default' | 'highlight' | 'pillarColor'
 const styles = {
     root: {
         paddingBottom: metrics.vertical,
-        paddingTop: metrics.vertical / 3,
     },
     rootWithHighlight: {
         backgroundColor: color.palette.highlight.main,

--- a/projects/Mallard/src/components/front/card-group/text-block.tsx
+++ b/projects/Mallard/src/components/front/card-group/text-block.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { View } from 'react-native'
+import { metrics } from '../../../theme/spacing'
+import { HeadlineCardText, HeadlineKickerText } from '../../styled-text'
+
+import { useArticleAppearance } from '../../../theme/appearance'
+import { color } from 'src/theme/color'
+
+type TextBlockAppearance = 'default' | 'highlight' | 'pillarColor'
+
+const styles = {
+    root: {
+        paddingBottom: metrics.vertical,
+        paddingTop: metrics.vertical / 3,
+    },
+    rootWithHighlight: {
+        backgroundColor: color.palette.highlight.main,
+        paddingHorizontal: metrics.horizontal / 2,
+    },
+    contrastText: {
+        color: color.palette.neutral[100],
+    },
+    headline: {
+        color: color.dimText,
+    },
+}
+
+const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
+    const { appearance } = useArticleAppearance()
+    switch (textBlockAppearance) {
+        case 'highlight':
+            return {
+                rootStyle: [styles.root, styles.rootWithHighlight],
+                kickerStyle: null,
+                headlineStyle: styles.headline,
+            }
+        case 'pillarColor':
+            return {
+                rootStyle: [
+                    styles.root,
+                    styles.rootWithHighlight,
+                    appearance.contrastCardBackgrounds,
+                ],
+                kickerStyle: styles.contrastText,
+                headlineStyle: styles.contrastText,
+            }
+        default:
+            return {
+                rootStyle: styles.root,
+                kickerStyle: [appearance.text, appearance.kicker],
+                headlineStyle: [
+                    styles.headline,
+                    appearance.text,
+                    appearance.kicker,
+                ],
+            }
+    }
+}
+
+const TextBlock = ({
+    kicker,
+    headline,
+    textBlockAppearance,
+}: {
+    kicker: string
+    headline: string
+    textBlockAppearance: TextBlockAppearance
+}) => {
+    const { rootStyle, kickerStyle, headlineStyle } = useTextBlockStyles(
+        textBlockAppearance,
+    )
+
+    return (
+        <View style={rootStyle}>
+            <HeadlineKickerText style={kickerStyle}>
+                Kick {kicker}
+            </HeadlineKickerText>
+            <HeadlineCardText style={headlineStyle}>
+                headline {headline}
+            </HeadlineCardText>
+        </View>
+    )
+}
+export { TextBlock }

--- a/projects/Mallard/src/components/front/card-group/text-block.tsx
+++ b/projects/Mallard/src/components/front/card-group/text-block.tsx
@@ -75,12 +75,16 @@ const TextBlock = ({
     return (
         <View style={[rootStyle, style]}>
             <HeadlineKickerText style={kickerStyle}>
-                Kick {kicker}
+                {kicker}
             </HeadlineKickerText>
             <HeadlineCardText style={headlineStyle}>
-                headline {headline}
+                {headline}
             </HeadlineCardText>
         </View>
     )
 }
+TextBlock.defaultProps = {
+    textBlockAppearance: 'default',
+}
+
 export { TextBlock }

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -8,7 +8,7 @@ import { ArticleAppearance } from '../../theme/appearance'
 import { Front as FrontType, Collection } from '../../../../backend/common'
 import { Spinner } from '../spinner'
 import { FlexCenter } from '../layout/flex-center'
-import { UiBodyCopy, UiExplainerCopy } from '../styled-text'
+import { FlexErrorMessage } from '../layout/errors/flex-error-message'
 
 interface AnimatedScrollViewRef {
     _component: ScrollView
@@ -119,10 +119,10 @@ export const Front: FunctionComponent<{
         ),
         error: err => (
             <Wrapper scrubber={<NavigatorSkeleton />}>
-                <FlexCenter>
-                    <UiBodyCopy>Oh no! something failed</UiBodyCopy>
-                    <UiExplainerCopy>{err.message}</UiExplainerCopy>
-                </FlexCenter>
+                <FlexErrorMessage
+                    title={'Oh no! something failed'}
+                    message={err.message}
+                />
             </Wrapper>
         ),
         success: frontData => {

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -204,7 +204,7 @@ export const Front: FunctionComponent<{
                         {collections.map(([id, collection], i) => (
                             <Page
                                 index={i}
-                                appearance={'comment'}
+                                appearance={'sport'}
                                 key={id}
                                 {...{ collection, scrollX }}
                             />

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-    useState,
-    useRef,
-    FunctionComponent,
-    ReactNode,
-    useMemo,
-} from 'react'
+import React, { useState, useRef, FunctionComponent, ReactNode } from 'react'
 import { ScrollView, View, Dimensions, Animated } from 'react-native'
 import { useEndpointResponse } from '../../hooks/use-fetch'
 import { metrics } from '../../theme/spacing'

--- a/projects/Mallard/src/components/layout/errors/error-message.tsx
+++ b/projects/Mallard/src/components/layout/errors/error-message.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Text } from 'react-native'
+import { UiExplainerCopy, UiBodyCopy } from 'src/components/styled-text'
+
+export interface PropTypes {
+    title: string
+    icon?: string
+    message?: string
+}
+
+const ErrorMessage = ({ icon, title, message }: PropTypes) => (
+    <>
+        {!!icon && <Text style={{ fontSize: 40 }}>{icon}</Text>}
+        <UiBodyCopy weight="bold">{title}</UiBodyCopy>
+        {!!message && <UiExplainerCopy>{message}</UiExplainerCopy>}
+    </>
+)
+
+export { ErrorMessage }

--- a/projects/Mallard/src/components/layout/errors/flex-error-message.tsx
+++ b/projects/Mallard/src/components/layout/errors/flex-error-message.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { ViewStyle, StyleProp } from 'react-native'
+import { PropTypes, ErrorMessage } from './error-message'
+import { FlexCenter } from '../flex-center'
+
+const FlexErrorMessage = ({
+    style,
+    ...props
+}: { style?: StyleProp<ViewStyle> } & PropTypes) => (
+    <FlexCenter {...{ style }}>
+        <ErrorMessage {...props} />
+    </FlexCenter>
+)
+
+export { FlexErrorMessage }

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -8,12 +8,12 @@ import {
 } from '../theme/appearance'
 import { Article } from '../components/article'
 import { Article as ArticleType, FrontArticle } from '../common'
-import { View, TouchableOpacity, Text, Button } from 'react-native'
+import { View, TouchableOpacity } from 'react-native'
 import { metrics } from '../theme/spacing'
 import { UiBodyCopy } from '../components/styled-text'
-import { FlexCenter } from '../components/layout/flex-center'
 import { SlideCard } from '../components/layout/slide-card/index'
 import { color } from '../theme/color'
+import { FlexErrorMessage } from 'src/components/layout/errors/flex-error-message'
 
 const useArticleResponse = (path: string) =>
     useEndpointResponse<ArticleType>(
@@ -53,19 +53,28 @@ export const ArticleScreen = ({
             />
             {articleResponse({
                 error: ({ message }) => (
-                    <FlexCenter style={{ backgroundColor: color.background }}>
-                        <Text style={{ fontSize: 40 }}>😭</Text>
-                        <UiBodyCopy weight="bold">{message}</UiBodyCopy>
-                    </FlexCenter>
-                ),
-                pending: () => (
-                    <Article
-                        kicker={(frontArticle && frontArticle.kicker) || ''}
-                        headline={(frontArticle && frontArticle.headline) || ''}
-                        byline={(frontArticle && frontArticle.byline) || ''}
-                        standfirst=""
+                    <FlexErrorMessage
+                        icon="😭"
+                        title={message}
+                        style={{ backgroundColor: color.background }}
                     />
                 ),
+                pending: () =>
+                    frontArticle ? (
+                        <Article
+                            image={frontArticle.image || ''}
+                            kicker={frontArticle.kicker || ''}
+                            headline={frontArticle.headline || ''}
+                            byline={frontArticle.byline || ''}
+                            standfirst=""
+                        />
+                    ) : (
+                        <FlexErrorMessage
+                            icon="😭"
+                            title={'loading'}
+                            style={{ backgroundColor: color.background }}
+                        />
+                    ),
                 success: ({
                     standfirst,
                     title,

--- a/projects/Mallard/src/theme/appearance.ts
+++ b/projects/Mallard/src/theme/appearance.ts
@@ -27,6 +27,12 @@ interface ArticleAppearanceStyles {
         backgroundColor?: string
     }
     /*
+    Contrast-y cards
+    */
+    contrastCardBackgrounds: {
+        backgroundColor?: string
+    }
+    /*
     Spread this over text and icons
     */
     text: {
@@ -98,6 +104,9 @@ export const articleAppearances: {
             backgroundColor: color.background,
             borderColor: color.line,
         },
+        contrastCardBackgrounds: {
+            backgroundColor: color.palette.neutral[7],
+        },
         cardBackgrounds: {},
         text: {
             color: color.text,
@@ -110,6 +119,7 @@ export const articleAppearances: {
     news: {
         backgrounds: {},
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: {
             color: color.palette.news.main,
         },
@@ -127,6 +137,7 @@ export const articleAppearances: {
             backgroundColor: color.palette.opinion.faded,
         },
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: {
             color: color.palette.opinion.main,
         },
@@ -142,6 +153,7 @@ export const articleAppearances: {
             backgroundColor: color.palette.sport.faded,
         },
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: {
             color: color.palette.sport.main,
         },
@@ -158,6 +170,7 @@ export const articleAppearances: {
             backgroundColor: color.palette.culture.faded,
         },
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: {
             color: color.palette.culture.main,
         },
@@ -175,6 +188,7 @@ export const articleAppearances: {
             backgroundColor: color.palette.lifestyle.faded,
         },
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: {
             color: color.palette.lifestyle.main,
         },
@@ -190,6 +204,7 @@ export const articleAppearances: {
             backgroundColor: color.palette.neutral[7],
         },
         cardBackgrounds: {},
+        contrastCardBackgrounds: {},
         text: { color: color.palette.neutral[100] },
         headline: {},
         kicker: {},

--- a/projects/Mallard/src/theme/appearance.ts
+++ b/projects/Mallard/src/theme/appearance.ts
@@ -153,7 +153,9 @@ export const articleAppearances: {
             backgroundColor: color.palette.sport.faded,
         },
         cardBackgrounds: {},
-        contrastCardBackgrounds: {},
+        contrastCardBackgrounds: {
+            backgroundColor: color.palette.sport.main,
+        },
         text: {
             color: color.palette.sport.main,
         },


### PR DESCRIPTION
## Why are you doing this?
This adds the sports yellow thingy and the arts+culture square in there. They aren't wired to the article type logic yet so, for now, they all default to the arts & culture square thing.

Also, and totes out of scope but felt like a good time to do this - The UI to display errors was copypasted around the app so I've tucked it away into it's own `<ErrorMessage/>` (inline) and `<FlexErrorMessage/>` (centered block) component

## Screenies
<img width="482" alt="Screenshot 2019-06-18 at 09 56 28" src="https://user-images.githubusercontent.com/11539094/59667989-98c71900-91af-11e9-8ed7-ad21264b3041.png">
