### PR TITLE
Rahb/zip images

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
     },
 })
 
-const persistenceKey = 'dev-nav-key-2312424'
+const persistenceKey = 'dev-nav-key-232asdf1asdfa34'
 const persistNavigationState = async (navState: any) => {
     try {
         await AsyncStorage.setItem(persistenceKey, JSON.stringify(navState))

--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react'
-import { ImageBackground, StyleSheet, View } from 'react-native'
-import { useDimensions, useMediaQuery } from 'src/hooks/use-screen'
-import { imagePath } from 'src/paths'
-import { Breakpoints } from 'src/theme/breakpoints'
+import { StyleSheet, ImageBackground, View } from 'react-native'
 import { Image as ImageT } from '../../common'
+import { useMediaQuery } from 'src/hooks/use-screen'
+import { Breakpoints } from 'src/theme/breakpoints'
+import { useImagePath } from 'src/hooks/use-image-paths'
 
 const styles = StyleSheet.create({
     image: {
@@ -26,6 +26,8 @@ const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
 
     const defaultAspectRatio = isLandscape ? 2 : 1.5
 
+    const path = useImagePath(image)
+
     return (
         <ImageBackground
             style={[
@@ -36,7 +38,7 @@ const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
                 },
             ]}
             source={{
-                uri: imagePath(image),
+                uri: path,
             }}
         >
             {proxy && <View style={styles.proxy}>{proxy}</View>}

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -80,7 +80,7 @@ export const render = (
                 case 'image':
                     return renderImageElement(el)
                 default:
-                    ''
+                    return ''
             }
         })
         .join('')

--- a/projects/Mallard/src/components/front/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page.tsx
@@ -154,7 +154,6 @@ const CollectionPage = ({
                                 issue,
                                 front,
                             }}
-                            issueID={issue}
                             size={size}
                             articleNavigator={articleNavigator}
                             article={article}

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,11 +1,7 @@
-import React, { useState } from 'react'
-import { FSPaths, APIPaths } from 'src/paths'
+import React from 'react'
 import { Image as IImage } from '../../../../common/src'
 import { Image, StyleProp, ImageStyle } from 'react-native'
-import { imageForScreenSize } from 'src/helpers/screen'
-
-// get the tail of an array, use in setPath, to move on to the next path after an error
-const tail = <T extends any>([, ...next]: T[]): T[] => next
+import { useImagePath } from 'src/hooks/use-image-paths'
 
 /**
  * This component abstracts away the endpoint for images
@@ -17,33 +13,15 @@ const tail = <T extends any>([, ...next]: T[]): T[] => next
  * as this implementation for API calls and seems slower for cache hits
  */
 const ImageResource = ({
-    issueID,
-    image: { source, path },
+    image,
     style,
 }: {
-    issueID: string
     image: IImage
     style?: StyleProp<ImageStyle>
 }) => {
-    const [paths, setPaths] = useState([
-        FSPaths.media(issueID, source, path),
-        `${APIPaths.mediaBackend}${APIPaths.media(
-            issueID,
-            imageForScreenSize(),
-            source,
-            path,
-        )}`,
-    ])
+    const path = useImagePath(image)
 
-    const handleError = () => setPaths(tail)
-
-    // this might be undefined if the API errors
-    // this is sort of fine but may want to handle this better
-    const currPath = paths[0]
-
-    return (
-        <Image style={style} source={{ uri: currPath }} onError={handleError} />
-    )
+    return <Image style={style} source={{ uri: path }} />
 }
 
 export { ImageResource }

--- a/projects/Mallard/src/components/front/items/item.tsx
+++ b/projects/Mallard/src/components/front/items/item.tsx
@@ -46,7 +46,6 @@ interface TappablePropTypes {
 
 export interface PropTypes extends TappablePropTypes {
     size: ItemSizes
-    issueID: string
 }
 
 /*
@@ -189,13 +188,12 @@ const coverStyles = StyleSheet.create({
     },
 })
 
-const CoverItem = ({ article, issueID, size, ...tappableProps }: PropTypes) => {
+const CoverItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }}>
             <View style={coverStyles.cover}>
                 {'image' in article && article.image ? (
                     <ImageResource
-                        issueID={issueID}
                         style={coverStyles.cover}
                         image={article.image}
                     />
@@ -247,12 +245,11 @@ const getImageHeight = ({ story, layout }: ItemSizes) => {
     }
 }
 
-const ImageItem = ({ article, issueID, size, ...tappableProps }: PropTypes) => {
+const ImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }}>
             {'image' in article && article.image ? (
                 <ImageResource
-                    issueID={issueID}
                     style={[
                         imageStyles.image,
                         { height: getImageHeight(size) },
@@ -293,12 +290,7 @@ const splitImageStyles = StyleSheet.create({
     },
 })
 
-const SplitImageItem = ({
-    article,
-    issueID,
-    size,
-    ...tappableProps
-}: PropTypes) => {
+const SplitImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...{ article }} {...tappableProps}>
             <View style={splitImageStyles.card}>
@@ -310,7 +302,6 @@ const SplitImageItem = ({
                 />
                 {'image' in article && article.image ? (
                     <ImageResource
-                        issueID={issueID}
                         style={[splitImageStyles.image]}
                         image={article.image}
                     />
@@ -347,17 +338,11 @@ const superHeroImageStyles = StyleSheet.create({
     },
 })
 
-const SuperHeroImageItem = ({
-    article,
-    issueID,
-    size,
-    ...tappableProps
-}: PropTypes) => {
+const SuperHeroImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
             {'image' in article && article.image ? (
                 <ImageResource
-                    issueID={issueID}
                     style={[superHeroImageStyles.image]}
                     image={article.image}
                 />
@@ -395,15 +380,12 @@ const splashImageStyles = StyleSheet.create({
     },
 })
 
-const SplashImageItem = ({ article, issueID, ...tappableProps }: PropTypes) => {
+const SplashImageItem = ({ article, ...tappableProps }: PropTypes) => {
     if (!article.image)
-        return (
-            <SuperHeroImageItem {...tappableProps} {...{ article, issueID }} />
-        )
+        return <SuperHeroImageItem {...tappableProps} {...{ article }} />
     return (
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
             <ImageResource
-                issueID={issueID}
                 style={[splashImageStyles.image]}
                 image={article.image}
             />

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+import { FSPaths, APIPaths } from 'src/paths'
+import { imageForScreenSize } from 'src/helpers/screen'
+import { Image } from '../../../common/src'
+import RNFetchBlob from 'rn-fetch-blob'
+import { useIssueId } from './use-issue-id'
+
+const selectImagePath = async (issueId: string, { source, path }: Image) => {
+    const api = `${APIPaths.mediaBackend}${APIPaths.media(
+        issueId,
+        imageForScreenSize(),
+        source,
+        path,
+    )}`
+    const fs = FSPaths.media(issueId, source, path)
+    const fsExists = await RNFetchBlob.fs.exists(fs)
+    return fsExists ? fs : api
+}
+
+/**
+ * A simple helper to get image paths in order to try from the cache,
+ * then the API if the error handler is called, otherwise returns `undefined`
+ * if none are found
+ *
+ * TODO: cache these paths in a context in order not to check every time
+ */
+
+const useImagePath = (image: Image) => {
+    const issueId = useIssueId()
+
+    const [paths, setPaths] = useState<string | undefined>()
+
+    useEffect(() => {
+        selectImagePath(issueId || 'issue', image).then(setPaths)
+    }, [])
+
+    return paths
+}
+
+export { useImagePath, selectImagePath }

--- a/projects/Mallard/src/hooks/use-issue-id.tsx
+++ b/projects/Mallard/src/hooks/use-issue-id.tsx
@@ -1,0 +1,29 @@
+import { useContext } from 'react'
+import { NavigationContext } from 'react-navigation'
+import {
+    ArticleNavigationProps,
+    IssueNavigationProps,
+} from 'src/navigation/helpers/base'
+
+/**
+ * This will try and look in the states of any navigator
+ * and discern an issue id. I've tried to be as defensive
+ * as possible here given these apis may change but given
+ * different screens have their issue ids in different places
+ * we can't do too much else, without a bigger refactor
+ */
+
+const useIssueId = () => {
+    const nav = useContext(NavigationContext)
+    const path: ArticleNavigationProps['path'] | undefined = nav.getParam(
+        'path',
+    )
+    if (path) return path.issue || null
+    const issue: IssueNavigationProps['issue'] | undefined = nav.getParam(
+        'issue',
+    )
+    if (issue) return issue.key || null
+    return null
+}
+
+export { useIssueId }

--- a/projects/Mallard/src/navigation/helpers/base.tsx
+++ b/projects/Mallard/src/navigation/helpers/base.tsx
@@ -7,6 +7,7 @@ import {
 import { routeNames } from 'src/navigation/routes'
 import { ArticleNavigator, PathToArticle } from 'src/screens/article-screen'
 import { PathToIssue } from 'src/screens/issue-screen'
+import { Issue } from '../../../../common/src'
 
 type NavigatorWrapper = ({ navigation }: NavigationInjectedProps) => JSX.Element
 export const addStaticRouter = (
@@ -84,6 +85,7 @@ const navigateToIssueList = (navigation: NavigationScreenProp<{}>): void => {
 
 export interface IssueNavigationProps {
     path?: PathToIssue
+    issue?: Issue
 }
 const navigateToIssue = (
     navigation: NavigationScreenProp<{}>,


### PR DESCRIPTION
## Why are you doing this?

This takes the main media from the zip now too if possible.

Worth noting this now uses `fs.exists` instead of trying to load an image directly in an `Image` element and if it fails then trying the next one.

It stops the ridiculous amount of yellow box warnings, it's quicker than I thought it was and it might be easier to use outside of a the react tree if we need to.
