### PR TITLE
Preview support in backend

### DIFF
--- a/projects/archiver/local.ts
+++ b/projects/archiver/local.ts
@@ -12,7 +12,7 @@ MemWatch.on('leak', ev => {
 })
 console.log('Node process running on', process.pid)
 const date = process.argv[2] || '2019-07-09'
-run(date)
+run(date, 'preview')
     .then(() => {
         process.exit(0)
     })

--- a/projects/archiver/local.ts
+++ b/projects/archiver/local.ts
@@ -11,8 +11,9 @@ MemWatch.on('leak', ev => {
     console.error('>>>LEAK LEAK LEAK')
 })
 console.log('Node process running on', process.pid)
-const date = process.argv[2] || '2019-07-09'
-run(date, 'preview')
+const date = process.argv[2]
+const source = process.argv[3]
+run(date, source)
     .then(() => {
         process.exit(0)
     })

--- a/projects/archiver/main.ts
+++ b/projects/archiver/main.ts
@@ -153,7 +153,6 @@ export const handler: Handler<
         if (event.Records) return s3Event(event.Records)
         const id = event.id
         if (!(id && typeof id === 'string')) throw new Error('No ID in event')
-        if (event.index) return summary()
         const source = event.source
         if (!(source && typeof source === 'string'))
             throw new Error('No source in event')

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -3,7 +3,7 @@ import {
     SearchResponseCodec,
     ContentType,
     ICapiDateTime as CapiDateTime64,
-    ICrossword,
+    IContent,
 } from '@guardian/capi-ts'
 import {
     Article,
@@ -17,7 +17,6 @@ import {
 } from '@creditkarma/thrift-server-core'
 import { getImage } from './assets'
 import { elementParser } from './elements'
-import { IContent } from '@guardian/capi-ts/dist/Content'
 import fetch from 'node-fetch'
 import { cleanupHtml } from '../utils/html'
 import { fromPairs } from 'ramda'

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -2,13 +2,18 @@ import { Request, Response } from 'express'
 import { lastModified } from '../lastModified'
 import { getFront } from '../fronts'
 import { hasFailed } from '../utils/try'
+import { isPreview } from '../preview'
 
 export const frontController = (req: Request, res: Response) => {
     const id: string = req.params[0]
     const issue: string = req.params.issueId
+    const source: string = decodeURIComponent(
+        isPreview ? 'preview' : req.params.source,
+    )
+
     const [date, updater] = lastModified()
     console.log(`Request for ${req.url} fetching front ${id}`)
-    getFront(issue, id, updater)
+    getFront(issue, id, source, updater)
         .then(data => {
             if (hasFailed(data)) {
                 console.error(`${req.url} threw ${JSON.stringify(data)}`)

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -1,4 +1,4 @@
-import { s3fetch, s3Latest } from './s3'
+import { s3fetch, Path } from './s3'
 import { Front, Collection, CAPIArticle, Appearance } from './common'
 import { LastModifiedUpdater } from './lastModified'
 import {
@@ -20,6 +20,7 @@ import {
 } from './fronts/issue'
 import { getCrosswordArticleOverrides } from './utils/crossword'
 import { notNull } from '../common/src'
+import { isPreview } from './preview'
 
 export const parseCollection = async (
     collectionResponse: PublishedCollection,
@@ -199,17 +200,14 @@ const getFrontColor = (front: string): Appearance => {
 export const getFront = async (
     issue: string,
     id: string,
+    source: string,
     lastModifiedUpdater: LastModifiedUpdater,
 ): Promise<Attempt<Front>> => {
-    const latest = await s3Latest(`daily-edition/${issue}/`)
-    if (hasFailed(latest)) {
-        return withFailureMessage(
-            latest,
-            `Could not get latest issue for ${issue} and ${id}.`,
-        )
+    const path: Path = {
+        key: `daily-edition/${issue}/${source}.json`,
+        bucket: isPreview ? 'preview' : 'published',
     }
-    const issuePath = latest.key
-    const resp = await s3fetch(issuePath)
+    const resp = await s3fetch(path)
 
     if (hasFailed(resp)) {
         return withFailureMessage(

--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -8,21 +8,36 @@ import { frontController } from './controllers/fronts'
 import { imageController, imageColourController } from './controllers/image'
 import { ImageSize, coloursPath } from '../common/src/index'
 import { issuePath, mediaPath, frontPath, issueSummaryPath } from './common'
+import { isPreview } from './preview'
 
 const app = express()
 
+if (isPreview) {
+    console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
+    console.log('🗞🗞🗞 HOT OFF THE PRESS THIS IS PREVIEW🗞🗞🗞')
+    console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
+}
+
+const issueId = isPreview ? ':issueId' : ':source/:issueId'
+
+app.use((req, res, next) => {
+    console.log(req.url)
+    console.log(JSON.stringify(req.params))
+    next()
+})
+
 app.get('/' + issueSummaryPath(), issuesSummaryController)
 
-app.get('/' + issuePath(':issueId'), issueController)
-
-app.get('/' + frontPath(':issueId', '*?'), frontController)
+app.get('/' + issuePath(issueId), issueController)
+console.log('/' + issuePath(issueId))
+app.get('/' + frontPath(issueId, '*?'), frontController)
 
 app.get(
-    '/' + mediaPath(':issueId', ':size' as ImageSize, ':source', '*?'),
+    '/' + mediaPath(issueId, ':size' as ImageSize, ':source', '*?'),
     imageController,
 )
 
-app.get('/' + coloursPath(':issueId', ':source', '*?'), imageColourController)
+app.get('/' + coloursPath(issueId, ':source', '*?'), imageColourController)
 
 app.get('/', (req, res) => {
     res.setHeader('Content-Type', 'application/json')

--- a/projects/backend/issue.ts
+++ b/projects/backend/issue.ts
@@ -1,0 +1,37 @@
+import { LastModifiedUpdater } from './lastModified'
+import { Issue } from './common'
+import { hasFailed } from './utils/try'
+import { s3fetch, Path } from './s3'
+import { PublishedIssue } from './fronts/issue'
+import { isPreview } from './preview'
+
+export const getIssue = async (
+    issue: string,
+    source: string,
+    lastModifiedUpdater: LastModifiedUpdater,
+): Promise<Issue | 'notfound'> => {
+    console.log('Attempting to get latest issue for', issue)
+    const path: Path = {
+        key: `daily-edition/${issue}/${source}.json`,
+        bucket: isPreview ? 'preview' : 'published',
+    }
+
+    console.log(`Fetching ${JSON.stringify(path)} for ${issue}`)
+
+    const issueData = await s3fetch(path)
+
+    if (hasFailed(issueData)) {
+        return 'notfound'
+    }
+
+    lastModifiedUpdater(issueData.lastModified)
+    const data = (await issueData.json()) as PublishedIssue
+    const fronts = data.fronts.map(_ => _.name)
+    return {
+        name: data.name,
+        key: issue,
+        id: data.id,
+        date: data.issueDate,
+        fronts,
+    }
+}

--- a/projects/backend/preview.ts
+++ b/projects/backend/preview.ts
@@ -1,0 +1,1 @@
+export const isPreview = process.env.publicationStage === 'preview'

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -256,6 +256,8 @@ export interface Palette {
 }
 export type ImageSize = typeof imageSizes[number] | 'sample'
 
+// These have issueids in the path, but you'll need to change the archiver if you want to use them.
+
 export const mediaPath = (
     issue: string,
     size: ImageSize,

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,8 @@ deployments:
             prefixStack: false
             bucket: editions-dist
             fileName: backend.zip
-            functionNames: [editions-backend-]
+            functionNames:
+                [editions-preview-backend-, editions-published-backend-]
     archiver:
         type: aws-lambda
         dependencies: [cloudformation]


### PR DESCRIPTION
~~the backend can now be called with an id of form `${id}_${source}` where source is a published version or `'preview'`~~

~~when it is preview, the preview edition is fetched
when it is any string we look in the published bucket for that json file
when it is not present behavior is unchanged~~

The backend must now be called with `source/id` instead of `id`. There is a second backend set of endpoints accessed as before which access preview. 

The s3 buckets can now be used as an endpoint in the app. Will raise as separate PR. 

the archiver now takes a source and publishes to s3 without that source in the path (as if we didn't have specific sources) this better matches the intent of the tools part of the api 

~~⚠️ This will break the app when it goes live ⚠️~~
This introduces a third lambda deployment which can be destroyed when the app stops using the main backend.
