### PR TITLE
Rahb/timeout modal

### DIFF
--- a/projects/Mallard/src/components/login/login-overlay.tsx
+++ b/projects/Mallard/src/components/login/login-overlay.tsx
@@ -1,9 +1,16 @@
-import React, { useEffect, useMemo } from 'react'
-import { View, StyleSheet, PanResponder } from 'react-native'
+import React, { useEffect, useRef } from 'react'
+import { View, StyleSheet } from 'react-native'
 import { useModal } from '../modal'
 import { useAuth } from 'src/authentication/auth-context'
 import { SignInModalCard } from '../sign-in-modal-card'
 import { SubNotFoundModalCard } from '../sub-not-found-modal-card'
+import { navigateToIssue } from 'src/navigation/helpers'
+import {
+    NavigationScreenProp,
+    withNavigation,
+    NavigationInjectedProps,
+} from 'react-navigation'
+import { routeNames } from 'src/navigation'
 
 const overlayStyles = StyleSheet.create({
     wrapper: {
@@ -11,6 +18,22 @@ const overlayStyles = StyleSheet.create({
         flex: 1,
     },
 })
+
+const useTimeout = (callback: () => void, delay: number) => {
+    const cb = useRef<() => void>(() => {})
+
+    // Remember the latest callback.
+    useEffect(() => {
+        cb.current = callback
+    }, [callback])
+
+    useEffect(() => {
+        const id = setTimeout(() => {
+            cb.current()
+        }, delay)
+        return () => clearTimeout(id)
+    }, [delay])
+}
 
 /**
  * This allows us to open a modal using a component in the view.
@@ -26,28 +49,18 @@ const ModalOpener = ({
     forceOpen?: boolean
     renderModal: (close: () => void) => React.ReactNode
 }) => {
-    const { open, close } = useModal()
+    const { open, close, isOpen } = useModal()
 
-    const swipeUpHandlers = useMemo(
-        () =>
-            PanResponder.create({
-                onStartShouldSetPanResponder: () => true,
-                onMoveShouldSetPanResponder: () => true,
-                onPanResponderMove: (_, gesture) => {
-                    gesture.dy < -10 && open(renderModal)
-                },
-            }),
-        [renderModal, open],
-    )
+    useTimeout(() => {
+        if (!isOpen) {
+            open(renderModal)
+        }
+    }, 5000)
 
     // ensure the modal is closed on unmount
     useEffect(() => () => close(), [close])
 
-    return (
-        <View style={overlayStyles.wrapper} {...swipeUpHandlers.panHandlers}>
-            {children}
-        </View>
-    )
+    return <View style={overlayStyles.wrapper}>{children}</View>
 }
 
 const LoginOverlay = ({

--- a/projects/Mallard/src/components/login/login-overlay.tsx
+++ b/projects/Mallard/src/components/login/login-overlay.tsx
@@ -12,6 +12,12 @@ const overlayStyles = StyleSheet.create({
     },
 })
 
+/**
+ * This turns a prop into a ref, which means closures that run
+ * asynchronously can get a reference to the most recent version
+ * of the prop rather than the value at the time it was closed
+ * over
+ */
 const usePropToRef = <T extends any>(value: T) => {
     const ref = useRef(value)
     useEffect(() => {

--- a/projects/Mallard/src/components/modal.tsx
+++ b/projects/Mallard/src/components/modal.tsx
@@ -34,9 +34,11 @@ const styles = StyleSheet.create({
 const ModalContext = React.createContext<{
     open: (render: ModalRenderer) => void
     close: () => void
+    isOpen: boolean
 }>({
     open: () => {},
     close: () => {},
+    isOpen: false,
 })
 
 const useModal = () => useContext(ModalContext)
@@ -52,6 +54,7 @@ const Modal = ({ children }: { children: React.ReactNode }) => {
                 value={{
                     open: renderModal => setState(() => renderModal),
                     close,
+                    isOpen: !!render,
                 }}
             >
                 {children}

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -222,6 +222,7 @@ const ArticleScreenWithProps = ({
                     onDismiss={() => navigation.goBack()}
                 >
                     <LoginOverlay
+                        isFocused={() => navigation.isFocused()}
                         onLoginPress={() =>
                             navigation.navigate(routeNames.SignIn)
                         }
@@ -250,6 +251,7 @@ const ArticleScreenWithProps = ({
                     onDismiss={() => navigation.goBack()}
                 >
                     <LoginOverlay
+                        isFocused={() => navigation.isFocused()}
                         onLoginPress={() =>
                             navigation.navigate(routeNames.SignIn)
                         }

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -99,7 +99,7 @@ const AuthSwitcherScreen = ({
                     if (!canViewEdition(data.membershipData)) {
                         open(close => (
                             <SubNotFoundModalCard
-                                onDismiss={() => navigation.goBack()}
+                                onDismiss={() => navigation.popToTop()}
                                 onOpenCASLogin={() =>
                                     navigation.navigate(routeNames.CasSignIn)
                                 }


### PR DESCRIPTION
## Why are you doing this?

This changes the login modal popup to work with a timeout rather then listening for a scroll, for two reasons:
- Crosswords don't require scrolling so the modal may never appear
- More importantly, our use of transparent cards means that Android doesn't ever fire the `panHandler`s event listeners as there is another View on one of the transparent cards that overrides them.

If this solution feels wonky to some people then we can potentially think about not using transparent cards on Android and revisiting the scroll idea, but for the time being this seems the most wide reaching fix.