### PR TITLE
Add redirects for images

### DIFF
--- a/projects/backend/capi/assets.ts
+++ b/projects/backend/capi/assets.ts
@@ -1,6 +1,14 @@
 import { IAsset } from '@guardian/capi-ts'
 
 export const extractImage: (assetArray: IAsset[]) => IAsset = assetArray => {
+    // This returns the master image, or, failing that, the largest.
+    // As long as our CAPI key is internal, we should always have a master.
+    const master = assetArray.find(_ => _.file && _.file.includes('/master/'))
+    if (master) return master
+    console.warn(
+        'Failed to find a master image in CAPI response',
+        assetArray[0].file,
+    )
     return assetArray.reduce((biggest, current) => {
         const biggestWidth = (biggest.typeData && biggest.typeData.width) || 0
         const currentWidth = (current.typeData && current.typeData.width) || -1

--- a/projects/backend/controllers/image.ts
+++ b/projects/backend/controllers/image.ts
@@ -1,8 +1,13 @@
 import { Request, Response } from 'express'
 import { getRedirect } from '../image'
+import { imageSizes } from '../../common/src/index'
 export const imageController = (req: Request, res: Response) => {
     const source = req.params.source
     const size = req.params.size
+    if (!imageSizes.includes(size)) {
+        res.status(500)
+        res.send('Invalid size')
+    }
     const path: string = req.params[0]
     const redirect = getRedirect(source, size, path)
     res.redirect(redirect)

--- a/projects/backend/controllers/image.ts
+++ b/projects/backend/controllers/image.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from 'express'
+import { getRedirect } from '../image'
+export const imageController = (req: Request, res: Response) => {
+    const source = req.params.source
+    const size = req.params.size
+    const path: string = req.params[0]
+    const redirect = getRedirect(source, size, path)
+    res.redirect(redirect)
+}

--- a/projects/backend/image.ts
+++ b/projects/backend/image.ts
@@ -1,0 +1,35 @@
+import { createHash } from 'crypto'
+import { ImageSize } from './common'
+const salt = process.env.IMAGE_SALT
+
+export const getImageSlug = (url: string) => {
+    const parsed = new URL(url)
+    const path = parsed.pathname
+    const host = parsed.hostname
+    const hostparts = host.split('.')
+    const source = hostparts[0]
+    return source + path
+}
+
+const getSignature = (path: string) => {
+    console.log(`${salt}${path}`)
+    return createHash('md5')
+        .update(`${salt}/${path}`)
+        .digest('hex')
+}
+
+const getSize = (size: ImageSize) => {
+    switch (size) {
+        case 'small':
+            return 500
+        case 'notsmall':
+            return 2000
+    }
+}
+
+export const getRedirect = (source: string, size: ImageSize, path: string) => {
+    const newPath = `${path}?q=85&w=${getSize(size)}` //&dpr=2&width=500&auto=format`
+    return `https://i.guim.co.uk/img/${source}/${newPath}&s=${getSignature(
+        newPath,
+    )}`
+}

--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -5,8 +5,11 @@ import { Handler } from 'aws-lambda'
 import express = require('express')
 import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController, collectionsController } from './controllers/fronts'
+import { imageController } from './controllers/image'
+import { ImageSize } from '../common/src/index'
 import {
     issuePath,
+    mediaPath,
     frontPath,
     collectionPath,
     issueSummaryPath,
@@ -19,6 +22,8 @@ app.get('/' + issueSummaryPath(), issuesSummaryController)
 app.get('/' + issuePath(':issueId'), issueController)
 
 app.get('/' + frontPath(':issueId', '*?'), frontController)
+
+app.get('/' + mediaPath(':source', ':size' as ImageSize, '*?'), imageController)
 
 app.get(
     '/' + collectionPath(':issueId', ':collectionId'),

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -181,7 +181,9 @@ const frontPath = (issueId: string, frontId: string) =>
 const collectionPath = (issueId: string, collectionId: string) =>
     `${issuePath(issueId)}/collection/${collectionId}`
 const issueSummaryPath = () => 'issues'
-export type ImageSize = 'small' | 'notsmall'
+export const imageSizes = ['small', 'notsmall'] as const
+
+export type ImageSize = typeof imageSizes[number]
 const mediaPath = (source: string, size: ImageSize, path: string) =>
     `media/${size}/${source}/${path}`
 

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -113,7 +113,6 @@ export type BlockElement =
     | AtomElement
     | PullquoteElement
 
-
 export interface CrosswordDimensions {
     cols: number
     rows: number
@@ -135,7 +134,7 @@ export interface CrosswordEntry {
     humanNumber?: string
     direction?: string
     position?: CrosswordPosition
-    separatorLocations?: { [key:string]: number[] }
+    separatorLocations?: { [key: string]: number[] }
     length?: number
     clue?: string
     group?: string[]
@@ -151,7 +150,7 @@ export enum CrosswordType {
     PRIZE = 4,
     EVERYMAN = 5,
     DIAN_QUIPTIC_CROSSWORD = 6,
-    WEEKEND = 7
+    WEEKEND = 7,
 }
 
 export interface CapiDateTime {
@@ -170,7 +169,7 @@ export interface Crossword {
     hasNumbers: boolean
     randomCluesOrdering: boolean
     instructions?: string
-    creator?: CrosswordCreator 
+    creator?: CrosswordCreator
     pdf?: string
     annotatedSolution?: string
     dateSolutionAvailable?: CapiDateTime
@@ -182,5 +181,8 @@ const frontPath = (issueId: string, frontId: string) =>
 const collectionPath = (issueId: string, collectionId: string) =>
     `${issuePath(issueId)}/collection/${collectionId}`
 const issueSummaryPath = () => 'issues'
+export type ImageSize = 'small' | 'notsmall'
+const mediaPath = (source: string, size: ImageSize, path: string) =>
+    `media/${size}/${source}/${path}`
 
-export { issuePath, frontPath, collectionPath, issueSummaryPath }
+export { issuePath, mediaPath, frontPath, collectionPath, issueSummaryPath }


### PR DESCRIPTION
## Why are you doing this?
By having the backend generate and sign redirect resizes we can store the images for an edition in s3 and zip them up nicely.

As far as integrations with content, this now pulls out master assets and I'll start pulling out some kind of asset object instead of urls in the CAPI response.