### PR TITLE
Add patch for pillar colours, and hook to use them

### DIFF
--- a/projects/Mallard/src/components/article/article-standfirst.tsx
+++ b/projects/Mallard/src/components/article/article-standfirst.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { View, StyleSheet, Animated, StyleProp } from 'react-native'
 import { StandfirstText, BodyCopy } from '../styled-text'
 import { metrics } from 'src/theme/spacing'
-import { useArticleAppearance } from 'src/theme/appearance'
+import { useArticleAppearance, useArticleToneColor } from 'src/theme/appearance'
 import { Multiline } from '../multiline'
 
 export interface PropTypes {
@@ -28,6 +28,7 @@ const styles = StyleSheet.create({
 
 const Standfirst = ({ standfirst, byline, style }: PropTypes) => {
     const { appearance, name } = useArticleAppearance()
+    const color = useArticleToneColor()
     return (
         <Animated.View
             style={[styles.background, appearance.backgrounds, style]}
@@ -55,7 +56,7 @@ const Standfirst = ({ standfirst, byline, style }: PropTypes) => {
                 />
                 <BodyCopy
                     weight={'bold'}
-                    style={[appearance.text, appearance.byline]}
+                    style={[appearance.text, appearance.byline, { color }]}
                 >
                     {byline}
                 </BodyCopy>

--- a/projects/Mallard/src/components/styled-text.tsx
+++ b/projects/Mallard/src/components/styled-text.tsx
@@ -8,7 +8,7 @@ import {
     TextProps,
     ViewStyle,
 } from 'react-native'
-import { useAppAppearance } from 'src/theme/appearance'
+import { useAppAppearance, useArticleToneColor } from 'src/theme/appearance'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
 import { getFont } from 'src/theme/typography'
@@ -106,7 +106,16 @@ export const HeadlineKickerText = ({
     children: string
     style?: StyleProp<TextStyle>
 } & TextProps) => {
-    return <Text {...props} style={[styles.headlineKickerText, style]} />
+    return (
+        <Text
+            {...props}
+            style={[
+                styles.headlineKickerText,
+                style,
+                { color: useArticleToneColor() },
+            ]}
+        />
+    )
 }
 
 export const StandfirstText = ({

--- a/projects/Mallard/src/theme/appearance.ts
+++ b/projects/Mallard/src/theme/appearance.ts
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react'
 import merge from 'deepmerge'
 import { ColorFromPalette } from 'src/common'
 import { metrics } from './spacing'
+import { getColor } from 'src/helpers/transform'
 
 /*
 Types
@@ -235,3 +236,6 @@ export const useArticleAppearance = (): {
             : articleAppearances.neutral,
     }
 }
+
+export const useArticleToneColor = () =>
+    getColor({ color: useArticleAppearance().name })

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -124,22 +124,45 @@ const getDisplayName = (front: string) => {
 }
 
 const getFrontColor = (front: string): WithColor => {
-    switch (front.split('/').pop() || front) {
+    switch ((front.split('/').pop() || front).toLowerCase()) {
+        case 'special1':
+        case 'special2':
         case 'topstories':
+        case 'crossword':
+        case 'special 1':
+        case 'special 2':
+        case 'top stories':
+        case 'crosswords':
             return { color: 'neutral' }
-        case 'news':
-        case 'new':
+        case 'uknewsguardian':
+        case 'uknewsobserver':
+        case 'worldnewsguardian':
+        case 'worldnewsobserver':
+        case 'uk news':
+        case 'world news':
             return { color: 'news' }
-        case 'opinion':
         case 'journal':
+        case 'comment':
+        case 'opinion':
             return { color: 'opinion' }
+        case 'arts':
+        case 'filmandmusic':
+        case 'guide':
+        case 'newreview':
+        case 'books':
+        case 'culture':
+        case 'books':
+            return { color: 'culture' }
         case 'sport':
             return { color: 'sport' }
-        case 'life':
-        case 'review':
-        case 'guide':
+        case 'features':
         case 'weekend':
+        case 'magazine':
         case 'food':
+        case 'observerfood':
+        case 'lifestyle':
+        case 'food':
+        case 'the fashion':
             return { color: 'lifestyle' }
     }
     return { color: 'neutral' }


### PR DESCRIPTION
## Why are you doing this?

We have different (temporary) names for fronts which meant that colours weren't coming through where they should have been. Additionally, I've added a way to get the correct tone colour for an article. This is used here in the kicker and byline.

![Screenshot 2019-07-23 at 18 28 04](https://user-images.githubusercontent.com/1652187/61733394-a1df7300-ad77-11e9-8506-2baad0908dd3.png)

