### PR TITLE
Provide article type to articles on the app.

### DIFF
--- a/projects/Mallard/src/components/article/article-header/types.ts
+++ b/projects/Mallard/src/components/article/article-header/types.ts
@@ -1,4 +1,4 @@
-import { Image, Article } from '../../../common'
+import { Image, Article, ArticleType } from '../../../common'
 
 export interface ArticleHeaderProps {
     byline: string

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -115,7 +115,12 @@ const ArticleScreenBody = ({
                             />
                         ) : null}
                         <WithArticle
-                            type={getEnumPosition(ArticleType, modifiedType)}
+                            type={
+                                isUsingProdDevtools
+                                    ? getEnumPosition(ArticleType, modifiedType)
+                                    : article.article.articleType ||
+                                      ArticleType.Article
+                            }
                             pillar={articlePillars[modifiedPillar]}
                         >
                             <ArticleController article={article.article} />

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -1,0 +1,93 @@
+import { IContent } from '@guardian/capi-ts/dist/Content'
+import { ArticleType } from '../../common/src/index'
+
+const doesTagExist = (article: IContent, tagId: string): boolean => {
+    return article.tags.find(tag => tag.id === tagId) != undefined
+}
+
+const articleTypePicker = (article: IContent): ArticleType => {
+    const isTagPresent = (tagId: string): boolean =>
+        doesTagExist(article, tagId)
+
+    const isImmersive: boolean =
+        (article.fields && article.fields.displayHint === 'immersive') || false
+    const isLongRead: boolean =
+        isTagPresent('theguardian/journal/the-long-read') && isImmersive
+    const isSeries: boolean = isTagPresent('tone/special-report') && isImmersive
+    const isInterview: boolean = isTagPresent('tone/interview')
+    const isObituary: boolean = isTagPresent('tone/obituaries')
+    const isAnalysis: boolean = isTagPresent('tone/analysis')
+    const isComment: boolean = isTagPresent('tone/comment')
+    const isLetter: boolean =
+        isTagPresent('tone/lettertotheeditor') && isImmersive
+    const isFeature: boolean = isTagPresent('tone/features')
+    const isGallery: boolean = isTagPresent('type/gallery')
+    const isReview: boolean = isTagPresent('tone/reviews')
+    const isRecipe: boolean = isTagPresent('tone/recipes')
+    const isMatchResult: boolean = isTagPresent('tone/matchreports')
+
+    /**
+     * Order of conditionals under each pillar is important as certain conditions take precedent.
+     */
+    if (article.pillarName) {
+        switch (article.pillarName.toLowerCase()) {
+            case 'news':
+                if (isLongRead) return ArticleType.Longread
+                else if (isSeries) return ArticleType.Series
+                else if (isInterview) return ArticleType.Interview
+                else if (isAnalysis) return ArticleType.Analysis
+                else if (isObituary) return ArticleType.Obituary
+                else return ArticleType.Article
+
+            case 'sport':
+                if (isMatchResult) return ArticleType.MatchResult
+                else if (isInterview) return ArticleType.Interview
+                else if (isLongRead) return ArticleType.Longread
+                else if (isAnalysis) return ArticleType.Analysis
+                else if (isObituary) return ArticleType.Obituary
+                else return ArticleType.Article
+
+            case 'opinion':
+            case 'journal':
+                if (isComment) return ArticleType.Opinion
+                else if (isLongRead) return ArticleType.Longread
+                else if (isLetter) return ArticleType.Letter
+                else if (isObituary) return ArticleType.Obituary
+                else if (isAnalysis) return ArticleType.Analysis
+                else return ArticleType.Article
+
+            case 'lifestyle':
+                if (isRecipe) return ArticleType.Recipe
+                else if (isInterview) return ArticleType.Interview
+                else if (isObituary) return ArticleType.Obituary
+                else if (isReview) return ArticleType.Review
+                else if (isGallery) return ArticleType.Gallery
+                else if (isAnalysis) return ArticleType.Analysis
+                else if (isFeature) return ArticleType.Feature
+                else if (isImmersive) return ArticleType.Immersive
+                else return ArticleType.Article
+
+            case 'culture':
+            case 'film':
+            case 'music':
+            case 'books':
+            case 'stage':
+            case 'games':
+            case 'classical':
+            case 'arts':
+                if (isReview) return ArticleType.Review
+                else if (isObituary) return ArticleType.Obituary
+                else if (isFeature) return ArticleType.Feature
+                else if (isAnalysis) return ArticleType.Analysis
+                else if (isImmersive) return ArticleType.Immersive
+                else return ArticleType.Article
+
+            default:
+                return ArticleType.Article
+        }
+    } else {
+        return ArticleType.Article
+    }
+}
+
+export { articleTypePicker }

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -23,6 +23,7 @@ import { fromPairs } from 'ramda'
 import { kickerPicker } from './kickerPicker'
 import { getBylineImages } from './byline'
 import { rationaliseAtoms } from './atoms'
+import { articleTypePicker } from './articleTypePicker'
 
 type NotInCAPI =
     | 'key'
@@ -31,7 +32,7 @@ type NotInCAPI =
     | 'mediaType'
     | 'slideshowImages'
 
-type OptionalInCAPI = 'kicker' | 'bylineImages' | 'trail'
+type OptionalInCAPI = 'kicker' | 'bylineImages' | 'trail' | 'articleType'
 
 interface CAPIExtras {
     path: string
@@ -74,6 +75,8 @@ const parseArticleResult = async (
 
     const parser = elementParser(path, atomData)
     const kicker = kickerPicker(result, title)
+
+    const articleType = articleTypePicker(result)
 
     const trail = result.fields && result.fields.trailText
 
@@ -129,6 +132,7 @@ const parseArticleResult = async (
                     path: path,
                     headline: title,
                     kicker,
+                    articleType,
                     trail,
                     image: maybeImage,
                     byline: byline || '',
@@ -149,6 +153,7 @@ const parseArticleResult = async (
                     headline: title,
                     trail,
                     kicker,
+                    articleType,
                     image: maybeImage,
                     byline: byline || '',
                     standfirst: standfirst || '',

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -19,6 +19,16 @@ export enum ArticleType {
     Longread = 'longread',
     Review = 'review',
     Opinion = 'opinion',
+    Series = 'series',
+    Interview = 'interview',
+    Analysis = 'analysis',
+    Obituary = 'obituary',
+    MatchResult = 'matchresult',
+    Letter = 'letter',
+    Recipe = 'recipe',
+    Gallery = 'gallery',
+    Feature = 'feature',
+    Immersive = 'immersive',
 }
 
 export type PillarFromPalette = typeof articlePillars[number]
@@ -67,6 +77,7 @@ export interface Content extends WithKey {
     type: string
     headline: string
     kicker: string
+    articleType?: ArticleType
     trail: string
     image?: Image
     standfirst?: string


### PR DESCRIPTION
## Why are you doing this?
  - Provides logic for deciding article type on backend (will need further tweaks on review)
 - Wires article display in app up to article type to render correct header/article design.
  - This PR does not change front card based on article type (which will be necessary)