### PR TITLE
Many capis

### DIFF
--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -20,9 +20,14 @@ export class EditionsStack extends cdk.Stack {
             description: 'Stage',
         })
 
-        const capiParameter = new cdk.CfnParameter(this, 'capi', {
+        const capiKeyParameter = new cdk.CfnParameter(this, 'capi', {
             type: 'String',
             description: 'Capi key',
+        })
+
+        const printSentURLParameter = new cdk.CfnParameter(this, 'psurl', {
+            type: 'String',
+            description: 'print sent url parameter',
         })
 
         const frontsRoleARN = new cdk.CfnParameter(this, 'fronts-role-arn', {
@@ -59,10 +64,11 @@ export class EditionsStack extends cdk.Stack {
             ),
             handler: 'index.handler',
             environment: {
-                CAPI_KEY: capiParameter.stringValue,
+                CAPI_KEY: capiKeyParameter.stringValue,
                 arn: frontsRoleARN.stringValue,
                 stage: stageParameter.stringValue,
                 atomArn: atomLambdaParam.stringValue,
+                psurl: printSentURLParameter.stringValue,
             },
         })
 

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -83,7 +83,7 @@ const parseArticleResult = async (
 }
 
 const printsent = (paths: string[]) =>
-    `xxxxxx?ids=${paths.join(',')}format=thrift&api-key=${
+    `${process.env.psurl}?ids=${paths.join(',')}format=thrift&api-key=${
         process.env.CAPI_KEY
     }&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=thrift&page-size=100`
 

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -12,7 +12,8 @@ import { IContent } from '@guardian/capi-ts/dist/Content'
 import fetch from 'node-fetch'
 
 interface CAPIArticle {
-    id: number | undefined
+    id: number
+    path: string
     headline: string
     image: string
     byline: string
@@ -21,27 +22,22 @@ interface CAPIArticle {
     elements: BlockElement[]
 }
 
-const url = (paths: string[]) =>
-    `https://content.guardianapis.com/search?ids=${paths.join(
-        ',',
-    )}format=thrift&api-key=${
-        process.env.CAPI_KEY
-    }&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=thrift&page-size=100`
-
 const parseArticleResult = async (
     result: IContent,
-): Promise<[string, CAPIArticle]> => {
-    const id = result.id
+): Promise<[number, CAPIArticle]> => {
+    const path = result.id
 
     if (result.type !== ContentType.ARTICLE)
-        throw new Error(`${id} isn't an article`)
+        throw new Error(`${path} isn't an article`)
     const internalid = result.fields && result.fields.internalPageCode
+    if (internalid == null)
+        throw new Error(`internalid was undefined in ${path}!`)
 
-    const parser = elementParser(id)
+    const parser = elementParser(path)
     const title = result && result.webTitle
     const standfirst = result && result.fields && result.fields.standfirst
     if (standfirst == null)
-        throw new Error(`Standfirst was undefined in ${id}!`)
+        throw new Error(`Standfirst was undefined in ${path}!`)
 
     const image =
         result &&
@@ -60,21 +56,23 @@ const parseArticleResult = async (
         result.blocks.body &&
         result.blocks.body.map(_ => _.elements)
     const body = blocks && blocks.reduce((acc, cur) => [...acc, ...cur], [])
-    if (body == null) throw new Error(`Body was undefined in ${id}!`)
+    if (body == null) throw new Error(`Body was undefined in ${path}!`)
 
     const elements = await attempt(Promise.all(body.map(parser)))
-    if (hasFailed(elements)) throw new Error(`Element parsing failed in ${id}!`) //This should not fire, the parser should log if anything async fails and then return the remainder.
+    if (hasFailed(elements))
+        throw new Error(`Element parsing failed in ${path}!`) //This should not fire, the parser should log if anything async fails and then return the remainder.
 
-    if (elements == null) throw new Error(`Elements was undefined in ${id}!`)
+    if (elements == null) throw new Error(`Elements was undefined in ${path}!`)
 
     const byline = result && result.fields && result.fields.byline
 
-    if (byline == null) throw new Error(`Byline was undefined in ${id}!`)
+    if (byline == null) throw new Error(`Byline was undefined in ${path}!`)
 
     return [
-        result.id,
+        internalid,
         {
             id: internalid,
+            path: path,
             byline,
             headline: title,
             standfirst,
@@ -84,18 +82,33 @@ const parseArticleResult = async (
     ]
 }
 
+const printsent = (paths: string[]) =>
+    `xxxxxx?ids=${paths.join(',')}format=thrift&api-key=${
+        process.env.CAPI_KEY
+    }&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=thrift&page-size=100`
+
+const search = (paths: string[]) =>
+    `https://content.guardianapis.com/search?ids=${paths.join(
+        ',',
+    )}format=thrift&api-key=${
+        process.env.CAPI_KEY
+    }&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&format=thrift&page-size=100`
+
 export const getArticles = async (
-    paths: string[],
+    ids: number[],
+    capi: 'printsent' | 'search',
 ): Promise<{ [key: string]: CAPIArticle }> => {
-    const endpoint = url(paths)
+    const paths = ids.map(_ => `internal-code/page/${_}`)
+
+    const endpoint = capi === 'printsent' ? printsent(paths) : search(paths)
     if (endpoint.length > 1000) {
         console.warn(
             `Unusually long CAPI request of ${endpoint.length}, splitting`,
             paths,
         )
-        const midpoint = ~~(paths.length / 2) //Coerece into int, even though apparently you can slice on a float
-        const firstRequest = attempt(getArticles(paths.slice(0, midpoint)))
-        const last = await attempt(getArticles(paths.slice(midpoint)))
+        const midpoint = ~~(ids.length / 2) //Coerece into int, even though apparently you can slice on a float
+        const firstRequest = attempt(getArticles(ids.slice(0, midpoint), capi))
+        const last = await attempt(getArticles(ids.slice(midpoint), capi))
         const first = await firstRequest
         if (hasFailed(first)) {
             console.error(first.error)

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import { lastModified } from '../lastModified'
 import { getFront, getCollection } from '../fronts'
+import { hasFailed } from '../utils/try'
 
 export const frontController = (req: Request, res: Response) => {
     const id: string = req.params[0]
@@ -25,12 +26,18 @@ export const collectionsController = (req: Request, res: Response) => {
 
     getCollection(id, true, updater)
         .then(data => {
+            if (hasFailed(data)) {
+                console.error('Exception in the collections controller.')
+                console.error(JSON.stringify(data))
+                res.sendStatus(500)
+                return
+            }
             res.setHeader('Last-Modifed', date())
             res.setHeader('Content-Type', 'application/json')
             res.send(JSON.stringify(data))
         })
         .catch(error => {
-            console.error('Error in the collections controller.')
+            console.error('Exception in the collections controller.')
             console.error(error)
             res.sendStatus(500)
         })

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -3,52 +3,71 @@ import fromEntries from 'object.fromentries'
 import { Diff } from 'utility-types'
 import { Front, Collection, Article } from './common'
 import { LastModifiedUpdater } from './lastModified'
-import { attempt, hasFailed } from './utils/try'
+import { attempt, hasFailed, Attempt, withFailureMessage } from './utils/try'
 import { getArticles } from './capi/articles'
 
 export const getCollection = async (
     id: string,
     live: boolean = true,
     lastModifiedUpdater: LastModifiedUpdater,
-): Promise<Collection> => {
+): Promise<Attempt<Collection>> => {
     const resp = await attempt(
         s3fetch(`frontsapi/collection/${id}/collection.json`),
     )
-    if (hasFailed(resp)) throw new Error('Could not fetch from S3.')
+    if (hasFailed(resp))
+        return withFailureMessage(resp, 'Could not fetch from S3')
 
     lastModifiedUpdater(resp.lastModified)
 
     const deserialized = await attempt(resp.json())
-    if (hasFailed(resp)) throw new Error('Response was not valid json')
+    if (hasFailed(deserialized))
+        return withFailureMessage(deserialized, 'Response was not valid json')
 
-    const collection: CollectionFromResponse = deserialized as CollectionFromResponse
+    const collection = deserialized as CollectionFromResponse
 
-    const articleFragmentList = live ? collection.live : collection.draft
-    if (articleFragmentList == null) throw new Error('Hello that didnt work')
-    const articleFragments = fromEntries(
-        articleFragmentList.map(
-            (fragment): [string, NestedArticleFragment] => [
-                fragment.id,
-                fragment,
-            ],
-        ),
+    const articleFragmentList = collection.live.map(
+        (fragment): [number, NestedArticleFragment] => [
+            parseInt(fragment.id.replace('internal-code/page/', '')),
+            fragment,
+        ],
     )
-
+    const articleFragments = fromEntries(articleFragmentList)
+    const ids: number[] = articleFragmentList.map(([id]) => id)
     const preview = live ? undefined : true
-    const capiArticles = await getArticles(Object.keys(articleFragments))
-    const articles: [string, Article][] = Object.entries(capiArticles).map(
-        ([key, article]) => {
-            const fragment =
-                articleFragments[`internal-code/page/${article.id}`] ||
-                articleFragments[key]
+    const capiPrintArticles = await attempt(getArticles(ids, 'printsent'))
+    const capiSearchArticles = await attempt(getArticles(ids, 'search'))
+    if (hasFailed(capiPrintArticles))
+        return withFailureMessage(
+            capiPrintArticles,
+            'Could not connect to capi print sent',
+        )
+    if (hasFailed(capiSearchArticles))
+        return withFailureMessage(
+            capiSearchArticles,
+            'Could not connect to CAPI',
+        )
+
+    const articles: [string, Article][] = Object.entries(articleFragments)
+        .filter(([key]) => {
+            const inResponse =
+                key in capiPrintArticles || key in capiSearchArticles
+            if (!inResponse) {
+                console.warn(`Removing ${key} as not in CAPI response.`)
+            }
+            return inResponse
+        })
+        .map(([key, fragment]) => {
+            const article = capiPrintArticles[key] || capiSearchArticles[key]
             const meta = fragment && (fragment.meta as ArticleFragmentRootMeta)
             const kicker = (meta && meta.customKicker) || '' // I'm not sure where else we should check for a kicker
             const headline = (meta && meta.headline) || article.headline
             const imageURL = (meta && meta.imageSrc) || article.imageURL
 
-            return [key, { ...article, key, kicker, headline, imageURL }]
-        },
-    )
+            return [
+                article.path,
+                { ...article, key, kicker, headline, imageURL },
+            ]
+        })
 
     return {
         key: id,

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -34,8 +34,10 @@ export const getCollection = async (
     const articleFragments = fromEntries(articleFragmentList)
     const ids: number[] = articleFragmentList.map(([id]) => id)
     const preview = live ? undefined : true
-    const capiPrintArticles = await attempt(getArticles(ids, 'printsent'))
-    const capiSearchArticles = await attempt(getArticles(ids, 'search'))
+    const [capiPrintArticles, capiSearchArticles] = await Promise.all([
+        attempt(getArticles(ids, 'printsent')),
+        attempt(getArticles(ids, 'search')),
+    ])
     if (hasFailed(capiPrintArticles))
         return withFailureMessage(
             capiPrintArticles,
@@ -57,7 +59,7 @@ export const getCollection = async (
             return inResponse
         })
         .map(([key, fragment]) => {
-            const article = capiPrintArticles[key] || capiSearchArticles[key]
+            const article = capiSearchArticles[key] || capiPrintArticles[key]
             const meta = fragment && (fragment.meta as ArticleFragmentRootMeta)
             const kicker = (meta && meta.customKicker) || '' // I'm not sure where else we should check for a kicker
             const headline = (meta && meta.headline) || article.headline

--- a/projects/backend/utils/try.ts
+++ b/projects/backend/utils/try.ts
@@ -1,7 +1,16 @@
 export interface Failure {
     __failure: true
     error: Error | {}
+    messages?: string[]
 }
+export const withFailureMessage = (
+    failure: Failure,
+    message: string,
+): Failure => ({
+    __failure: true,
+    error: failure.error,
+    messages: [message, ...(failure.messages || [])],
+})
 
 export type Attempt<T> = Failure | T
 


### PR DESCRIPTION
## Why are you doing this?

Originally, this was an attempt to add sorting to 
https://github.com/guardian/editions/pull/109
but after discussing with @blishen we will need to use multiple capi sources until we get rid of print sent (especially for crosswords)...
and then discussing https://github.com/guardian/editions/pull/110 with @LATaylor-guardian I realised there was a better way of using the `Attempt<T>` pattern...
