### PR TITLE
Ensure duplicate front names don't cause shonky rendering

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -102,6 +102,11 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                     <>
                         <Header issue={issue} />
                         <FlatList
+                            // this is horrible but in the worst case where we get duplicate ids
+                            // (which we have done in the past) then we shouldn't break the rendering
+                            // even if it does mean showing the same front twice
+                            // we could filter out duplicates but in this case it'd probably be more
+                            // obvious for someone previewing if we did render it twice
                             data={issue.fronts.map((key, index) => ({
                                 key,
                                 index,
@@ -110,7 +115,7 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                             maxToRenderPerBatch={2}
                             initialNumToRender={1}
                             ListHeaderComponent={<Weather />}
-                            keyExtractor={item => `${item.index}${item.key}`}
+                            keyExtractor={item => `${item.index}::${item.key}`}
                             renderItem={({ item }) => (
                                 <Front
                                     issue={issue.key}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -102,16 +102,19 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                     <>
                         <Header issue={issue} />
                         <FlatList
-                            data={issue.fronts}
+                            data={issue.fronts.map((key, index) => ({
+                                key,
+                                index,
+                            }))}
                             windowSize={3}
                             maxToRenderPerBatch={2}
                             initialNumToRender={1}
                             ListHeaderComponent={<Weather />}
-                            keyExtractor={item => item}
+                            keyExtractor={item => `${item.index}${item.key}`}
                             renderItem={({ item }) => (
                                 <Front
                                     issue={issue.key}
-                                    front={item}
+                                    front={item.key}
                                     {...{ viewIsTransitioning }}
                                 />
                             )}


### PR DESCRIPTION
## Why are you doing this?

As this is readonly, index should be fine. This will hopefully fix glitchy rendering on some issues that have the same front names (although quite how that .
