### PR TITLE
Sign debug builds with the developer certificate

### DIFF
--- a/projects/Mallard/ios/exports-plists/debug.plist
+++ b/projects/Mallard/ios/exports-plists/debug.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>method</key>
 	<string>development</string>
+    <key>signingCertificate</key>
+	<string>iPhone Developer</string>
 	<key>signingStyle</key>
 	<string>automatic</string>
 	<key>stripSwiftSymbols</key>


### PR DESCRIPTION
## Why are you doing this?

Attempting to fix the signing process for debug builds.