### PR TITLE
New settings headers

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
     },
 })
 
-const persistenceKey = 'dev-nav-key-2321324'
+const persistenceKey = 'dev-nav-key-231212324'
 const persistNavigationState = async (navState: any) => {
     try {
         await AsyncStorage.setItem(persistenceKey, JSON.stringify(navState))

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -95,8 +95,8 @@ const Header = ({
                         </View>
                     </GridRowSplit>
                 ) : (
-                    <>
-                        <View style={[styles.centerWrapper, {}]}>
+                    <View style={{ paddingTop, width: '100%' }}>
+                        <View style={[styles.centerWrapper]}>
                             <View style={styles.centerAction}>
                                 {leftAction}
                             </View>
@@ -105,7 +105,7 @@ const Header = ({
                                 <IssueTitle {...otherProps} />
                             </View>
                         </View>
-                    </>
+                    </View>
                 )}
             </View>
         </WithAppAppearance>

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -12,6 +12,7 @@ import { WithAppAppearance } from 'src/theme/appearance'
 import { useIssueDate } from 'src/helpers/issues'
 import { Issue } from 'src/common'
 import { Highlight } from 'src/components/highlight'
+import { getFont } from 'src/theme/typography'
 
 const styles = StyleSheet.create({
     background: {
@@ -20,6 +21,7 @@ const styles = StyleSheet.create({
         paddingHorizontal: metrics.horizontal,
         justifyContent: 'flex-end',
         flexDirection: 'row',
+        minHeight: getFont('titlepiece', 1.25).lineHeight * 2,
     },
     flex: {
         flexDirection: 'row',
@@ -33,6 +35,22 @@ const styles = StyleSheet.create({
         flexGrow: 1,
         flexShrink: 0,
     },
+
+    centerWrapper: {
+        width: '100%',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    centerTitle: {
+        ...StyleSheet.absoluteFillObject,
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1,
+    },
+    centerAction: {
+        zIndex: 2,
+    },
 })
 
 type TouchableHeaderProps =
@@ -42,33 +60,53 @@ type TouchableHeaderProps =
 type HeaderProps = {
     action?: ReactNode
     leftAction?: ReactNode
+    layout?: 'issue' | 'center'
 } & IssueTitleProps &
     TouchableHeaderProps
 
-const Header = ({ action, leftAction, ...otherProps }: HeaderProps) => {
+const Header = ({
+    action,
+    leftAction,
+    layout = 'issue',
+    ...otherProps
+}: HeaderProps) => {
     const { top: paddingTop } = useInsets()
     return (
         <WithAppAppearance value={'primary'}>
             <View style={[styles.background]}>
-                <GridRowSplit proxy={leftAction} style={{ paddingTop }}>
-                    <View style={styles.headerSplit}>
-                        <View style={styles.headerTitle}>
-                            {'onPress' in otherProps ? (
-                                <Highlight
-                                    onPress={otherProps.onPress}
-                                    accessibilityHint={
-                                        otherProps.accessibilityHint
-                                    }
-                                >
+                {layout === 'issue' ? (
+                    <GridRowSplit proxy={leftAction} style={{ paddingTop }}>
+                        <View style={styles.headerSplit}>
+                            <View style={styles.headerTitle}>
+                                {'onPress' in otherProps ? (
+                                    <Highlight
+                                        onPress={otherProps.onPress}
+                                        accessibilityHint={
+                                            otherProps.accessibilityHint
+                                        }
+                                    >
+                                        <IssueTitle {...otherProps} />
+                                    </Highlight>
+                                ) : (
                                     <IssueTitle {...otherProps} />
-                                </Highlight>
-                            ) : (
-                                <IssueTitle {...otherProps} />
-                            )}
+                                )}
+                            </View>
+                            {action}
                         </View>
-                        {action}
-                    </View>
-                </GridRowSplit>
+                    </GridRowSplit>
+                ) : (
+                    <>
+                        <View style={[styles.centerWrapper, {}]}>
+                            <View style={styles.centerAction}>
+                                {leftAction}
+                            </View>
+                            <View style={styles.centerAction}>{action}</View>
+                            <View style={styles.centerTitle}>
+                                <IssueTitle {...otherProps} />
+                            </View>
+                        </View>
+                    </>
+                )}
             </View>
         </WithAppAppearance>
     )

--- a/projects/Mallard/src/components/layout/slide-card/index.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/index.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View, PanResponder } from 'react-native'
 import { Header } from './header'
 import { dismissAt } from './helpers'
 import { color } from 'src/theme/color'
+import { metrics } from 'src/theme/spacing'
 
 /*
 This is the swipey contraption that contains an article.
@@ -14,8 +15,8 @@ const styles = StyleSheet.create({
         flexShrink: 0,
         height: '100%',
         backgroundColor: color.background,
-        borderTopLeftRadius: 10,
-        borderTopRightRadius: 10,
+        borderTopLeftRadius: metrics.radius,
+        borderTopRightRadius: metrics.radius,
         overflow: 'hidden',
     },
     flexGrow: {

--- a/projects/Mallard/src/components/layout/ui/modal-for-tablet.tsx
+++ b/projects/Mallard/src/components/layout/ui/modal-for-tablet.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, Animated } from 'react-native'
 import { AnimatedValue } from 'react-navigation'
 import { WithBreakpoints } from 'src/components/layout/ui/sizing/with-breakpoints'
 import { Breakpoints } from 'src/theme/breakpoints'
+import { metrics } from 'src/theme/spacing'
 
 const modalStyles = StyleSheet.create({
     root: {
@@ -19,6 +20,8 @@ const modalStyles = StyleSheet.create({
         ...StyleSheet.absoluteFillObject,
     },
     modal: {
+        borderRadius: metrics.radius,
+        overflow: 'hidden',
         width: 400,
         height: 600,
         backgroundColor: 'red',

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -59,52 +59,50 @@ const transitionOptionsOverArtboard = (bounces: boolean) => ({
 })
 
 const AppStack = createModalNavigator(
-    {
-        [routeNames.Issue]: createStackNavigator(
-            {
-                [routeNames.Issue]: createStackNavigator(
-                    {
-                        [routeNames.Issue]: IssueScreen,
-                        [routeNames.Article]: ArticleScreen,
-                    },
-                    {
-                        transparentCard: true,
-                        initialRouteName: routeNames.Issue,
-                        mode: 'modal',
-                        headerMode: 'none',
-                        cardOverlayEnabled: true,
-                        transitionConfig: () => ({
-                            ...transitionOptionsOverArtboard(true),
-                            screenInterpolator: issueToArticleScreenInterpolator,
-                        }),
-                        defaultNavigationOptions: {
-                            gesturesEnabled: false,
-                        },
-                    },
-                ),
-                [routeNames.IssueList]: HomeScreen,
-            },
-            {
-                defaultNavigationOptions: {
-                    header: null,
-                    gesturesEnabled: false,
+    createStackNavigator(
+        {
+            [routeNames.Issue]: createStackNavigator(
+                {
+                    [routeNames.Issue]: IssueScreen,
+                    [routeNames.Article]: ArticleScreen,
                 },
-                initialRouteName: routeNames.Issue,
-                ...(supportsTransparentCards()
-                    ? {
-                          transparentCard: true,
-                          mode: 'modal',
-                          headerMode: 'none',
-                          cardOverlayEnabled: true,
-                          transitionConfig: () => ({
-                              ...transitionOptionsOverArtboard(false),
-                              screenInterpolator: issueToIssueListInterpolator,
-                          }),
-                      }
-                    : {}),
+                {
+                    transparentCard: true,
+                    initialRouteName: routeNames.Issue,
+                    mode: 'modal',
+                    headerMode: 'none',
+                    cardOverlayEnabled: true,
+                    transitionConfig: () => ({
+                        ...transitionOptionsOverArtboard(true),
+                        screenInterpolator: issueToArticleScreenInterpolator,
+                    }),
+                    defaultNavigationOptions: {
+                        gesturesEnabled: false,
+                    },
+                },
+            ),
+            [routeNames.IssueList]: HomeScreen,
+        },
+        {
+            defaultNavigationOptions: {
+                header: null,
+                gesturesEnabled: false,
             },
-        ),
-    },
+            initialRouteName: routeNames.Issue,
+            ...(supportsTransparentCards()
+                ? {
+                      transparentCard: true,
+                      mode: 'modal',
+                      headerMode: 'none',
+                      cardOverlayEnabled: true,
+                      transitionConfig: () => ({
+                          ...transitionOptionsOverArtboard(false),
+                          screenInterpolator: issueToIssueListInterpolator,
+                      }),
+                  }
+                : {}),
+        },
+    ),
     {
         [routeNames.Settings]: createHeaderStackNavigator(
             {
@@ -128,49 +126,54 @@ const AppStack = createModalNavigator(
     },
 )
 
-const OnboardingStack = createStackNavigator(
-    {
-        [routeNames.onboarding.OnboardingStart]: mapNavigationToProps(
-            OnboardingIntroScreen,
-            nav => ({
-                onContinue: () =>
-                    nav.navigate(routeNames.onboarding.OnboardingConsent),
-            }),
-        ),
-        [routeNames.onboarding.OnboardingConsent]: createStackNavigator(
-            {
-                Main: {
-                    screen: mapNavigationToProps(
-                        OnboardingConsentScreen,
-                        nav => ({
-                            onContinue: () => nav.navigate('App'),
-                            onOpenGdprConsent: () =>
-                                nav.navigate(
-                                    routeNames.onboarding
-                                        .OnboardingConsentInline,
-                                ),
-                        }),
-                    ),
-                    navigationOptions: {
-                        header: null,
+const OnboardingStack = createModalNavigator(
+    createStackNavigator(
+        {
+            [routeNames.onboarding.OnboardingStart]: mapNavigationToProps(
+                OnboardingIntroScreen,
+                nav => ({
+                    onContinue: () =>
+                        nav.navigate(routeNames.onboarding.OnboardingConsent),
+                }),
+            ),
+            [routeNames.onboarding.OnboardingConsent]: createStackNavigator(
+                {
+                    Main: {
+                        screen: mapNavigationToProps(
+                            OnboardingConsentScreen,
+                            nav => ({
+                                onContinue: () => nav.navigate('App'),
+                                onOpenGdprConsent: () =>
+                                    nav.navigate(
+                                        routeNames.onboarding
+                                            .OnboardingConsentInline,
+                                    ),
+                            }),
+                        ),
+                        navigationOptions: {
+                            header: null,
+                        },
                     },
                 },
-                [routeNames.onboarding
-                    .OnboardingConsentInline]: GdprConsentScreen,
-            },
-            {
-                mode: 'modal',
-                defaultNavigationOptions: {
-                    ...navOptionsWithGraunHeader,
+                {
+                    mode: 'modal',
+                    defaultNavigationOptions: {
+                        ...navOptionsWithGraunHeader,
+                    },
                 },
-            },
-        ),
-    },
+            ),
+        },
+        {
+            headerMode: 'none',
+        },
+    ),
     {
-        headerMode: 'none',
+        [routeNames.onboarding
+            .OnboardingConsentInline]: createHeaderStackNavigator({
+            GdprConsentScreen,
+        }),
     },
 )
-
 const RootNavigator = createAppContainer(
     createStackNavigator(
         {

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -36,6 +36,7 @@ import { HelpScreen } from 'src/screens/settings/help-screen'
 import { CreditsScreen } from 'src/screens/settings/credits-screen'
 import { FAQScreen } from 'src/screens/settings/faq-screen'
 import { createModalNavigator } from './navigators/modal'
+import { createHeaderStackNavigator } from './navigators/header'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -105,7 +106,7 @@ const AppStack = createModalNavigator(
         ),
     },
     {
-        [routeNames.Settings]: createStackNavigator(
+        [routeNames.Settings]: createHeaderStackNavigator(
             {
                 [routeNames.Settings]: SettingsScreen,
                 [routeNames.Downloads]: DownloadScreen,

--- a/projects/Mallard/src/navigation/navigators/header.tsx
+++ b/projects/Mallard/src/navigation/navigators/header.tsx
@@ -5,13 +5,12 @@ import {
     NavigationParams,
 } from 'react-navigation'
 
-import React, { ReactElement } from 'react'
+import React from 'react'
 import { Header } from 'src/components/layout/header/header'
 import { Button } from 'src/components/button/button'
 
 interface NavigationOptions {
     title?: string
-    headerLeft: () => ReactElement
 }
 
 type NavOrFn =

--- a/projects/Mallard/src/navigation/navigators/header.tsx
+++ b/projects/Mallard/src/navigation/navigators/header.tsx
@@ -1,0 +1,73 @@
+import {
+    NavigationContainer,
+    NavigationInjectedProps,
+    createStackNavigator,
+    NavigationParams,
+} from 'react-navigation'
+
+import React, { ReactElement } from 'react'
+import { Header } from 'src/components/layout/header/header'
+import { Button } from 'src/components/button/button'
+
+interface NavigationOptions {
+    title?: string
+    headerLeft: () => ReactElement
+}
+
+type NavOrFn =
+    | ((navigation: NavigationParams) => NavigationOptions)
+    | NavigationOptions
+
+const getNavigationOptions = (
+    navigation: NavigationParams,
+    options: NavOrFn,
+): NavigationOptions => {
+    if (!options) return {}
+    if (typeof options === 'function') {
+        return options(navigation)
+    }
+    return options
+}
+const wrapNavigatorWithHeader = (
+    Navigator: NavigationContainer,
+): NavigationContainer => {
+    const { router } = Navigator
+
+    const WithHeader = ({ navigation }: NavigationInjectedProps) => {
+        const component = router.getComponentForState(navigation.state)
+        const options = getNavigationOptions(
+            navigation,
+            component.navigationOptions,
+        )
+
+        return (
+            <>
+                <Header
+                    leftAction={
+                        <Button
+                            icon=""
+                            alt="Back"
+                            onPress={() => navigation.goBack(null)}
+                        ></Button>
+                    }
+                    layout={'center'}
+                    title={options.title || navigation.state.routeName}
+                ></Header>
+                <Navigator navigation={navigation} />
+            </>
+        )
+    }
+    WithHeader.router = router
+
+    return (WithHeader as unknown) as NavigationContainer
+}
+
+const createHeaderStackNavigator = (
+    routes: Parameters<typeof createStackNavigator>[0],
+    options: Parameters<typeof createStackNavigator>[1],
+) =>
+    wrapNavigatorWithHeader(
+        createStackNavigator(routes, { ...options, headerMode: 'none' }),
+    )
+
+export { createHeaderStackNavigator }

--- a/projects/Mallard/src/navigation/navigators/header.tsx
+++ b/projects/Mallard/src/navigation/navigators/header.tsx
@@ -64,7 +64,7 @@ const wrapNavigatorWithHeader = (
 
 const createHeaderStackNavigator = (
     routes: Parameters<typeof createStackNavigator>[0],
-    options: Parameters<typeof createStackNavigator>[1],
+    options?: Parameters<typeof createStackNavigator>[1],
 ) =>
     wrapNavigatorWithHeader(
         createStackNavigator(routes, { ...options, headerMode: 'none' }),

--- a/projects/Mallard/src/navigation/navigators/modal.tsx
+++ b/projects/Mallard/src/navigation/navigators/modal.tsx
@@ -27,17 +27,15 @@ const wrapNavigatorWithModal = (
     return (WithModal as unknown) as NavigationContainer
 }
 
-const createModalNavigator = <T extends string>(
-    topRoute: {
-        [key in T]: NavigationContainer
-    },
+const createModalNavigator = (
+    parent: NavigationContainer,
     modalRoutes: {
         [key: string]: NavigationContainer
     },
 ) => {
     let animatedValue = new Animated.Value(0)
 
-    const navigation: { [key: string]: NavigationContainer } = { ...topRoute }
+    const navigation: { [key: string]: NavigationContainer } = { _: parent }
     for (const [key, value] of Object.entries(modalRoutes)) {
         navigation[key] = wrapNavigatorWithModal(value, () => animatedValue)
     }
@@ -47,7 +45,7 @@ const createModalNavigator = <T extends string>(
         headerMode: 'none',
         transparentCard: true,
         cardOverlayEnabled: true,
-        initialRouteName: Object.keys(topRoute)[0],
+        initialRouteName: '_',
         defaultNavigationOptions: {
             gesturesEnabled: false,
         },

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -157,7 +157,6 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const signInHandler = useIdentity()
     const authHandler = useAuth()
     const { signOut } = useContext(AuthContext)
-
     const styles = StyleSheet.create({
         signOut: {
             color: color.ui.supportBlue,

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { Text, Dimensions, View, Alert, StyleSheet } from 'react-native'
 import AsyncStorage from '@react-native-community/async-storage'
 
@@ -35,7 +35,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const { apiUrl } = settings
     return (
         <>
-            <Heading>💣 DEVELOPER ZONE 💣</Heading>
+            <Heading>🦆 SECRET DUCK MENU 🦆</Heading>
             <Footer>
                 <UiBodyCopy>
                     Only wander here if you know what you are doing!!
@@ -109,7 +109,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         key: 'Hide this menu',
                         title: 'Hide this menu',
                         explainer:
-                            'Scroll down and tap the duck to bring it back',
+                            'Tap the version 7 times & confirm the fake scary message to bring it back',
                         data: {
                             onPress: () => {
                                 setSetting('isUsingProdDevtools', false)
@@ -156,6 +156,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const { isUsingProdDevtools } = settings
     const signInHandler = useIdentity()
     const authHandler = useAuth()
+    const [versionClickedTimes, setVersionClickedTimes] = useState(0)
     const { signOut } = useContext(AuthContext)
     const styles = StyleSheet.create({
         signOut: {
@@ -326,7 +327,41 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                             key: 'Version',
                             title: 'Version',
                             data: {
-                                onPress: () => {},
+                                onPress: () => {
+                                    if (!isUsingProdDevtools) {
+                                        setVersionClickedTimes(t => {
+                                            if (t < 7) return t + 1
+                                            Alert.alert(
+                                                'Delete all stored data',
+                                                'Are you sure?',
+                                                [
+                                                    {
+                                                        text: 'Delete data',
+                                                        style: 'destructive',
+                                                        onPress: () => {
+                                                            setSetting(
+                                                                'isUsingProdDevtools',
+                                                                true,
+                                                            )
+                                                            Alert.alert(
+                                                                'You are a developer now!',
+                                                            )
+                                                        },
+                                                    },
+                                                    {
+                                                        text: 'Cancel',
+                                                        style: 'cancel',
+                                                        onPress: () => {
+                                                            AsyncStorage.clear()
+                                                        },
+                                                    },
+                                                ],
+                                                { cancelable: false },
+                                            )
+                                            return 0
+                                        })
+                                    }
+                                },
                             },
                             proxy: <Text>{getVersionInfo().version}</Text>,
                         },
@@ -345,50 +380,14 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                         {`Send us feedback to ${FEEDBACK_EMAIL}`}
                     </UiBodyCopy>
                 </Footer>
-                {!isUsingProdDevtools ? (
-                    <>
-                        <View
-                            style={{
-                                height: Dimensions.get('window').height,
-                            }}
-                        />
-                        <Highlight
-                            style={{ alignItems: 'center' }}
-                            onPress={() => {
-                                setSetting('isUsingProdDevtools', true)
-                            }}
-                        >
-                            <Text
-                                style={{
-                                    textAlign: 'center',
-                                    padding: 40,
-                                }}
-                            >
-                                🦆
-                            </Text>
-                        </Highlight>
-                    </>
-                ) : (
-                    <DevZone />
-                )}
+                {isUsingProdDevtools && <DevZone />}
             </ScrollContainer>
         </WithAppAppearance>
     )
 }
 
-SettingsScreen.navigationOptions = ({
-    navigation,
-}: {
-    navigation: NavigationScreenProp<{}>
-}) => ({
+SettingsScreen.navigationOptions = {
     title: 'Settings',
-    headerTitleStyle: {
-        textAlign: 'center',
-        flex: 1,
-    },
-    headerLeft: () => (
-        <Button onPress={() => navigation.goBack(null)}>Back</Button>
-    ),
-})
+}
 
 export { SettingsScreen }

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,23 +1,17 @@
 import React, { useContext, useState } from 'react'
-import { Text, Dimensions, View, Alert, StyleSheet } from 'react-native'
+import { Text, Alert, StyleSheet } from 'react-native'
 import AsyncStorage from '@react-native-community/async-storage'
 
 import { List } from 'src/components/lists/list'
-import {
-    withNavigation,
-    NavigationInjectedProps,
-    NavigationScreenProp,
-} from 'react-navigation'
+import { withNavigation, NavigationInjectedProps } from 'react-navigation'
 import { useSettings } from 'src/hooks/use-settings'
 import { UiBodyCopy } from 'src/components/styled-text'
-import { Highlight } from 'src/components/highlight'
 import { APP_DISPLAY_NAME, FEEDBACK_EMAIL } from 'src/helpers/words'
 import { clearCache } from 'src/helpers/fetch/cache'
 import { Heading, Footer } from 'src/components/layout/ui/row'
 import { getVersionInfo } from 'src/helpers/settings'
 import { metrics } from 'src/theme/spacing'
 import { ScrollContainer } from 'src/components/layout/ui/container'
-import { Button } from 'src/components/button/button'
 import { WithAppAppearance } from 'src/theme/appearance'
 import {
     useIdentity,

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -13,6 +13,7 @@ const scrubberRadius = 18
 export const metrics = {
     ...basicMetrics,
     headerHeight,
+    radius: 10,
     article: {
         sides: basicMetrics.horizontal / 2,
         sidesTablet: basicMetrics.horizontal * 1.5,


### PR DESCRIPTION
## Why are you doing this?

I love react-navigation now.

This updates the settings and the inline settings menu in the onboarding so they both use modals with custom headers (which are no longer ugly)

![Screenshot 2019-08-16 at 16 02 43](https://user-images.githubusercontent.com/11539094/63178061-2d7bb500-c041-11e9-98d2-9b512b439ba0.png)
![Screenshot 2019-08-16 at 16 02 50](https://user-images.githubusercontent.com/11539094/63178068-31a7d280-c041-11e9-870a-a929eb6f4e9e.png)

## About the duck menu

This PR also hides the dev menu a bit better, relevant parties like CP will need a shout. To bring up the dev menu.

1. Go to settings
2. Tap seven times on the version number
![Screenshot 2019-08-16 at 16 15 21](https://user-images.githubusercontent.com/11539094/63178184-6ae04280-c041-11e9-9031-6e8344489908.png)
3. Confirm that you want to delete all your data (this is a lie)
![Screenshot 2019-08-16 at 16 15 26](https://user-images.githubusercontent.com/11539094/63178201-75024100-c041-11e9-8d49-fecd632ad4ff.png)

The idea for this is that this is, I think, well enough hidden for the production app, should we need it for some cases