### PR TITLE
Fix fastfile

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -48,11 +48,14 @@ end
 platform :android do
   desc "Push a new internal testing build to Google Play"
   lane :beta do
-    gradle(properties: {
-        "versionName" => version["version"]
-    })
     gradle(task: 'clean', project_dir: 'android/')
-    gradle(task: 'assemble', build_type: 'Release', project_dir: 'android/')
+    gradle(task: 'assemble',
+           build_type: 'Release',
+           project_dir: 'android/',
+           properties: {
+               "versionName" => version["version"]
+           }
+    )
     supply(
       track: 'internal',
       package_name: 'com.guardian.editions'


### PR DESCRIPTION
## Why are you doing this?

To make the android beta build properly.

`gradle(` needs an argument of `task` so I moved the properties block to the assemble task