### PR TITLE
Rahb/signin tweaks

### DIFF
--- a/projects/Mallard/src/components/missing-iap-modal-card.tsx
+++ b/projects/Mallard/src/components/missing-iap-modal-card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { ModalButton } from './modal-button'
 
 const MissingIAPModalCard = ({
     close,
@@ -13,21 +14,25 @@ const MissingIAPModalCard = ({
         subtitle="There was a problem whilst verifying your subscription"
         appearance={CardAppearance.blue}
         size="small"
-        mainActions={[
-            {
-                label: 'Try again',
-                onPress: () => {
-                    close()
-                    onTryAgain()
-                },
-            },
-            {
-                label: 'Close',
-                onPress: () => {
-                    close()
-                },
-            },
-        ]}
+        bottomContent={
+            <>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onTryAgain()
+                    }}
+                >
+                    Try again
+                </ModalButton>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                    }}
+                >
+                    Close
+                </ModalButton>
+            </>
+        }
     />
 )
 

--- a/projects/Mallard/src/components/modal-button.tsx
+++ b/projects/Mallard/src/components/modal-button.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Button, ButtonAppearance } from './button/button'
+
+const ModalButton = (props: {
+    onPress: () => void
+    children: string
+    alt?: string
+}) => (
+    <Button
+        {...props}
+        alt={props.alt || props.children}
+        style={{
+            marginTop: 10,
+            marginRight: 10,
+        }}
+        appearance={ButtonAppearance.light}
+    />
+)
+
+export { ModalButton }

--- a/projects/Mallard/src/components/modal-button.tsx
+++ b/projects/Mallard/src/components/modal-button.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
 import { Button, ButtonAppearance } from './button/button'
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+    button: {
+        marginTop: 10,
+        marginRight: 10,
+    },
+})
 
 const ModalButton = (props: {
     onPress: () => void
@@ -9,10 +17,7 @@ const ModalButton = (props: {
     <Button
         {...props}
         alt={props.alt || props.children}
-        style={{
-            marginTop: 10,
-            marginRight: 10,
-        }}
+        style={styles.button}
         appearance={ButtonAppearance.light}
     />
 )

--- a/projects/Mallard/src/components/onboarding/onboarding-card.tsx
+++ b/projects/Mallard/src/components/onboarding/onboarding-card.tsx
@@ -4,7 +4,6 @@ import { TitlepieceText, UiExplainerCopy } from '../styled-text'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
-import { Button, ButtonAppearance } from '../button/button'
 import { minScreenSize } from 'src/helpers/screen'
 
 export enum CardAppearance {
@@ -35,9 +34,9 @@ const styles = StyleSheet.create({
     explainerTitle: {
         marginBottom: metrics.vertical * 2,
     },
-    button: {
-        marginTop: 10,
-        marginRight: 10,
+    explainerSubtitle: {
+        ...getFont('titlepiece', 1.25),
+        marginBottom: metrics.vertical * 1.5,
     },
 })
 
@@ -69,8 +68,9 @@ const OnboardingCard = ({
     children,
     title,
     subtitle,
-    mainActions,
+    bottomContent,
     explainerTitle,
+    explainerSubtitle,
     style,
     appearance,
     size = 'big',
@@ -79,8 +79,9 @@ const OnboardingCard = ({
     children?: string
     title: string
     subtitle?: string
-    mainActions?: { label: string; onPress: () => void }[]
+    bottomContent?: React.ReactNode
     explainerTitle?: string
+    explainerSubtitle?: string
     style?: StyleProp<ViewStyle>
     appearance: CardAppearance
     size?: 'big' | 'small'
@@ -125,29 +126,25 @@ const OnboardingCard = ({
                     )}
                 </View>
                 <View>
-                    {mainActions && (
+                    {bottomContent && (
                         <View
                             style={{ flexDirection: 'row', flexWrap: 'wrap' }}
                         >
-                            {mainActions.map(({ label, onPress }) => (
-                                <Button
-                                    style={styles.button}
-                                    appearance={ButtonAppearance.light}
-                                    key={label}
-                                    onPress={onPress}
-                                >
-                                    {label}
-                                </Button>
-                            ))}
+                            {bottomContent}
                         </View>
                     )}
                 </View>
             </View>
-            {(explainerTitle || children) && (
+            {(explainerTitle || explainerSubtitle || children) && (
                 <View style={styles.explainer}>
                     {explainerTitle && (
                         <TitlepieceText style={styles.explainerTitle}>
                             {explainerTitle}
+                        </TitlepieceText>
+                    )}
+                    {explainerSubtitle && (
+                        <TitlepieceText style={styles.explainerSubtitle}>
+                            {explainerSubtitle}
                         </TitlepieceText>
                     )}
                     {children && <UiExplainerCopy>{children}</UiExplainerCopy>}

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -3,6 +3,7 @@ import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { View } from 'react-native'
 import { ModalButton } from './modal-button'
 import { Link } from './link'
+import { ButtonAppearance } from './button/button'
 
 const SignInModalCard = ({
     close,
@@ -44,10 +45,8 @@ const SignInModalCard = ({
             </>
         }
         explainerTitle="Not subscribed yet?"
-        explainerSubtitle="Check the benefits of the digital pack"
-    >
-        Not subscribed yet? Learn more ...
-    </OnboardingCard>
+        explainerSubtitle="Get a free trial with our Digital Pack, on our website"
+    />
 )
 
 export { SignInModalCard }

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { View } from 'react-native'
+import { ModalButton } from './modal-button'
+import { Link } from './link'
 
 const SignInModalCard = ({
     close,
@@ -11,26 +14,37 @@ const SignInModalCard = ({
     onDismiss: () => void
 }) => (
     <OnboardingCard
-        title="Already a subscriber?"
+        title="Already subscribed?"
         subtitle="Sign in to continue with the app"
         appearance={CardAppearance.blue}
         size="small"
-        mainActions={[
-            {
-                label: 'Continue',
-                onPress: () => {
-                    close()
-                    onLoginPress()
-                },
-            },
-            {
-                label: 'Close',
-                onPress: () => {
-                    close()
-                    onDismiss()
-                },
-            },
-        ]}
+        bottomContent={
+            <>
+                <View style={{ width: '100%' }}>
+                    <Link href="https://www.theguardian.com/help/identity-faq">
+                        Need help signing in?
+                    </Link>
+                </View>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onLoginPress()
+                    }}
+                >
+                    Continue
+                </ModalButton>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onDismiss()
+                    }}
+                >
+                    Close
+                </ModalButton>
+            </>
+        }
+        explainerTitle="Not subscribed yet?"
+        explainerSubtitle="Check the benefits of the digital pack"
     >
         Not subscribed yet? Learn more ...
     </OnboardingCard>

--- a/projects/Mallard/src/components/sub-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-found-modal-card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { ModalButton } from './modal-button'
 
 const SubFoundModalCard = ({ close }: { close: () => void }) => (
     <OnboardingCard
@@ -7,14 +8,15 @@ const SubFoundModalCard = ({ close }: { close: () => void }) => (
         subtitle="Enjoy the Guardian and thank you for your support"
         appearance={CardAppearance.blue}
         size="small"
-        mainActions={[
-            {
-                label: 'Close',
-                onPress: () => {
+        bottomContent={
+            <ModalButton
+                onPress={() => {
                     close()
-                },
-            },
-        ]}
+                }}
+            >
+                Close
+            </ModalButton>
+        }
     />
 )
 

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { ModalButton } from './modal-button'
 
 const SubNotFoundModalCard = ({
     close,
@@ -16,29 +17,34 @@ const SubNotFoundModalCard = ({
         title="Subscription not found"
         appearance={CardAppearance.blue}
         size="small"
-        mainActions={[
-            {
-                label: 'Sign-in with different account',
-                onPress: () => {
-                    close()
-                    onLoginPress()
-                },
-            },
-            {
-                label: 'Activate with subscriber ID',
-                onPress: () => {
-                    close()
-                    onOpenCASLogin()
-                },
-            },
-            {
-                label: 'Close',
-                onPress: () => {
-                    close()
-                    onDismiss()
-                },
-            },
-        ]}
+        bottomContent={
+            <>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onLoginPress()
+                    }}
+                >
+                    Sign-in with different account
+                </ModalButton>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onOpenCASLogin()
+                    }}
+                >
+                    Activate with subscriber ID
+                </ModalButton>
+                <ModalButton
+                    onPress={() => {
+                        close()
+                        onDismiss()
+                    }}
+                >
+                    Close
+                </ModalButton>
+            </>
+        }
     >
         We were unable to find a subscription with that account
     </OnboardingCard>

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -19,6 +19,7 @@ import { useArticleResponse } from 'src/hooks/use-issue'
 import { useSettingsValue } from 'src/hooks/use-settings'
 import { color } from 'src/theme/color'
 import { DevTools, getEnumPosition } from './dev-tools'
+import { ModalRenderer } from '../../components/modal'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -62,55 +63,61 @@ const ArticleScreenBody = ({
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
 
     return (
-        <ScrollView
-            scrollEventThrottle={8}
-            onScroll={ev => {
-                onTopPositionChange(ev.nativeEvent.contentOffset.y <= 0)
-            }}
-            style={{ width }}
-            contentContainerStyle={styles.flex}
-        >
-            {articleResponse({
-                error: ({ message }) => (
-                    <FlexErrorMessage
-                        title={message}
-                        style={{ backgroundColor: color.background }}
-                    />
-                ),
-                pending: () => (
-                    <FlexErrorMessage
-                        title={'loading'}
-                        style={{ backgroundColor: color.background }}
-                    />
-                ),
-                success: article => (
-                    <>
-                        {previewNotice && (
-                            <UiBodyCopy>{previewNotice}</UiBodyCopy>
-                        )}
-                        {isUsingProdDevtools ? (
-                            <DevTools
-                                pillar={modifiedPillar}
-                                setPillar={setPillar}
-                                type={modifiedType}
-                                setType={setType}
-                            />
-                        ) : null}
-                        <WithArticle
-                            type={
-                                isUsingProdDevtools
-                                    ? getEnumPosition(ArticleType, modifiedType)
-                                    : article.article.articleType ||
-                                      ArticleType.Article
-                            }
-                            pillar={articlePillars[modifiedPillar]}
-                        >
-                            <ArticleController article={article.article} />
-                        </WithArticle>
-                    </>
-                ),
-            })}
-        </ScrollView>
+        <>
+            <ModalRenderer />
+            <ScrollView
+                scrollEventThrottle={8}
+                onScroll={ev => {
+                    onTopPositionChange(ev.nativeEvent.contentOffset.y <= 0)
+                }}
+                style={{ width }}
+                contentContainerStyle={styles.flex}
+            >
+                {articleResponse({
+                    error: ({ message }) => (
+                        <FlexErrorMessage
+                            title={message}
+                            style={{ backgroundColor: color.background }}
+                        />
+                    ),
+                    pending: () => (
+                        <FlexErrorMessage
+                            title={'loading'}
+                            style={{ backgroundColor: color.background }}
+                        />
+                    ),
+                    success: article => (
+                        <>
+                            {previewNotice && (
+                                <UiBodyCopy>{previewNotice}</UiBodyCopy>
+                            )}
+                            {isUsingProdDevtools ? (
+                                <DevTools
+                                    pillar={modifiedPillar}
+                                    setPillar={setPillar}
+                                    type={modifiedType}
+                                    setType={setType}
+                                />
+                            ) : null}
+                            <WithArticle
+                                type={
+                                    isUsingProdDevtools
+                                        ? getEnumPosition(
+                                              ArticleType,
+                                              modifiedType,
+                                          )
+                                        : article.article.articleType ||
+                                          ArticleType.Article
+                                }
+                                pillar={articlePillars[modifiedPillar]}
+                            >
+                                <ArticleController article={article.article} />
+                            </WithArticle>
+                        </>
+                    ),
+                })}
+            </ScrollView>
+        </>
     )
 }
 


### PR DESCRIPTION
## Why are you doing this?

This moves sign in cards a bit closer to done but I'll leave this in draft for now.

- [x] Move the modal and overlay down into the article body so that a user can still swipe down to close an article.
- [x] Extract buttons out of the `OnboardingCard` so that we can put more than buttons in the bottom of an overlay card. (This allows the link to ["need help logging in"](https://trello.com/c/LIqvCush/308-login-need-help-signing-in-screen) to be added.)
- ~Still need to add an orange digipack font and change the color of the font for the title / subtitle at the bottom. This is used by GDPR onboarding card, so this needs to be conditional)~ this will be moved to another card

## Screenshots

![ezgif-4-5d5b62c616b3](https://user-images.githubusercontent.com/1652187/63367193-31764280-c373-11e9-84e8-7952ab1d896e.gif)
