### PR TITLE
fix multi metro

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -16,7 +16,7 @@
         "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\"",
         "validate": "cd ../.. && yarn validate-mallard",
         "fix": "cd ../.. && yarn fix-mallard",
-        "exit-if-metro-running": "lsof -ni tcp:8081 | grep \"node\" && exit 1",
+        "exit-if-metro-running": "lsof -ni tcp:8081 | grep \"node\" && echo \"Build already running on other build agent, please requeue\" && exit 1",
         "kill-metro": "lsof -ti tcp:8081 | xargs kill",
         "bundle-android": "yarn pre-bundle && react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
         "bundle-ios": "yarn pre-bundle && react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "pre-run": "yarn watch-html & node ./scripts/versioning.js",
-        "pre-bundle": "yarn bundle-html && node ./scripts/versioning.js",
+        "pre-bundle": "yarn exit-if-metro-running && yarn bundle-html && node ./scripts/versioning.js",
         "postinstall": "yarn pre-bundle",
         "start": "yarn pre-run && node node_modules/react-native/local-cli/cli.js start",
         "test": "jest --coverage",
@@ -16,6 +16,8 @@
         "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\"",
         "validate": "cd ../.. && yarn validate-mallard",
         "fix": "cd ../.. && yarn fix-mallard",
+        "exit-if-metro-running": "lsof -ni tcp:8081 | grep \"node\" && exit 1",
+        "kill-metro": "lsof -ti tcp:8081 | xargs kill",
         "bundle-android": "yarn pre-bundle && react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
         "bundle-ios": "yarn pre-bundle && react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest=ios",
         "rn-link": "react-native link",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "scripts": {
         "pre-run": "yarn watch-html & node ./scripts/versioning.js",
-        "pre-bundle": "yarn exit-if-metro-running && yarn bundle-html && node ./scripts/versioning.js",
+        "pre-bundle": "yarn exit-if-metro-running && yarn bundle-html",
+        "postinstall": "node ./scripts/versioning.js",
         "start": "yarn pre-run && node node_modules/react-native/local-cli/cli.js start",
         "test": "jest --coverage",
         "test:watch": "jest --watch",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -5,7 +5,6 @@
     "scripts": {
         "pre-run": "yarn watch-html & node ./scripts/versioning.js",
         "pre-bundle": "yarn exit-if-metro-running && yarn bundle-html && node ./scripts/versioning.js",
-        "postinstall": "yarn pre-bundle",
         "start": "yarn pre-run && node node_modules/react-native/local-cli/cli.js start",
         "test": "jest --coverage",
         "test:watch": "jest --watch",


### PR DESCRIPTION
While looking at the build agent with @LATaylor-guardian I noticed that metro would continue to run after the build had finished. As there are two agents running on the build mac, and each one has a working directory it seems plausible that we could bundle an old version of the app when building. 

Todo: update tc build to kill metro on finishing.