### PR TITLE
feat: Download todays issue when the app starts

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -12,7 +12,11 @@ import { RootNavigator } from 'src/navigation'
 import { AuthProvider } from './authentication/auth-context'
 import { ErrorBoundary } from './components/layout/ui/errors/error-boundary'
 import { Modal } from './components/modal'
-import { prepFileSystem, clearOldIssues } from './helpers/files'
+import {
+    prepFileSystem,
+    clearOldIssues,
+    downloadTodaysIssue,
+} from './helpers/files'
 import { nestProviders } from './helpers/provider'
 import { pushNotifcationRegistration } from './helpers/push-notifications'
 
@@ -20,6 +24,7 @@ useScreens()
 prepFileSystem()
 pushNotifcationRegistration()
 clearOldIssues()
+downloadTodaysIssue()
 
 const styles = StyleSheet.create({
     appContainer: {

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -11,6 +11,7 @@ import {
 } from './fetch/cached-or-promise'
 import { getJson, isIssueOnDevice } from './files'
 import { Issue } from 'src/common'
+import { defaultSettings } from './settings/defaults'
 
 export type ValidatorFn<T> = (response: any | T) => boolean
 
@@ -212,9 +213,24 @@ const fetchFromNotificationService = async (deviceToken: { token: string }) => {
         .catch(e => console.log('Error', JSON.stringify(e)))
 }
 
+const isUrlAvailable = async (url: string): Promise<boolean> => {
+    try {
+        const response = await fetch(url, {
+            method: 'HEAD',
+        })
+        return response.status === 200 && true
+    } catch (error) {
+        return false
+    }
+}
+
+const isRemoteZipAvailable = async (issue: string): Promise<boolean> =>
+    await isUrlAvailable(`${defaultSettings.zipUrl}${issue}.zip`)
+
 export {
     fetchFromIssue,
     fetchFromApi,
     fetchWeather,
     fetchFromNotificationService,
+    isRemoteZipAvailable,
 }

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -4,7 +4,9 @@ import { Issue } from 'src/common'
 import { FSPaths } from 'src/paths'
 import { ImageSize } from '../../../common/src'
 import { defaultSettings } from './settings/defaults'
-import { lastSevenDays } from './issues'
+import { lastSevenDays, todayAsFolder } from './issues'
+import { imageForScreenSize } from './screen'
+import { isRemoteZipAvailable } from './fetch'
 
 interface BasicFile {
     filename: string
@@ -293,4 +295,15 @@ export const clearOldIssues = async () => {
         issue => !lastSevenDays().includes(issue),
     )
     issuesToDelete.map(issue => RNFetchBlob.fs.unlink(FSPaths.issueRoot(issue)))
+}
+
+export const downloadTodaysIssue = async () => {
+    const todaysKey = todayAsFolder()
+    const isTodaysIssueOnDevice = await isIssueOnDevice(todaysKey)
+    if (!isTodaysIssueOnDevice) {
+        const isValidIssue = await isRemoteZipAvailable(todaysKey)
+        if (isValidIssue) {
+            downloadAndUnzipIssue(todaysKey, imageForScreenSize())
+        }
+    }
 }


### PR DESCRIPTION
## Why are you doing this?

Push Notifications are notorious for not always being delivered. In the cases where its not, this will download the latest issue when starting up the app. This follows the same methodology as the current Editions app 

[**Trello Card ->**](https://trello.com/c/ygsvhVz5/474-check-and-download-zip-on-app-start)

## Changes

* Helper function to check URL exists
* Above function used to check the Zip is on the server
* General workflow = Get Todays as key -> Check if issue is on device -> If not then check the issue is available on the zip -> If it is, then download it.
