### PR TITLE
Add in builders for sentry config files

### DIFF
--- a/projects/Mallard/.env.production.js
+++ b/projects/Mallard/.env.production.js
@@ -1,7 +1,15 @@
-const { writeRequiredEnvVars } = require('./scripts/helpers/helpers.js')
+const { writeEnvVarsToFiles } = require('./scripts/helpers/helpers.js')
 
-writeRequiredEnvVars`
+writeEnvVarsToFiles('.env')`
 ID_ACCESS_TOKEN
 ID_API_URL
 MEMBERS_DATA_API_URL
+`
+
+writeEnvVarsToFiles('android/sentry.properties', 'ios/sentry.properties')`
+defaults.url=SENTRY_DEFAULTS_URL
+defaults.org=SENTRY_DEFAULTS_ORG
+defaults.project=SENTRY_DEFAULTS_PROJECT
+auth.token=SENTRY_AUTH_TOKEN
+cli.executable=SENTRY_CLI_EXECUTABLE
 `

--- a/projects/Mallard/.gitignore
+++ b/projects/Mallard/.gitignore
@@ -22,6 +22,9 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
+# Sentry
+sentry.properties
+
 # Android/IntelliJ
 #
 build/

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "pre-run": "yarn fetch-dev-env && yarn watch-html & node ./scripts/versioning.js",
-        "pre-bundle": "yarn fetch-prod-env && yarn bundle-html",
+        "pre-bundle": "yarn write-prod-env && yarn bundle-html",
         "postinstall": "node ./scripts/versioning.js",
         "start": "yarn pre-run && node node_modules/react-native/local-cli/cli.js start",
         "test": "jest --coverage",
@@ -23,7 +23,7 @@
         "watch-html": "node ./scripts/watch-html.js",
         "convert-svg": "node ./scripts/svgs.js",
         "fetch-dev-env": "aws s3 cp s3://editions-config/Mallard/dev/.env ./.env --region=eu-west-1 --profile=frontend",
-        "fetch-prod-env": "node .env.production.js"
+        "write-prod-env": "node .env.production.js"
     },
     "rnpm": {
         "assets": [

--- a/projects/Mallard/scripts/helpers/helpers.js
+++ b/projects/Mallard/scripts/helpers/helpers.js
@@ -4,22 +4,43 @@ const fs = require('fs')
 const NEWLINE = '\n'
 const removeWhiteSpace = s => s.trim()
 const isNonEmpty = s => s
-const getValueFromKey = map => key => {
-    const value = map[key]
-    if (!value) throw new Error(`Could not find ${key}`)
-    return `${key}=${value}`
-}
-const writeToEnvFileinCWD = data =>
-    fs.writeFileSync(path.join(process.cwd(), '.env'), data)
 
-const writeRequiredEnvVars = strings =>
-    writeToEnvFileinCWD(
+/**
+ *
+ * `key` is expected to be in the format:
+ * `MY_ENV_VAR`
+ * where `value` will be read from the environment variable `process.env.MY_ENV_VAR` and then
+ * set as `MY_ENV_VAR=value` in the file
+ *
+ * or it can be in the format:
+ * `test.var=MY_ENV_VAR`
+ * where the `value` will be read from `process.env.MY_ENV_VAR` and set as `test.var=value`
+ * in the file
+ *
+ * This is useful for when config files require chars that cannot be used in environment variables
+ * such as periods. Or when the same env var needs to be written to two different properties
+ */
+
+const getValueFromEnvironment = key => {
+    let [writeKey, readKey = writeKey] = key.split('=')
+    const value = process.env[readKey]
+    if (!value) throw new Error(`Could not find ${readKey} in environment`)
+    return `${writeKey}=${value}`
+}
+const writeToFile = (relativePaths, data) =>
+    relativePaths.forEach(relativePath =>
+        fs.writeFileSync(path.join(process.cwd(), relativePath), data),
+    )
+
+const writeEnvVarsToFiles = (...paths) => strings =>
+    writeToFile(
+        paths,
         strings[0]
             .split(NEWLINE)
             .map(removeWhiteSpace)
             .filter(isNonEmpty)
-            .map(getValueFromKey(process.env))
+            .map(getValueFromEnvironment)
             .join(NEWLINE),
     )
 
-module.exports = { writeRequiredEnvVars }
+module.exports = { writeEnvVarsToFiles }


### PR DESCRIPTION
## Why are you doing this?

This adds a way to build our `sentry.properties` on Team City rather than commit them to git.
