### PR TITLE
Remove flash of 'undefined'

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -31,11 +31,11 @@ export interface PathToIssue {
 
 const IssueHeader = withNavigation(
     ({ issue, navigation }: { issue?: Issue } & NavigationInjectedProps) => {
-        const { date, weekday } = useMemo(
+        const { date, weekday } = useMemo<{ date: string; weekday?: string }>(
             () =>
                 issue
                     ? renderIssueDate(issue.date * 1000 || Date.now())
-                    : { date: 'Issue', weekday: 'undefined' },
+                    : { date: 'Issue' },
             [issue && issue.key, issue],
         )
         return (


### PR DESCRIPTION
## Why are you doing this?

This isn't a total fix for the flash between `Issue` placeholder and the actual issue data (roll on Suspense!). But it does remove a flash of the word undefined ... which is my biggest JS fear.

## Screenshots

### Before
![Kapture 2019-07-11 at 10 49 38](https://user-images.githubusercontent.com/1652187/61041322-ff63df00-a3c9-11e9-8aa0-12928f0e0f37.gif)

### After
![Kapture 2019-07-11 at 10 50 55](https://user-images.githubusercontent.com/1652187/61041324-fffc7580-a3c9-11e9-91c3-c3c582bccffd.gif)

