### PR TITLE
[WIP] Add ugly signin / signout flows

### DIFF
--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -22,6 +22,8 @@ import { NavigationScreenProp } from 'react-navigation'
 import { mapNavigationToProps } from './helpers'
 import { shouldShowOnboarding } from 'src/helpers/settings'
 import { issueToArticleScreenInterpolator } from './interpolators'
+import { AuthSwitcherScreen } from 'src/screens/auth-switcher-screen'
+import { SignoutScreen } from 'src/screens/signout-screen'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -110,29 +112,40 @@ const OnboardingStack = createStackNavigator(
     },
 )
 
+const AuthedStack = createSwitchNavigator(
+    {
+        Main: ({ navigation }: { navigation: NavigationScreenProp<{}> }) => {
+            const [settings] = useSettings()
+            useEffect(() => {
+                if (shouldShowOnboarding(settings)) {
+                    navigation.navigate('Onboarding')
+                } else {
+                    navigation.navigate('App')
+                }
+            })
+            return null
+        },
+        App: AppStack,
+        Onboarding: OnboardingStack,
+    },
+    {
+        initialRouteName: 'Main',
+    },
+)
+
 const RootNavigator = createAppContainer(
     createSwitchNavigator(
         {
-            Main: ({
-                navigation,
-            }: {
-                navigation: NavigationScreenProp<{}>
-            }) => {
-                const [settings] = useSettings()
-                useEffect(() => {
-                    if (shouldShowOnboarding(settings)) {
-                        navigation.navigate('Onboarding')
-                    } else {
-                        navigation.navigate('App')
-                    }
-                })
-                return null
-            },
-            App: AppStack,
-            Onboarding: OnboardingStack,
+            Authed: AuthedStack,
+            Unauthed: AuthSwitcherScreen,
+            Signout: mapNavigationToProps(SignoutScreen, nav => ({
+                onSignout: () => {
+                    nav.navigate('Unauthed')
+                },
+            })),
         },
         {
-            initialRouteName: 'Main',
+            initialRouteName: 'Unauthed',
         },
     ),
 )

--- a/projects/Mallard/src/screens/auth-switcher-screen.tsx
+++ b/projects/Mallard/src/screens/auth-switcher-screen.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useRef, useState } from 'react'
+import WebView from 'react-native-webview'
+import { NativeSyntheticEvent } from 'react-native'
+import { WebViewMessage } from 'react-native-webview/lib/WebViewTypes'
+import { NavigationScreenProp } from 'react-navigation'
+
+const USER_DATA_SUCCESS = 'USER_DATA_SUCCESS'
+const USER_DATA_FAILURE = 'USER_DATA_FAILURE'
+const COOKIES_NOT_SET = 'COOKIES_NOT_SET'
+
+const LOG = 'LOG'
+
+// for some reason this needs to be called inside a function when in injecting
+const injectedJavascript = `
+const hasGuIdentityCookie =
+    document
+        .cookie
+        .split(";")
+        .map(c => c.split("=")[0].trim())
+        .find(key => key === "GU_U");
+
+
+const msg = (type, data) =>
+    window.ReactNativeWebView.postMessage(JSON.stringify({
+        type,
+        data
+    }));
+
+// for debugging
+const log = str => msg('${LOG}', str);
+
+// for some reason this needs wrapping in a function
+const tryToAuthenticate = () => {
+    if (hasGuIdentityCookie) {
+        fetch('https://members-data-api.theguardian.com/user-attributes/me', {
+            credentials: 'include'
+        })
+            .then(res => res.status === 200 ? res.json() : Promise.reject())
+            .then(res => msg('${USER_DATA_SUCCESS}', res))
+            .catch(() => msg('${USER_DATA_FAILURE}'))
+    } else {
+        msg('${COOKIES_NOT_SET}')
+    }
+}
+
+tryToAuthenticate();
+`
+
+const AuthSwitcherScreen = ({
+    navigation,
+}: {
+    navigation: NavigationScreenProp<{}>
+}) => {
+    const [isWebViewHidden, setIsWebViewHidden] = useState(true)
+
+    const webViewRef = useRef<WebView>(null)
+
+    const handleLoad = useCallback(() => {
+        const { current } = webViewRef
+
+        if (current) {
+            current.injectJavaScript(injectedJavascript)
+        }
+    }, [])
+
+    const handleMessage = useCallback(
+        (event: NativeSyntheticEvent<WebViewMessage>) => {
+            const { type, data } = JSON.parse(event.nativeEvent.data)
+
+            switch (type) {
+                case USER_DATA_SUCCESS: {
+                    // TODO - change true to false
+                    if (data.contentAccess.paidMember === false) {
+                        // TODO - set a setting here rather than just navigating?
+                        navigation.navigate('Authed')
+                    }
+                    break
+                }
+                case USER_DATA_FAILURE: {
+                    // no-op
+                }
+                case COOKIES_NOT_SET: {
+                    setIsWebViewHidden(false)
+                }
+                case LOG: {
+                    console.log(data)
+                }
+            }
+        },
+        [navigation],
+    )
+
+    return (
+        <WebView
+            ref={webViewRef}
+            style={[{ display: isWebViewHidden ? 'none' : 'flex' }]}
+            source={{
+                uri: 'https://profile.theguardian.com/signin/current',
+            }}
+            onLoad={handleLoad}
+            onMessage={handleMessage}
+        />
+    )
+}
+
+export { AuthSwitcherScreen }

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -38,6 +38,15 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                 onPress={({ onPress }) => onPress()}
                 data={[
                     {
+                        key: 'Sign out',
+                        title: 'Sign out',
+                        data: {
+                            onPress: () => {
+                                navigation.navigate('Signout')
+                            },
+                        },
+                    },
+                    {
                         key: 'Downloads',
                         title: 'Manage issues',
                         data: {

--- a/projects/Mallard/src/screens/signout-screen.tsx
+++ b/projects/Mallard/src/screens/signout-screen.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import WebView from 'react-native-webview'
+
+const SignoutScreen = ({ onSignout }: { onSignout: () => void }) => (
+    <WebView
+        style={[{ display: 'none' }]}
+        source={{
+            uri: 'https://profile.theguardian.com/signout',
+        }}
+        onLoadProgress={e => {
+            // use this as a proxy for having received headers
+            // probably a better way to do this!
+            if (e.nativeEvent.title) {
+                onSignout()
+            }
+        }}
+    />
+)
+
+export { SignoutScreen }


### PR DESCRIPTION
## Why are you doing this?

This branch "works" but has the issue of only having a cookie in the webview (not in the native layer) and therefore injecting a string of js to make requests to the app from inside the web view. Oh and the sign in blocks the whole app (isn't in the right place in the flow) in order to test it more easily.

@walaura if you can get `react-native-cookies` to work reliably across devices then that might be a solution to keeping the cookie in the native layer and using them for fetching, but it kept breaking for me. Additionally, the `GU_U` cookie is the only one readable (`SC_GU_U` is not as it's secure) from the web view unless there is a special web view way of reading secure cookies that I've missed.

To get `setFromResponse` working across platforms you need to do this: https://github.com/joeferraro/react-native-cookies/issues/15#issuecomment-243125572 but even then I'm unable to auth.

If `SC_GU_U` is the only cookie that allows us to auth (which I'm pretty sure it is) then - as far as I see it - we'll need to fix _both_ of these problems to auth using the `profile.theguardian.com` flow.
