### PR TITLE
Show a refresh button when we are on a preview backend

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -10,7 +10,7 @@
         "test": "jest --coverage",
         "test:watch": "jest --watch",
         "shake-android": "echo '👋 📱' && adb shell input keyevent 82 && echo '🙌📲🙌'",
-        "wifi-android": "yarn pre-run && ip=$(adb shell ifconfig wlan0  | awk '/inet addr/{print substr($2,6)}') && adb tcpip 5555 && adb connect $ip:5555",
+        "wifi-android": "ip=$(adb shell ifconfig wlan0  | awk '/inet addr/{print substr($2,6)}') && adb tcpip 5555 && adb connect $ip:5555",
         "run-android": "yarn pre-run && adb reverse tcp:8081 tcp:8081 && adb reverse tcp:8097 tcp:8097 && adb reverse tcp:3131 tcp:3131 && react-native run-android",
         "run-ios": "yarn pre-run && yarn install-pods &&  react-native run-ios",
         "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\"",

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, Alert } from 'react-native'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import {
@@ -13,6 +13,7 @@ import { useIssueDate } from 'src/helpers/issues'
 import { Issue } from 'src/common'
 import { Highlight } from 'src/components/highlight'
 import { getFont } from 'src/theme/typography'
+import { Button, ButtonAppearance } from 'src/components/button/button'
 
 const styles = StyleSheet.create({
     background: {

--- a/projects/Mallard/src/components/reloadButton.tsx
+++ b/projects/Mallard/src/components/reloadButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { View } from 'react-native'
+import { Button, ButtonAppearance } from './button/button'
+import { useInsets } from 'src/hooks/use-screen'
+export const ReloadButton: React.FC<{
+    onPress: () => void
+}> = ({ onPress }) => {
+    const { top, left } = useInsets()
+    return (
+        <View
+            style={[
+                {
+                    position: 'absolute',
+                    top: top + 20,
+                    left: left + 20,
+                    zIndex: 99999,
+                },
+            ]}
+        >
+            <Button
+                appearance={ButtonAppearance.tomato}
+                onPress={onPress}
+                buttonStyles={{ left: 0 }}
+            >
+                Reload
+            </Button>
+        </View>
+    )
+}

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -8,24 +8,33 @@ export const backends = [
     {
         title: 'PROD published',
         value: 'https://editions-store.s3-eu-west-1.amazonaws.com/',
+        preview: false,
     },
     {
         title: 'PROD preview',
         value: 'https://d2cf1ljtg904cv.cloudfront.net/',
+        preview: true,
     },
     {
         title: 'CODE published',
         value: 'https://editions-store-code.s3-eu-west-1.amazonaws.com/',
+        preview: false,
     },
     {
         title: 'CODE preview',
         value: 'https://d2mztzjulnpyb8.cloudfront.net/',
+        preview: true,
     },
     {
         title: 'DEV',
         value: 'http://localhost:3131/',
+        preview: true,
     },
-] as const
+] as {
+    title: string
+    value: string
+    preview: boolean
+}[]
 
 export const notificationServiceRegister = {
     prod: 'https://notifications.guardianapis.com/device/register',
@@ -41,4 +50,9 @@ export const defaultSettings: Settings = {
     notificationServiceRegister: __DEV__
         ? notificationServiceRegister.code
         : notificationServiceRegister.prod,
+}
+
+export const isPreview = (settings: Settings): boolean => {
+    const backend = backends.find(backend => backend.value === settings.apiUrl)
+    return (backend && backend.preview) || false
 }

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -16,7 +16,7 @@ import {
     Issue,
     PillarFromPalette,
 } from 'src/common'
-import { Dimensions, Animated, View, StyleSheet } from 'react-native'
+import { Dimensions, Animated, Text, View, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { SlideCard } from 'src/components/layout/slide-card/index'
 import { color } from 'src/theme/color'
@@ -40,6 +40,8 @@ import { LoginOverlay } from 'src/components/login/login-overlay'
 import { routeNames } from 'src/navigation/routes'
 import { WithBreakpoints } from 'src/components/layout/ui/sizing/with-breakpoints'
 import { useDimensions } from 'src/hooks/use-screen'
+import { UiBodyCopy } from 'src/components/styled-text'
+import { isPreview } from 'src/helpers/settings/defaults'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -67,11 +69,13 @@ const ArticleScreenBody = ({
     onTopPositionChange,
     pillar,
     width,
+    previewNotice,
 }: {
     path: PathToArticle
     onTopPositionChange: (isAtTop: boolean) => void
     pillar: PillarFromPalette
     width: number
+    previewNotice?: string
 }) => {
     const [modifiedPillar, setPillar] = useState(
         articlePillars.indexOf(pillar) || 0,
@@ -104,6 +108,9 @@ const ArticleScreenBody = ({
                 ),
                 success: article => (
                     <>
+                        {previewNotice && (
+                            <UiBodyCopy>{previewNotice}</UiBodyCopy>
+                        )}
                         {isUsingProdDevtools ? (
                             <>
                                 <Button
@@ -212,6 +219,9 @@ const ArticleScreenWithProps = ({
         outputRange: [0, 1],
     })
 
+    const preview = isPreview(useSettings()[0])
+    const previewNotice = preview ? `${path.collection}:${current}` : undefined
+
     return (
         <ClipFromTop
             easing={navigationPosition && navigationPosition.position}
@@ -242,6 +252,7 @@ const ArticleScreenWithProps = ({
                                         width={width}
                                         pillar={pillar}
                                         onTopPositionChange={() => {}}
+                                        previewNotice={previewNotice}
                                     />
                                 ),
                             }}
@@ -320,6 +331,7 @@ const ArticleScreenWithProps = ({
                                     onTopPositionChange={isAtTop => {
                                         setArticleIsAtTop(isAtTop)
                                     }}
+                                    previewNotice={previewNotice}
                                 />
                             )}
                         />

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -20,13 +20,24 @@ import { navigateToIssueList } from 'src/navigation/helpers'
 import { Container } from 'src/components/layout/ui/container'
 import { Weather } from 'src/components/weather'
 import { WithBreakpoints } from 'src/components/layout/ui/sizing/with-breakpoints'
-import { Text, View, ViewStyle, StyleProp, StyleSheet } from 'react-native'
+import {
+    Text,
+    View,
+    ViewStyle,
+    StyleProp,
+    StyleSheet,
+    Alert,
+} from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { WithIssueScreenSize, useIssueScreenSize } from './issue/use-size'
 import { PageLayoutSizes } from 'src/components/front/helpers/helpers'
 import { WithLayoutRectangle } from 'src/components/layout/ui/sizing/with-layout-rectangle'
+import { ReloadButton } from 'src/components/reloadButton'
+import { clearCache } from 'src/helpers/fetch/cache'
+import { useSettings } from 'src/hooks/use-settings'
+import { isPreview } from 'src/helpers/settings/defaults'
 
 export interface PathToIssue {
     issue: Issue['key']
@@ -118,7 +129,7 @@ const IssueFronts = ({
 
 const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
     const response = useIssueOrLatestResponse(path && path.issue)
-
+    const preview = isPreview(useSettings()[0])
     return (
         <Container>
             {response({
@@ -140,8 +151,16 @@ const IssueScreenWithPath = ({ path }: { path: PathToIssue | undefined }) => {
                         </FlexCenter>
                     </>
                 ),
-                success: issue => (
+                success: (issue, { retry }) => (
                     <>
+                        {preview && (
+                            <ReloadButton
+                                onPress={() => {
+                                    clearCache()
+                                    retry()
+                                }}
+                            />
+                        )}
                         <WithBreakpoints>
                             {{
                                 0: () => (

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -24,6 +24,7 @@ import { isPreview } from './preview'
 
 export const parseCollection = async (
     collectionResponse: PublishedCollection,
+    i: number,
     front: PublishedFront,
 ): Promise<Attempt<Collection>> => {
     const articleFragmentList = collectionResponse.items.map((itemResponse): [
@@ -142,7 +143,7 @@ export const parseCollection = async (
         })
 
     return {
-        key: collectionResponse.id,
+        key: `${i}:${collectionResponse.name}`,
         cards: createCardsFromAllArticlesInCollection(articles, front),
     }
 }
@@ -228,7 +229,7 @@ export const getFront = async (
     const collections = await Promise.all(
         front.collections
             .filter(collection => collection.items.length > 0)
-            .map(collection => parseCollection(collection, front)),
+            .map((collection, i) => parseCollection(collection, i, front)),
     )
 
     collections.filter(hasFailed).forEach(failedCollection => {

--- a/projects/backend/fronts/issue.ts
+++ b/projects/backend/fronts/issue.ts
@@ -13,6 +13,7 @@ export interface PublishedFront {
 }
 export interface PublishedCollection {
     id: string
+    name: string
     items: PublishedArticle[]
 }
 export interface PublishedArticle {


### PR DESCRIPTION
## Why are you doing this?
Publication requires ability to refresh issue.
## Screenshots
<img width="481" alt="image" src="https://user-images.githubusercontent.com/2670496/62873476-618c6880-bd17-11e9-9134-bb2b672320ba.png">
I think these emoji express what it is to refresh.

This also shows a number when on preview.
![image](https://user-images.githubusercontent.com/2670496/62947051-bd1f2a80-bdd9-11e9-922b-eeecd72508f6.png)

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
