### PR TITLE
Remove article appearance, just get pillar colours instead

### DIFF
--- a/projects/Mallard/src/components/article/article-byline/__tests__/__snapshots__/article-byline.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-byline/__tests__/__snapshots__/article-byline.spec.tsx.snap
@@ -14,7 +14,6 @@ exports[`ArticleByline should display a default Byline 1`] = `
         Object {
           "color": "#121212",
         },
-        Object {},
         undefined,
       ],
     ]

--- a/projects/Mallard/src/components/article/article-byline/index.tsx
+++ b/projects/Mallard/src/components/article/article-byline/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { BodyCopy } from '../../styled-text'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { StyleProp, TextStyle } from 'react-native'
+import { useArticle } from 'src/hooks/use-article'
 
 interface ArticleBylineProps {
     children: string
@@ -9,12 +9,10 @@ interface ArticleBylineProps {
 }
 
 const ArticleByline = ({ children, style }: ArticleBylineProps) => {
-    const { appearance } = useArticleAppearance()
+    const [color] = useArticle()
+
     return (
-        <BodyCopy
-            weight={'bold'}
-            style={[appearance.text, appearance.byline, style]}
-        >
+        <BodyCopy weight={'bold'} style={[{ color: color.main }, style]}>
             {children}
         </BodyCopy>
     )

--- a/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/long-read-header.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/long-read-header.spec.tsx.snap
@@ -11,10 +11,6 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
         "justifyContent": "flex-end",
         "marginTop": -10,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
     ]
   }
 >
@@ -44,31 +40,22 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
     style={
       Array [
         Object {
+          "backgroundColor": "#121212",
           "marginEnd": 24,
           "padding": 12,
           "paddingVertical": 6,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
   >
     <View
       style={
-        Array [
-          Object {
-            "borderBottomWidth": 0.5,
-            "marginBottom": 3,
-            "paddingBottom": 18,
-            "width": "100%",
-          },
-          Object {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#999999",
-          },
-        ]
+        Object {
+          "borderBottomWidth": 0.5,
+          "marginBottom": 3,
+          "paddingBottom": 18,
+          "width": "100%",
+        }
       }
     >
       <Text
@@ -80,15 +67,9 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
               "fontSize": 18,
               "lineHeight": 18,
             },
-            Array [
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-              Object {
-                "marginTop": 2.4,
-              },
-            ],
+            Object {
+              "color": "#ffffff",
+            },
           ]
         }
       >
@@ -105,135 +86,71 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
             "fontSize": 28,
             "lineHeight": 30,
           },
-          Array [
-            Object {},
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "color": "#ffffff",
+          },
         ]
       }
     >
       Theresa May makes final speech as PM
     </Text>
   </View>
-  <View>
-    <View
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#121212",
+          "marginEnd": 24,
+          "padding": 12,
+          "paddingVertical": 6,
+        },
+      ]
+    }
+  >
+    <Text
       style={
         Array [
           Object {
-            "marginBottom": 12,
-            "marginTop": 12,
-            "paddingTop": 3,
+            "flexShrink": 0,
+            "fontFamily": "GuardianTextEgyptian-Reg",
+            "fontSize": 17,
+            "lineHeight": 21,
+          },
+          Object {
+            "color": "#ffffff",
+          },
+        ]
+      }
+    >
+      Rolling coverage of the day’s political developments as they happen
+    </Text>
+    <RNSVGSvgView
+      bbHeight={16}
+      bbWidth="100%"
+      fill="none"
+      height={16}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          undefined,
+          null,
+          Object {
+            "flex": 0,
+            "height": 16,
             "width": "100%",
           },
-          Object {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#999999",
-          },
-          Object {
-            "alignContent": "stretch",
-            "alignItems": "stretch",
-            "justifyContent": "flex-end",
-          },
         ]
       }
+      width="100%"
     >
-      <Text
-        style={
-          Array [
-            Object {
-              "flexShrink": 0,
-              "fontFamily": "GuardianTextEgyptian-Reg",
-              "fontSize": 17,
-              "lineHeight": 21,
-            },
-            Array [
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
-          ]
-        }
-      >
-        Rolling coverage of the day’s political developments as they happen
-      </Text>
-    </View>
-  </View>
-  <RNSVGSvgView
-    bbHeight={16}
-    bbWidth="100%"
-    fill="none"
-    height={16}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-          "borderWidth": 0,
-        },
-        undefined,
-        null,
-        Object {
-          "flex": 0,
-          "height": 16,
-          "width": "100%",
-        },
-      ]
-    }
-    width="100%"
-  >
-    <RNSVGGroup
-      fill={null}
-      fillOpacity={1}
-      fillRule={1}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
-      propList={
-        Array [
-          "fill",
-        ]
-      }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
-    >
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
+      <RNSVGGroup
+        fill={null}
         fillOpacity={1}
         fillRule={1}
-        height={1}
+        font={Object {}}
         matrix={
           Array [
             1,
@@ -253,8 +170,6 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
           ]
         }
         rotation={0}
-        rx={0}
-        ry={0}
         scaleX={1}
         scaleY={1}
         skewX={0}
@@ -268,177 +183,226 @@ exports[`LongReadHeader should show a full featured long read header 1`] = `
         strokeOpacity={1}
         strokeWidth={1}
         vectorEffect={0}
-        width="100%"
         x={0}
         y={0}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={4}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={8}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={12}
-      />
-    </RNSVGGroup>
-  </RNSVGSvgView>
-  <Text
-    style={
-      Array [
-        Object {
-          "flexShrink": 0,
-          "fontFamily": "GuardianTextEgyptian-Bold",
-          "fontSize": 17,
-          "lineHeight": 21,
-        },
+      >
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={0}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={4}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={8}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={12}
+        />
+      </RNSVGGroup>
+    </RNSVGSvgView>
+    <Text
+      style={
         Array [
           Object {
-            "color": "#121212",
+            "flexShrink": 0,
+            "fontFamily": "GuardianTextEgyptian-Bold",
+            "fontSize": 17,
+            "lineHeight": 21,
           },
-          Object {},
-          undefined,
-        ],
-      ]
-    }
-  >
-    Andrew Sparrow
-  </Text>
+          Array [
+            Object {
+              "color": "#121212",
+            },
+            Object {
+              "color": "#ffffff",
+            },
+          ],
+        ]
+      }
+    >
+      Andrew Sparrow
+    </Text>
+  </View>
 </View>
 `;
 
@@ -453,10 +417,6 @@ exports[`LongReadHeader should show long read header without an image or a kicke
         "justifyContent": "flex-end",
         "marginTop": -10,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
     ]
   }
 >
@@ -464,13 +424,10 @@ exports[`LongReadHeader should show long read header without an image or a kicke
     style={
       Array [
         Object {
+          "backgroundColor": "#121212",
           "marginEnd": 24,
           "padding": 12,
           "paddingVertical": 6,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
@@ -485,135 +442,71 @@ exports[`LongReadHeader should show long read header without an image or a kicke
             "fontSize": 28,
             "lineHeight": 30,
           },
-          Array [
-            Object {},
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "color": "#ffffff",
+          },
         ]
       }
     >
       Theresa May makes final speech as PM
     </Text>
   </View>
-  <View>
-    <View
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#121212",
+          "marginEnd": 24,
+          "padding": 12,
+          "paddingVertical": 6,
+        },
+      ]
+    }
+  >
+    <Text
       style={
         Array [
           Object {
-            "marginBottom": 12,
-            "marginTop": 12,
-            "paddingTop": 3,
+            "flexShrink": 0,
+            "fontFamily": "GuardianTextEgyptian-Reg",
+            "fontSize": 17,
+            "lineHeight": 21,
+          },
+          Object {
+            "color": "#ffffff",
+          },
+        ]
+      }
+    >
+      Rolling coverage of the day’s political developments as they happen
+    </Text>
+    <RNSVGSvgView
+      bbHeight={16}
+      bbWidth="100%"
+      fill="none"
+      height={16}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          undefined,
+          null,
+          Object {
+            "flex": 0,
+            "height": 16,
             "width": "100%",
           },
-          Object {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#999999",
-          },
-          Object {
-            "alignContent": "stretch",
-            "alignItems": "stretch",
-            "justifyContent": "flex-end",
-          },
         ]
       }
+      width="100%"
     >
-      <Text
-        style={
-          Array [
-            Object {
-              "flexShrink": 0,
-              "fontFamily": "GuardianTextEgyptian-Reg",
-              "fontSize": 17,
-              "lineHeight": 21,
-            },
-            Array [
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
-          ]
-        }
-      >
-        Rolling coverage of the day’s political developments as they happen
-      </Text>
-    </View>
-  </View>
-  <RNSVGSvgView
-    bbHeight={16}
-    bbWidth="100%"
-    fill="none"
-    height={16}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-          "borderWidth": 0,
-        },
-        undefined,
-        null,
-        Object {
-          "flex": 0,
-          "height": 16,
-          "width": "100%",
-        },
-      ]
-    }
-    width="100%"
-  >
-    <RNSVGGroup
-      fill={null}
-      fillOpacity={1}
-      fillRule={1}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
-      propList={
-        Array [
-          "fill",
-        ]
-      }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
-    >
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
+      <RNSVGGroup
+        fill={null}
         fillOpacity={1}
         fillRule={1}
-        height={1}
+        font={Object {}}
         matrix={
           Array [
             1,
@@ -633,8 +526,6 @@ exports[`LongReadHeader should show long read header without an image or a kicke
           ]
         }
         rotation={0}
-        rx={0}
-        ry={0}
         scaleX={1}
         scaleY={1}
         skewX={0}
@@ -648,176 +539,225 @@ exports[`LongReadHeader should show long read header without an image or a kicke
         strokeOpacity={1}
         strokeWidth={1}
         vectorEffect={0}
-        width="100%"
         x={0}
         y={0}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={4}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={8}
-      />
-      <RNSVGRect
-        fill={
-          Array [
-            0,
-            4279374354,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        height={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-        rotation={0}
-        rx={0}
-        ry={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        width="100%"
-        x={0}
-        y={12}
-      />
-    </RNSVGGroup>
-  </RNSVGSvgView>
-  <Text
-    style={
-      Array [
-        Object {
-          "flexShrink": 0,
-          "fontFamily": "GuardianTextEgyptian-Bold",
-          "fontSize": 17,
-          "lineHeight": 21,
-        },
+      >
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={0}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={4}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={8}
+        />
+        <RNSVGRect
+          fill={
+            Array [
+              0,
+              4294967295,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          height={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+          rotation={0}
+          rx={0}
+          ry={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          width="100%"
+          x={0}
+          y={12}
+        />
+      </RNSVGGroup>
+    </RNSVGSvgView>
+    <Text
+      style={
         Array [
           Object {
-            "color": "#121212",
+            "flexShrink": 0,
+            "fontFamily": "GuardianTextEgyptian-Bold",
+            "fontSize": 17,
+            "lineHeight": 21,
           },
-          Object {},
-          undefined,
-        ],
-      ]
-    }
-  >
-    Andrew Sparrow
-  </Text>
+          Array [
+            Object {
+              "color": "#121212",
+            },
+            Object {
+              "color": "#ffffff",
+            },
+          ],
+        ]
+      }
+    >
+      Andrew Sparrow
+    </Text>
+  </View>
 </View>
 `;

--- a/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/news-header.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/news-header.spec.tsx.snap
@@ -9,10 +9,6 @@ exports[`NewsHeader should show a full featured news header 1`] = `
         "paddingBottom": 12,
         "paddingHorizontal": 12,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
     ]
   }
 >
@@ -37,18 +33,12 @@ exports[`NewsHeader should show a full featured news header 1`] = `
   />
   <View
     style={
-      Array [
-        Object {
-          "borderBottomWidth": 0.5,
-          "marginBottom": 3,
-          "paddingBottom": 18,
-          "width": "100%",
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
-        },
-      ]
+      Object {
+        "borderBottomWidth": 0.5,
+        "marginBottom": 3,
+        "paddingBottom": 18,
+        "width": "100%",
+      }
     }
   >
     <Text
@@ -62,11 +52,10 @@ exports[`NewsHeader should show a full featured news header 1`] = `
           },
           Array [
             Object {
-              "color": "#121212",
-            },
-            Object {},
-            Object {
               "marginTop": 2.4,
+            },
+            Object {
+              "color": "#121212",
             },
           ],
         ]
@@ -86,16 +75,10 @@ exports[`NewsHeader should show a full featured news header 1`] = `
             "fontSize": 28,
             "lineHeight": 30,
           },
-          Array [
-            Object {
-              "marginRight": 24,
-              "marginTop": 3,
-            },
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "marginRight": 24,
+            "marginTop": 3,
+          },
         ]
       }
     >
@@ -107,19 +90,15 @@ exports[`NewsHeader should show a full featured news header 1`] = `
       style={
         Array [
           Object {
+            "alignContent": "stretch",
+            "alignItems": "stretch",
+            "justifyContent": "flex-end",
+          },
+          Object {
             "marginBottom": 12,
             "marginTop": 12,
             "paddingTop": 3,
             "width": "100%",
-          },
-          Object {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#999999",
-          },
-          Object {
-            "alignContent": "stretch",
-            "alignItems": "stretch",
-            "justifyContent": "flex-end",
           },
         ]
       }
@@ -133,12 +112,9 @@ exports[`NewsHeader should show a full featured news header 1`] = `
               "fontSize": 17,
               "lineHeight": 21,
             },
-            Array [
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
+            Object {
+              "color": "#333333",
+            },
           ]
         }
       >
@@ -415,7 +391,6 @@ exports[`NewsHeader should show a full featured news header 1`] = `
           Object {
             "color": "#121212",
           },
-          Object {},
           Object {
             "marginBottom": 12,
           },
@@ -437,10 +412,6 @@ exports[`NewsHeader should show news header without an image or a kicker 1`] = `
         "paddingBottom": 12,
         "paddingHorizontal": 12,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
     ]
   }
 >
@@ -455,16 +426,10 @@ exports[`NewsHeader should show news header without an image or a kicker 1`] = `
             "fontSize": 28,
             "lineHeight": 30,
           },
-          Array [
-            Object {
-              "marginRight": 24,
-              "marginTop": 3,
-            },
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "marginRight": 24,
+            "marginTop": 3,
+          },
         ]
       }
     >
@@ -476,19 +441,15 @@ exports[`NewsHeader should show news header without an image or a kicker 1`] = `
       style={
         Array [
           Object {
+            "alignContent": "stretch",
+            "alignItems": "stretch",
+            "justifyContent": "flex-end",
+          },
+          Object {
             "marginBottom": 12,
             "marginTop": 12,
             "paddingTop": 3,
             "width": "100%",
-          },
-          Object {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#999999",
-          },
-          Object {
-            "alignContent": "stretch",
-            "alignItems": "stretch",
-            "justifyContent": "flex-end",
           },
         ]
       }
@@ -502,12 +463,9 @@ exports[`NewsHeader should show news header without an image or a kicker 1`] = `
               "fontSize": 17,
               "lineHeight": 21,
             },
-            Array [
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
+            Object {
+              "color": "#333333",
+            },
           ]
         }
       >
@@ -784,7 +742,6 @@ exports[`NewsHeader should show news header without an image or a kicker 1`] = `
           Object {
             "color": "#121212",
           },
-          Object {},
           Object {
             "marginBottom": 12,
           },

--- a/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/opinion-header.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-header/__tests__/__snapshots__/opinion-header.spec.tsx.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OpinionHeader should show a full featured opinion header 1`] = `
-Array [
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#fef9f5",
+      },
+    ]
+  }
+>
   <View
     style={
       Array [
@@ -9,10 +17,6 @@ Array [
           "alignItems": "flex-start",
           "paddingBottom": 12,
           "paddingHorizontal": 12,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
@@ -47,16 +51,10 @@ Array [
               "fontSize": 28,
               "lineHeight": 30,
             },
-            Array [
-              Object {
-                "marginRight": 24,
-                "marginTop": 3,
-              },
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
+            Object {
+              "marginRight": 24,
+              "marginTop": 3,
+            },
           ]
         }
       >
@@ -127,7 +125,7 @@ Array [
               fill={
                 Array [
                   0,
-                  4294934287,
+                  4279374354,
                 ]
               }
               fillOpacity={1}
@@ -176,7 +174,6 @@ Array [
               Object {
                 "color": "#121212",
               },
-              Object {},
               Object {
                 "fontFamily": "GTGuardianTitlepiece-Bold",
                 "width": "100%",
@@ -190,7 +187,7 @@ Array [
         </Text>
       </Text>
     </View>
-  </View>,
+  </View>
   <RNSVGSvgView
     bbHeight={16}
     bbWidth="100%"
@@ -446,7 +443,7 @@ Array [
         y={12}
       />
     </RNSVGGroup>
-  </RNSVGSvgView>,
+  </RNSVGSvgView>
   <View
     style={
       Array [
@@ -454,10 +451,6 @@ Array [
           "alignItems": "flex-start",
           "paddingBottom": 12,
           "paddingHorizontal": 12,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
@@ -467,20 +460,11 @@ Array [
         style={
           Array [
             Object {
-              "marginBottom": 12,
-              "marginTop": 12,
-              "paddingTop": 3,
-              "width": "100%",
-            },
-            Object {
-              "backgroundColor": "#ffffff",
-              "borderColor": "#999999",
-            },
-            Object {
               "alignContent": "stretch",
               "alignItems": "stretch",
               "justifyContent": "flex-end",
             },
+            undefined,
           ]
         }
       >
@@ -493,12 +477,9 @@ Array [
                 "fontSize": 17,
                 "lineHeight": 21,
               },
-              Array [
-                Object {
-                  "color": "#121212",
-                },
-                Object {},
-              ],
+              Object {
+                "color": "#333333",
+              },
             ]
           }
         >
@@ -506,12 +487,20 @@ Array [
         </Text>
       </View>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`OpinionHeader should show opinion header without an image or a kicker 1`] = `
-Array [
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#fef9f5",
+      },
+    ]
+  }
+>
   <View
     style={
       Array [
@@ -519,10 +508,6 @@ Array [
           "alignItems": "flex-start",
           "paddingBottom": 12,
           "paddingHorizontal": 12,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
@@ -538,16 +523,10 @@ Array [
               "fontSize": 28,
               "lineHeight": 30,
             },
-            Array [
-              Object {
-                "marginRight": 24,
-                "marginTop": 3,
-              },
-              Object {
-                "color": "#121212",
-              },
-              Object {},
-            ],
+            Object {
+              "marginRight": 24,
+              "marginTop": 3,
+            },
           ]
         }
       >
@@ -618,7 +597,7 @@ Array [
               fill={
                 Array [
                   0,
-                  4294934287,
+                  4279374354,
                 ]
               }
               fillOpacity={1}
@@ -667,7 +646,6 @@ Array [
               Object {
                 "color": "#121212",
               },
-              Object {},
               Object {
                 "fontFamily": "GTGuardianTitlepiece-Bold",
                 "width": "100%",
@@ -681,7 +659,7 @@ Array [
         </Text>
       </Text>
     </View>
-  </View>,
+  </View>
   <RNSVGSvgView
     bbHeight={16}
     bbWidth="100%"
@@ -937,7 +915,7 @@ Array [
         y={12}
       />
     </RNSVGGroup>
-  </RNSVGSvgView>,
+  </RNSVGSvgView>
   <View
     style={
       Array [
@@ -945,10 +923,6 @@ Array [
           "alignItems": "flex-start",
           "paddingBottom": 12,
           "paddingHorizontal": 12,
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
         },
       ]
     }
@@ -958,20 +932,11 @@ Array [
         style={
           Array [
             Object {
-              "marginBottom": 12,
-              "marginTop": 12,
-              "paddingTop": 3,
-              "width": "100%",
-            },
-            Object {
-              "backgroundColor": "#ffffff",
-              "borderColor": "#999999",
-            },
-            Object {
               "alignContent": "stretch",
               "alignItems": "stretch",
               "justifyContent": "flex-end",
             },
+            undefined,
           ]
         }
       >
@@ -984,12 +949,9 @@ Array [
                 "fontSize": 17,
                 "lineHeight": 21,
               },
-              Array [
-                Object {
-                  "color": "#121212",
-                },
-                Object {},
-              ],
+              Object {
+                "color": "#333333",
+              },
             ]
           }
         >
@@ -997,6 +959,6 @@ Array [
         </Text>
       </View>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/projects/Mallard/src/components/article/article-header/long-read-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/long-read-header.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
-import { HeadlineText } from 'src/components/styled-text'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { getNavigationPosition } from 'src/helpers/positions'
 import { ArticleImage } from '../article-image'
 import { longReadHeaderStyles } from '../styles'
@@ -19,22 +17,16 @@ const LongReadHeader = ({
     kicker,
     standfirst,
 }: ArticleHeaderProps) => {
-    const { appearance } = useArticleAppearance()
     const navigationPosition = getNavigationPosition('article')
     return (
-        <View style={[longReadHeaderStyles.background, appearance.backgrounds]}>
+        <View style={[longReadHeaderStyles.background]}>
             {image ? (
                 <ArticleImage
                     style={StyleSheet.absoluteFillObject}
                     image={image}
                 />
             ) : null}
-            <View
-                style={[
-                    longReadHeaderStyles.textBackground,
-                    appearance.backgrounds,
-                ]}
-            >
+            <View style={[longReadHeaderStyles.textBackground]}>
                 {kicker ? (
                     <ArticleKicker kicker={kicker} type="longRead" />
                 ) : null}

--- a/projects/Mallard/src/components/article/article-header/long-read-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/long-read-header.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
-import { getNavigationPosition } from 'src/helpers/positions'
 import { ArticleImage } from '../article-image'
 import { longReadHeaderStyles } from '../styles'
-import { ArticleKicker } from '../article-kicker'
-import { ArticleStandfirst } from '../article-standfirst'
 import { ArticleHeaderProps } from './types'
 import { Multiline } from '../../multiline'
 import { ArticleByline } from '../article-byline'
-import { ArticleHeadline } from '../article-headline'
+import {
+    HeadlineText,
+    HeadlineKickerText,
+    StandfirstText,
+} from 'src/components/styled-text'
+import { color } from 'src/theme/color'
 
 const LongReadHeader = ({
     byline,
@@ -17,7 +19,6 @@ const LongReadHeader = ({
     kicker,
     standfirst,
 }: ArticleHeaderProps) => {
-    const navigationPosition = getNavigationPosition('article')
     return (
         <View style={[longReadHeaderStyles.background]}>
             {image ? (
@@ -28,15 +29,27 @@ const LongReadHeader = ({
             ) : null}
             <View style={[longReadHeaderStyles.textBackground]}>
                 {kicker ? (
-                    <ArticleKicker kicker={kicker} type="longRead" />
+                    <View style={longReadHeaderStyles.kicker}>
+                        <HeadlineKickerText
+                            style={{ color: color.palette.neutral[100] }}
+                        >
+                            {kicker}
+                        </HeadlineKickerText>
+                    </View>
                 ) : null}
-                <ArticleHeadline type="longRead">{headline}</ArticleHeadline>
+                <HeadlineText style={longReadHeaderStyles.headline}>
+                    {headline}
+                </HeadlineText>
             </View>
-            <ArticleStandfirst
-                {...{ byline, standfirst, navigationPosition }}
-            />
-            <Multiline count={4} />
-            <ArticleByline>{byline}</ArticleByline>
+            <View style={[longReadHeaderStyles.textBackground]}>
+                <StandfirstText style={{ color: color.palette.neutral[100] }}>
+                    {standfirst}
+                </StandfirstText>
+                <Multiline count={4} color={color.palette.neutral[100]} />
+                <ArticleByline style={{ color: color.palette.neutral[100] }}>
+                    {byline}
+                </ArticleByline>
+            </View>
         </View>
     )
 }

--- a/projects/Mallard/src/components/article/article-header/news-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/news-header.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { View, Animated, Alert } from 'react-native'
+import { View, Animated, Alert, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { ArticleImage } from '../article-image'
 import { getNavigationPosition } from 'src/helpers/positions'
 import { animationStyles, newsHeaderStyles } from '../styles'
@@ -12,6 +11,15 @@ import { ArticleByline } from '../article-byline'
 import { ArticleHeadline } from '../article-headline'
 import { ArticleMultiline } from '../article-multiline'
 
+const styles = StyleSheet.create({
+    bylineBackground: {
+        marginTop: metrics.vertical,
+        marginBottom: metrics.vertical,
+        paddingTop: metrics.vertical / 4,
+        width: '100%',
+    },
+})
+
 const NewsHeader = ({
     byline,
     headline,
@@ -19,10 +27,9 @@ const NewsHeader = ({
     kicker,
     standfirst,
 }: ArticleHeaderProps) => {
-    const { appearance } = useArticleAppearance()
     const navigationPosition = getNavigationPosition('article')
     return (
-        <View style={[newsHeaderStyles.background, appearance.backgrounds]}>
+        <View style={[newsHeaderStyles.background]}>
             {image ? (
                 <ArticleImage
                     style={{
@@ -38,6 +45,7 @@ const NewsHeader = ({
                 <ArticleHeadline type="news">{headline}</ArticleHeadline>
             </Animated.View>
             <ArticleStandfirst
+                style={styles.bylineBackground}
                 {...{ byline, standfirst, navigationPosition }}
             />
             <ArticleMultiline />

--- a/projects/Mallard/src/components/article/article-header/news-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/news-header.tsx
@@ -40,9 +40,9 @@ const NewsHeader = ({
                 />
             ) : null}
 
-            {kicker ? <ArticleKicker kicker={kicker} type="news" /> : null}
+            {kicker ? <ArticleKicker kicker={kicker} /> : null}
             <Animated.View style={animationStyles(navigationPosition)}>
-                <ArticleHeadline type="news">{headline}</ArticleHeadline>
+                <ArticleHeadline>{headline}</ArticleHeadline>
             </Animated.View>
             <ArticleStandfirst
                 style={styles.bylineBackground}

--- a/projects/Mallard/src/components/article/article-header/opinion-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/opinion-header.tsx
@@ -45,7 +45,7 @@ const OpinionHeader = ({
                     />
                 ) : null}
                 <Animated.View style={animationStyles(navigationPosition)}>
-                    <ArticleHeadline type="news">
+                    <ArticleHeadline>
                         <Quote fill={color.main} />
                         {headline}
                         <Text style={[{ color: color.main }, styles.byline]}>

--- a/projects/Mallard/src/components/article/article-header/opinion-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/opinion-header.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { View, Animated, Text, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { ArticleImage } from '../article-image'
 import { getNavigationPosition } from 'src/helpers/positions'
 import { animationStyles, newsHeaderStyles } from '../styles'
@@ -12,8 +11,13 @@ import { ArticleByline } from '../article-byline'
 import { ArticleHeadline } from '../article-headline'
 import Quote from 'src/components/icons/Quote'
 import { getFont } from 'src/theme/typography'
+import { color } from 'src/theme/color'
+import { useArticle } from 'src/hooks/use-article'
 
 const styles = StyleSheet.create({
+    background: {
+        backgroundColor: color.palette.opinion.faded,
+    },
     byline: {
         fontFamily: getFont('titlepiece', 1).fontFamily,
         width: '100%',
@@ -26,11 +30,11 @@ const OpinionHeader = ({
     image,
     standfirst,
 }: ArticleHeaderProps) => {
-    const { appearance } = useArticleAppearance()
+    const [color] = useArticle()
     const navigationPosition = getNavigationPosition('article')
     return (
-        <>
-            <View style={[newsHeaderStyles.background, appearance.backgrounds]}>
+        <View style={[styles.background]}>
+            <View style={[newsHeaderStyles.background]}>
                 {image ? (
                     <ArticleImage
                         style={{
@@ -44,13 +48,7 @@ const OpinionHeader = ({
                     <ArticleHeadline type="news">
                         <Quote />
                         {headline}
-                        <Text
-                            style={[
-                                appearance.text,
-                                appearance.byline,
-                                styles.byline,
-                            ]}
-                        >
+                        <Text style={[{ color: color.dark }, styles.byline]}>
                             {'\n'}
                             {byline}
                         </Text>
@@ -58,10 +56,10 @@ const OpinionHeader = ({
                 </Animated.View>
             </View>
             <Multiline count={4} />
-            <View style={[newsHeaderStyles.background, appearance.backgrounds]}>
+            <View style={[newsHeaderStyles.background]}>
                 <ArticleStandfirst {...{ standfirst, navigationPosition }} />
             </View>
-        </>
+        </View>
     )
 }
 

--- a/projects/Mallard/src/components/article/article-header/opinion-header.tsx
+++ b/projects/Mallard/src/components/article/article-header/opinion-header.tsx
@@ -46,9 +46,9 @@ const OpinionHeader = ({
                 ) : null}
                 <Animated.View style={animationStyles(navigationPosition)}>
                     <ArticleHeadline type="news">
-                        <Quote />
+                        <Quote fill={color.main} />
                         {headline}
-                        <Text style={[{ color: color.dark }, styles.byline]}>
+                        <Text style={[{ color: color.main }, styles.byline]}>
                             {'\n'}
                             {byline}
                         </Text>

--- a/projects/Mallard/src/components/article/article-headline/__tests__/__snapshots__/article-headline.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-headline/__tests__/__snapshots__/article-headline.spec.tsx.snap
@@ -11,13 +11,10 @@ exports[`ArticleHeadline should show a long read headling 1`] = `
         "fontSize": 28,
         "lineHeight": 30,
       },
-      Array [
-        Object {},
-        Object {
-          "color": "#121212",
-        },
-        Object {},
-      ],
+      Object {
+        "marginRight": 24,
+        "marginTop": 3,
+      },
     ]
   }
 >
@@ -36,16 +33,10 @@ exports[`ArticleHeadline should show a news headling 1`] = `
         "fontSize": 28,
         "lineHeight": 30,
       },
-      Array [
-        Object {
-          "marginRight": 24,
-          "marginTop": 3,
-        },
-        Object {
-          "color": "#121212",
-        },
-        Object {},
-      ],
+      Object {
+        "marginRight": 24,
+        "marginTop": 3,
+      },
     ]
   }
 >

--- a/projects/Mallard/src/components/article/article-headline/__tests__/article-headline.spec.tsx
+++ b/projects/Mallard/src/components/article/article-headline/__tests__/article-headline.spec.tsx
@@ -5,7 +5,7 @@ import { ArticleHeadline } from '..'
 describe('ArticleHeadline', () => {
     it('should show a news headling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <ArticleHeadline type="news">
+            <ArticleHeadline>
                 England’s Suzy Petty hopes to help GB hockey team make it to
                 Olympics
             </ArticleHeadline>,
@@ -14,7 +14,7 @@ describe('ArticleHeadline', () => {
     })
     it('should show a long read headling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <ArticleHeadline type="longRead">
+            <ArticleHeadline>
                 England’s Suzy Petty hopes to help GB hockey team make it to
                 Olympics
             </ArticleHeadline>,

--- a/projects/Mallard/src/components/article/article-headline/index.tsx
+++ b/projects/Mallard/src/components/article/article-headline/index.tsx
@@ -1,21 +1,14 @@
 import React from 'react'
 import { HeadlineText } from 'src/components/styled-text'
-import { longReadHeaderStyles, newsHeaderStyles } from '../styles'
+import { newsHeaderStyles } from '../styles'
 
 export interface ArticleHeadlineProps {
     children: any
-    type: 'news' | 'longRead'
 }
 
-const ArticleHeadline = ({ children, type }: ArticleHeadlineProps) => {
+const ArticleHeadline = ({ children }: ArticleHeadlineProps) => {
     return (
-        <HeadlineText
-            style={[
-                type === 'news'
-                    ? newsHeaderStyles.headline
-                    : longReadHeaderStyles.headline,
-            ]}
-        >
+        <HeadlineText style={newsHeaderStyles.headline}>
             {children}
         </HeadlineText>
     )

--- a/projects/Mallard/src/components/article/article-headline/index.tsx
+++ b/projects/Mallard/src/components/article/article-headline/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { HeadlineText } from 'src/components/styled-text'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { longReadHeaderStyles, newsHeaderStyles } from '../styles'
 
 export interface ArticleHeadlineProps {
@@ -9,15 +8,12 @@ export interface ArticleHeadlineProps {
 }
 
 const ArticleHeadline = ({ children, type }: ArticleHeadlineProps) => {
-    const { appearance } = useArticleAppearance()
     return (
         <HeadlineText
             style={[
                 type === 'news'
                     ? newsHeaderStyles.headline
                     : longReadHeaderStyles.headline,
-                appearance.text,
-                appearance.headline,
             ]}
         >
             {children}

--- a/projects/Mallard/src/components/article/article-kicker/__tests__/__snapshots__/article-kicker.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-kicker/__tests__/__snapshots__/article-kicker.spec.tsx.snap
@@ -3,18 +3,12 @@
 exports[`ArticleKicker should display a default Kicker 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "borderBottomWidth": 0.5,
-        "marginBottom": 3,
-        "paddingBottom": 18,
-        "width": "100%",
-      },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
-    ]
+    Object {
+      "borderBottomWidth": 0.5,
+      "marginBottom": 3,
+      "paddingBottom": 18,
+      "width": "100%",
+    }
   }
 >
   <Text
@@ -28,11 +22,10 @@ exports[`ArticleKicker should display a default Kicker 1`] = `
         },
         Array [
           Object {
-            "color": "#121212",
-          },
-          Object {},
-          Object {
             "marginTop": 2.4,
+          },
+          Object {
+            "color": "#121212",
           },
         ],
       ]
@@ -46,18 +39,12 @@ exports[`ArticleKicker should display a default Kicker 1`] = `
 exports[`ArticleKicker should display a long read style kicker 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "borderBottomWidth": 0.5,
-        "marginBottom": 3,
-        "paddingBottom": 18,
-        "width": "100%",
-      },
-      Object {
-        "backgroundColor": "#ffffff",
-        "borderColor": "#999999",
-      },
-    ]
+    Object {
+      "borderBottomWidth": 0.5,
+      "marginBottom": 3,
+      "paddingBottom": 18,
+      "width": "100%",
+    }
   }
 >
   <Text
@@ -71,11 +58,10 @@ exports[`ArticleKicker should display a long read style kicker 1`] = `
         },
         Array [
           Object {
-            "color": "#121212",
-          },
-          Object {},
-          Object {
             "marginTop": 2.4,
+          },
+          Object {
+            "color": "#121212",
           },
         ],
       ]

--- a/projects/Mallard/src/components/article/article-kicker/__tests__/article-kicker.spec.tsx
+++ b/projects/Mallard/src/components/article/article-kicker/__tests__/article-kicker.spec.tsx
@@ -11,7 +11,7 @@ describe('ArticleKicker', () => {
     })
     it('should display a long read style kicker', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <ArticleKicker kicker="Sport" type="longRead" />,
+            <ArticleKicker kicker="Sport" />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/article/article-kicker/index.tsx
+++ b/projects/Mallard/src/components/article/article-kicker/index.tsx
@@ -1,29 +1,23 @@
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
 import { HeadlineKickerText } from 'src/components/styled-text'
-import { longReadHeaderStyles, newsHeaderStyles } from '../styles'
+import { newsHeaderStyles } from '../styles'
 import { metrics } from 'src/theme/spacing'
 import { useArticle } from 'src/hooks/use-article'
 
 export interface ArticleKickerProps {
     kicker: string
-    type?: 'news' | 'longRead'
+    type?: 'news'
 }
 
 const styles = StyleSheet.create({
     kicker: { marginTop: metrics.vertical / 5 },
 })
 
-export const ArticleKicker = ({ kicker, type }: ArticleKickerProps) => {
+export const ArticleKicker = ({ kicker }: ArticleKickerProps) => {
     const [color] = useArticle()
     return (
-        <View
-            style={[
-                type && type === 'news'
-                    ? newsHeaderStyles.kicker
-                    : longReadHeaderStyles.kicker,
-            ]}
-        >
+        <View style={newsHeaderStyles.kicker}>
             <HeadlineKickerText style={[styles.kicker, { color: color.main }]}>
                 {kicker}
             </HeadlineKickerText>

--- a/projects/Mallard/src/components/article/article-kicker/index.tsx
+++ b/projects/Mallard/src/components/article/article-kicker/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { HeadlineKickerText } from 'src/components/styled-text'
 import { longReadHeaderStyles, newsHeaderStyles } from '../styles'
 import { metrics } from 'src/theme/spacing'
+import { useArticle } from 'src/hooks/use-article'
 
 export interface ArticleKickerProps {
     kicker: string
@@ -15,19 +15,16 @@ const styles = StyleSheet.create({
 })
 
 export const ArticleKicker = ({ kicker, type }: ArticleKickerProps) => {
-    const { appearance } = useArticleAppearance()
+    const [color] = useArticle()
     return (
         <View
             style={[
                 type && type === 'news'
                     ? newsHeaderStyles.kicker
                     : longReadHeaderStyles.kicker,
-                appearance.backgrounds,
             ]}
         >
-            <HeadlineKickerText
-                style={[appearance.text, appearance.kicker, styles.kicker]}
-            >
+            <HeadlineKickerText style={[styles.kicker, { color: color.main }]}>
                 {kicker}
             </HeadlineKickerText>
         </View>

--- a/projects/Mallard/src/components/article/article-standfirst/__tests__/__snapshots__/article-standfirst.spec.tsx.snap
+++ b/projects/Mallard/src/components/article/article-standfirst/__tests__/__snapshots__/article-standfirst.spec.tsx.snap
@@ -6,20 +6,11 @@ exports[`ArticleStandfirst should be able to asborb an injected style 1`] = `
     style={
       Array [
         Object {
-          "marginBottom": 12,
-          "marginTop": 12,
-          "paddingTop": 3,
-          "width": "100%",
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
-        },
-        Object {
           "alignContent": "stretch",
           "alignItems": "stretch",
           "justifyContent": "flex-end",
         },
+        undefined,
       ]
     }
   >
@@ -32,12 +23,9 @@ exports[`ArticleStandfirst should be able to asborb an injected style 1`] = `
             "fontSize": 17,
             "lineHeight": 21,
           },
-          Array [
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "color": "#333333",
+          },
         ]
       }
     >
@@ -53,20 +41,11 @@ exports[`ArticleStandfirst should display a default Standfirst 1`] = `
     style={
       Array [
         Object {
-          "marginBottom": 12,
-          "marginTop": 12,
-          "paddingTop": 3,
-          "width": "100%",
-        },
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#999999",
-        },
-        Object {
           "alignContent": "stretch",
           "alignItems": "stretch",
           "justifyContent": "flex-end",
         },
+        undefined,
       ]
     }
   >
@@ -79,12 +58,9 @@ exports[`ArticleStandfirst should display a default Standfirst 1`] = `
             "fontSize": 17,
             "lineHeight": 21,
           },
-          Array [
-            Object {
-              "color": "#121212",
-            },
-            Object {},
-          ],
+          Object {
+            "color": "#333333",
+          },
         ]
       }
     >

--- a/projects/Mallard/src/components/article/article-standfirst/index.tsx
+++ b/projects/Mallard/src/components/article/article-standfirst/index.tsx
@@ -1,45 +1,37 @@
 import React from 'react'
-import { View, StyleSheet, Animated, StyleProp } from 'react-native'
+import { View, StyleSheet, Animated, StyleProp, ViewStyle } from 'react-native'
 import { StandfirstText } from '../../styled-text'
 import { metrics } from 'src/theme/spacing'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { animationStyles } from '../styles'
 import { NavigationPosition } from 'src/helpers/positions'
+import { color } from 'src/theme/color'
 
 export interface PropTypes {
     standfirst: string
     navigationPosition?: NavigationPosition
+    style?: StyleProp<ViewStyle>
 }
 
-const styles = StyleSheet.create({
-    bylineBackground: {
-        marginTop: metrics.vertical,
-        marginBottom: metrics.vertical,
-        paddingTop: metrics.vertical / 4,
-        width: '100%',
-    },
-})
-
-const ArticleStandfirst = ({ standfirst, navigationPosition }: PropTypes) => {
-    const { appearance, name } = useArticleAppearance()
+const ArticleStandfirst = ({
+    standfirst,
+    navigationPosition,
+    style,
+}: PropTypes) => {
     return (
         <Animated.View
             style={navigationPosition && animationStyles(navigationPosition)}
         >
             <View
                 style={[
-                    name !== 'opinion' && styles.bylineBackground,
-                    appearance.backgrounds,
                     {
                         justifyContent: 'flex-end',
                         alignContent: 'stretch',
                         alignItems: 'stretch',
                     },
+                    style,
                 ]}
             >
-                <StandfirstText
-                    style={[appearance.text, appearance.standfirst]}
-                >
+                <StandfirstText style={{ color: color.dimText }}>
                     {standfirst}
                 </StandfirstText>
             </View>

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -6,10 +6,7 @@ import { metrics } from 'src/theme/spacing'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { LongReadHeader, NewsHeader, OpinionHeader } from './article-header'
 import { ArticleHeaderProps } from './article-header/types'
-import {
-    ArticleStandfirst,
-    PropTypes as StandfirstPropTypes,
-} from './article-standfirst'
+import { PropTypes as StandfirstPropTypes } from './article-standfirst'
 import { BlockElement } from 'src/common'
 import { render } from './html/render'
 import { CAPIArticle } from 'src/common'
@@ -92,6 +89,10 @@ const Article = ({
         <View style={styles.container}>
             {type === 'opinion' ? (
                 <OpinionHeader
+                    {...{ byline, headline, image, kicker, standfirst }}
+                />
+            ) : type === 'longread' ? (
+                <LongReadHeader
                     {...{ byline, headline, image, kicker, standfirst }}
                 />
             ) : (

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -4,7 +4,6 @@ import { WebView } from 'react-native-webview'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
-import { useArticleAppearance } from 'src/theme/appearance'
 import { LongReadHeader, NewsHeader, OpinionHeader } from './article-header'
 import { ArticleHeaderProps } from './article-header/types'
 import {
@@ -17,6 +16,7 @@ import { CAPIArticle } from 'src/common'
 import { getNavigationPosition } from 'src/helpers/positions'
 import { Gallery } from './types/gallery'
 import { Crossword } from './types/crossword'
+import { useArticle } from 'src/hooks/use-article'
 
 /*
 This is the article view! For all of the articles.
@@ -84,14 +84,13 @@ const Article = ({
     article?: BlockElement[]
 } & ArticleHeaderProps &
     StandfirstPropTypes) => {
-    const { name: appearanceName } = useArticleAppearance()
     const [height, setHeight] = useState(Dimensions.get('window').height)
     const html = useMemo(() => (article ? render(article) : ''), [article])
     const navigationPosition = getNavigationPosition('article')
-
+    const [, { type }] = useArticle()
     return (
         <View style={styles.container}>
-            {appearanceName === 'opinion' ? (
+            {type === 'opinion' ? (
                 <OpinionHeader
                     {...{ byline, headline, image, kicker, standfirst }}
                 />

--- a/projects/Mallard/src/components/article/styles.ts
+++ b/projects/Mallard/src/components/article/styles.ts
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { NavigationPosition } from 'src/helpers/positions'
+import { color } from 'src/theme/color'
 
 interface Style {
     /* kicker */
@@ -50,12 +51,13 @@ export const longReadHeaderStyles: StyleSheet.NamedStyles<
     kicker: {
         ...newsHeaderStyles.kicker,
     },
-    byline: {},
-    headline: {},
+    byline: { color: color.palette.neutral[100] },
+    headline: { color: color.palette.neutral[100] },
     textBackground: {
         padding: metrics.horizontal,
         paddingVertical: metrics.vertical / 2,
         marginEnd: metrics.horizontal * 2,
+        backgroundColor: color.palette.neutral[7],
     },
 })
 

--- a/projects/Mallard/src/components/front/collection-page/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page/collection-page.tsx
@@ -2,11 +2,10 @@ import React from 'react'
 import { StyleSheet, Animated, View } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 
-import { useArticleAppearance } from 'src/theme/appearance'
 import { color } from 'src/theme/color'
 import { Row } from './row'
 import { CAPIArticle, Issue, Collection, Front } from 'src/common'
-import { PageLayout } from '../helpers'
+import { PageLayout, useCardBackgroundStyle } from '../helpers'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import {
     splashPage,
@@ -19,6 +18,7 @@ import {
 } from '../layouts'
 import { PathToArticle } from 'src/screens/article-screen'
 import { ArticleNavigator } from '../../../screens/article-screen'
+import { useArticle } from 'src/hooks/use-article'
 
 const styles = StyleSheet.create({
     root: {
@@ -58,7 +58,7 @@ const CollectionPage = ({
     front,
     pageLayout,
 }: { translate: Animated.AnimatedInterpolation } & PropTypes) => {
-    const { appearance } = useArticleAppearance()
+    const background = useCardBackgroundStyle()
     if (!articlesInCard.length) {
         return <FlexErrorMessage />
     }
@@ -88,7 +88,7 @@ const CollectionPage = ({
         }
     }
     return (
-        <View style={[styles.root, appearance.backgrounds]}>
+        <View style={[styles.root, background]}>
             {pageLayout.map((row, index) => (
                 <Row
                     index={index}

--- a/projects/Mallard/src/components/front/collection-page/row.tsx
+++ b/projects/Mallard/src/components/front/collection-page/row.tsx
@@ -3,10 +3,10 @@ import { StyleSheet, Animated, View } from 'react-native'
 import { Multiline } from '../../multiline'
 import { metrics } from 'src/theme/spacing'
 
-import { useArticleAppearance } from 'src/theme/appearance'
 import { CAPIArticle, Collection, Issue, Front } from 'src/common'
 import { getRowHeightForSize, RowLayout } from '../helpers'
 import { ArticleNavigator } from '../../../screens/article-screen'
+import { color } from 'src/theme/color'
 
 const styles = StyleSheet.create({
     row: {
@@ -55,7 +55,6 @@ const RowWithChildren = ({
 }: {
     children: ReactNode
 } & RowPropTypes) => {
-    const { appearance } = useArticleAppearance()
     const height = useMemo(() => getRowHeightForSize(row.size), [row.size])
     return (
         <Animated.View
@@ -78,12 +77,7 @@ const RowWithChildren = ({
                 },
             ]}
         >
-            {index !== 0 ? (
-                <Multiline
-                    color={appearance.backgrounds.borderColor}
-                    count={2}
-                />
-            ) : null}
+            {index !== 0 ? <Multiline color={color.line} count={2} /> : null}
             {children}
         </Animated.View>
     )
@@ -142,8 +136,6 @@ const Row = ({
     articles: [CAPIArticle] | [CAPIArticle, CAPIArticle]
 } & NavigationPropTypes &
     RowPropTypes) => {
-    const { appearance } = useArticleAppearance()
-
     if (row.columns.length !== 2 || !articles[1]) {
         if (!articles[0]) return null
         return (
@@ -177,7 +169,7 @@ const Row = ({
                         styles.card,
                         styles.rightItem,
                         {
-                            borderColor: appearance.backgrounds.borderColor,
+                            borderColor: color.line,
                         },
                     ]}
                     path={{

--- a/projects/Mallard/src/components/front/helpers.ts
+++ b/projects/Mallard/src/components/front/helpers.ts
@@ -4,6 +4,8 @@ import { FlatList } from 'react-native'
 import { Dimensions, Animated } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { Front } from 'src/common'
+import { useArticle } from 'src/hooks/use-article'
+import { useAppAppearance } from 'src/theme/appearance'
 
 type Item = FunctionComponent<PropTypes>
 
@@ -105,4 +107,18 @@ export const getTranslateForPage = (scrollX: Animated.Value, page: number) => {
             metrics.frontsPageSides * 1.75,
         ],
     })
+}
+
+/*get the card bg */
+export const useCardBackgroundStyle = () => {
+    const [color, { pillar }] = useArticle()
+    const appColor = useAppAppearance()
+    return pillar !== 'news' && pillar !== 'sport'
+        ? { backgroundColor: color.faded }
+        : { backgroundColor: appColor.cardBackgroundColor }
+}
+
+export const useKickerColorStyle = () => {
+    const [color, { pillar }] = useArticle()
+    return pillar !== 'news' ? { color: color.main } : {}
 }

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -4,7 +4,7 @@ import { CollectionPage, PropTypes } from './collection-page/collection-page'
 import { Navigator, NavigatorSkeleton } from '../navigator'
 import { Spinner } from '../spinner'
 import { FlexCenter } from '../layout/flex-center'
-import { Issue, ColorFromPalette, Front as FrontType } from 'src/common'
+import { Issue, PillarFromPalette, Front as FrontType } from 'src/common'
 import { FlexErrorMessage } from '../layout/ui/errors/flex-error-message'
 import { GENERIC_ERROR } from 'src/helpers/words'
 import { useSettings } from 'src/hooks/use-settings'
@@ -20,12 +20,9 @@ import {
     AnimatedFlatListRef,
     getNearestPage,
 } from './helpers'
-import {
-    WithArticleAppearance,
-    getAppearancePillar,
-} from 'src/theme/appearance'
 import { useFrontsResponse } from 'src/hooks/use-issue'
 import { ArticleNavigator } from '../../screens/article-screen'
+import { WithArticle, getAppearancePillar } from '../../hooks/use-article'
 
 const CollectionPageInFront = ({
     index,
@@ -34,7 +31,7 @@ const CollectionPageInFront = ({
     ...collectionPageProps
 }: {
     index: number
-    appearance: ColorFromPalette
+    appearance: PillarFromPalette
     scrollX: Animated.Value
 } & PropTypes) => {
     const { width } = Dimensions.get('window')
@@ -52,12 +49,12 @@ const CollectionPageInFront = ({
                 },
             ]}
         >
-            <WithArticleAppearance value={appearance}>
+            <WithArticle type={'article'} pillar={appearance}>
                 <CollectionPage
                     translate={translate}
                     {...collectionPageProps}
                 />
-            </WithArticleAppearance>
+            </WithArticle>
         </Animated.View>
     )
 }

--- a/projects/Mallard/src/components/front/item/item.tsx
+++ b/projects/Mallard/src/components/front/item/item.tsx
@@ -4,7 +4,6 @@ import { metrics } from 'src/theme/spacing'
 import { withNavigation, NavigationInjectedProps } from 'react-navigation'
 import { Highlight } from '../../highlight'
 
-import { useArticleAppearance } from 'src/theme/appearance'
 import { CAPIArticle } from 'src/common'
 import {
     PathToArticle,
@@ -14,7 +13,11 @@ import {
 
 import { TextBlock } from './text-block'
 import { StandfirstText, HeadlineCardText } from 'src/components/styled-text'
-import { RowSize, getRowHeightForSize } from '../helpers'
+import {
+    RowSize,
+    getRowHeightForSize,
+    useCardBackgroundStyle,
+} from '../helpers'
 import {
     setScreenPositionOfItem,
     getScreenPositionOfItem,
@@ -67,7 +70,6 @@ const ItemTappable = withNavigation(
         hasPadding?: boolean
     } & TappablePropTypes &
         NavigationInjectedProps) => {
-        const { appearance } = useArticleAppearance()
         const tappableRef = useRef<View>()
 
         return (
@@ -111,8 +113,7 @@ const ItemTappable = withNavigation(
                         style={[
                             tappableStyles.root,
                             hasPadding && tappableStyles.padding,
-                            appearance.backgrounds,
-                            appearance.cardBackgrounds,
+                            useCardBackgroundStyle(),
                         ]}
                     >
                         {children}

--- a/projects/Mallard/src/components/front/item/text-block.tsx
+++ b/projects/Mallard/src/components/front/item/text-block.tsx
@@ -3,10 +3,10 @@ import { View, ViewStyle, StyleProp } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { HeadlineCardText, HeadlineKickerText } from '../../styled-text'
 
-import { useArticleAppearance } from 'src/theme/appearance'
 import { color } from 'src/theme/color'
-import { RowSize } from '../helpers'
+import { RowSize, useKickerColorStyle } from '../helpers'
 import { getFont } from 'src/theme/typography'
+import { useArticle } from 'src/hooks/use-article'
 
 type TextBlockAppearance = 'default' | 'highlight' | 'pillarColor'
 
@@ -27,7 +27,9 @@ const styles = {
 }
 
 const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
-    const { appearance } = useArticleAppearance()
+    const [color, {}] = useArticle()
+    const kickerStyle = useKickerColorStyle()
+
     switch (textBlockAppearance) {
         case 'highlight':
             return {
@@ -40,7 +42,7 @@ const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
                 rootStyle: [
                     styles.root,
                     styles.rootWithHighlight,
-                    appearance.contrastCardBackgrounds,
+                    { backgroundColor: color.main },
                 ],
                 kickerStyle: styles.contrastText,
                 headlineStyle: styles.contrastText,
@@ -48,16 +50,8 @@ const useTextBlockStyles = (textBlockAppearance: TextBlockAppearance) => {
         default:
             return {
                 rootStyle: styles.root,
-                kickerStyle: [
-                    appearance.text,
-                    appearance.kicker,
-                    appearance.cardKicker,
-                ],
-                headlineStyle: [
-                    styles.headline,
-                    appearance.text,
-                    appearance.headline,
-                ],
+                kickerStyle,
+                headlineStyle: [styles.headline],
             }
     }
 }

--- a/projects/Mallard/src/components/icons/Quote.tsx
+++ b/projects/Mallard/src/components/icons/Quote.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import Svg, { Path } from 'react-native-svg'
+import { color } from 'src/theme/color'
 
-const Quote = ({ fill = '#FF7F0F', height = 25, width = 38 }) => (
+const Quote = ({ fill = color.text, height = 25, width = 38 }) => (
     <Svg width={width} height={height} fill="none">
         <Path
             fill-rule="evenodd"

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/Quote.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/Quote.spec.tsx.snap
@@ -68,7 +68,7 @@ exports[`Quote should display a Quote icon in SVG 1`] = `
       fill={
         Array [
           0,
-          4294934287,
+          4279374354,
         ]
       }
       fillOpacity={1}

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext } from 'react'
+import { color } from '../theme/color'
+import { PillarFromPalette, ArticleType, Appearance } from '../common'
+import { PillarColours } from '@guardian/pasteup/palette'
+
+/*
+  Exports
+ */
+const ArticlePillarContext = createContext<PillarFromPalette>('neutral')
+const ArticleTypeContext = createContext<ArticleType>('article')
+
+export const WithArticlePillar = ArticlePillarContext.Provider
+export const WithArticleType = ArticleTypeContext.Provider
+
+export const WithArticle = ({
+    type,
+    pillar,
+    children,
+}: {
+    type: ArticleType
+    pillar: PillarFromPalette
+    children: Element
+}) => (
+    <WithArticleType value={type}>
+        <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
+    </WithArticleType>
+)
+
+const neutrals: PillarColours = {
+    dark: color.palette.neutral[7],
+    main: color.palette.neutral[7],
+    bright: color.palette.neutral[20],
+    pastel: color.palette.neutral[60],
+    faded: color.palette.neutral[97],
+}
+
+export const useArticle = (): [
+    PillarColours,
+    {
+        pillar: PillarFromPalette
+        type: ArticleType
+    },
+] => {
+    const pillar = useContext(ArticlePillarContext)
+    const type = useContext(ArticleTypeContext)
+    return [
+        pillar === 'neutral' ? neutrals : color.palette[pillar],
+        {
+            pillar,
+            type,
+        },
+    ]
+}
+
+export const getAppearancePillar = (app: Appearance) =>
+    app.type === 'custom' ? 'neutral' : app.name

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -5,13 +5,17 @@ import {
     NavigationEvents,
     ScrollView,
 } from 'react-navigation'
-import {
-    WithArticleAppearance,
-    articleAppearances,
-    getAppearancePillar,
-} from 'src/theme/appearance'
 import { ArticleController } from 'src/components/article'
-import { CAPIArticle, Collection, Front, ColorFromPalette } from 'src/common'
+import {
+    CAPIArticle,
+    Collection,
+    Front,
+    articlePillars,
+    Appearance,
+    articleTypes,
+    Issue,
+    PillarFromPalette,
+} from 'src/common'
 import { Dimensions, Animated, View, Text, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { SlideCard } from 'src/components/layout/slide-card/index'
@@ -19,7 +23,6 @@ import { color } from 'src/theme/color'
 import { PathToArticle } from './article-screen'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { ERR_404_MISSING_PROPS } from 'src/helpers/words'
-import { Issue, Appearance } from '../../../backend/common'
 import { ClipFromTop } from 'src/components/layout/clipFromTop/clipFromTop'
 import { useSettings } from 'src/hooks/use-settings'
 import { Button } from 'src/components/button/button'
@@ -29,10 +32,10 @@ import {
     getArticleNavigationProps,
     ArticleRequiredNavigationProps,
 } from 'src/navigation/helpers'
-import { UiBodyCopy } from '../components/styled-text'
 import { Navigator } from 'src/components/navigator'
 import { useAlphaIn } from 'src/hooks/use-alpha-in'
 import { getColor } from 'src/helpers/transform'
+import { WithArticle, getAppearancePillar } from 'src/hooks/use-article'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -57,19 +60,19 @@ const styles = StyleSheet.create({
 
 const ArticleScreenBody = ({
     path,
-    appearance,
     viewIsTransitioning,
     onTopPositionChange,
+    pillar,
 }: {
     path: PathToArticle
-    appearance: string
     viewIsTransitioning: boolean
     onTopPositionChange: (isAtTop: boolean) => void
+    pillar: PillarFromPalette
 }) => {
-    const appearances = Object.keys(articleAppearances)
-    const [modifiedAppearance, setAppearance] = useState(
-        appearances.indexOf(appearance) || 0,
+    const [modifiedPillar, setPillar] = useState(
+        articlePillars.indexOf(pillar) || 0,
     )
+    const [modifiedType, setType] = useState(0)
     const articleResponse = useArticleResponse(path)
     const [{ isUsingProdDevtools }] = useSettings()
     const { width } = Dimensions.get('window')
@@ -99,39 +102,68 @@ const ArticleScreenBody = ({
                 success: article => (
                     <>
                         {isUsingProdDevtools ? (
-                            <Button
-                                onPress={() => {
-                                    setAppearance(app => {
-                                        if (app + 1 >= appearances.length) {
-                                            return 0
-                                        }
-                                        return app + 1
-                                    })
-                                }}
-                                style={{
-                                    position: 'absolute',
-                                    zIndex: 9999,
-                                    elevation: 999,
-                                    top: Dimensions.get('window').height - 600,
-                                    right: metrics.horizontal,
-                                    alignSelf: 'flex-end',
-                                }}
-                            >
-                                {`${appearances[modifiedAppearance]} 🌈`}
-                            </Button>
+                            <>
+                                <Button
+                                    onPress={() => {
+                                        setPillar(app => {
+                                            if (
+                                                app + 1 >=
+                                                articlePillars.length
+                                            ) {
+                                                return 0
+                                            }
+                                            return app + 1
+                                        })
+                                    }}
+                                    style={{
+                                        position: 'absolute',
+                                        zIndex: 9999,
+                                        elevation: 999,
+                                        top:
+                                            Dimensions.get('window').height -
+                                            600,
+                                        right: metrics.horizontal,
+                                        alignSelf: 'flex-end',
+                                    }}
+                                >
+                                    {`${articlePillars[modifiedPillar]} 🌈`}
+                                </Button>
+                                <Button
+                                    onPress={() => {
+                                        setType(app => {
+                                            if (
+                                                app + 1 >=
+                                                articleTypes.length
+                                            ) {
+                                                return 0
+                                            }
+                                            return app + 1
+                                        })
+                                    }}
+                                    style={{
+                                        position: 'absolute',
+                                        zIndex: 9999,
+                                        elevation: 999,
+                                        top:
+                                            Dimensions.get('window').height -
+                                            560,
+                                        right: metrics.horizontal,
+                                        alignSelf: 'flex-end',
+                                    }}
+                                >
+                                    {`${articleTypes[modifiedType]} 🌈`}
+                                </Button>
+                            </>
                         ) : null}
-                        <WithArticleAppearance
-                            value={
-                                appearances[
-                                    modifiedAppearance
-                                ] as ColorFromPalette
-                            }
+                        <WithArticle
+                            type={articleTypes[modifiedType]}
+                            pillar={articlePillars[modifiedPillar]}
                         >
                             <ArticleController
                                 article={article.article}
                                 viewIsTransitioning={viewIsTransitioning}
                             />
-                        </WithArticleAppearance>
+                        </WithArticle>
                     </>
                 ),
             })}
@@ -163,7 +195,7 @@ const ArticleScreenWithProps = ({
     navigation: NavigationScreenProp<{}, ArticleNavigationProps>
 }) => {
     const { width } = Dimensions.get('window')
-    const appearance = getAppearancePillar(articleNavigator.appearance)
+    const pillar = getAppearancePillar(articleNavigator.appearance)
 
     /*
     we don't wanna render a massive tree at once
@@ -206,7 +238,7 @@ const ArticleScreenWithProps = ({
                 >
                     <ArticleScreenBody
                         path={path}
-                        appearance={appearance}
+                        pillar={pillar}
                         onTopPositionChange={() => {}}
                         {...{ viewIsTransitioning }}
                     />
@@ -269,7 +301,7 @@ const ArticleScreenWithProps = ({
                         }) => (
                             <ArticleScreenBody
                                 path={item}
-                                appearance={appearance}
+                                pillar={pillar}
                                 onTopPositionChange={isAtTop => {
                                     setArticleIsAtTop(isAtTop)
                                 }}

--- a/projects/Mallard/src/theme/appearance.ts
+++ b/projects/Mallard/src/theme/appearance.ts
@@ -1,11 +1,5 @@
 import { color } from './color'
 import { createContext, useContext } from 'react'
-import merge from 'deepmerge'
-import { ColorFromPalette } from 'src/common'
-import { metrics } from './spacing'
-import { getColor } from 'src/helpers/transform'
-import { Appearance } from '../../../common/src'
-import { getFont } from './typography'
 
 /*
 Types
@@ -16,68 +10,6 @@ export interface AppAppearanceStyles {
     borderColor: string
     color: string
     dimColor: string
-}
-interface ArticleAppearanceStyles {
-    /*
-    You can spread this over any 'hero'
-    background in the article page
-    */
-    backgrounds: {
-        backgroundColor?: string
-        borderColor?: string
-    }
-    /*
-    Card bg overrides
-    */
-    cardBackgrounds: {
-        backgroundColor?: string
-    }
-    /*
-    Contrast-y cards
-    */
-    contrastCardBackgrounds: {
-        backgroundColor?: string
-    }
-    /*
-    Spread this over text and icons
-    */
-    text: {
-        color?: string
-    }
-    /*
-    Overrides for the headline
-    */
-    headline: {
-        color?: string
-        fontFamily?: string
-    }
-    /*
-    Overrides for the kicker
-    */
-    kicker: {
-        color?: string
-    }
-    /*
-    Overrides for the kicker in a card
-    */
-    cardKicker: {
-        color?: string
-    }
-    /*
-    Overrides for the standfirst
-    */
-    standfirst: {
-        color?: string
-    }
-    /*
-    Overrides for the byline
-    */
-    byline: {
-        color?: string
-    }
-    /*
-    Feel free to add more stuff as needed!!
-    */
 }
 
 export type AppAppearance = 'default' | 'primary' | 'tertiary' | 'settings'
@@ -114,157 +46,10 @@ export const appAppearances: { [key in AppAppearance]: AppAppearanceStyles } = {
 }
 
 /*
-COLOURS
-*/
-export const articleAppearances: {
-    [key in ColorFromPalette]: ArticleAppearanceStyles
-} = {
-    neutral: {
-        backgrounds: {
-            backgroundColor: color.background,
-            borderColor: color.line,
-        },
-        contrastCardBackgrounds: {
-            backgroundColor: color.palette.neutral[7],
-        },
-        cardBackgrounds: {},
-        text: {
-            color: color.text,
-        },
-        headline: {},
-        kicker: {},
-        cardKicker: {},
-        byline: {},
-        standfirst: {},
-    },
-    news: {
-        backgrounds: {},
-        cardBackgrounds: {},
-        contrastCardBackgrounds: {},
-        text: {},
-        headline: {
-            color: color.dimText,
-        },
-        kicker: {
-            color: color.palette.news.main,
-        },
-        cardKicker: {
-            color: color.text,
-        },
-        byline: {
-            color: color.palette.news.main,
-        },
-        standfirst: {
-            color: color.text,
-        },
-    },
-    opinion: {
-        backgrounds: {
-            backgroundColor: color.palette.opinion.faded,
-        },
-        cardBackgrounds: {},
-        contrastCardBackgrounds: {},
-        text: {
-            color: color.palette.opinion.bright,
-        },
-        headline: {
-            color: color.palette.neutral[7],
-            fontFamily: 'GHGuardianHeadline-Light',
-        },
-        kicker: {},
-        cardKicker: {
-            color: color.text,
-        },
-        byline: {},
-        standfirst: {
-            color: color.palette.neutral[7],
-        },
-    },
-    sport: {
-        backgrounds: {
-            backgroundColor: color.palette.sport.faded,
-        },
-        cardBackgrounds: {},
-        contrastCardBackgrounds: {
-            backgroundColor: color.palette.sport.main,
-        },
-        text: {
-            color: color.palette.sport.main,
-        },
-        headline: {
-            fontFamily: 'GHGuardianHeadline-Light',
-            color: color.text,
-        },
-        kicker: {},
-        cardKicker: {},
-        byline: {},
-        standfirst: { color: color.text },
-    },
-    culture: {
-        backgrounds: {
-            backgroundColor: color.palette.culture.faded,
-        },
-        cardBackgrounds: {},
-        contrastCardBackgrounds: {},
-        text: {
-            color: color.palette.culture.main,
-        },
-        headline: {
-            color: color.text,
-        },
-        kicker: {},
-        cardKicker: {},
-        byline: {},
-        standfirst: {
-            color: color.text,
-        },
-    },
-    lifestyle: {
-        backgrounds: {
-            backgroundColor: color.palette.lifestyle.faded,
-        },
-        cardBackgrounds: {},
-        contrastCardBackgrounds: {},
-        text: {},
-        headline: {
-            //fontFamily: 'GHGuardianHeadline-Bold',
-        },
-        kicker: {
-            color: color.palette.lifestyle.main,
-        },
-        cardKicker: {},
-        byline: {},
-        standfirst: {},
-    },
-}
-
-/*
   Exports
  */
 const AppAppearanceContext = createContext<AppAppearance>('default')
-const ArticleAppearanceContext = createContext<ColorFromPalette>('neutral')
 
 export const WithAppAppearance = AppAppearanceContext.Provider
 export const useAppAppearance = (): AppAppearanceStyles =>
     appAppearances[useContext(AppAppearanceContext)]
-
-export const WithArticleAppearance = ArticleAppearanceContext.Provider
-
-export const useArticleAppearance = (): {
-    name: ColorFromPalette
-    appearance: ArticleAppearanceStyles
-} => {
-    const name = useContext(ArticleAppearanceContext)
-    return {
-        name,
-        appearance: name
-            ? merge(articleAppearances.neutral, articleAppearances[name])
-            : articleAppearances.neutral,
-    }
-}
-
-export const getAppearancePillar = (app: Appearance) =>
-    app.type === 'custom' ? 'neutral' : app.name
-
-export const useArticleToneColor = () =>
-    getColor({ type: 'pillar', name: useArticleAppearance().name })

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -4,13 +4,18 @@ interface WithKey {
     key: string
 }
 
-export type ColorFromPalette =
-    | 'news'
-    | 'opinion'
-    | 'sport'
-    | 'culture'
-    | 'lifestyle'
-    | 'neutral'
+export const articlePillars = [
+    'news',
+    'opinion',
+    'sport',
+    'culture',
+    'lifestyle',
+    'neutral',
+] as const
+export const articleTypes = ['article', 'opinion'] as const
+
+export type PillarFromPalette = typeof articlePillars[number]
+export type ArticleType = typeof articleTypes[number]
 
 interface ColorAppearance {
     type: 'custom'
@@ -18,7 +23,7 @@ interface ColorAppearance {
 }
 interface PillarAppearance {
     type: 'pillar'
-    name: ColorFromPalette
+    name: PillarFromPalette
 }
 
 export type Appearance = PillarAppearance | ColorAppearance

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -12,7 +12,7 @@ export const articlePillars = [
     'lifestyle',
     'neutral',
 ] as const
-export const articleTypes = ['article', 'opinion'] as const
+export const articleTypes = ['article', 'opinion', 'longread'] as const
 
 export type PillarFromPalette = typeof articlePillars[number]
 export type ArticleType = typeof articleTypes[number]


### PR DESCRIPTION
Instead of `articleAppearance` being a weird mix of low-level and high-level css now you can get an article type and and the pillar colors and do whatever with them