### PR TITLE
Rahb/change credential stores

### DIFF
--- a/projects/Mallard/src/authentication/__tests__/auth-context.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/auth-context.spec.ts
@@ -6,7 +6,7 @@ describe('auth-context', () => {
     describe('needsReauth', () => {
         it('returns false when the previous attempt was `authed` and the attempt was created more recently than a day ago', () => {
             const res = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'live'),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'live'),
                 { isConnected: true },
             )
 
@@ -15,7 +15,7 @@ describe('auth-context', () => {
 
         it('returns true when the previous attempt was `authed` and the attempt was created longer than a day ago', () => {
             const res = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'live', 0),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'live', 0),
                 { isConnected: true },
             )
 
@@ -32,7 +32,7 @@ describe('auth-context', () => {
 
         it('returns true when the previous attempt was `cached` and `isConnected` is true', () => {
             const res = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'cached'),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'cached'),
                 { isConnected: true },
             )
 
@@ -41,7 +41,7 @@ describe('auth-context', () => {
 
         it('returns false when the previous attempt was `cached` and `isConnected` is false', () => {
             const res = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'cached'),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'cached'),
                 { isConnected: false },
             )
 
@@ -50,14 +50,14 @@ describe('auth-context', () => {
 
         it('returns false when the previous attempt was `live` and `isConnected` changes', () => {
             const res1 = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'live'),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'live'),
                 { isConnected: true },
             )
 
             expect(res1).toBe(false)
 
             const res2 = needsReauth(
-                createAuthAttempt(CASAuthStatus(casExpiry), 'live'),
+                createAuthAttempt(CASAuthStatus(casExpiry()), 'live'),
                 { isConnected: false },
             )
 

--- a/projects/Mallard/src/authentication/__tests__/credentials-chain.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/credentials-chain.spec.ts
@@ -3,6 +3,7 @@ import {
     IdentityAuthStatus,
     CASAuthStatus,
     isAuthed,
+    authTypeFromCAS,
 } from '../credentials-chain'
 import { userData, casExpiry } from './fixtures'
 
@@ -15,7 +16,7 @@ import { userData, casExpiry } from './fixtures'
  *  ```js
  *  const val = await Promise.race([
  *     createOrderPromise(2, IdentityAuthStatus(userData).data),
- *     createOrderPromise(1, CASAuthStatus(casExpiry).data),
+ *     createOrderPromise(1, CASAuthStatus(casExpiry()).data),
  *  ])
  *  expect(val.type).toBe('cas')
  * ```
@@ -30,7 +31,7 @@ describe('credentials-chain', () => {
         it('runs the chain in serial', async () => {
             const res: any = await runAuthChain([
                 () => createOrderPromise(2, IdentityAuthStatus(userData).data),
-                () => createOrderPromise(1, CASAuthStatus(casExpiry).data),
+                () => createOrderPromise(1, CASAuthStatus(casExpiry()).data),
             ])
 
             expect(isAuthed(res)).toBe(true)
@@ -40,7 +41,7 @@ describe('credentials-chain', () => {
         it('returns the value of the first truthy Promise in the chain', async () => {
             const res: any = await runAuthChain([
                 async () => IdentityAuthStatus(userData).data,
-                async () => CASAuthStatus(casExpiry).data,
+                async () => CASAuthStatus(casExpiry()).data,
             ])
 
             expect(isAuthed(res)).toBe(true)
@@ -52,7 +53,7 @@ describe('credentials-chain', () => {
                 async () => {
                     throw new Error()
                 },
-                async () => CASAuthStatus(casExpiry).data,
+                async () => CASAuthStatus(casExpiry()).data,
             ])
 
             expect(res.data.type).toBe('cas')
@@ -61,7 +62,7 @@ describe('credentials-chain', () => {
         it('tries the next provider if the current one returns false', async () => {
             const res: any = await runAuthChain([
                 async () => false,
-                async () => CASAuthStatus(casExpiry).data,
+                async () => CASAuthStatus(casExpiry()).data,
             ])
 
             expect(res.data.type).toBe('cas')
@@ -76,6 +77,22 @@ describe('credentials-chain', () => {
             ])
 
             expect(isAuthed(res)).not.toBe(true)
+        })
+    })
+
+    describe('authTypeFromCAS', () => {
+        it('returns a CAS auth when the expiry is in the future', () => {
+            expect(
+                authTypeFromCAS(casExpiry({ expiryDate: '2025-12-12' })),
+            ).toMatchObject({
+                type: 'cas',
+            })
+        })
+
+        it('returns false when the CAS expiry is in the past', () => {
+            expect(
+                authTypeFromCAS(casExpiry({ expiryDate: '2012-12-12' })),
+            ).toBe(false)
         })
     })
 })

--- a/projects/Mallard/src/authentication/__tests__/fixtures.ts
+++ b/projects/Mallard/src/authentication/__tests__/fixtures.ts
@@ -37,12 +37,18 @@ const userData = {
     membershipData: membershipResponse,
 }
 
-const casExpiry = {
-    content: '',
-    expiryDate: '',
-    expiryType: '',
-    provider: '',
-    subscriptionCode: '123',
-}
+const casExpiry = ({
+    content = '',
+    expiryDate = '2012-05-05',
+    expiryType = '',
+    provider = '',
+    subscriptionCode = 'G99123456',
+} = {}) => ({
+    content,
+    expiryDate,
+    expiryType,
+    provider,
+    subscriptionCode,
+})
 
 export { membershipResponse, userResponse, userData, casExpiry }

--- a/projects/Mallard/src/authentication/__tests__/helpers.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/helpers.spec.ts
@@ -25,6 +25,7 @@ describe('helpers', () => {
             const fetchMembershipData = getMockPromise(membershipResponse)
             const fetchUserData = getMockPromise(userResponse)
             const fetchMembershipToken = getMockPromise('any')
+            const getLegacyUserAccessToken = getMockPromise(false as const)
             const resetMock = getMockPromise(true)
 
             const data = await fetchUserDataForKeychainUser(
@@ -33,6 +34,7 @@ describe('helpers', () => {
                 fetchMembershipData,
                 fetchUserData,
                 fetchMembershipToken,
+                getLegacyUserAccessToken,
                 resetMock,
             )
 
@@ -50,6 +52,7 @@ describe('helpers', () => {
             const fetchMembershipData = getMockPromise(membershipResponse)
             const fetchUserData = getMockPromise(userResponse)
             const fetchMembershipToken = getMockPromise('mtoken')
+            const getLegacyUserAccessToken = getMockPromise(false as const)
             const resetMock = getMockPromise(true)
 
             const data = await fetchUserDataForKeychainUser(
@@ -58,6 +61,36 @@ describe('helpers', () => {
                 fetchMembershipData,
                 fetchUserData,
                 fetchMembershipToken,
+                getLegacyUserAccessToken,
+                resetMock,
+            )
+
+            expect(data).toEqual({
+                userDetails: userResponse,
+                membershipData: membershipResponse,
+            })
+            expect(resetMock).not.toHaveBeenCalled()
+            expect(userStore.get).toBeCalledTimes(1)
+            expect(fetchUserData).toBeCalledTimes(1)
+            expect(fetchMembershipData).toBeCalledTimes(1)
+        })
+
+        it('queries the membership and user data when it finds a legacy user token', async () => {
+            const membershipStore = getMockStore('mtoken')
+            const userStore = getMockStore()
+            const fetchMembershipData = getMockPromise(membershipResponse)
+            const fetchUserData = getMockPromise(userResponse)
+            const fetchMembershipToken = getMockPromise('mtoken')
+            const getLegacyUserAccessToken = getMockStore('token').get
+            const resetMock = getMockPromise(true)
+
+            const data = await fetchUserDataForKeychainUser(
+                membershipStore,
+                userStore,
+                fetchMembershipData,
+                fetchUserData,
+                fetchMembershipToken,
+                getLegacyUserAccessToken,
                 resetMock,
             )
 
@@ -77,6 +110,7 @@ describe('helpers', () => {
             const fetchMembershipData = getMockPromise(membershipResponse)
             const fetchUserData = getMockPromise(userResponse)
             const fetchMembershipToken = getMockPromise('mtoken')
+            const getLegacyUserAccessToken = getMockPromise(false as const)
             const resetMock = getMockPromise(true)
 
             const data = await fetchUserDataForKeychainUser(
@@ -85,6 +119,7 @@ describe('helpers', () => {
                 fetchMembershipData,
                 fetchUserData,
                 fetchMembershipToken,
+                getLegacyUserAccessToken,
                 resetMock,
             )
 
@@ -104,6 +139,7 @@ describe('helpers', () => {
             const fetchMembershipData = getMockPromise(membershipResponse)
             const fetchUserData = getMockPromise(userResponse)
             const fetchMembershipToken = getMockPromise('mtoken')
+            const getLegacyUserAccessToken = getMockPromise(false as const)
             const resetMock = getMockPromise(true)
 
             const data = await fetchUserDataForKeychainUser(
@@ -112,6 +148,7 @@ describe('helpers', () => {
                 fetchMembershipData,
                 fetchUserData,
                 fetchMembershipToken,
+                getLegacyUserAccessToken,
                 resetMock,
             )
 

--- a/projects/Mallard/src/authentication/credentials-chain.ts
+++ b/projects/Mallard/src/authentication/credentials-chain.ts
@@ -153,4 +153,6 @@ export {
     getIdentityData,
     IdentityAuthStatus,
     CASAuthStatus,
+    /* exported for testing */
+    authTypeFromCAS,
 }

--- a/projects/Mallard/src/authentication/credentials-chain.ts
+++ b/projects/Mallard/src/authentication/credentials-chain.ts
@@ -4,7 +4,7 @@ import {
     fetchCASExpiryForKeychainCredentials,
 } from './helpers'
 import { CasExpiry } from '../services/content-auth-service'
-import { userDataCache, casDataCache } from './storage'
+import { userDataCache, casDataCache, legacyCASExpiryCache } from './storage'
 
 interface IdentityAuth {
     type: 'identity'
@@ -97,7 +97,8 @@ const authTypeFromIdentity = (info: UserData | null): IdentityAuth | false =>
     }
 
 const authTypeFromCAS = (info: CasExpiry | null): CASAuth | false =>
-    !!info && {
+    !!info &&
+    new Date(info.expiryDate).getTime() > Date.now() && {
         type: 'cas',
         info,
     }
@@ -133,7 +134,10 @@ const liveAuthChain = () =>
 const cachedIdentityAuthProvider = () =>
     userDataCache.get().then(authTypeFromIdentity)
 
-const cachedCasAuthProvider = () => casDataCache.get().then(authTypeFromCAS)
+const cachedCasAuthProvider = async () => {
+    const auth = await casDataCache.get().then(authTypeFromCAS)
+    return auth || authTypeFromCAS(legacyCASExpiryCache.get())
+}
 
 const cachedAuthChain = () =>
     runAuthChain([cachedIdentityAuthProvider, cachedCasAuthProvider])

--- a/projects/Mallard/src/authentication/helpers.ts
+++ b/projects/Mallard/src/authentication/helpers.ts
@@ -95,11 +95,12 @@ const fetchUserDataForKeychainUser = async (
     fetchMembershipDataImpl = fetchMembershipData,
     fetchUserDetailsImpl = fetchUserDetails,
     fetchMembershipAccessTokenImpl = fetchMembershipAccessToken,
+    getLegacyUserAccessTokenImpl = getLegacyUserAccessToken,
     resetCredentialsImpl = resetCredentials,
 ): Promise<UserData | null> => {
     const [userToken, legacyUserToken, membershipToken] = await Promise.all([
         userTokenStore.get(),
-        getLegacyUserAccessToken(),
+        getLegacyUserAccessTokenImpl(),
         membershipTokenStore.get(),
     ])
 

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -3,7 +3,6 @@ import { UserData } from './helpers'
 import AsyncStorage from '@react-native-community/async-storage'
 import { CasExpiry } from 'src/services/content-auth-service'
 import { Settings } from 'react-native'
-import DeviceInfo from 'react-native-device-info'
 import {
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -15,21 +15,21 @@ import {
  * `Settings` only works on iOS but we only ever had a legacy app on iOS
  * and not Android.
  */
-const createSyncBinaryCacheIOS = <T = any>(key: string) => ({
+const createSyncCacheIOS = <T = any>(key: string) => ({
     set: (value: T) => Settings.set({ [key]: value }),
     get: (): T => Settings.get(key),
     reset: (): void => Settings.set({ [key]: void 0 }),
 })
 
-const legacyCASUsernameCache = createSyncBinaryCacheIOS<string>(
+const legacyCASUsernameCache = createSyncCacheIOS<string>(
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
 )
 
-const legacyCASPasswordCache = createSyncBinaryCacheIOS<string>(
+const legacyCASPasswordCache = createSyncCacheIOS<string>(
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
 )
 
-const legacyCASExpiryCache = createSyncBinaryCacheIOS<CasExpiry>(
+const legacyCASExpiryCache = createSyncCacheIOS<CasExpiry>(
     LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
 )
 

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -4,9 +4,16 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { CasExpiry } from 'src/services/content-auth-service'
 import { Settings } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
+import {
+    LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
+    LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
+    LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
+} from 'src/constants'
 
 /**
- * this is ostensibly used to find the legacy binary data from the old GCE app
+ * this is ostensibly used to get the legacy data from the old GCE app
+ * `Settings` only works on iOS but we only ever had a legacy app on iOS
+ * and not Android.
  */
 const createSyncBinaryCacheIOS = <T = any>(key: string) => ({
     set: (value: T) => Settings.set({ [key]: value }),
@@ -15,15 +22,15 @@ const createSyncBinaryCacheIOS = <T = any>(key: string) => ({
 })
 
 const legacyCASUsernameCache = createSyncBinaryCacheIOS<string>(
-    'printSubscriberID',
+    LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
 )
 
 const legacyCASPasswordCache = createSyncBinaryCacheIOS<string>(
-    'printSubscriberPostcode',
+    LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
 )
 
 const legacyCASExpiryCache = createSyncBinaryCacheIOS<CasExpiry>(
-    `${DeviceInfo.getBundleId()}_expiryDict`,
+    LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
 )
 
 /**

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -67,6 +67,11 @@ const membershipAccessTokenKeychain = createServiceTokenStore(
 )
 const casCredentialsKeychain = createServiceTokenStore('CASCredentials')
 
+/**
+ * For the legacy token we're not going to expose the whole store as we're never going
+ * to write to if from the application and additionally, the token is set in a JSON object
+ * in the old app so we need to fetch that out in the `getLegacyUserAccessToken` helper.
+ */
 const _legacyUserAccessTokenKeychain = createServiceTokenStore('AccessToken')
 
 const getLegacyUserAccessToken = async (): ReturnType<

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native'
-
+import DeviceInfo from 'react-native-device-info'
 import Config from 'react-native-config'
 
 const { ID_API_URL, MEMBERS_DATA_API_URL, ID_ACCESS_TOKEN } = Config
@@ -17,6 +17,10 @@ const GOOGLE_CLIENT_ID =
             : '774465807556-cjat38acttpl7md4nfc4pfediouh7v97'
         : '774465807556-kgaj5an4pc4fmr3svp5nfpulekc1rl3n'
 
+const LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY = 'printSubscriberID'
+const LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY = 'printSubscriberPostcode'
+const LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY = `${DeviceInfo.getBundleId()}_expiryDict`
+
 export {
     CAS_ENDPOINT_URL,
     ID_API_URL,
@@ -25,4 +29,7 @@ export {
     FACEBOOK_CLIENT_ID,
     GOOGLE_CLIENT_ID,
     AUTH_TTL,
+    LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
+    LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
+    LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
 }


### PR DESCRIPTION
## Why are you doing this?

This PR took no time to write and forever to actually test 😢 but it's here 😆 

This adds ways for getting to the legacy keychain / NSUserDefaults for the various tokens that existed in the existing Daily Edition app. I've also changed the keychain `service` values for different new credentials in the app. Previously they key used for they keychain store was the URL for the various services. On advice from others it's better to keep those distinct just in case the endpoints change for any of those services, in which case we'd be reading from the wrong place in the keychain. Very unlikely but may as well do it now.

__This will mean everyone will be logged out when this change goes live!__
