### PR TITLE
Change reset credentials to sign out

### DIFF
--- a/projects/Mallard/src/authentication/auth-context.tsx
+++ b/projects/Mallard/src/authentication/auth-context.tsx
@@ -5,7 +5,7 @@ import React, {
     useEffect,
     useMemo,
 } from 'react'
-import { resetCredentials } from './storage'
+import { signOutIdentity } from './storage'
 import { useNetInfo } from '@react-native-community/netinfo'
 import {
     liveAuthChain,
@@ -42,14 +42,14 @@ const createAuthAttempt = (
 const AuthContext = createContext<{
     status: AuthStatus
     setStatus: (status: AuthStatus) => void
-    signOut: () => Promise<void>
+    signOutIdentity: () => Promise<void>
     restorePurchases: () => Promise<void>
     isRestoring: boolean
     isAuthing: boolean
 }>({
     status: pending,
     setStatus: () => {},
-    signOut: () => Promise.resolve(),
+    signOutIdentity: () => Promise.resolve(),
     restorePurchases: () => Promise.resolve(),
     isRestoring: false,
     isAuthing: false,
@@ -188,8 +188,8 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             status: authAttempt.status,
             setStatus: (status: AuthStatus) =>
                 setAuthAttempt(createAuthAttempt(status, 'live')),
-            signOut: async () => {
-                await resetCredentials()
+            signOutIdentity: async () => {
+                await signOutIdentity()
                 setAuthAttempt(createAuthAttempt(unauthed, 'live'))
             },
             isRestoring,

--- a/projects/Mallard/src/authentication/helpers.ts
+++ b/projects/Mallard/src/authentication/helpers.ts
@@ -1,7 +1,7 @@
 import {
     membershipAccessTokenKeychain,
     userAccessTokenKeychain,
-    resetCredentials,
+    signOutIdentity,
     casCredentialsKeychain,
     casDataCache,
     userDataCache,
@@ -97,7 +97,7 @@ const fetchUserDataForKeychainUser = async (
     fetchUserDetailsImpl = fetchUserDetails,
     fetchMembershipAccessTokenImpl = fetchMembershipAccessToken,
     getLegacyUserAccessTokenImpl = getLegacyUserAccessToken,
-    resetCredentialsImpl = resetCredentials,
+    signOutIdentityImpl = signOutIdentity,
 ): Promise<UserData | null> => {
     const [userToken, legacyUserToken, membershipToken] = await Promise.all([
         userTokenStore.get(),
@@ -110,7 +110,7 @@ const fetchUserDataForKeychainUser = async (
     if (!actualUserToken) {
         // no userToken - we need to be logged in again
         // make sure everything is reset before doing that
-        await resetCredentialsImpl()
+        await signOutIdentityImpl()
         return null
     }
 

--- a/projects/Mallard/src/authentication/storage.ts
+++ b/projects/Mallard/src/authentication/storage.ts
@@ -1,14 +1,13 @@
-import * as Keychain from 'react-native-keychain'
-import { UserData } from './helpers'
 import AsyncStorage from '@react-native-community/async-storage'
-import { CasExpiry } from 'src/services/content-auth-service'
 import { Settings } from 'react-native'
-import { ReceiptIOS } from '../services/iap'
+import * as Keychain from 'react-native-keychain'
 import {
+    LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
-    LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
 } from 'src/constants'
+import { CasExpiry } from 'src/services/content-auth-service'
+import { UserData } from './helpers'
 
 /**
  * this is ostensibly used to get the legacy data from the old GCE app
@@ -90,22 +89,19 @@ const getLegacyUserAccessToken = async (): ReturnType<
  * Removes all the relevent keychain, storage entries that mark a user as logged in
  * and returns a boolean indicating whether all these operations succeeded
  */
-const resetCredentials = (): Promise<boolean> =>
+const signOutIdentity = (): Promise<boolean> =>
     Promise.all([
         userAccessTokenKeychain.reset(),
         membershipAccessTokenKeychain.reset(),
         userDataCache.reset(),
-        casCredentialsKeychain.reset(),
-        casDataCache.reset(),
         _legacyUserAccessTokenKeychain.reset(),
-        legacyCASExpiryCache.reset(),
     ]).then(all => all.every(_ => _))
 
 export {
     userAccessTokenKeychain,
     membershipAccessTokenKeychain,
     casCredentialsKeychain,
-    resetCredentials,
+    signOutIdentity,
     casDataCache,
     userDataCache,
     getLegacyUserAccessToken,

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -80,7 +80,7 @@ const AuthSwitcherScreen = ({
 
     const validatorString = useRandomState()
 
-    const { setStatus, signOut } = useContext(AuthContext)
+    const { setStatus, signOutIdentity } = useContext(AuthContext)
     const { open } = useModal()
 
     const handleAuthClick = async (
@@ -95,7 +95,7 @@ const AuthSwitcherScreen = ({
             requiresFunctionalConsent ? 'gdprAllowFunctionality' : null,
             {
                 allow: async () => {
-                    await signOut()
+                    await signOutIdentity()
                     tryAuth(
                         {
                             onStart: () => {

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -151,7 +151,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const signInHandler = useIdentity()
     const authHandler = useAuth()
     const [versionClickedTimes, setVersionClickedTimes] = useState(0)
-    const { signOut } = useContext(AuthContext)
+    const { signOutIdentity } = useContext(AuthContext)
     const styles = StyleSheet.create({
         signOut: {
             color: color.ui.supportBlue,
@@ -170,7 +170,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                     title: data.userDetails.publicFields.displayName,
                     data: {
                         onPress: async () => {
-                            await signOut()
+                            await signOutIdentity()
                         },
                     },
                     proxy: <Text style={styles.signOut}>Sign Out</Text>,


### PR DESCRIPTION
## Why are you doing this?

Sign out will now only sign you out of an identity account and not delete CAS codes. I've also renamed all functions that implemented this behaviour to make it more obvious.
