### PR TITLE
Ensure key uses path instead of internal page code

### DIFF
--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -65,7 +65,7 @@ export const getCollection = async (
 
             return [
                 article.path,
-                { ...article, key, kicker, headline, imageURL },
+                { ...article, key: article.path, kicker, headline, imageURL },
             ]
         })
 


### PR DESCRIPTION
## Why are you doing this?

Fixes an issue where the `key` on an article was not the same as they key in a collection's `articles` object.

@AWare is there anything else we need to do here?
