### PR TITLE
Update async storage to use community version

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@guardian/pasteup": "^1.0.0-alpha.11",
-        "@react-native-community/async-storage": "^1.4.0",
+        "@react-native-community/async-storage": "^1.5.0",
         "deepmerge": "^3.2.0",
         "react": "^16.8.6",
         "react-native": "0.59.3",

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native'
+import AsyncStorage from '@react-native-community/async-storage'
 export interface Settings {
     apiUrl: string
     isUsingProdDevtools: boolean

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -5,9 +5,9 @@ import {
     Text,
     Dimensions,
     View,
-    AsyncStorage,
     Alert,
 } from 'react-native'
+import AsyncStorage from '@react-native-community/async-storage'
 
 import { List, ListHeading } from 'src/components/lists/list'
 import { NavigationScreenProp } from 'react-navigation'

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -816,10 +816,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@react-native-community/async-storage@^1.4.0":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.4.2.tgz#b29d2fa1b294fec8526f69b852a3deda248c8d81"
-  integrity sha512-gDQENh7uPLGPKbRFI07GiUXZPhm2j17K4FT308OwAmIiOKbfO/cxy0sCWB0YzD/SLw9F3D9tLBRPJY6GG9YZLw==
+"@react-native-community/async-storage@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.5.0.tgz#647ffcd832272068b0be57332e08d73036ed391f"
+  integrity sha512-2yE4RzQ5IL+UTPhuMY0ykNRKHf1m90jOnmp8fcDPUun5U97cXlorjI4p66ovDgF0FuOv8ZpiUKvunGy3qqBxwg==
 
 "@react-native-community/cli@^1.2.1":
   version "1.9.7"


### PR DESCRIPTION
## Why are you doing this?

As per the error message `AsyncStorage` will be being moved out of react native core. This changes our dependency to the supported version and removes an error message.
