### PR TITLE
Add install for common

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "install-archiver": "cd projects/archiver && yarn --mutex network",
         "install-aws": "cd projects/aws && yarn --mutex network",
         "install-crosswords": "cd projects/editions-crossword-renderer-app && yarn --mutex network",
+        "install-common": "cd projects/common && yarn --mutex network",
         "postinstall": "run-p -ln --aggregate-output install-*",
         "build-archiver": "cd projects/archiver && yarn build",
         "build-backend": "cd projects/backend && yarn build",


### PR DESCRIPTION
## Why are you doing this?

Common was never getting installed on any of our build agents so it broke all of our builds. @AWare - this seems like it should work?
