### PR TITLE
First pass at IAP provider

### DIFF
--- a/projects/Mallard/.env.production.js
+++ b/projects/Mallard/.env.production.js
@@ -5,6 +5,7 @@ ID_ACCESS_TOKEN
 ID_API_URL
 MEMBERS_DATA_API_URL
 SENTRY_DSN_URL
+ITUNES_CONNECT_SHARED_SECRET
 `
 
 writeEnvVarsToFiles('android/sentry.properties', 'ios/sentry.properties')`

--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -156,6 +156,7 @@ android {
 }
 
 dependencies {
+    implementation project(':react-native-iap')
     implementation project(':react-native-device-info')
     implementation project(':@react-native-community_netinfo')
     implementation project(':react-native-sentry')

--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
@@ -3,6 +3,7 @@ package com.guardian.editions;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.dooboolab.RNIap.RNIapPackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.reactnativecommunity.netinfo.NetInfoPackage;
 import io.sentry.RNSentryPackage;
@@ -37,6 +38,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNIapPackage(),
             new RNDeviceInfo(),
             new NetInfoPackage(),
             new RNSentryPackage(),

--- a/projects/Mallard/android/settings.gradle
+++ b/projects/Mallard/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'Mallard'
+include ':react-native-iap'
+project(':react-native-iap').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-iap/android')
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':@react-native-community_netinfo'

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302C01ABCB91800DB3ED1 /* libRCTImage.a */; };
@@ -27,6 +28,7 @@
 		19F2EE290B674883B5BFCBFA /* libRNDeviceInfo-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A5301B683D485F8DDBF24A /* libRNDeviceInfo-tvOS.a */; };
 		1E1950B0D52446F3A33585F8 /* libRNCAsyncStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E402822012C34F64AA00D0D0 /* libRNCAsyncStorage.a */; };
 		230F903D8CD24F6AA5B55117 /* guardianIcons_1.12.otf in Resources */ = {isa = PBXBuildFile; fileRef = CEC9D18600B14CC098C48387 /* guardianIcons_1.12.otf */; };
+		25B4363BB2E541E78E98ED2E /* libRNIap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6E2DA163EB14C5AA6FF0526 /* libRNIap.a */; };
 		2795FFC912F745B79C95E324 /* libRNCWebView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3FAFC61256B42E39F76C701 /* libRNCWebView.a */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
@@ -422,6 +424,20 @@
 			remoteGlobalIDString = B5027B1B2237B30F00F1AABA;
 			remoteInfo = "RNCNetInfo-tvOS";
 		};
+		A1844CD12302B96900F4AA53 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNIap;
+		};
+		A1844CD32302B96900F4AA53 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 070744702296C0EF00B1DC9D;
+			remoteInfo = "RNIap-tvOS";
+		};
 		A1EFE3B122CCE4020058AC0A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6B4B191CA6E247A7ADFEE706 /* RNCMaskedView.xcodeproj */;
@@ -583,6 +599,7 @@
 		2D16E6891FA4F8E400B85C8A /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		32B3CC9963BA4216B98F3053 /* GuardianTextSans-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextSans-BoldItalic.ttf"; path = "../src/assets/fonts/GuardianTextSans-BoldItalic.ttf"; sourceTree = "<group>"; };
 		338B754465C14DBA81420461 /* ReactNativeConfig.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = ReactNativeConfig.xcodeproj; path = "../node_modules/react-native-config/ios/ReactNativeConfig.xcodeproj"; sourceTree = "<group>"; };
+		350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNIap.xcodeproj; path = "../node_modules/react-native-iap/ios/RNIap.xcodeproj"; sourceTree = "<group>"; };
 		3A3CB24411DD4F45B51A1081 /* RNFetchBlob.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFetchBlob.xcodeproj; path = "../node_modules/rn-fetch-blob/ios/RNFetchBlob.xcodeproj"; sourceTree = "<group>"; };
 		3DA2FD0EC69B436384494394 /* GHGuardianHeadline-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GHGuardianHeadline-BoldItalic.ttf"; path = "../src/assets/fonts/GHGuardianHeadline-BoldItalic.ttf"; sourceTree = "<group>"; };
 		3DA6B7E32F1A492799562BFE /* RNGestureHandler.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNGestureHandler.xcodeproj; path = "../node_modules/react-native-gesture-handler/ios/RNGestureHandler.xcodeproj"; sourceTree = "<group>"; };
@@ -636,6 +653,7 @@
 		ED175DCD22A3452EA1C9C2E4 /* GHGuardianHeadline-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GHGuardianHeadline-Light.ttf"; path = "../src/assets/fonts/GHGuardianHeadline-Light.ttf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+		F6E2DA163EB14C5AA6FF0526 /* libRNIap.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNIap.a; sourceTree = "<group>"; };
 		F89749D218B4491B86CF7AE5 /* libRNSVG-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNSVG-tvOS.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -681,6 +699,7 @@
 				B18B5E72E70E40B1990E985B /* libRNSentry.a in Frameworks */,
 				400A457871E1405DAFE1448A /* libRNCNetInfo.a in Frameworks */,
 				6D627F9CFC2B410CAC37BE52 /* libRNDeviceInfo.a in Frameworks */,
+				25B4363BB2E541E78E98ED2E /* libRNIap.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -953,6 +972,7 @@
 				BC757C34E5404D4DACDBE7F3 /* RNSentry.xcodeproj */,
 				8A53A94B53FA4CDAB532D2FC /* RNCNetInfo.xcodeproj */,
 				A70EB17FF4504C6D97FC3456 /* RNDeviceInfo.xcodeproj */,
+				350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1020,6 +1040,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		A1844CCD2302B96900F4AA53 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1844CD22302B96900F4AA53 /* libRNIap.a */,
+				A1844CD42302B96900F4AA53 /* libRNIap.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		A1EFE3A922CCE4020058AC0A /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1077,6 +1106,7 @@
 				B90C70436F5F407A8D555C60 /* libRNCNetInfo-tvOS.a */,
 				47AAFC905A9244988FFF732E /* libRNDeviceInfo.a */,
 				27A5301B683D485F8DDBF24A /* libRNDeviceInfo-tvOS.a */,
+				F6E2DA163EB14C5AA6FF0526 /* libRNIap.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1335,6 +1365,10 @@
 				{
 					ProductGroup = ABFED90A2284261600DA41EA /* Products */;
 					ProjectRef = 3DA6B7E32F1A492799562BFE /* RNGestureHandler.xcodeproj */;
+				},
+				{
+					ProductGroup = A1844CCD2302B96900F4AA53 /* Products */;
+					ProjectRef = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
 				},
 				{
 					ProductGroup = A1EFE3AB22CCE4020058AC0A /* Products */;
@@ -1664,6 +1698,20 @@
 			fileType = archive.ar;
 			path = "libRNCNetInfo-tvOS.a";
 			remoteRef = A17C2BAD22F8919A005B4D42 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A1844CD22302B96900F4AA53 /* libRNIap.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNIap.a;
+			remoteRef = A1844CD12302B96900F4AA53 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A1844CD42302B96900F4AA53 /* libRNIap.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNIap.a;
+			remoteRef = A1844CD32302B96900F4AA53 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		A1EFE3B222CCE4020058AC0A /* libRNCMaskedView.a */ = {
@@ -2004,12 +2052,14 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = MallardTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -2051,12 +2101,14 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = MallardTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -2102,6 +2154,7 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = Mallard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2143,6 +2196,7 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = Mallard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2187,11 +2241,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -2241,11 +2297,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -2294,11 +2352,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -2347,11 +2407,13 @@
 					"$(SRCROOT)/../node_modules/react-native-sentry/ios/**",
 					"$(SRCROOT)/../node_modules/@react-native-community/netinfo/ios",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-iap/ios",
 				);
 				INFOPLIST_FILE = "Mallard-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -424,14 +424,14 @@
 			remoteGlobalIDString = B5027B1B2237B30F00F1AABA;
 			remoteInfo = "RNCNetInfo-tvOS";
 		};
-		A1844CD12302B96900F4AA53 /* PBXContainerItemProxy */ = {
+		A1844BCC2301C3F500F4AA53 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RNIap;
 		};
-		A1844CD32302B96900F4AA53 /* PBXContainerItemProxy */ = {
+		A1844BCE2301C3F500F4AA53 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
 			proxyType = 2;
@@ -1040,11 +1040,11 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		A1844CCD2302B96900F4AA53 /* Products */ = {
+		A1844BC82301C3F500F4AA53 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A1844CD22302B96900F4AA53 /* libRNIap.a */,
-				A1844CD42302B96900F4AA53 /* libRNIap.a */,
+				A1844BCD2301C3F500F4AA53 /* libRNIap.a */,
+				A1844BCF2301C3F500F4AA53 /* libRNIap.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1367,7 +1367,7 @@
 					ProjectRef = 3DA6B7E32F1A492799562BFE /* RNGestureHandler.xcodeproj */;
 				},
 				{
-					ProductGroup = A1844CCD2302B96900F4AA53 /* Products */;
+					ProductGroup = A1844BC82301C3F500F4AA53 /* Products */;
 					ProjectRef = 350A99D1AB074D79813F88E6 /* RNIap.xcodeproj */;
 				},
 				{
@@ -1700,18 +1700,18 @@
 			remoteRef = A17C2BAD22F8919A005B4D42 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A1844CD22302B96900F4AA53 /* libRNIap.a */ = {
+		A1844BCD2301C3F500F4AA53 /* libRNIap.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRNIap.a;
-			remoteRef = A1844CD12302B96900F4AA53 /* PBXContainerItemProxy */;
+			remoteRef = A1844BCC2301C3F500F4AA53 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A1844CD42302B96900F4AA53 /* libRNIap.a */ = {
+		A1844BCF2301C3F500F4AA53 /* libRNIap.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRNIap.a;
-			remoteRef = A1844CD32302B96900F4AA53 /* PBXContainerItemProxy */;
+			remoteRef = A1844BCE2301C3F500F4AA53 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		A1EFE3B222CCE4020058AC0A /* libRNCMaskedView.a */ = {

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -52,6 +52,7 @@
         "react-native-config": "^0.11.7",
         "react-native-device-info": "^2.3.2",
         "react-native-gesture-handler": "^1.2.1",
+        "react-native-iap": "^3.3.9",
         "react-native-keychain": "^3.1.3",
         "react-native-push-notification": "^3.1.3",
         "react-native-screens": "^1.0.0-alpha.22",

--- a/projects/Mallard/src/authentication/__tests__/credentials-chain.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/credentials-chain.spec.ts
@@ -4,8 +4,9 @@ import {
     CASAuthStatus,
     isAuthed,
     authTypeFromCAS,
+    authTypeFromIAP,
 } from '../credentials-chain'
-import { userData, casExpiry } from './fixtures'
+import { userData, casExpiry, receiptIOS } from './fixtures'
 
 /**
  * This helper ensures an ordering or resolving promises, any promise
@@ -92,6 +93,30 @@ describe('credentials-chain', () => {
         it('returns false when the CAS expiry is in the past', () => {
             expect(
                 authTypeFromCAS(casExpiry({ expiryDate: '2012-12-12' })),
+            ).toBe(false)
+        })
+    })
+
+    describe('authTypeFromIAP', () => {
+        it('returns an IAP auth when the IAP receipt expiry is in the future', () => {
+            expect(
+                authTypeFromIAP(
+                    receiptIOS({
+                        expires_date_ms: `${Date.now() + 1000}`,
+                    }),
+                ),
+            ).toMatchObject({
+                type: 'iap',
+            })
+        })
+
+        it('returns false when the IAP receipt expiry is in the past', () => {
+            expect(
+                authTypeFromIAP(
+                    receiptIOS({
+                        expires_date_ms: `${Date.now() - 1000}`,
+                    }),
+                ),
             ).toBe(false)
         })
     })

--- a/projects/Mallard/src/authentication/__tests__/fixtures.ts
+++ b/projects/Mallard/src/authentication/__tests__/fixtures.ts
@@ -1,3 +1,5 @@
+import { ReceiptIOS } from 'src/services/iap'
+
 const membershipResponse = {
     userId: 'uid',
     showSupportMessaging: true,
@@ -51,4 +53,40 @@ const casExpiry = ({
     subscriptionCode,
 })
 
-export { membershipResponse, userResponse, userData, casExpiry }
+const receiptIOS = ({
+    expires_date = '',
+    expires_date_ms = `${Date.now()}`,
+    expires_date_pst = '',
+    is_in_intro_offer_period = '',
+    is_trial_period = '',
+    original_purchase_date = '',
+    original_purchase_date_ms = '',
+    original_purchase_date_pst = '',
+    original_transaction_id = '',
+    product_id = '',
+    purchase_date = '',
+    purchase_date_ms = '',
+    purchase_date_pst = '',
+    quantity = '',
+    transaction_id = '',
+    web_order_line_item_id = '',
+} = {}): ReceiptIOS => ({
+    expires_date,
+    expires_date_ms,
+    expires_date_pst,
+    is_in_intro_offer_period,
+    is_trial_period,
+    original_purchase_date,
+    original_purchase_date_ms,
+    original_purchase_date_pst,
+    original_transaction_id,
+    product_id,
+    purchase_date,
+    purchase_date_ms,
+    purchase_date_pst,
+    quantity,
+    transaction_id,
+    web_order_line_item_id,
+})
+
+export { receiptIOS, membershipResponse, userResponse, userData, casExpiry }

--- a/projects/Mallard/src/authentication/credentials-chain.ts
+++ b/projects/Mallard/src/authentication/credentials-chain.ts
@@ -10,7 +10,11 @@ import {
     legacyCASExpiryCache,
     iapReceiptCache,
 } from './storage'
-import { ReceiptIOS, fetchActiveIOSSubscriptionReceipt } from '../services/iap'
+import {
+    ReceiptIOS,
+    fetchActiveIOSSubscriptionReceipt,
+    isReceiptActive,
+} from '../services/iap'
 
 interface IdentityAuth {
     type: 'identity'
@@ -116,7 +120,8 @@ const authTypeFromCAS = (info: CasExpiry | null): CASAuth | false =>
     }
 
 const authTypeFromIAP = (info: ReceiptIOS | null): IAPAuth | false =>
-    !!info && {
+    !!info &&
+    isReceiptActive(info) && {
         type: 'iap',
         info,
     }

--- a/projects/Mallard/src/authentication/credentials-chain.ts
+++ b/projects/Mallard/src/authentication/credentials-chain.ts
@@ -187,4 +187,5 @@ export {
     CASAuthStatus,
     /* exported for testing */
     authTypeFromCAS,
+    authTypeFromIAP,
 }

--- a/projects/Mallard/src/authentication/helpers.ts
+++ b/projects/Mallard/src/authentication/helpers.ts
@@ -8,6 +8,7 @@ import {
     getLegacyUserAccessToken,
     legacyCASUsernameCache,
     legacyCASPasswordCache,
+    iapReceiptCache,
 } from './storage'
 import {
     fetchMembershipData,
@@ -22,6 +23,7 @@ import {
     User,
 } from 'src/services/id-service'
 import { fetchCasSubscription } from '../services/content-auth-service'
+import { fetchActiveIOSSubscriptionReceipt } from '../services/iap'
 
 /**
  * This helper attempts to get an Identity user access token with an email and password.
@@ -72,6 +74,13 @@ const fetchAndPersistCASExpiry = async (
     casCredentialsKeychain.set(subscriberId, password)
     casDataCache.set(expiry)
     return expiry
+}
+
+const fetchAndPersistIAPReceipt = async () => {
+    const receipt = await fetchActiveIOSSubscriptionReceipt()
+    if (!receipt) return null
+    iapReceiptCache.set(receipt)
+    return receipt
 }
 
 export interface UserData {
@@ -167,4 +176,5 @@ export {
     fetchCASExpiryForKeychainCredentials,
     canViewEdition,
     fetchAndPersistCASExpiry,
+    fetchAndPersistIAPReceipt,
 }

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -3,6 +3,7 @@ import { UserData } from './helpers'
 import AsyncStorage from '@react-native-community/async-storage'
 import { CasExpiry } from 'src/services/content-auth-service'
 import { Settings } from 'react-native'
+import { ReceiptIOS } from '../services/iap'
 import {
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
@@ -47,6 +48,8 @@ const createAsyncCache = <T extends object>(key: string) => ({
 const casDataCache = createAsyncCache<CasExpiry>('cas-data-cache')
 
 const userDataCache = createAsyncCache<UserData>('user-data-cache')
+
+const iapReceiptCache = createAsyncCache<ReceiptIOS>('iap-receipt-cache')
 
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
@@ -98,6 +101,7 @@ const resetCredentials = (): Promise<boolean> =>
         casDataCache.reset(),
         _legacyUserAccessTokenKeychain.reset(),
         legacyCASExpiryCache.reset(),
+        iapReceiptCache.reset(),
     ]).then(all => all.every(_ => _))
 
 export {
@@ -111,4 +115,5 @@ export {
     legacyCASExpiryCache,
     legacyCASUsernameCache,
     legacyCASPasswordCache,
+    iapReceiptCache,
 }

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -2,7 +2,12 @@ import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import Config from 'react-native-config'
 
-const { ID_API_URL, MEMBERS_DATA_API_URL, ID_ACCESS_TOKEN } = Config
+const {
+    ID_API_URL,
+    MEMBERS_DATA_API_URL,
+    ID_ACCESS_TOKEN,
+    ITUNES_CONNECT_SHARED_SECRET,
+} = Config
 
 const FACEBOOK_CLIENT_ID = '180444840287'
 
@@ -32,4 +37,5 @@ export {
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
     LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
+    ITUNES_CONNECT_SHARED_SECRET,
 }

--- a/projects/Mallard/src/services/iap.ts
+++ b/projects/Mallard/src/services/iap.ts
@@ -36,7 +36,7 @@ const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {
         .transactionReceipt
 }
 
-const receiptIsCurrentlyActive = (receipt: ReceiptIOS) => {
+const isReceiptActive = (receipt: ReceiptIOS) => {
     const expirationInMilliseconds = Number(receipt.expires_date_ms)
     const nowInMilliseconds = Date.now()
     return expirationInMilliseconds > nowInMilliseconds
@@ -52,9 +52,9 @@ const fetchActiveIOSSubscriptionReceipt = async (): Promise<ReceiptIOS | null> =
     if (!decodedReceipt) return null
     return (
         (decodedReceipt.latest_receipt_info as ReceiptIOS[]).find(
-            receiptIsCurrentlyActive,
+            isReceiptActive,
         ) || null
     )
 }
 
-export { fetchActiveIOSSubscriptionReceipt }
+export { fetchActiveIOSSubscriptionReceipt, isReceiptActive }

--- a/projects/Mallard/src/services/iap.ts
+++ b/projects/Mallard/src/services/iap.ts
@@ -1,0 +1,60 @@
+import RNIAP, { Purchase } from 'react-native-iap'
+import { Platform } from 'react-native'
+import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants'
+
+export interface ReceiptIOS {
+    expires_date: string
+    expires_date_ms: string
+    expires_date_pst: string
+    is_in_intro_offer_period: string
+    is_trial_period: string
+    original_purchase_date: string
+    original_purchase_date_ms: string
+    original_purchase_date_pst: string
+    original_transaction_id: string
+    product_id: string
+    purchase_date: string
+    purchase_date_ms: string
+    purchase_date_pst: string
+    quantity: string
+    transaction_id: string
+    web_order_line_item_id: string
+}
+
+const fetchDecodeReceipt = (receipt: string) =>
+    RNIAP.validateReceiptIos(
+        {
+            'receipt-data': receipt,
+            password: ITUNES_CONNECT_SHARED_SECRET,
+        },
+        __DEV__,
+    )
+
+const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {
+    if (!purchases.length) return false
+    return purchases.sort((a, b) => b.transactionDate - a.transactionDate)[0]
+        .transactionReceipt
+}
+
+const receiptIsCurrentlyActive = (receipt: ReceiptIOS) => {
+    const expirationInMilliseconds = Number(receipt.expires_date_ms)
+    const nowInMilliseconds = Date.now()
+    return expirationInMilliseconds > nowInMilliseconds
+}
+
+// The essence of this came from here: https://github.com/dooboolab/react-native-iap/issues/275#issuecomment-433582389
+const fetchActiveIOSSubscriptionReceipt = async (): Promise<ReceiptIOS | null> => {
+    if (Platform.OS !== 'ios') return null
+    const purchases = await RNIAP.getAvailablePurchases()
+    const mostRecentReceipt = getMostRecentTransactionReceipt(purchases)
+    if (!mostRecentReceipt) return null
+    const decodedReceipt = await fetchDecodeReceipt(mostRecentReceipt)
+    if (!decodedReceipt) return null
+    return (
+        (decodedReceipt.latest_receipt_info as ReceiptIOS[]).find(
+            receiptIsCurrentlyActive,
+        ) || null
+    )
+}
+
+export { fetchActiveIOSSubscriptionReceipt }

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2197,6 +2197,13 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dooboolab-welcome@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.1.0.tgz#4a0aa9d2cbc4e2b1008bf7683bc056b41caa3d0d"
+  integrity sha512-K9TKEeefzDXZiUyLZG+bIr8cy9UoYIfFMseowp/o3czVl7TfkVm3gQpeB85w+TO8xeqzWHiIcEelZbBgt5WUwQ==
+  dependencies:
+    chalk "^2.4.1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -5560,6 +5567,13 @@ react-native-gesture-handler@^1.2.1:
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.2"
     prop-types "^15.5.10"
+
+react-native-iap@^3.3.9:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-3.3.9.tgz#581c1b0453bf5339603891926f4c34a589f2ade6"
+  integrity sha512-td23Dm/irLq5CEXUBuXx5KcmoAkFZM4q3z+gv/eYtMQ3wjBIiZTm3JyS8Df34J2MTKrzg57sGFcwtHVo6v6Vew==
+  dependencies:
+    dooboolab-welcome "^1.1.0"
 
 react-native-keychain@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
## Why are you doing this?

To allow users to login with existing IAP credentials from the previous daily edition app. I'm going to leave this as draft as it will require a fair bit of testing before I know that this works. The essence of the PR is good. The specifics might not be quite right.

Things still to consider:
- [x] check this actually works on an upgrade!
- [x] can we just check _any_ receipt from the array of purchases, or are there some criteria by which a receipt may not be valid for a subscription? I think we only have one type of purchase (all under one group of purchases) so this _should_ be ok.
- [x] the way I've implemented it at current means that even if a receipt auto renews, if the user is offline, if the receipt that was cached when they were online has expired they won't be able to login. Is this fine, and should we highlight this somewhere? Perhaps we could assume that any receipt in the cache means they can login while offline - but this seems like it might be prone to exploitation.
- [x] Do we need a way of explaining how to cancel an IAP subscription anywhere - this is doable from the iCloud settings but potentially we have a screen to explain this in the old DE app which we may need to replicate @blishen (sorry you're the only one on github) ...

## Screenshots

Nothing to see here ...
