### PR TITLE
Rahb/show issue card

### DIFF
--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, ViewProps } from 'react-native'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import {
@@ -38,17 +38,23 @@ type TouchableHeaderProps =
     | { onPress: () => void; accessibilityHint: string }
     | {}
 
-type HeaderProps = {
+export type HeaderProps = {
     action?: ReactNode
     leftAction?: ReactNode
+    onLayout?: ViewProps['onLayout']
 } & IssueTitleProps &
     TouchableHeaderProps
 
-const Header = ({ action, leftAction, ...otherProps }: HeaderProps) => {
+const Header = ({
+    action,
+    leftAction,
+    onLayout,
+    ...otherProps
+}: HeaderProps) => {
     const { top: paddingTop } = useInsets()
     return (
         <WithAppAppearance value={'primary'}>
-            <View style={[styles.background]}>
+            <View onLayout={onLayout} style={[styles.background]}>
                 <GridRowSplit proxy={leftAction} style={{ paddingTop }}>
                     <View style={styles.headerSplit}>
                         <View style={styles.headerTitle}>

--- a/projects/Mallard/src/components/layout/ui/container.tsx
+++ b/projects/Mallard/src/components/layout/ui/container.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react'
-import { StyleSheet, ScrollView, View } from 'react-native'
+import { StyleSheet, ScrollView, View, Animated } from 'react-native'
 import { useAppAppearance } from 'src/theme/appearance'
+import { useAlphaIn } from 'src/hooks/use-alpha-in'
 
 const styles = StyleSheet.create({
     container: { flex: 1 },
@@ -15,10 +16,33 @@ const ScrollContainer = ({ children }: { children: ReactNode }) => {
     )
 }
 
-const Container = ({ children }: { children: ReactNode }) => {
+/**
+ * the translateY and transitionDuration allows us to translate the view along the y axis
+ * in an animated way, which is useful for obscuring parts of the view when it's only partially
+ * in view, i.e.: sliding the header out of the way when the issue screen is poking out the
+ * bottom of the window when viewing the issue list
+ */
+const Container = ({
+    children,
+    translateY,
+    transitionDuration,
+}: {
+    children: ReactNode
+    translateY: number
+    transitionDuration: number
+}) => {
     const { backgroundColor } = useAppAppearance()
+    const value = useAlphaIn(transitionDuration, translateY, translateY)
     return (
-        <View style={[styles.container, { backgroundColor }]}>{children}</View>
+        <Animated.View
+            style={[
+                styles.container,
+                { backgroundColor },
+                { transform: [{ translateY: value }] },
+            ]}
+        >
+            {children}
+        </Animated.View>
     )
 }
 

--- a/projects/Mallard/src/hooks/use-alpha-in.ts
+++ b/projects/Mallard/src/hooks/use-alpha-in.ts
@@ -1,14 +1,27 @@
 import { Animated, Easing } from 'react-native'
-import { useState, useEffect } from 'react'
+import { useRef, useLayoutEffect } from 'react'
 
-const useAlphaIn = (duration: number, easing = Easing.linear) => {
-    const [value] = useState(new Animated.Value(0))
+const useAlphaIn = (
+    duration: number,
+    initialValue = 0,
+    currentValue = 1,
+    easing = Easing.linear,
+) => {
+    const animated = useRef(new Animated.Value(initialValue))
 
-    useEffect(() => {
-        Animated.timing(value, { duration, toValue: 1, easing }).start()
-    }, [duration, easing, value])
+    console.log(duration, currentValue)
 
-    return value
+    useLayoutEffect(() => {
+        console.log('effect')
+        Animated.timing(animated.current, {
+            duration,
+            toValue: currentValue,
+            easing,
+            useNativeDriver: true,
+        }).start()
+    }, [duration, currentValue]) // ignore changes to easing
+
+    return animated.current
 }
 
 export { useAlphaIn }

--- a/projects/Mallard/src/hooks/use-previous.ts
+++ b/projects/Mallard/src/hooks/use-previous.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react'
+
+/**
+ *
+ * Like `useState` but gives you back the last two state values
+ */
+
+export const usePrevious = <T extends any>(
+    curr: T,
+): [[null | T, T], (t: T) => void] => {
+    const [state, setState] = useState<[null | T, T]>([null, curr])
+    return [
+        state,
+        (next: T) => {
+            setState(([, curr]) => [curr, next])
+        },
+    ]
+}

--- a/projects/Mallard/src/navigation/interpolators.ts
+++ b/projects/Mallard/src/navigation/interpolators.ts
@@ -6,6 +6,7 @@ import {
 } from 'src/helpers/positions'
 import { metrics } from 'src/theme/spacing'
 import { routeNames } from '.'
+import { supportsTransparentCards } from 'src/helpers/features'
 
 export const getScaleForArticle = (width: LayoutRectangle['width']) => {
     return width / Dimensions.get('window').width
@@ -148,21 +149,18 @@ const issueScreenToIssueList = (sceneProps: NavigationTransitionProps) => {
     const sceneIndex = scene.index
     const { height: windowHeight } = Dimensions.get('window')
 
-    const finalTranslate = windowHeight
+    const finalTranslate = supportsTransparentCards()
+        ? windowHeight - 100
+        : windowHeight
 
     const translateY = position.interpolate({
         inputRange: [sceneIndex, sceneIndex + 1],
         outputRange: [0, finalTranslate],
     })
-    const borderRadius = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
-        outputRange: [0, radius],
-    })
 
     return {
         zIndex: 9999,
         elevation: 9999,
-        borderRadius,
         transform: [{ translateY }],
         overflow: 'hidden',
     }


### PR DESCRIPTION
## Why are you doing this?

The first commit in this PR shows the top of the issue card when on the issue list. Like so:

<img width="428" alt="Screenshot 2019-07-24 at 23 22 09" src="https://user-images.githubusercontent.com/1652187/61832721-f19e6700-ae69-11e9-92af-7f5b61bdfffb.png">

The second commit gives you an animated, disappearing header (to show the weather as per the designs):

![ezgif-3-01697002530b](https://user-images.githubusercontent.com/1652187/61833051-0b8c7980-ae6b-11e9-8cee-35806ad72f11.gif)

**HOWEVER**: `willFocus` doesn't seem to fire all the time (https://github.com/react-navigation/react-navigation/issues/4867) so we have the little bit of black (as seen at the end of the gif) appear intermittently. If anyone has any ideas then feel free to pitch in, but other than the focus events (which are broke), it seems pretty hard to workout if the screen is active or not.

Additionally I cannot for the life of me get shadows to appear on the cards ...