### PR TITLE
Add ability to retrieve Crossword data by date.

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -21,11 +21,13 @@ interface CAPIArticle {
     elements: BlockElement[]
 }
 
+const capiKey: string | undefined = process.env.CAPI_KEY || undefined
+
 const url = (paths: string[]) =>
     `https://content.guardianapis.com/search?ids=${paths.join(
         ',',
     )}format=thrift&api-key=${
-        process.env.CAPI_KEY
+        capiKey
     }&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=thrift&page-size=100`
 
 const parseArticleResult = async (

--- a/projects/backend/controllers/crossword.ts
+++ b/projects/backend/controllers/crossword.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from 'express'
+import { Issue } from '../common'
+import { lastModified } from '../lastModified'
+import fetch from 'node-fetch'
+import { Crossword } from '@guardian/capi-ts'
+import moment from 'moment'
+import console = require('console');
+
+
+const crosswordDateParamFormat: string = 'YYYY-MM-DD'
+const crosswordApiKey: string | undefined = process.env.CROSSWORD_API_KEY || undefined
+
+const crossswordApiUrl = (date: string, crosswordApiKey: string) => `https://x-puzzle-hrd.appspot.com/api/crosswords/${date}.json?api-key=${crosswordApiKey}`
+
+const getCrossword = async (
+    date: string,
+): Promise<Crossword | 'notfound' | 'notallowed'> => {
+    if (!crosswordApiKey) throw new Error('Invalid API key')    
+
+    const crosswordReponse = await fetch(`${crossswordApiUrl(date, crosswordApiKey)}`)
+    if (crosswordReponse.status === 405) return 'notallowed'
+    if (crosswordReponse.status === 404) return 'notfound'
+    if (!crosswordReponse.ok) throw new Error('Something went wrong')
+
+    return crosswordReponse.json().then(res => ({ ...res })) as Promise<Crossword>
+}
+
+export const crosswordController = (req: Request, res: Response) => {
+    const date: string = req.params.date
+    if (!moment(date, crosswordDateParamFormat, true).isValid()) throw new Error(`Invalid date: Date must be in format ${crosswordDateParamFormat}`)
+
+    getCrossword(date)
+        .then(data => {
+            res.setHeader('Content-Type', 'application/json')
+            res.send(JSON.stringify(data))
+        })
+        .catch(e => console.error(e))
+}

--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -5,6 +5,7 @@ import { Handler } from 'aws-lambda'
 import express = require('express')
 import { issueController } from './controllers/issue'
 import { frontController, collectionsController } from './controllers/fronts'
+import { crosswordController } from './controllers/crossword'
 
 const app = express()
 
@@ -13,6 +14,8 @@ app.get('/issue/:editionId', issueController)
 app.get('/front/*?', frontController)
 
 app.get('/collection/:collectionId', collectionsController)
+
+app.get('/crossword/:date', crosswordController)
 
 app.get('/', (req, res) => {
     res.setHeader('Content-Type', 'application/json')

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -31,6 +31,7 @@
         "aws-sdk": "2.437.0",
         "aws-serverless-express": "^3.3.6",
         "express": "^4.16.4",
+        "moment": "^2.24.0",
         "node-fetch": "^2.5.0",
         "object.fromentries": "^2.0.0",
         "utility-types": "^3.7.0"

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -919,6 +919,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Why are you doing this?

The daily edition will have a daily crossword. By exposing the crossword data via api, we can both package it into the downloaded bundle for use on the device and use it live for active development.

## Next Steps
1. Make sure the crossword json for a given day makes its way into the bundle once Alex's Lambda bundler is done.
2. Use the data to render the crossword in the app as per my POC.


