### PR TITLE
Allow .js in backend

### DIFF
--- a/projects/backend/.gitignore
+++ b/projects/backend/.gitignore
@@ -1,4 +1,3 @@
-*.js
 *.d.ts
 !types/*.d.ts
 coverage

--- a/projects/backend/jest.config.js
+++ b/projects/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    preset: 'ts-jest/presets/default',
+    setupFilesAfterEnv: ['./jest-matchers.ts'],
+}


### PR DESCRIPTION
## Why are you doing this?

The `jest.config.js` was not being added which means people can't run tests!

`.js` in a `.gitignore` seems a bit broad so have removed. The only `.js` that gets output in this project goes into `dist`, which is already ignored from the root `.gitignore`.