### PR TITLE
Make API a little less crash happy

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -168,7 +168,31 @@ const parseArticleResult = async (
             return crosswordArticle
 
         default:
-            throw new Error(`${path} isn't an article, crossword or gallery.`)
+            return [
+                internalid,
+                {
+                    type: 'article',
+                    id: internalid,
+                    path: path,
+                    headline: title,
+                    kicker,
+                    image: maybeImage,
+                    byline: byline || '',
+                    standfirst: standfirst || '',
+                    elements: [
+                        {
+                            id: 'html',
+                            html: `We can't render content type ${
+                                ContentType[result.type]
+                            } currently`,
+                        },
+                        {
+                            id: 'html',
+                            html: `<pre>${JSON.stringify(result.apiUrl)}</pre>`,
+                        },
+                    ],
+                },
+            ]
     }
 }
 

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -12,7 +12,11 @@ const getIssue = async (
 ): Promise<Issue | 'notfound'> => {
     console.log('Attempting to get latest issue for', issue)
     const latest = await s3Latest(`daily-edition/${issue}/`)
-    if (hasFailed(latest)) return 'notfound'
+    if (hasFailed(latest)) {
+        console.error(`Could not get latest issue.`)
+        console.error(JSON.stringify(latest))
+        return 'notfound'
+    }
     const { key } = latest
     console.log(`Fetching ${key} for ${issue}`)
 

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -80,13 +80,6 @@ export const parseCollection = async (
                     ]
 
                 case 'gallery':
-                    const galleryImage = imageOverride || article.image
-                    if (galleryImage == null) {
-                        throw new Error(
-                            `No image found in article: ${article.path}`,
-                        )
-                    }
-
                     return [
                         article.path,
                         {
@@ -94,18 +87,10 @@ export const parseCollection = async (
                             key: article.path,
                             headline,
                             kicker,
-                            image: galleryImage,
                         },
                     ]
 
                 case 'article':
-                    const articleImage = imageOverride || article.image
-                    if (articleImage == null) {
-                        throw new Error(
-                            `No image found in article: ${article.path}`,
-                        )
-                    }
-
                     return [
                         article.path,
                         {
@@ -113,7 +98,7 @@ export const parseCollection = async (
                             key: article.path,
                             headline,
                             kicker,
-                            image: articleImage,
+                            image: imageOverride || article.image,
                         },
                     ]
 

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -173,7 +173,9 @@ export const getFront = async (
     }
 
     const collections = await Promise.all(
-        front.collections.map(collection => parseCollection(collection)),
+        front.collections
+            .filter(collection => collection.items.length > 0)
+            .map(collection => parseCollection(collection)),
     )
 
     collections.filter(hasFailed).forEach(failedCollection => {

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -23,8 +23,8 @@ const s3 = new S3({
         : new SharedIniFileCredentials({ profile: 'cmsFronts' }),
 })
 
-const stage = process.env.stage || 'code'
-const bucket = `published-editions-${stage.toLowerCase()}`
+// const stage = process.env.stage || 'code'
+const bucket = `published-editions-prod` //${stage.toLowerCase()}`
 
 interface S3Response {
     text: () => Promise<string>

--- a/projects/common/src/collection/card-layouts.ts
+++ b/projects/common/src/collection/card-layouts.ts
@@ -1,6 +1,7 @@
 import { CollectionCardLayouts } from '..'
 
 export const cardLayouts: CollectionCardLayouts = {
+    0: [],
     1: [1],
     2: [1, 1],
     3: [1, 2],

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -50,7 +50,7 @@ export interface Article extends WithKey {
     type: 'article'
     headline: string
     kicker: string
-    image: Image
+    image?: Image
     byline: string
     standfirst: string
     elements: BlockElement[]


### PR DESCRIPTION
## Why are you doing this?
The backend currently crashes on content without images and deletes things it can't display. So this will just send a response without an image and a placeholder  for now.