### PR TITLE
Implement editorial rules for displaying kicker.

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -13,6 +13,7 @@ import { ICrossword } from '@guardian/capi-ts/dist/Crossword'
 import fetch from 'node-fetch'
 import { cleanupHtml } from '../utils/html'
 import { fromPairs } from 'ramda'
+import { kickerPicker } from './kickerPicker'
 
 interface Article {
     type: 'article'
@@ -50,63 +51,6 @@ export interface CrosswordArticle {
 }
 
 export type CAPIContent = Article | CrosswordArticle | GalleryArticle
-
-/*
- - Use series tag if we have one
- - Use tone for {"Letters", "Analysis", "Obituaries"}
- - Use tone without the last character for {"Reviews", "Editorials", "Match Reports", "Explainers"}
- - Use byline for "Comment" tone
- - Use top tag if both top and second tag feature in the headline
- - Use second tag if top tag features in the headline
- - Otherwise use top tag
- */
-const kickerPicker = (article: IContent, headline: string, byline: string) => {
-    let seriesTag: ITag | undefined = article.tags.filter(
-        tag => tag.type == TagType.SERIES,
-    )[0]
-
-    let toneTag: ITag | undefined = article.tags.filter(
-        tag => tag.type == TagType.TONE,
-    )[0]
-
-    let topTag: ITag | undefined = article.tags[0]
-    let secondTag: ITag | undefined = article.tags[1]
-
-    if (seriesTag) return seriesTag.webTitle
-
-    if (
-        (toneTag && toneTag.id && toneTag.id == 'tone/letters') ||
-        toneTag.id == 'tone/analysis' ||
-        toneTag.id == 'tone/obituaries'
-    )
-        return toneTag.webTitle
-
-    if (
-        (toneTag && toneTag.id && toneTag.id == 'tone/reviews') ||
-        toneTag.id == 'tone/editorials' ||
-        toneTag.id == 'tone/matchreports' ||
-        toneTag.id == 'tone/explainers'
-    )
-        return toneTag.webTitle.substring(0, toneTag.webTitle.length - 1)
-
-    if (toneTag && toneTag.id && toneTag.id == 'tone/comment') return byline
-
-    if (
-        topTag &&
-        headline.toLowerCase().includes(topTag.webTitle.toLowerCase()) &&
-        secondTag &&
-        headline.toLowerCase().includes(secondTag.webTitle.toLowerCase())
-    )
-        return topTag.webTitle
-
-    if (
-        topTag &&
-        headline.toLowerCase().includes(topTag.webTitle.toLowerCase())
-    )
-        return secondTag && secondTag.webTitle
-
-    return topTag && topTag.webTitle
-}
 
 const parseArticleResult = async (
     result: IContent,

--- a/projects/backend/capi/kickerPicker.ts
+++ b/projects/backend/capi/kickerPicker.ts
@@ -1,0 +1,66 @@
+import { TagType } from '@guardian/capi-ts'
+import { IContent } from '@guardian/capi-ts/dist/Content'
+import { ITag } from '@guardian/capi-ts/dist/Tag'
+
+/*
+ - Use series tag if we have one
+ - Use tone for {"Letters", "Analysis", "Obituaries"}
+ - Use tone without the last character for {"Reviews", "Editorials", "Match Reports", "Explainers"}
+ - Use byline for "Comment" tone
+ - Use top tag if both top and second tag feature in the headline
+ - Use second tag if top tag features in the headline
+ - Otherwise use top tag
+ */
+const kickerPicker = (
+    article: IContent,
+    headline: string,
+    byline: string | undefined,
+) => {
+    let seriesTag: ITag | undefined = article.tags.filter(
+        tag => tag.type == TagType.SERIES,
+    )[0]
+
+    let toneTag: ITag | undefined = article.tags.filter(
+        tag => tag.type == TagType.TONE,
+    )[0]
+
+    let topTag: ITag | undefined = article.tags[0]
+    let secondTag: ITag | undefined = article.tags[1]
+
+    if (seriesTag) return seriesTag.webTitle
+
+    if (
+        (toneTag && toneTag.id && toneTag.id == 'tone/letters') ||
+        toneTag.id == 'tone/analysis' ||
+        toneTag.id == 'tone/obituaries'
+    )
+        return toneTag.webTitle
+
+    if (
+        (toneTag && toneTag.id && toneTag.id == 'tone/reviews') ||
+        toneTag.id == 'tone/editorials' ||
+        toneTag.id == 'tone/matchreports' ||
+        toneTag.id == 'tone/explainers'
+    )
+        return toneTag.webTitle.substring(0, toneTag.webTitle.length - 1)
+
+    if (toneTag && toneTag.id && toneTag.id == 'tone/comment') return byline
+
+    if (
+        topTag &&
+        headline.toLowerCase().includes(topTag.webTitle.toLowerCase()) &&
+        secondTag &&
+        headline.toLowerCase().includes(secondTag.webTitle.toLowerCase())
+    )
+        return topTag.webTitle
+
+    if (
+        topTag &&
+        headline.toLowerCase().includes(topTag.webTitle.toLowerCase())
+    )
+        return secondTag && secondTag.webTitle
+
+    return topTag && topTag.webTitle
+}
+
+export { kickerPicker }


### PR DESCRIPTION
## Why are you doing this?
In order to avoid the kicker being repeated across content and duplicating parts of the headline, we have established editorial rules for displaying a given kicker for an article. 
