### PR TITLE
Bump icons downward

### DIFF
--- a/projects/Mallard/src/components/weather/weatherIcon.tsx
+++ b/projects/Mallard/src/components/weather/weatherIcon.tsx
@@ -6,6 +6,7 @@ const styles = StyleSheet.create({
         flex: 0,
     },
     baseWeatherIcon: {
+        bottom: 0,
         fontFamily: 'GuardianWeatherIcons-Regular',
         position: 'absolute',
     },


### PR DESCRIPTION
## Why are you doing this?

This knocks down the weather icons to the bottom of their content boxes. This isn't an issue on the emulators so it's quite difficult to make a screenshot, just trust me!
