### PR TITLE
Refresh issue list when opening the issue menu

### DIFF
--- a/projects/Mallard/src/helpers/response.ts
+++ b/projects/Mallard/src/helpers/response.ts
@@ -1,10 +1,5 @@
 import { ReactElement } from 'react'
-import {
-    FetchableResponse,
-    Error,
-    ResponseHookCallbacks,
-} from 'src/hooks/use-response'
-import { CachedOrPromise } from './fetch/cached-or-promise'
+import { FetchableResponse, Error } from 'src/hooks/use-response'
 
 interface WithResponseCallbacks<T> {
     retry: () => void
@@ -16,15 +11,24 @@ export const withResponse = <T>(response: FetchableResponse<T>) => ({
     error,
 }: {
     success: (resp: T, callbacks: WithResponseCallbacks<T>) => ReactElement
-    pending: (callbacks: WithResponseCallbacks<T>) => ReactElement
-    error: (error: Error, callbacks: WithResponseCallbacks<T>) => ReactElement
+    pending: (
+        stale: T | null,
+        callbacks: WithResponseCallbacks<T>,
+    ) => ReactElement
+    error: (
+        error: Error,
+        stale: T | null,
+        callbacks: WithResponseCallbacks<T>,
+    ) => ReactElement
 }): ReactElement => {
     switch (response.state) {
         case 'success':
             return success(response.response, { retry: response.retry })
         case 'error':
-            return error(response.error, { retry: response.retry })
+            return error(response.error, response.staleResponse, {
+                retry: response.retry,
+            })
         case 'pending':
-            return pending({ retry: response.retry })
+            return pending(response.staleResponse, { retry: response.retry })
     }
 }

--- a/projects/Mallard/src/hooks/use-api.ts
+++ b/projects/Mallard/src/hooks/use-api.ts
@@ -12,8 +12,11 @@ export const getIssueSummary = () =>
     })
 
 export const useIssueSummary = () => {
-    const resp = useCachedOrPromise(getIssueSummary())
-    return { response: withResponse<IssueSummary[]>(resp), retry: resp.retry }
+    const response = useCachedOrPromise(getIssueSummary())
+    return {
+        response: withResponse<IssueSummary[]>(response),
+        retry: response.retry,
+    }
 }
 
 export const getLatestIssue = () => {

--- a/projects/Mallard/src/hooks/use-api.ts
+++ b/projects/Mallard/src/hooks/use-api.ts
@@ -11,8 +11,10 @@ export const getIssueSummary = () =>
         validator: res => res.length > 0,
     })
 
-export const useIssueSummary = () =>
-    withResponse<IssueSummary[]>(useCachedOrPromise(getIssueSummary()))
+export const useIssueSummary = () => {
+    const resp = useCachedOrPromise(getIssueSummary())
+    return { response: withResponse<IssueSummary[]>(resp), retry: resp.retry }
+}
 
 export const getLatestIssue = () => {
     return chain<IssueSummary[], Issue>(getIssueSummary(), summary =>

--- a/projects/Mallard/src/hooks/use-response.ts
+++ b/projects/Mallard/src/hooks/use-response.ts
@@ -37,10 +37,12 @@ export interface Error {
 type Response<T> =
     | {
           state: 'pending'
+          staleResponse: T | null
       }
     | {
           state: 'error'
           error: Error
+          staleResponse: T | null
       }
     | {
           state: 'success'
@@ -64,16 +66,24 @@ const useResponse = <T>(
               }
             : {
                   state: 'pending',
+                  staleResponse: null,
               },
     )
     const onSuccess = (response: T) => {
         setResponse({ state: 'success', response })
     }
     const onError = (error: Error) => {
-        setResponse({ state: 'error', error })
+        setResponse({
+            state: 'error',
+            error,
+            staleResponse: 'response' in response ? response.response : null,
+        })
     }
     const onPending = () => {
-        setResponse({ state: 'pending' })
+        setResponse({
+            state: 'pending',
+            staleResponse: 'response' in response ? response.response : null,
+        })
     }
     return [
         response,

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -177,10 +177,10 @@ export const HomeScreen = ({
                             />
                         </>
                     ),
-                    pending: (stale, { retry }) =>
+                    pending: stale =>
                         stale ? (
                             <>
-                                <IssueList issueList={stale} onRetry={retry} />
+                                <IssueList issueList={stale} />
                                 {isUsingProdDevtools ? (
                                     <Spinner></Spinner>
                                 ) : null}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { View, Alert } from 'react-native'
 import { List, BaseList } from 'src/components/lists/list'
 import { NavigationScreenProp, NavigationEvents } from 'react-navigation'
@@ -67,11 +67,9 @@ const HomeScreenHeader = withNavigation(
 const IssueList = withNavigation(
     ({
         issueList,
-        onRetry,
         navigation,
     }: {
         issueList: IssueSummary[]
-        onRetry: () => void
     } & NavigationInjectedProps) => {
         const [{ isUsingProdDevtools }] = useSettings()
         return (
@@ -169,14 +167,10 @@ export const HomeScreen = ({
                     }}
                 />
                 {issueSummary({
-                    success: (issueList, { retry }) => (
-                        <IssueList issueList={issueList} onRetry={retry} />
-                    ),
+                    success: issueList => <IssueList issueList={issueList} />,
                     error: ({ message }, stale, { retry }) => (
                         <>
-                            {stale ? (
-                                <IssueList issueList={stale} onRetry={retry} />
-                            ) : null}
+                            {stale ? <IssueList issueList={stale} /> : null}
                             <FlexErrorMessage
                                 debugMessage={message}
                                 action={['Retry', retry]}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { View, Alert } from 'react-native'
 import { List, BaseList } from 'src/components/lists/list'
 import { NavigationScreenProp } from 'react-navigation'
@@ -74,6 +74,11 @@ const IssueList = withNavigation(
         onRetry: () => void
     } & NavigationInjectedProps) => {
         const [{ isUsingProdDevtools }] = useSettings()
+
+        /* Refresh this list every time it's drawn */
+        useEffect(() => {
+            onRetry()
+        }, [])
         return (
             <>
                 <BaseList
@@ -135,6 +140,7 @@ const IssueList = withNavigation(
         )
     },
 )
+
 export const HomeScreen = ({
     navigation,
 }: {
@@ -142,7 +148,6 @@ export const HomeScreen = ({
 }) => {
     const [files, { refreshIssues }] = useFileList()
     const issueSummary = useIssueSummary()
-    const [{ isUsingProdDevtools }] = useSettings()
     const from = navigation.getParam('from', undefined)
 
     return (

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -19,7 +19,7 @@ import { ScrollContainer } from 'src/components/layout/ui/container'
 import { IssueHeader } from 'src/components/layout/header/header'
 import { navigateToIssue } from 'src/navigation/helpers'
 import { useIssueOrLatestResponse } from 'src/hooks/use-issue'
-import { Issue } from 'src/common'
+import { Issue, IssueSummary } from 'src/common'
 import { useSettings } from 'src/hooks/use-settings'
 import { navigateToSettings } from 'src/navigation/helpers'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
@@ -64,6 +64,77 @@ const HomeScreenHeader = withNavigation(
     },
 )
 
+const IssueList = withNavigation(
+    ({
+        issueList,
+        onRetry,
+        navigation,
+    }: {
+        issueList: IssueSummary[]
+        onRetry: () => void
+    } & NavigationInjectedProps) => {
+        const [{ isUsingProdDevtools }] = useSettings()
+        return (
+            <>
+                <BaseList
+                    style={{ paddingTop: 0 }}
+                    data={issueList}
+                    renderItem={({ item }) => (
+                        <IssueRow
+                            proxy={
+                                <Button
+                                    onPress={() => {
+                                        Alert.alert(
+                                            'Sorry, downloading is not supported yet',
+                                        )
+                                    }}
+                                    icon={'\uE077'}
+                                    alt={'Download'}
+                                    appearance={ButtonAppearance.skeleton}
+                                ></Button>
+                            }
+                            onPress={() => {
+                                navigateToIssue(navigation, {
+                                    path: {
+                                        issue: item.key,
+                                    },
+                                })
+                            }}
+                            issue={item}
+                        ></IssueRow>
+                    )}
+                />
+                {isUsingProdDevtools ? (
+                    <View
+                        style={{
+                            padding: metrics.horizontal,
+                            paddingVertical: metrics.vertical * 4,
+                        }}
+                    >
+                        <GridRowSplit>
+                            <Button
+                                onPress={onRetry}
+                                icon={''}
+                                alt={'refresh'}
+                                appearance={ButtonAppearance.skeleton}
+                            ></Button>
+                            <Button
+                                appearance={ButtonAppearance.skeleton}
+                                onPress={() => {
+                                    navigateToIssue(navigation, {
+                                        path: undefined,
+                                    })
+                                }}
+                            >
+                                Go to latest
+                            </Button>
+                        </GridRowSplit>
+                    </View>
+                ) : null}
+            </>
+        )
+    },
+)
 export const HomeScreen = ({
     navigation,
 }: {
@@ -99,81 +170,27 @@ export const HomeScreen = ({
                 />
                 {issueSummary({
                     success: (issueList, { retry }) => (
+                        <IssueList issueList={issueList} onRetry={retry} />
+                    ),
+                    error: ({ message }, stale, { retry }) => (
                         <>
-                            <BaseList
-                                style={{ paddingTop: 0 }}
-                                data={issueList}
-                                renderItem={({ item }) => (
-                                    <IssueRow
-                                        proxy={
-                                            <Button
-                                                onPress={() => {
-                                                    Alert.alert(
-                                                        'Sorry, downloading is not supported yet',
-                                                    )
-                                                }}
-                                                icon={'\uE077'}
-                                                alt={'Download'}
-                                                appearance={
-                                                    ButtonAppearance.skeleton
-                                                }
-                                            ></Button>
-                                        }
-                                        onPress={() => {
-                                            navigateToIssue(navigation, {
-                                                path: {
-                                                    issue: item.key,
-                                                },
-                                            })
-                                        }}
-                                        issue={item}
-                                    ></IssueRow>
-                                )}
-                            />
-                            {isUsingProdDevtools ? (
-                                <View
-                                    style={{
-                                        padding: metrics.horizontal,
-                                        paddingVertical: metrics.vertical * 4,
-                                    }}
-                                >
-                                    <GridRowSplit>
-                                        <Button
-                                            onPress={retry}
-                                            icon={''}
-                                            alt={'refresh'}
-                                            appearance={
-                                                ButtonAppearance.skeleton
-                                            }
-                                        ></Button>
-                                        <Button
-                                            appearance={
-                                                ButtonAppearance.skeleton
-                                            }
-                                            onPress={() => {
-                                                navigateToIssue(navigation, {
-                                                    path: undefined,
-                                                })
-                                            }}
-                                        >
-                                            Go to latest
-                                        </Button>
-                                    </GridRowSplit>
-                                </View>
+                            {stale ? (
+                                <IssueList issueList={stale} onRetry={retry} />
                             ) : null}
+                            <FlexErrorMessage
+                                debugMessage={message}
+                                action={['Retry', retry]}
+                            />
                         </>
                     ),
-                    error: ({ message }, { retry }) => (
-                        <FlexErrorMessage
-                            debugMessage={message}
-                            action={['Retry', retry]}
-                        />
-                    ),
-                    pending: () => (
-                        <FlexCenter>
-                            <Spinner></Spinner>
-                        </FlexCenter>
-                    ),
+                    pending: (stale, { retry }) =>
+                        stale ? (
+                            <IssueList issueList={stale} onRetry={retry} />
+                        ) : (
+                            <FlexCenter>
+                                <Spinner></Spinner>
+                            </FlexCenter>
+                        ),
                 })}
                 {files.length > 0 && (
                     <>

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -16,7 +16,7 @@ import { useIssueOrLatestResponse } from 'src/hooks/use-issue'
 import { Spinner } from 'src/components/spinner'
 
 import { withNavigation } from 'react-navigation'
-import { Button, ButtonAppearance } from 'src/components/button/button'
+import { Button } from 'src/components/button/button'
 import { navigateToIssueList } from 'src/navigation/helpers'
 import { Container } from 'src/components/layout/ui/container'
 import { Weather } from 'src/components/weather'

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -68,7 +68,7 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                 }}
             />
             {response({
-                error: ({ message }, { retry }) => (
+                error: ({ message }, _, { retry }) => (
                     <>
                         <Header />
 


### PR DESCRIPTION
## Why are you doing this?

This means we don't need a reload button and new issues will always come in.

I added some extra methods to `withRequest` to allow it to display stale data during an error or a refresh so there's no spinners flashing around

<img width="436" alt="Screenshot 2019-07-26 at 14 42 44" src="https://user-images.githubusercontent.com/11539094/61955777-a55f3e00-afb3-11e9-91bb-d4604eda698a.png">
