### PR TITLE
feat: ios bundle id change

### DIFF
--- a/projects/Mallard/fastlane/Appfile
+++ b/projects/Mallard/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier("uk.co.guardian.editions") # The bundle identifier of your app
+app_identifier("uk.co.guardian.gce") # The bundle identifier of your app
 apple_id("apps.automation@guardian.co.uk") # Your Apple email address
 
 itc_team_id("304191") # App Store Connect Team ID

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
   lane :beta do
     increment_build_number(
       xcodeproj: "ios/Mallard.xcodeproj",
-      build_number: version["version"]
+      build_number: latest_testflight_build_number + 1
     )
     build_app(
       scheme: "Mallard",
@@ -37,8 +37,8 @@ platform :ios do
       }
     )
     upload_to_testflight(
-        distribute_external: true,
-        notify_external_testers: true,
+        distribute_external: false,
+        notify_external_testers: false,
         changelog: "Thanks for testing the app! We've done some improvements",
         groups: ["GNM"]
     )

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :ios do
       }
     )
     upload_to_testflight(
-        distribute_external: false,
+        distribute_external: true,
         notify_external_testers: false,
         changelog: "Thanks for testing the app! We've done some improvements",
         groups: ["GNM"]

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :ios do
     )
     upload_to_testflight(
         distribute_external: true,
-        notify_external_testers: false,
+        notify_external_testers: true,
         changelog: "Thanks for testing the app! We've done some improvements",
         groups: ["GNM"]
     )

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
   lane :beta do
     increment_build_number(
       xcodeproj: "ios/Mallard.xcodeproj",
-      build_number: latest_testflight_build_number + 1
+      build_number: latest_testflight_build_number.to_i + 1
     )
     build_app(
       scheme: "Mallard",

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -377,6 +377,20 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		950CA4AE22F86DD300E4C729 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC757C34E5404D4DACDBE7F3 /* RNSentry.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNSentry;
+		};
+		950CA4B022F86DD300E4C729 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BC757C34E5404D4DACDBE7F3 /* RNSentry.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 274692C321B4414400BF91A8;
+			remoteInfo = "RNSentry-tvOS";
+		};
 		95FC7DAB22EA085300C41645 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 95FC7D9B22EA085300C41645 /* RCTPushNotification.xcodeproj */;
@@ -946,6 +960,15 @@
 				00E356EE1AD99517003FC87E /* MallardTests.xctest */,
 				2D02E47B1E0B4A5D006451C7 /* Mallard-tvOS.app */,
 				2D02E4901E0B4A5D006451C7 /* Mallard-tvOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		950CA4AA22F86DD300E4C729 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				950CA4AF22F86DD300E4C729 /* libRNSentry.a */,
+				950CA4B122F86DD300E4C729 /* libRNSentry-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1551,6 +1574,20 @@
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		950CA4AF22F86DD300E4C729 /* libRNSentry.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNSentry.a;
+			remoteRef = 950CA4AE22F86DD300E4C729 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		950CA4B122F86DD300E4C729 /* libRNSentry-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNSentry-tvOS.a";
+			remoteRef = 950CA4B022F86DD300E4C729 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		95FC7DAC22EA085300C41645 /* libRCTPushNotification.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1995,7 +2032,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.editions;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = Mallard;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2034,7 +2071,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.editions;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = Mallard;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>465</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -63,7 +63,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>GHGuardianHeadline-Black.ttf</string>


### PR DESCRIPTION
## Why are you doing this?

In order to get Push Notifications (and some of the Auth) working to its fullest potential, we need to use the production iOS bundle id.

[**Trello Card ->**](https://trello.com/c/QkO169QG/402-change-the-ios-bundle-id)

## Changes

* Change the bundle id
* Update the fastlane files to manage the build
* Move from timestamp build numbers to sequential to follow the existing pattern.
