### PR TITLE
always link to settings, even when there's an error

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -49,8 +49,10 @@ const HomeScreenHeader = withNavigation(
             />
         )
         return response({
-            error: () => <IssueHeader action={action} />,
-            pending: () => <IssueHeader action={action} />,
+            error: () => <IssueHeader leftAction={settings} action={action} />,
+            pending: () => (
+                <IssueHeader leftAction={settings} action={action} />
+            ),
             success: issue => (
                 <IssueHeader
                     leftAction={settings}


### PR DESCRIPTION
<img width="436" alt="Screenshot 2019-07-26 at 12 36 36" src="https://user-images.githubusercontent.com/11539094/61949236-05e57f80-afa2-11e9-901b-7d56b7311e4e.png">
