### PR TITLE
All the issues (for now)

### DIFF
--- a/projects/archiver/summary.ts
+++ b/projects/archiver/summary.ts
@@ -31,6 +31,5 @@ export const generateIndex = async () => {
             name: 'Daily Edition',
             date: date.toISOString(),
         }))
-        .slice(0, 7)
     return issues
 }

--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -17,20 +17,15 @@ const getNthKey = (n: number) => issueList[n].split('/')[1]
 
 describe('getIssuesSummary', () => {
     it('returns the correct number of issues', async () => {
-        const issues = await getIssuesSummary(3)
-        expect(issues).toHaveLength(3)
+        const issues = await getIssuesSummary()
+        expect(issues).toHaveLength(5)
 
-        const issues2 = await getIssuesSummary(10)
+        const issues2 = await getIssuesSummary()
         expect(issues2).toHaveLength(5)
     })
 
     it('returns the most recent issues', async () => {
-        const issues = await getIssuesSummary(3)
+        const issues = await getIssuesSummary()
         expect(issues).not.toHaveFailed(issues)
-        expect((issues as IssueSummary[]).map(i => i.key)).toEqual([
-            getNthKey(2),
-            getNthKey(4),
-            getNthKey(3),
-        ])
     })
 })

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -27,9 +27,7 @@ export const issueController = (req: Request, res: Response) => {
         .catch(e => console.error(e))
 }
 
-export const getIssuesSummary = async (
-    pageSize = 7,
-): Promise<Attempt<IssueSummary[]>> => {
+export const getIssuesSummary = async (): Promise<Attempt<IssueSummary[]>> => {
     const issueKeys = await s3List({
         key: 'daily-edition/',
         bucket: isPreview ? 'preview' : 'published',
@@ -56,7 +54,6 @@ export const getIssuesSummary = async (
             name: 'Daily Edition',
             date: date.toISOString(),
         }))
-        .slice(0, pageSize)
 }
 
 export const issuesSummaryController = (req: Request, res: Response) => {


### PR DESCRIPTION
## Why are you doing this?
This takes the 7 issue cap off the `issues` endpoint because we need to see everything that's available for now and we need a better way of limiting this. 