### PR TITLE
Rahb/fix iap checking

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -31,6 +31,7 @@ import { color } from 'src/theme/color'
 
 const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [settings, setSetting] = useSettings()
+    const { status } = useContext(AuthContext)
     const { apiUrl } = settings
     return (
         <>
@@ -120,11 +121,23 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
             <Heading>Your settings</Heading>
             <List
                 onPress={() => {}}
-                data={Object.entries(settings).map(([title, explainer]) => ({
-                    key: title,
-                    title,
-                    explainer: explainer + '',
-                }))}
+                data={Object.entries(settings)
+                    .map(([title, explainer]) => ({
+                        key: title,
+                        title,
+                        explainer: explainer + '',
+                    }))
+                    .concat([
+                        {
+                            key: 'Authentication details',
+                            title: 'Authentication details',
+                            explainer: `Signed in status ${status.type} : ${
+                                status.type === 'authed'
+                                    ? status.data.type
+                                    : '_'
+                            }`,
+                        },
+                    ])}
             />
         </>
     )

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -148,7 +148,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const { isUsingProdDevtools } = settings
     const signInHandler = useIdentity()
     const authHandler = useAuth()
-    const { signOut } = useContext(AuthContext)
+    const { signOut, restorePurchases } = useContext(AuthContext)
 
     const styles = StyleSheet.create({
         signOut: {
@@ -217,7 +217,18 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
             <ScrollContainer>
                 <List
                     onPress={({ onPress }) => onPress()}
-                    data={[...signInListItems]}
+                    data={[
+                        ...signInListItems,
+                        {
+                            key: 'Restore purchases',
+                            title: 'Restore purchases',
+                            data: {
+                                onPress: () => {
+                                    restorePurchases()
+                                },
+                            },
+                        },
+                    ]}
                 />
                 <Heading>{``}</Heading>
                 <List

--- a/projects/Mallard/src/services/iap.ts
+++ b/projects/Mallard/src/services/iap.ts
@@ -2,6 +2,7 @@ import RNIAP, { Purchase } from 'react-native-iap'
 import { Platform } from 'react-native'
 import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants'
 import { ReceiptValidationResponse } from 'react-native-iap/apple'
+import { authTypeFromIAP } from 'src/authentication/credentials-chain'
 
 export interface ReceiptIOS {
     expires_date: string
@@ -59,6 +60,11 @@ const restoreActiveIOSSubscriptionReceipt = async (): Promise<ReceiptIOS | null>
     return findValidReceipt(decodedReceipt)
 }
 
+const tryToRestoreActiveIOSSubscriptionToAuth = () =>
+    restoreActiveIOSSubscriptionReceipt()
+        .then(authTypeFromIAP)
+        .catch(() => false as const)
+
 // This will attempt to look for the existing receipt without trying to restore those purchases
 const fetchActiveIOSSubscriptionReceipt = async (): Promise<ReceiptIOS | null> => {
     if (Platform.OS !== 'ios') return null
@@ -73,4 +79,8 @@ const fetchActiveIOSSubscriptionReceipt = async (): Promise<ReceiptIOS | null> =
     return findValidReceipt(decodedReceipt)
 }
 
-export { fetchActiveIOSSubscriptionReceipt, isReceiptActive }
+export {
+    fetchActiveIOSSubscriptionReceipt,
+    tryToRestoreActiveIOSSubscriptionToAuth,
+    isReceiptActive,
+}


### PR DESCRIPTION
## Why are you doing this?

This fixes an issue where I was using the wrong method on RNIAP. Previously the API call was not looking for the current transaction receipt that was sat on the device but was calling the Apple API, which required the user to potentially login. This is more apt for a "restore purchases" flow.

I've now changed the credentials-chain to use the method to look for an existing receipt, and fail if it can't find / validate that receipt. There is not also a restore purchases button, that will also, in time, be added to some of the front-and-center auth flows.