### PR TITLE
Ensure we only pick `n` issues from backend

### DIFF
--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -9,21 +9,23 @@ const issueList = [
     'daily-edition/2019-03-25/',
 ]
 
-const getIssues = () => Promise.resolve(issueList)
+jest.mock('../../s3', () => ({
+    s3List: () => Promise.resolve(issueList),
+}))
 
 const getNthKey = (n: number) => issueList[n].split('/')[1]
 
 describe('getIssuesSummary', () => {
     it('returns the correct number of issues', async () => {
-        const issues = await getIssuesSummary(3, getIssues)
+        const issues = await getIssuesSummary(3)
         expect(issues).toHaveLength(3)
 
-        const issues2 = await getIssuesSummary(10, getIssues)
+        const issues2 = await getIssuesSummary(10)
         expect(issues2).toHaveLength(5)
     })
 
     it('returns the most recent issues', async () => {
-        const issues = await getIssuesSummary(3, getIssues)
+        const issues = await getIssuesSummary(3)
         expect(issues).not.toHaveFailed(issues)
         expect((issues as IssueSummary[]).map(i => i.key)).toEqual([
             getNthKey(2),

--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -1,0 +1,34 @@
+import { getIssuesSummary } from '../issue'
+import { IssueSummary } from '../../../common/src'
+
+const issueList = [
+    'daily-edition/2019-03-22/',
+    'daily-edition/2019-03-23/',
+    'daily-edition/2019-03-26/',
+    'daily-edition/2019-03-24/',
+    'daily-edition/2019-03-25/',
+]
+
+const getIssues = () => Promise.resolve(issueList)
+
+const getNthKey = (n: number) => issueList[n].split('/')[1]
+
+describe('getIssuesSummary', () => {
+    it('returns the correct number of issues', async () => {
+        const issues = await getIssuesSummary(3, getIssues)
+        expect(issues).toHaveLength(3)
+
+        const issues2 = await getIssuesSummary(10, getIssues)
+        expect(issues2).toHaveLength(5)
+    })
+
+    it('returns the most recent issues', async () => {
+        const issues = await getIssuesSummary(3, getIssues)
+        expect(issues).not.toHaveFailed(issues)
+        expect((issues as IssueSummary[]).map(i => i.key)).toEqual([
+            getNthKey(2),
+            getNthKey(4),
+            getNthKey(3),
+        ])
+    })
+})

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -55,8 +55,12 @@ export const issueController = (req: Request, res: Response) => {
         .catch(e => console.error(e))
 }
 
-const getIssuesSummary = async (): Promise<Attempt<IssueSummary[]>> => {
-    const issueKeys = await s3List('daily-edition/')
+export const getIssuesSummary = async (
+    pageSize = 7,
+    /* mock for tests */
+    getIssueKeys = () => s3List('daily-edition/'),
+): Promise<Attempt<IssueSummary[]>> => {
+    const issueKeys = await getIssueKeys()
     if (hasFailed(issueKeys)) {
         console.error('Error in issue index controller')
         console.error(JSON.stringify(issueKeys))
@@ -70,13 +74,16 @@ const getIssuesSummary = async (): Promise<Attempt<IssueSummary[]>> => {
                 console.warn(`Issue with path ${key} is not a valid date`)
                 return null
             }
-            return {
-                key,
-                name: 'Daily Edition',
-                date: date.toISOString(),
-            }
+            return { key, date }
         })
         .filter(notNull)
+        .sort((a, b) => b.date.getTime() - a.date.getTime())
+        .map(({ key, date }) => ({
+            key,
+            name: 'Daily Edition',
+            date: date.toISOString(),
+        }))
+        .slice(0, pageSize)
 }
 
 export const issuesSummaryController = (req: Request, res: Response) => {

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -57,10 +57,8 @@ export const issueController = (req: Request, res: Response) => {
 
 export const getIssuesSummary = async (
     pageSize = 7,
-    /* mock for tests */
-    getIssueKeys = () => s3List('daily-edition/'),
 ): Promise<Attempt<IssueSummary[]>> => {
-    const issueKeys = await getIssueKeys()
+    const issueKeys = await s3List('daily-edition/')
     if (hasFailed(issueKeys)) {
         console.error('Error in issue index controller')
         console.error(JSON.stringify(issueKeys))

--- a/projects/backend/jest-matchers.ts
+++ b/projects/backend/jest-matchers.ts
@@ -1,0 +1,16 @@
+import { hasFailed, Attempt } from './utils/try'
+
+expect.extend({
+    toHaveFailed: <T>(received: Attempt<T>) => {
+        if (hasFailed(received)) {
+            return {
+                pass: true,
+                message: `expected ${received} not to have failed, however it failed with ${received.error}`,
+            }
+        }
+        return {
+            pass: false,
+            message: `expected ${received} to have failed, however it passed`,
+        }
+    },
+})

--- a/projects/backend/types/jest.d.ts
+++ b/projects/backend/types/jest.d.ts
@@ -1,0 +1,9 @@
+import { Attempt } from '../utils/try'
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toHaveFailed<T>(value: Attempt<T>): CustomMatcherResult
+        }
+    }
+}


### PR DESCRIPTION
## Why are you doing this?

Because we only _want_ 7 issues on the issues list! I've also promoted the most recent issues to the top.
