### PR TITLE
Ensure weather is split right on all screens

### DIFF
--- a/projects/Mallard/src/components/header/index.tsx
+++ b/projects/Mallard/src/components/header/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 import { View, StyleSheet } from 'react-native'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
-import { IssueTitle, IssueTitleProps, IssueRowSplit } from '../issue'
+import { IssueTitle, IssueTitleProps, GridRowSplit } from '../issue'
 import { useInsets } from 'src/hooks/use-insets'
 
 const styles = StyleSheet.create({
@@ -27,7 +27,7 @@ const Header = ({
     const { top: paddingTop } = useInsets()
     return (
         <View style={[styles.background]}>
-            <IssueRowSplit style={{ paddingTop }}>
+            <GridRowSplit style={{ paddingTop }}>
                 <View
                     style={{
                         justifyContent: 'space-between',
@@ -38,7 +38,7 @@ const Header = ({
                     <IssueTitle {...IssueIssueTitleProps} />
                     {action}
                 </View>
-            </IssueRowSplit>
+            </GridRowSplit>
         </View>
     )
 }

--- a/projects/Mallard/src/components/issue/index.tsx
+++ b/projects/Mallard/src/components/issue/index.tsx
@@ -13,7 +13,7 @@ const splitStyles = StyleSheet.create({
     },
 })
 
-const IssueRowSplit = ({
+const GridRowSplit = ({
     children,
     style,
 }: {
@@ -22,7 +22,7 @@ const IssueRowSplit = ({
         Pick<ViewStyle, 'paddingTop' | 'paddingVertical' | 'paddingBottom'>
     >
 }) => {
-    const width = metrics.issueHeaderSplit()
+    const width = metrics.gridRowSplit()
     return (
         <View style={[splitStyles.container, style]}>
             <View style={[splitStyles.inner, { width }]}>{children}</View>
@@ -79,4 +79,4 @@ IssueTitle.defaultProps = {
     appearance: IssueTitleAppearance.default,
 }
 
-export { IssueTitle, IssueRowSplit }
+export { IssueTitle, GridRowSplit }

--- a/projects/Mallard/src/components/layout/ui/issue-row.tsx
+++ b/projects/Mallard/src/components/layout/ui/issue-row.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import {
     IssueTitle,
     IssueTitleAppearance,
-    IssueRowSplit,
+    GridRowSplit,
 } from 'src/components/issue'
 import { RowWrapper, RowWrapperProps } from './row'
 import { IssueSummary } from 'src/common'
@@ -18,13 +18,13 @@ const IssueRow = ({
 
     return (
         <RowWrapper onPress={onPress}>
-            <IssueRowSplit>
+            <GridRowSplit>
                 <IssueTitle
                     title={date}
                     subtitle={weekday}
                     appearance={IssueTitleAppearance.ocean}
                 />
-            </IssueRowSplit>
+            </GridRowSplit>
         </RowWrapper>
     )
 }

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -7,6 +7,9 @@ import { metrics } from 'src/theme/spacing'
 import { WeatherIcon } from './weather/weatherIcon'
 import Moment from 'moment'
 import { fetchWeather } from 'src/helpers/fetch'
+import { GridRowSplit } from './issue'
+
+const narrowSpace = String.fromCharCode(8201)
 
 const styles = StyleSheet.create({
     weatherContainer: {
@@ -14,6 +17,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         width: 'auto',
         height: 60,
+        marginBottom: 24,
         paddingLeft: metrics.horizontal,
         paddingRight: metrics.horizontal,
     },
@@ -26,7 +30,7 @@ const styles = StyleSheet.create({
         borderColor: '#BDBDBD',
         justifyContent: 'center',
         alignItems: 'flex-start',
-        paddingLeft: 10,
+        paddingLeft: 4,
         paddingTop: 2,
     },
     temperature: {
@@ -42,7 +46,7 @@ const styles = StyleSheet.create({
         lineHeight: 13,
     },
     locationNameContainer: {
-        flex: 7.5,
+        flex: 1,
         height: 60,
         flexDirection: 'row',
     },
@@ -97,29 +101,41 @@ const Weather = () => {
                         <Text style={styles.locationPinIcon}>{'\uE01B'}</Text>
                         <Text style={styles.locationName}>{'London'}</Text>
                     </View>
-                    {/*Get the hourly forecast in 2 hour intervals from the 12 hour forecast.*/}
-                    {[0, 2, 4, 6, 8].map(idx => {
-                        return (
-                            <View style={styles.forecastItem} key={idx}>
-                                <WeatherIcon
-                                    iconNumber={forecasts[idx].WeatherIcon}
-                                    fontSize={30}
-                                />
-                                <Text style={styles.temperature}>
-                                    {Math.round(
-                                        forecasts[idx].Temperature.Value,
-                                    ) +
-                                        ' ' +
-                                        forecasts[idx].Temperature.Unit}
-                                </Text>
-                                <Text style={styles.dateTime}>
-                                    {Moment(forecasts[idx].DateTime).format(
-                                        'h a',
-                                    )}
-                                </Text>
-                            </View>
-                        )
-                    })}
+                    <GridRowSplit>
+                        {/*Get the hourly forecast in 2 hour intervals from the 12 hour forecast.*/}
+                        {[0, 2, 4, 6, 8].map(idx => {
+                            return (
+                                <View style={styles.forecastItem} key={idx}>
+                                    <WeatherIcon
+                                        iconNumber={forecasts[idx].WeatherIcon}
+                                        fontSize={30}
+                                    />
+                                    <Text
+                                        numberOfLines={1}
+                                        ellipsizeMode="clip"
+                                        style={styles.temperature}
+                                    >
+                                        {Math.round(
+                                            forecasts[idx].Temperature.Value,
+                                        ) +
+                                            ' ' +
+                                            forecasts[idx].Temperature.Unit}
+                                    </Text>
+                                    <Text
+                                        numberOfLines={1}
+                                        ellipsizeMode="clip"
+                                        style={styles.dateTime}
+                                    >
+                                        {Moment(forecasts[idx].DateTime).format(
+                                            `h${
+                                                narrowSpace /* Narrow space for iPhone 5 */
+                                            }a`,
+                                        )}
+                                    </Text>
+                                </View>
+                            )
+                        })}
+                    </GridRowSplit>
                 </View>
             )
         }

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -18,7 +18,7 @@ import { IssueRow } from 'src/components/layout/ui/issue-row'
 import { useInsets } from 'src/hooks/use-insets'
 import { Highlight } from 'src/components/highlight'
 import { IssueTitleText } from 'src/components/styled-text'
-import { IssueRowSplit } from 'src/components/issue'
+import { GridRowSplit } from 'src/components/issue'
 import { ScrollContainer } from 'src/components/layout/ui/container'
 
 const SettingsLink = ({ onPress }: { onPress: () => void }) => (
@@ -32,9 +32,9 @@ const SettingsLink = ({ onPress }: { onPress: () => void }) => (
                 borderBottomWidth: StyleSheet.hairlineWidth,
             }}
         >
-            <IssueRowSplit>
+            <GridRowSplit>
                 <IssueTitleText>Settings</IssueTitleText>
-            </IssueRowSplit>
+            </GridRowSplit>
         </View>
     </Highlight>
 )
@@ -80,7 +80,7 @@ export const HomeScreen = ({
                                     paddingVertical: metrics.vertical * 4,
                                 }}
                             >
-                                <IssueRowSplit>
+                                <GridRowSplit>
                                     <Button
                                         onPress={retry}
                                         icon={''}
@@ -97,7 +97,7 @@ export const HomeScreen = ({
                                     >
                                         Go to latest
                                     </Button>
-                                </IssueRowSplit>
+                                </GridRowSplit>
                             </View>
                         </>
                     ),

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -13,7 +13,7 @@ export const metrics = {
     headerHeight,
     frontsPageSides: basicMetrics.horizontal * 1.5,
     frontsPageHeight: 540,
-    issueHeaderSplit: () => {
+    gridRowSplit: () => {
         const { width } = Dimensions.get('window')
         return width * 0.6
     },


### PR DESCRIPTION
## Why are you doing this?

Fixes weather layout on wider screens using the previously named `IssueRowSplit`, I've renamed to `GridRowSplit` for the time being to be more generic.

[**Trello Card ->**](https://trello.com/c/opEncVf0/286-clean-up-design-debt-first-set-of-snags-timebox)

## Screenshots

<img width="842" alt="Screenshot 2019-07-22 at 14 30 55" src="https://user-images.githubusercontent.com/1652187/61636340-551f6d80-ac8d-11e9-92d5-7a3bc5746a37.png">

