### PR TITLE
Rahb/add article slide

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -20,7 +20,10 @@ import {
     AnimatedFlatListRef,
     getNearestPage,
 } from './helpers'
-import { WithArticleAppearance } from 'src/theme/appearance'
+import {
+    WithArticleAppearance,
+    getAppearancePillar,
+} from 'src/theme/appearance'
 import { useFrontsResponse } from 'src/hooks/use-issue'
 import { ArticleNavigator } from '../../screens/article-screen'
 
@@ -66,9 +69,8 @@ const FrontWithResponse = ({
     issue: Issue['key']
     frontData: FrontType
 }) => {
-    const color = getColor(frontData)
-    const appearance =
-        frontData.color === 'custom' ? 'neutral' : frontData.color
+    const color = getColor(frontData.appearance)
+    const appearance = getAppearancePillar(frontData.appearance)
 
     const [scrollX] = useState(() => new Animated.Value(0))
     const flatListRef = useRef<AnimatedFlatListRef | undefined>()
@@ -87,6 +89,7 @@ const FrontWithResponse = ({
                         issue,
                     }),
                 ),
+                appearance: frontData.appearance,
             }
             return [flatCollections, navigator]
         },

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -90,6 +90,7 @@ const FrontWithResponse = ({
                     }),
                 ),
                 appearance: frontData.appearance,
+                frontName: frontData.displayName || '',
             }
             return [flatCollections, navigator]
         },

--- a/projects/Mallard/src/components/layout/slide-card/index.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/index.tsx
@@ -54,7 +54,6 @@ export const SlideCard = ({
             if (gestureState.dy > 10) {
                 blocked = true
             }
-            console.log(enabled)
             return enabled && blocked
         },
         onPanResponderTerminationRequest: () => false,

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -13,6 +13,10 @@ export const backends = [
         title: 'CODE',
         value: 'https://d2mztzjulnpyb8.cloudfront.net/',
     },
+    {
+        title: 'DEV',
+        value: 'http://localhost:3131/',
+    },
 ]
 
 export const defaultSettings: Settings = {

--- a/projects/Mallard/src/helpers/transform.ts
+++ b/projects/Mallard/src/helpers/transform.ts
@@ -1,4 +1,4 @@
-import { Collection, CAPIArticle, WithColor } from 'src/common'
+import { Collection, CAPIArticle, Appearance } from 'src/common'
 import { palette } from '@guardian/pasteup/palette'
 
 export interface FlatCard {
@@ -15,10 +15,18 @@ const colorMap = {
     neutral: palette.neutral[7],
 }
 
-export const getColor = (color: WithColor): string => {
-    if (!color.color) return colorMap['neutral']
-    if (color.color === 'custom') return color.customColor
-    return colorMap[color.color]
+export const getColor = (app: Appearance): string => {
+    switch (app.type) {
+        case 'pillar': {
+            return colorMap[app.name]
+        }
+        case 'custom': {
+            return app.color
+        }
+        default: {
+            return colorMap.neutral
+        }
+    }
 }
 
 export const flattenCollectionsToCards = (

--- a/projects/Mallard/src/hooks/use-alpha-in.ts
+++ b/projects/Mallard/src/hooks/use-alpha-in.ts
@@ -1,14 +1,24 @@
 import { Animated, Easing } from 'react-native'
-import { useState, useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-const useAlphaIn = (duration: number, easing = Easing.linear) => {
-    const [value] = useState(new Animated.Value(0))
+const useAlphaIn = (
+    duration: number,
+    initialValue = 0,
+    currentValue = 1,
+    easing = Easing.linear,
+) => {
+    const animated = useRef(new Animated.Value(initialValue))
 
     useEffect(() => {
-        Animated.timing(value, { duration, toValue: 1, easing }).start()
-    }, [duration, easing, value])
+        Animated.timing(animated.current, {
+            duration,
+            toValue: currentValue,
+            easing,
+            useNativeDriver: true,
+        }).start()
+    }, [duration, currentValue, animated.current]) // ignore changes to easing
 
-    return value
+    return animated.current
 }
 
 export { useAlphaIn }

--- a/projects/Mallard/src/navigation/helpers.tsx
+++ b/projects/Mallard/src/navigation/helpers.tsx
@@ -60,6 +60,7 @@ const getArticleNavigationProps = (
     const transitionProps = navigation.getParam('transitionProps')
     const articleNavigator = navigation.getParam('articleNavigator', {
         articles: [],
+        appearance: { type: 'pillar', name: 'neutral' },
     })
 
     if (!path || !path.article || !path.collection || !path.issue) {

--- a/projects/Mallard/src/navigation/helpers.tsx
+++ b/projects/Mallard/src/navigation/helpers.tsx
@@ -61,6 +61,7 @@ const getArticleNavigationProps = (
     const articleNavigator = navigation.getParam('articleNavigator', {
         articles: [],
         appearance: { type: 'pillar', name: 'neutral' },
+        frontName: '',
     })
 
     if (!path || !path.article || !path.collection || !path.issue) {

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -30,6 +30,8 @@ import {
     ArticleRequiredNavigationProps,
 } from 'src/navigation/helpers'
 import { UiBodyCopy } from '../components/styled-text'
+import { Navigator } from 'src/components/navigator'
+import { useAlphaIn } from 'src/hooks/use-alpha-in'
 import { getColor } from 'src/helpers/transform'
 
 export interface PathToArticle {
@@ -177,6 +179,11 @@ const ArticleScreenWithProps = ({
     const { isInScroller, startingPoint } = getData(articleNavigator, path)
     const [current, setCurrent] = useState(startingPoint)
 
+    const sliderPos = useAlphaIn(200, 0, current).interpolate({
+        inputRange: [0, articleNavigator.articles.length - 1],
+        outputRange: [0, 1],
+    })
+
     return (
         <ClipFromTop
             easing={navigationPosition && navigationPosition.position}
@@ -199,6 +206,7 @@ const ArticleScreenWithProps = ({
                 >
                     <ArticleScreenBody
                         path={path}
+                        appearance={appearance}
                         onTopPositionChange={() => {}}
                         {...{ viewIsTransitioning }}
                     />
@@ -213,12 +221,15 @@ const ArticleScreenWithProps = ({
                         style={{
                             padding: metrics.vertical,
                             justifyContent: 'center',
-                            alignItems: 'center',
+                            alignItems: 'stretch',
                         }}
                     >
-                        <UiBodyCopy>{`Article ${current + 1}/${
-                            articleNavigator.articles.length
-                        }`}</UiBodyCopy>
+                        <Navigator
+                            title={'h'}
+                            fill={getColor(articleNavigator.appearance)}
+                            stops={2}
+                            position={sliderPos}
+                        />
                     </View>
                     <Animated.FlatList
                         showsHorizontalScrollIndicator={false}

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -5,7 +5,11 @@ import {
     NavigationEvents,
     ScrollView,
 } from 'react-navigation'
-import { WithArticleAppearance, articleAppearances } from 'src/theme/appearance'
+import {
+    WithArticleAppearance,
+    articleAppearances,
+    getAppearancePillar,
+} from 'src/theme/appearance'
 import { ArticleController } from 'src/components/article'
 import { CAPIArticle, Collection, Front, ColorFromPalette } from 'src/common'
 import { Dimensions, Animated, View, Text, StyleSheet } from 'react-native'
@@ -15,7 +19,7 @@ import { color } from 'src/theme/color'
 import { PathToArticle } from './article-screen'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { ERR_404_MISSING_PROPS } from 'src/helpers/words'
-import { Issue } from '../../../backend/common'
+import { Issue, Appearance } from '../../../backend/common'
 import { ClipFromTop } from 'src/components/layout/clipFromTop/clipFromTop'
 import { useSettings } from 'src/hooks/use-settings'
 import { Button } from 'src/components/button/button'
@@ -26,6 +30,7 @@ import {
     ArticleRequiredNavigationProps,
 } from 'src/navigation/helpers'
 import { UiBodyCopy } from '../components/styled-text'
+import { getColor } from 'src/helpers/transform'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -40,6 +45,7 @@ export interface ArticleTransitionProps {
 
 export interface ArticleNavigator {
     articles: PathToArticle[]
+    appearance: Appearance
 }
 
 const styles = StyleSheet.create({
@@ -48,15 +54,19 @@ const styles = StyleSheet.create({
 
 const ArticleScreenBody = ({
     path,
+    appearance,
     viewIsTransitioning,
     onTopPositionChange,
 }: {
     path: PathToArticle
+    appearance: string
     viewIsTransitioning: boolean
     onTopPositionChange: (isAtTop: boolean) => void
 }) => {
-    const [appearance, setAppearance] = useState(0)
     const appearances = Object.keys(articleAppearances)
+    const [modifiedAppearance, setAppearance] = useState(
+        appearances.indexOf(appearance) || 0,
+    )
     const articleResponse = useArticleResponse(path)
     const [{ isUsingProdDevtools }] = useSettings()
     const { width } = Dimensions.get('window')
@@ -105,11 +115,15 @@ const ArticleScreenBody = ({
                                     alignSelf: 'flex-end',
                                 }}
                             >
-                                {`${appearances[appearance]} 🌈`}
+                                {`${appearances[modifiedAppearance]} 🌈`}
                             </Button>
                         ) : null}
                         <WithArticleAppearance
-                            value={appearances[appearance] as ColorFromPalette}
+                            value={
+                                appearances[
+                                    modifiedAppearance
+                                ] as ColorFromPalette
+                            }
                         >
                             <ArticleController
                                 article={article.article}
@@ -147,6 +161,7 @@ const ArticleScreenWithProps = ({
     navigation: NavigationScreenProp<{}, ArticleNavigationProps>
 }) => {
     const { width } = Dimensions.get('window')
+    const appearance = getAppearancePillar(articleNavigator.appearance)
 
     /*
     we don't wanna render a massive tree at once
@@ -243,6 +258,7 @@ const ArticleScreenWithProps = ({
                         }) => (
                             <ArticleScreenBody
                                 path={item}
+                                appearance={appearance}
                                 onTopPositionChange={isAtTop => {
                                     setArticleIsAtTop(isAtTop)
                                 }}

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -48,6 +48,7 @@ export interface ArticleTransitionProps {
 export interface ArticleNavigator {
     articles: PathToArticle[]
     appearance: Appearance
+    frontName: string
 }
 
 const styles = StyleSheet.create({
@@ -225,7 +226,7 @@ const ArticleScreenWithProps = ({
                         }}
                     >
                         <Navigator
-                            title={'h'}
+                            title={articleNavigator.frontName.slice(0, 1)}
                             fill={getColor(articleNavigator.appearance)}
                             stops={2}
                             position={sliderPos}

--- a/projects/Mallard/src/theme/appearance.ts
+++ b/projects/Mallard/src/theme/appearance.ts
@@ -4,6 +4,7 @@ import merge from 'deepmerge'
 import { ColorFromPalette } from 'src/common'
 import { metrics } from './spacing'
 import { getColor } from 'src/helpers/transform'
+import { Appearance } from '../../../common/src'
 
 /*
 Types
@@ -237,5 +238,8 @@ export const useArticleAppearance = (): {
     }
 }
 
+export const getAppearancePillar = (app: Appearance) =>
+    app.type === 'custom' ? 'neutral' : app.name
+
 export const useArticleToneColor = () =>
-    getColor({ color: useArticleAppearance().name })
+    getColor({ type: 'pillar', name: useArticleAppearance().name })

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -4,7 +4,7 @@ import {
     Collection,
     CAPIArticle,
     Crossword,
-    WithColor,
+    Appearance,
     cardLayouts,
 } from './common'
 import { LastModifiedUpdater } from './lastModified'
@@ -123,7 +123,7 @@ const getDisplayName = (front: string) => {
     return split.charAt(0).toUpperCase() + split.slice(1)
 }
 
-const getFrontColor = (front: string): WithColor => {
+const getFrontColor = (front: string): Appearance => {
     switch ((front.split('/').pop() || front).toLowerCase()) {
         case 'special1':
         case 'special2':
@@ -133,18 +133,18 @@ const getFrontColor = (front: string): WithColor => {
         case 'special 2':
         case 'top stories':
         case 'crosswords':
-            return { color: 'neutral' }
+            return { type: 'pillar', name: 'neutral' }
         case 'uknewsguardian':
         case 'uknewsobserver':
         case 'worldnewsguardian':
         case 'worldnewsobserver':
         case 'uk news':
         case 'world news':
-            return { color: 'news' }
+            return { type: 'pillar', name: 'news' }
         case 'journal':
         case 'comment':
         case 'opinion':
-            return { color: 'opinion' }
+            return { type: 'pillar', name: 'opinion' }
         case 'arts':
         case 'filmandmusic':
         case 'guide':
@@ -152,9 +152,9 @@ const getFrontColor = (front: string): WithColor => {
         case 'books':
         case 'culture':
         case 'books':
-            return { color: 'culture' }
+            return { type: 'pillar', name: 'culture' }
         case 'sport':
-            return { color: 'sport' }
+            return { type: 'pillar', name: 'sport' }
         case 'features':
         case 'weekend':
         case 'magazine':
@@ -163,9 +163,9 @@ const getFrontColor = (front: string): WithColor => {
         case 'lifestyle':
         case 'food':
         case 'the fashion':
-            return { color: 'lifestyle' }
+            return { type: 'pillar', name: 'lifestyle' }
     }
-    return { color: 'neutral' }
+    return { type: 'pillar', name: 'neutral' }
 }
 
 export const getFront = async (
@@ -192,7 +192,7 @@ export const getFront = async (
 
     lastModifiedUpdater(resp.lastModified)
 
-    const tone = getFrontColor(id)
+    const appearance = getFrontColor(id)
     const issueResponse: PublishedIssue = (await resp.json()) as PublishedIssue
     const front = issueResponse.fronts.find(_ => _.name === id)
     if (!front) {
@@ -215,7 +215,7 @@ export const getFront = async (
 
     return {
         ...front,
-        ...tone,
+        appearance,
         displayName: getDisplayName(id),
         collections: collections.filter(hasSucceeded),
         key: id,

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -12,15 +12,16 @@ export type ColorFromPalette =
     | 'lifestyle'
     | 'neutral'
 
-interface WithCustomColor {
-    color: 'custom'
-    customColor: string
+interface ColorAppearance {
+    type: 'custom'
+    color: string
 }
-interface WithPillar {
-    color: ColorFromPalette
+interface PillarAppearance {
+    type: 'pillar'
+    name: ColorFromPalette
 }
 
-export type WithColor = WithCustomColor | WithPillar
+export type Appearance = PillarAppearance | ColorAppearance
 
 export interface Card {
     layout: null
@@ -88,23 +89,23 @@ export interface Collection extends WithKey {
     cards: Card[]
 }
 
-export type Front = WithColor &
-    WithKey & {
-        collections: Collection[]
-        displayName?: string
-        canonical?: string
-        group?: string
-        isHidden?: boolean
-        isImageDisplayed?: boolean
-        imageHeight?: number
-        imageWidth?: number
-        imageUrl?: string
-        onPageDescription?: string
-        description?: string
-        title?: string
-        webTitle?: string
-        navSection?: string
-    }
+export type Front = WithKey & {
+    collections: Collection[]
+    displayName?: string
+    canonical?: string
+    group?: string
+    isHidden?: boolean
+    isImageDisplayed?: boolean
+    imageHeight?: number
+    imageWidth?: number
+    imageUrl?: string
+    onPageDescription?: string
+    description?: string
+    title?: string
+    webTitle?: string
+    navSection?: string
+    appearance: Appearance
+}
 
 export interface UnknownElement {
     id: 'unknown'


### PR DESCRIPTION
## Why are you doing this?

This updates the top of the article to include a slider as opposed to `Article 1/2` or similar. In so doing I've changed how we pass `appearance` / `colors` from the backend to the frontend. It seems easier to work with proper discriminated unions in this case and keep that information as a separate property on a `Front` that we can extend as we see fit. Also `color` was sometimes `customColor` as a hex value or `color` which was actually a pillar name. This seemed a bit confusing. Happy to discuss though.

## Screenshots

![ezgif-4-9651cead07ef](https://user-images.githubusercontent.com/1652187/61793797-bd01bf80-ae17-11e9-94eb-49ba188dbc36.gif)

