### PR TITLE
Revert to superhero card for time being

### DIFF
--- a/projects/Mallard/src/components/front/collection-page/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page/collection-page.tsx
@@ -69,7 +69,7 @@ const CollectionPage = ({
             //     break
             //THIS IS JUST FOR DEVELOPMENT TODO: Make this layout work from API
             case 1:
-                pageLayout = splashPage
+                pageLayout = superHeroPage
                 break
             case 2:
                 pageLayout = twoStoryPage


### PR DESCRIPTION
## Why are you doing this?

The current leading card (_the one with the massive image ™️_) requires some tooling to make the image actually suitable. For now we're reverting back to the square-imaged card.

## Screenshots
<img width="415" alt="Screenshot 2019-07-23 at 16 58 52" src="https://user-images.githubusercontent.com/1652187/61727470-58892680-ad6b-11e9-85af-b095246518da.png">

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
