### PR TITLE
Bouncy cards, hide btn that cycles article styles

### DIFF
--- a/projects/Mallard/src/components/layout/clipFromTop/clipFromTop.tsx
+++ b/projects/Mallard/src/components/layout/clipFromTop/clipFromTop.tsx
@@ -8,9 +8,9 @@ import {
 } from 'react-native'
 import MaskedView from '@react-native-community/masked-view'
 
-/* 
+/*
 This is part of the transition from articles to fronts
-and it crops the bottom end of the article so it feels 
+and it crops the bottom end of the article so it feels
 as if it's coming out of its card
 */
 
@@ -35,9 +35,9 @@ const MaskClipFromTop = ({ children, from }: PropTypes) => {
     )
     useEffect(() => {
         Animated.sequence([
-            Animated.delay(50),
+            Animated.delay(75),
             Animated.timing(height, {
-                toValue: 2,
+                toValue: 2.25,
                 duration: 300,
                 easing: Easing.inOut(Easing.linear),
                 useNativeDriver: true,

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -53,8 +53,8 @@ const AppStack = createStackNavigator(
                 backgroundColor: 'transparent',
             },
             transitionSpec: {
-                duration: 300,
-                easing: Easing.ease,
+                duration: 500,
+                easing: Easing.elastic(1.1),
                 timing: Animated.timing,
                 useNativeDriver: true,
             },

--- a/projects/Mallard/src/navigation/interpolators.ts
+++ b/projects/Mallard/src/navigation/interpolators.ts
@@ -97,6 +97,7 @@ const articleScreenInterpolator = (sceneProps: NavigationTransitionProps) => {
 
     return {
         opacity,
+        marginBottom: metrics.slideCardSpacing,
         transform: [{ translateX }, { translateY }, { scale }],
     }
 }


### PR DESCRIPTION
## Why are you doing this?

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborare
-->
