### PR TITLE
Add scripts for fetching env files

### DIFF
--- a/projects/Mallard/.env.production.js
+++ b/projects/Mallard/.env.production.js
@@ -1,0 +1,6 @@
+const { fetchRequiredEnvVars } = require('./scripts/helpers/helpers.js')
+
+fetchRequiredEnvVars`
+ID_ACCESS_TOKEN
+ID_API_URL
+`

--- a/projects/Mallard/.env.production.js
+++ b/projects/Mallard/.env.production.js
@@ -1,6 +1,6 @@
-const { fetchRequiredEnvVars } = require('./scripts/helpers/helpers.js')
+const { writeRequiredEnvVars } = require('./scripts/helpers/helpers.js')
 
-fetchRequiredEnvVars`
+writeRequiredEnvVars`
 ID_ACCESS_TOKEN
 ID_API_URL
 `

--- a/projects/Mallard/Makefile
+++ b/projects/Mallard/Makefile
@@ -1,12 +1,10 @@
 debug-android:
 	mkdir -p android/app/src/main/assets
-	yarn pre-bundle
 	yarn bundle-android
 	cd android && ./gradlew assembleDebug && cd ..
 	cp android/app/build/outputs/apk/debug/app-debug.apk .
 
 debug-ios:
-	yarn pre-bundle
 	yarn bundle-ios
 	xcodebuild archive -allowProvisioningUpdates -project ios/Mallard.xcodeproj -configuration Debug -scheme Mallard -derivedDataPath ./ -archivePath "./Mallard.xcarchive" > build.log
 	xcodebuild -exportArchive -allowProvisioningUpdates -exportOptionsPlist ios/exports-plists/debug.plist -archivePath "./Mallard.xcarchive" -exportPath ./ >> build.log
@@ -17,7 +15,6 @@ beta-ios:
 
 beta-android:
 	mkdir -p android/app/src/main/assets
-	yarn pre-bundle
 	yarn bundle-android
 	rm -rf android/app/src/main/res/drawable-*
 	fastlane android beta

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -3,8 +3,8 @@
     "version": "0.0.1",
     "private": true,
     "scripts": {
-        "pre-run": "yarn watch-html & node ./scripts/versioning.js",
-        "pre-bundle": "yarn bundle-html",
+        "pre-run": "yarn fetch-dev-env && yarn watch-html & node ./scripts/versioning.js",
+        "pre-bundle": "yarn fetch-prod-env && yarn bundle-html",
         "postinstall": "node ./scripts/versioning.js",
         "start": "yarn pre-run && node node_modules/react-native/local-cli/cli.js start",
         "test": "jest --coverage",
@@ -16,12 +16,14 @@
         "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\"",
         "validate": "cd ../.. && yarn validate-mallard",
         "fix": "cd ../.. && yarn fix-mallard",
-        "bundle-android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
-        "bundle-ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
+        "bundle-android": "yarn pre-bundle && react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
+        "bundle-ios": "yarn pre-bundle && react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
         "rn-link": "react-native link",
         "bundle-html": "node ./scripts/bundle-html.js",
         "watch-html": "node ./scripts/watch-html.js",
-        "convert-svg": "node ./scripts/svgs.js"
+        "convert-svg": "node ./scripts/svgs.js",
+        "fetch-dev-env": "aws s3 cp s3://editions-config/Mallard/dev/.env ./.env --region=eu-west-1 --profile=frontend",
+        "fetch-prod-env": "node .env.production.js"
     },
     "rnpm": {
         "assets": [

--- a/projects/Mallard/scripts/helpers/helpers.js
+++ b/projects/Mallard/scripts/helpers/helpers.js
@@ -12,7 +12,7 @@ const getValueFromKey = map => key => {
 const writeToEnvFileinCWD = data =>
     fs.writeFileSync(path.join(process.cwd(), '.env'), data)
 
-const fetchRequiredEnvVars = strings =>
+const writeRequiredEnvVars = strings =>
     writeToEnvFileinCWD(
         strings[0]
             .split(NEWLINE)
@@ -22,4 +22,4 @@ const fetchRequiredEnvVars = strings =>
             .join(NEWLINE),
     )
 
-module.exports = { fetchRequiredEnvVars }
+module.exports = { writeRequiredEnvVars }

--- a/projects/Mallard/scripts/helpers/helpers.js
+++ b/projects/Mallard/scripts/helpers/helpers.js
@@ -1,0 +1,25 @@
+const path = require('path')
+const fs = require('fs')
+
+const NEWLINE = '\n'
+const removeWhiteSpace = s => s.trim()
+const isNonEmpty = s => s
+const getValueFromKey = map => key => {
+    const value = map[key]
+    if (!value) throw new Error(`Could not find ${key}`)
+    return `${key}=${value}`
+}
+const writeToEnvFileinCWD = data =>
+    fs.writeFileSync(path.join(process.cwd(), '.env'), data)
+
+const fetchRequiredEnvVars = strings =>
+    writeToEnvFileinCWD(
+        strings[0]
+            .split(NEWLINE)
+            .map(removeWhiteSpace)
+            .filter(isNonEmpty)
+            .map(getValueFromKey(process.env))
+            .join(NEWLINE),
+    )
+
+module.exports = { fetchRequiredEnvVars }


### PR DESCRIPTION
## Why are you doing this?

Add two scripts to fetch `.env` files for either `DEV` or `PROD` environments. As can be seen in the code, the prod config will be fetched on `pre-bundle` and the dev config on `pre-run`. This means that the dev config is fetched quite a lot (every time we run) but it seemed safer to do it this way. Additionally, the error should be pretty obvious for people who try this offline.

(I've added two files to s3 for this too).

@AWare - it looks like `aws` isn't on the boxes so it looks like this _isn't_ how this is done in the wild - let's do this idiomatically.