### PR TITLE
feat: Clear issues on push

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -1,7 +1,7 @@
 import PushNotification from 'react-native-push-notification'
 import { PushNotificationIOS, Platform } from 'react-native'
 import { fetchFromNotificationService } from 'src/helpers/fetch'
-import { downloadAndUnzipIssue } from 'src/helpers/files'
+import { downloadAndUnzipIssue, clearOldIssues } from 'src/helpers/files'
 import { imageForScreenSize } from 'src/helpers/screen'
 
 const pushNotifcationRegistration = () =>
@@ -17,6 +17,7 @@ const pushNotifcationRegistration = () =>
             if (key) {
                 const screenSize = imageForScreenSize()
                 downloadAndUnzipIssue(key, screenSize)
+                clearOldIssues()
             }
 
             // required on iOS only (see fetchCompletionHandler docs: https://facebook.github.io/react-native/docs/pushnotificationios.html)


### PR DESCRIPTION
## Why are you doing this?

A user who has the app in the background but doesnt use the app will potentially download days and days worth of issues without opening the app. This means the clearing of issues will never happen and has a potential to fill up their device.

This clears old issues when a push is received to keep it to a maximum.