### PR TITLE
Don't use /issue for fronts so we can archive it.

### DIFF
--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -213,9 +213,9 @@ export type CollectionCardLayout = number[]
 export interface CollectionCardLayouts {
     [countOfArticles: number]: CollectionCardLayout
 }
-const issueDir = (issueId: string) => `${issueId}/issue`
+const issueDir = (issueId: string) => `${issueId}`
 
-const issuePath = (issueId: string) => `${issueDir(issueId)}`
+const issuePath = (issueId: string) => `${issueDir(issueId)}/issue`
 
 // const issuePath = (issueId: string) => `${issueDir(issueId)}issue`
 const frontPath = (issueId: string, frontId: string) =>


### PR DESCRIPTION
this removes the /issue from all the paths that aren't the issue index
this will allow the archviers zip to be extracted
(testing on code)