### PR TITLE
Show the url for fetch errors and allow them to be copied

### DIFF
--- a/projects/Mallard/src/components/front/collection-page/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page/collection-page.tsx
@@ -60,7 +60,7 @@ const CollectionPage = ({
 }: { translate: Animated.AnimatedInterpolation } & PropTypes) => {
     const { appearance } = useArticleAppearance()
     if (!articlesInCard.length) {
-        return <FlexErrorMessage title={GENERIC_ERROR} />
+        return <FlexErrorMessage />
     }
     if (!pageLayout) {
         switch (articlesInCard.length) {

--- a/projects/Mallard/src/components/front/collection-page/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page/collection-page.tsx
@@ -8,7 +8,6 @@ import { Row } from './row'
 import { CAPIArticle, Issue, Collection, Front } from 'src/common'
 import { PageLayout } from '../helpers'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
-import { GENERIC_ERROR } from 'src/helpers/words'
 import {
     splashPage,
     twoStoryPage,

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -184,7 +184,6 @@ export const Front: FunctionComponent<{
     viewIsTransitioning: boolean
 }> = ({ front, issue }) => {
     const frontsResponse = useFrontsResponse(issue, front)
-    const [{ isUsingProdDevtools }] = useSettings()
 
     return frontsResponse({
         pending: () => (
@@ -196,10 +195,7 @@ export const Front: FunctionComponent<{
         ),
         error: err => (
             <Wrapper scrubber={<NavigatorSkeleton />}>
-                <FlexErrorMessage
-                    title={GENERIC_ERROR}
-                    message={isUsingProdDevtools ? err.message : undefined}
-                />
+                <FlexErrorMessage debugMessage={err.message} />
             </Wrapper>
         ),
         success: frontData => <FrontWithResponse {...{ frontData, issue }} />,

--- a/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
@@ -26,9 +26,11 @@ const ErrorMessage = ({
     return (
         <>
             {!!icon && <Text style={{ fontSize: 40 }}>{icon}</Text>}
-            <UiBodyCopy weight="bold" style={{ textAlign: 'center' }}>
-                {title}
-            </UiBodyCopy>
+            {!!title && (
+                <UiBodyCopy weight="bold" style={{ textAlign: 'center' }}>
+                    {title}
+                </UiBodyCopy>
+            )}
             {!!message && (
                 <UiExplainerCopy style={{ textAlign: 'center' }}>
                     {message}

--- a/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, Clipboard } from 'react-native'
+import { Text, Clipboard, TouchableOpacity } from 'react-native'
 import { UiExplainerCopy, UiBodyCopy } from 'src/components/styled-text'
 import { Button } from 'src/components/button/button'
 import { metrics } from 'src/theme/spacing'
@@ -35,19 +35,15 @@ const ErrorMessage = ({
                 </UiExplainerCopy>
             )}
             {isUsingProdDevtools && debugMessage ? (
-                <>
+                <TouchableOpacity
+                    onPress={() => {
+                        Clipboard.setString(debugMessage)
+                    }}
+                >
                     <UiExplainerCopy style={{ textAlign: 'center' }}>
                         {debugMessage}
                     </UiExplainerCopy>
-                    <Button
-                        style={{ marginTop: metrics.vertical }}
-                        onPress={() => {
-                            Clipboard.setString(debugMessage)
-                        }}
-                    >
-                        Copy
-                    </Button>
-                </>
+                </TouchableOpacity>
             ) : null}
             {!!action && (
                 <Button

--- a/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
@@ -1,33 +1,67 @@
 import React from 'react'
-import { Text } from 'react-native'
+import { Text, Clipboard } from 'react-native'
 import { UiExplainerCopy, UiBodyCopy } from 'src/components/styled-text'
 import { Button } from 'src/components/button/button'
 import { metrics } from 'src/theme/spacing'
+import { GENERIC_ERROR } from 'src/helpers/words'
+import { useSettings } from 'src/hooks/use-settings'
 
 export interface PropTypes {
-    title: string
+    title?: string
     icon?: string
     message?: string
+    debugMessage?: string
     action?: [string, () => void]
 }
 
-const ErrorMessage = ({ icon, title, message, action }: PropTypes) => (
-    <>
-        {!!icon && <Text style={{ fontSize: 40 }}>{icon}</Text>}
-        <UiBodyCopy weight="bold" style={{ textAlign: 'center' }}>
-            {title}
-        </UiBodyCopy>
-        {!!message && (
-            <UiExplainerCopy style={{ textAlign: 'center' }}>
-                {message}
-            </UiExplainerCopy>
-        )}
-        {!!action && (
-            <Button style={{ marginTop: metrics.vertical }} onPress={action[1]}>
-                {action[0]}
-            </Button>
-        )}
-    </>
-)
+const ErrorMessage = ({
+    icon,
+    title,
+    message,
+    debugMessage,
+    action,
+}: PropTypes) => {
+    const [{ isUsingProdDevtools }] = useSettings()
+
+    return (
+        <>
+            {!!icon && <Text style={{ fontSize: 40 }}>{icon}</Text>}
+            <UiBodyCopy weight="bold" style={{ textAlign: 'center' }}>
+                {title}
+            </UiBodyCopy>
+            {!!message && (
+                <UiExplainerCopy style={{ textAlign: 'center' }}>
+                    {message}
+                </UiExplainerCopy>
+            )}
+            {isUsingProdDevtools && debugMessage ? (
+                <>
+                    <UiExplainerCopy style={{ textAlign: 'center' }}>
+                        {debugMessage}
+                    </UiExplainerCopy>
+                    <Button
+                        style={{ marginTop: metrics.vertical }}
+                        onPress={() => {
+                            Clipboard.setString(debugMessage)
+                        }}
+                    >
+                        Copy
+                    </Button>
+                </>
+            ) : null}
+            {!!action && (
+                <Button
+                    style={{ marginTop: metrics.vertical }}
+                    onPress={action[1]}
+                >
+                    {action[0]}
+                </Button>
+            )}
+        </>
+    )
+}
+ErrorMessage.defaultProps = {
+    title: GENERIC_ERROR,
+}
 
 export { ErrorMessage }

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -36,6 +36,9 @@ const fetchFromApiSlow = async <T>(
                 throw new Error(REQUEST_INVALID_RESPONSE_VALIDATION)
             }
         })
+        .catch(err => {
+            throw new Error(`${err.message} @ [${apiUrl + path}]`)
+        })
 }
 
 const fetchFromFileSystemSlow = <T>(

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -106,8 +106,7 @@ export const HomeScreen = ({
                     ),
                     error: ({ message }, { retry }) => (
                         <FlexErrorMessage
-                            title={GENERIC_ERROR}
-                            message={isUsingProdDevtools ? message : undefined}
+                            debugMessage={message}
                             action={['Retry', retry]}
                         />
                     ),

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -7,11 +7,9 @@ import { WithAppAppearance } from 'src/theme/appearance'
 import { metrics } from 'src/theme/spacing'
 import { useFileList } from 'src/hooks/use-fs'
 import { unzipIssue } from 'src/helpers/files'
-import { GENERIC_ERROR } from 'src/helpers/words'
 import { color } from 'src/theme/color'
 import { Spinner } from 'src/components/spinner'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
-import { useSettings } from 'src/hooks/use-settings'
 import { FlexCenter } from 'src/components/layout/flex-center'
 import { useIssueSummary } from 'src/hooks/use-api'
 import { Button, ButtonAppearance } from 'src/components/button/button'
@@ -48,7 +46,6 @@ export const HomeScreen = ({
 }) => {
     const [files, { refreshIssues }] = useFileList()
     const issueSummary = useIssueSummary()
-    const [{ isUsingProdDevtools }] = useSettings()
     const { top: paddingTop } = useInsets()
 
     return (

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -82,8 +82,7 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                         <IssueHeader />
 
                         <FlexErrorMessage
-                            title={GENERIC_ERROR}
-                            message={isUsingProdDevtools ? message : undefined}
+                            debugMessage={message}
                             action={['Retry', retry]}
                         />
                     </>


### PR DESCRIPTION
## Why are you doing this?

Not having this was making debugging a bit painful. Click on them to copy the text.

<img width="436" alt="Screenshot 2019-07-15 at 10 05 11" src="https://user-images.githubusercontent.com/11539094/61205501-1e26e600-a6e8-11e9-862e-e9ab5cef6f13.png">
