### PR TITLE
Fix iOS Beta Deploy

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -28,10 +28,10 @@ platform :ios do
     )
     build_app(
       scheme: "Mallard",
+      project: "ios/Mallard.xcodeproj",
       export_options: {
         exportOptionsPlist: "exports-plists/release.plist"
       }
-      project: "ios/Mallard.xcodeproj",
     )
     upload_to_testflight(
       skip_waiting_for_build_processing: true


### PR DESCRIPTION
## Why are you doing this?

I broke the iOS beta deploy with a careless [merge](https://github.com/guardian/editions/pull/90/commits/8d05eff6a56402e99e7143ebc3b85e4c43f416c5) commit. This PR fixes the problem. 

## Changes

* Fix Fastfile formatting
