### PR TITLE
fix: Remove Webview warning

### DIFF
--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -127,7 +127,6 @@ const Article = ({
                 <WebView
                     originWhitelist={['*']}
                     scrollEnabled={false}
-                    useWebKit={false}
                     source={{ html: html }}
                     onShouldStartLoadWithRequest={event => {
                         if (event.url !== 'about:blank') {


### PR DESCRIPTION
## Why are you doing this?

Removing the `webkit` flag on the Webview to remove the warning. This flag was forcing the use of the outdated `UIWebView` over `WKWebView`. There doesn't appear to be any need for this.
