### PR TITLE
Move onboarding & consent screens closer to various designs.

### DIFF
--- a/projects/Mallard/src/components/button/button.tsx
+++ b/projects/Mallard/src/components/button/button.tsx
@@ -19,11 +19,13 @@ import { getFont } from 'src/theme/typography'
 export enum ButtonAppearance {
     default,
     skeleton,
+    skeletonBlue,
     tomato,
     apricot,
     skeletonLight,
     skeletonActive,
     light,
+    dark,
 }
 
 const height = metrics.buttonHeight
@@ -31,7 +33,7 @@ const height = metrics.buttonHeight
 const styles = StyleSheet.create({
     background: {
         borderRadius: 999,
-        paddingHorizontal: metrics.horizontal * 2,
+        paddingHorizontal: metrics.horizontal * 1.5,
         alignItems: 'center',
         justifyContent: 'center',
         height,
@@ -71,6 +73,14 @@ const getButtonAppearance = (
         },
         text: { color: appAppearance.color },
     }),
+    [ButtonAppearance.skeletonBlue]: StyleSheet.create({
+        background: {
+            backgroundColor: undefined,
+            borderWidth: 1,
+            borderColor: color.primary,
+        },
+        text: { color: color.primary },
+    }),
     [ButtonAppearance.skeletonActive]: StyleSheet.create({
         background: {
             backgroundColor: appAppearance.color,
@@ -90,6 +100,10 @@ const getButtonAppearance = (
     [ButtonAppearance.light]: StyleSheet.create({
         background: { backgroundColor: color.palette.neutral[100] },
         text: { color: color.primary },
+    }),
+    [ButtonAppearance.dark]: StyleSheet.create({
+        background: { backgroundColor: color.primary },
+        text: { color: color.palette.neutral[100] },
     }),
     [ButtonAppearance.tomato]: StyleSheet.create({
         background: { backgroundColor: color.ui.tomato },

--- a/projects/Mallard/src/components/button/close-modal-button.tsx
+++ b/projects/Mallard/src/components/button/close-modal-button.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import { Button } from '../button/button'
+import { color } from 'src/theme/color'
+
+const closeModalButtonStyles = StyleSheet.create({
+    dismissButton: {
+        paddingHorizontal: 0,
+        backgroundColor: 'transparent',
+        borderColor: color.primary,
+        borderWidth: 1,
+    },
+    dismissText: {
+        color: color.primary,
+    },
+})
+
+const CloseModalButton = ({ onPress }: { onPress: () => void }) => (
+    <Button
+        icon=""
+        alt="Dismiss"
+        buttonStyles={closeModalButtonStyles.dismissButton}
+        textStyles={closeModalButtonStyles.dismissText}
+        onPress={onPress}
+    />
+)
+
+export { CloseModalButton }

--- a/projects/Mallard/src/components/login/login-layout.tsx
+++ b/projects/Mallard/src/components/login/login-layout.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, KeyboardAvoidingView } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
 import { useInsets } from 'src/hooks/use-screen'
-import { Button } from '../button/button'
+import { CloseModalButton } from '../button/close-modal-button'
 import { TitlepieceText, UiBodyCopy } from '../styled-text'
 import { Spinner } from '../spinner'
 
@@ -17,15 +17,6 @@ const loginHeaderStyles = StyleSheet.create({
     actionRow: {
         alignItems: 'flex-end',
         marginBottom: metrics.vertical / 2,
-    },
-    dismissButton: {
-        paddingHorizontal: 0,
-        backgroundColor: 'transparent',
-        borderColor: color.primary,
-        borderWidth: 1,
-    },
-    dismissText: {
-        color: color.primary,
     },
     title: {
         color: color.primary,
@@ -48,13 +39,7 @@ const LoginHeader = ({
             ]}
         >
             <View style={loginHeaderStyles.actionRow}>
-                <Button
-                    icon=""
-                    alt="Dismiss"
-                    buttonStyles={loginHeaderStyles.dismissButton}
-                    textStyles={loginHeaderStyles.dismissText}
-                    onPress={onDismiss}
-                />
+                <CloseModalButton onPress={onDismiss} />
             </View>
             <View>
                 <TitlepieceText style={loginHeaderStyles.title}>

--- a/projects/Mallard/src/components/modal-button.tsx
+++ b/projects/Mallard/src/components/modal-button.tsx
@@ -13,12 +13,13 @@ const ModalButton = (props: {
     onPress: () => void
     children: string
     alt?: string
+    buttonAppearance?: ButtonAppearance
 }) => (
     <Button
         {...props}
         alt={props.alt || props.children}
         style={styles.button}
-        appearance={ButtonAppearance.light}
+        appearance={props.buttonAppearance || ButtonAppearance.light}
     />
 )
 

--- a/projects/Mallard/src/components/onboarding/onboarding-card.tsx
+++ b/projects/Mallard/src/components/onboarding/onboarding-card.tsx
@@ -5,6 +5,8 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
 import { minScreenSize } from 'src/helpers/screen'
+import { Button } from '../button/button'
+import { CloseModalButton } from '../button/close-modal-button'
 
 export enum CardAppearance {
     tomato,
@@ -13,15 +15,15 @@ export enum CardAppearance {
 }
 
 const styles = StyleSheet.create({
+    flexRow: {
+        flexDirection: 'row',
+    },
     container: {
         flex: 0,
         flexDirection: 'column',
     },
     top: {
-        aspectRatio: 1,
-        flexDirection: 'column',
-        justifyContent: 'space-around',
-        flexGrow: 0,
+        alignContent: 'space-between',
         padding: metrics.horizontal,
         paddingVertical: metrics.vertical,
         width: '100%',
@@ -36,7 +38,16 @@ const styles = StyleSheet.create({
     },
     explainerSubtitle: {
         ...getFont('titlepiece', 1.25),
-        marginBottom: metrics.vertical * 1.5,
+    },
+    bottomContentContainer: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        marginTop: metrics.vertical * 3,
+    },
+    dismissIconContainer: {
+        alignItems: 'flex-end',
+        marginBottom: metrics.vertical / 2,
+        marginLeft: '-2%',
     },
 })
 
@@ -71,6 +82,8 @@ const OnboardingCard = ({
     bottomContent,
     explainerTitle,
     explainerSubtitle,
+    bottomExplainerContent,
+    onDismissThisCard,
     style,
     appearance,
     size = 'big',
@@ -82,12 +95,14 @@ const OnboardingCard = ({
     bottomContent?: React.ReactNode
     explainerTitle?: string
     explainerSubtitle?: string
+    bottomExplainerContent?: React.ReactNode
+    onDismissThisCard?: () => void
     style?: StyleProp<ViewStyle>
     appearance: CardAppearance
     size?: 'big' | 'small'
     maxSize?: number
 }) => {
-    const max = Math.min(minScreenSize() * 0.9, maxSize)
+    const max = Math.min(minScreenSize() * 0.95, maxSize)
     return (
         <View
             style={[
@@ -100,17 +115,24 @@ const OnboardingCard = ({
             ]}
         >
             <View style={[styles.top, appearances[appearance].background]}>
-                <View style={{ flexGrow: 1 }}>
+                <View style={styles.flexRow}>
                     <TitlepieceText
                         accessibilityRole="header"
                         style={[
-                            getFont('titlepiece', size === 'big' ? 2.5 : 2.0),
+                            getFont('titlepiece', size === 'big' ? 2.5 : 2.25),
                             { marginBottom: size === 'big' ? 16 : 8 },
                             appearances[appearance].titleText,
                         ]}
                     >
                         {title}
                     </TitlepieceText>
+                    {onDismissThisCard && (
+                        <View style={styles.dismissIconContainer}>
+                            <CloseModalButton onPress={onDismissThisCard} />
+                        </View>
+                    )}
+                </View>
+                <View>
                     {subtitle && (
                         <TitlepieceText
                             style={[
@@ -127,9 +149,7 @@ const OnboardingCard = ({
                 </View>
                 <View>
                     {bottomContent && (
-                        <View
-                            style={{ flexDirection: 'row', flexWrap: 'wrap' }}
-                        >
+                        <View style={styles.bottomContentContainer}>
                             {bottomContent}
                         </View>
                     )}
@@ -138,16 +158,31 @@ const OnboardingCard = ({
             {(explainerTitle || explainerSubtitle || children) && (
                 <View style={styles.explainer}>
                     {explainerTitle && (
-                        <TitlepieceText style={styles.explainerTitle}>
+                        <TitlepieceText
+                            style={[
+                                styles.explainerTitle,
+                                appearances[appearance].subtitleText,
+                            ]}
+                        >
                             {explainerTitle}
                         </TitlepieceText>
                     )}
                     {explainerSubtitle && (
-                        <TitlepieceText style={styles.explainerSubtitle}>
+                        <TitlepieceText
+                            style={[
+                                styles.explainerSubtitle,
+                                appearances[appearance].subtitleText,
+                            ]}
+                        >
                             {explainerSubtitle}
                         </TitlepieceText>
                     )}
                     {children && <UiExplainerCopy>{children}</UiExplainerCopy>}
+                    {bottomExplainerContent && (
+                        <View style={styles.bottomContentContainer}>
+                            {bottomExplainerContent}
+                        </View>
+                    )}
                 </View>
             )}
         </View>

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,9 +1,19 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
-import { View } from 'react-native'
+import { View, Platform, Linking, StyleSheet } from 'react-native'
 import { ModalButton } from './modal-button'
 import { Link } from './link'
 import { ButtonAppearance } from './button/button'
+import { getFont } from 'src/theme/typography'
+
+const styles = StyleSheet.create({
+    bottomContentContainer: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+})
 
 const SignInModalCard = ({
     close,
@@ -15,37 +25,58 @@ const SignInModalCard = ({
     onDismiss: () => void
 }) => (
     <OnboardingCard
-        title="Already subscribed?"
+        title="Already a subscriber?"
         subtitle="Sign in to continue with the app"
         appearance={CardAppearance.blue}
         size="small"
         bottomContent={
             <>
-                <View style={{ width: '100%' }}>
-                    <Link href="https://www.theguardian.com/help/identity-faq">
-                        Need help signing in?
-                    </Link>
+                <View style={styles.bottomContentContainer}>
+                    <View>
+                        <ModalButton
+                            onPress={() => {
+                                close()
+                                onLoginPress()
+                            }}
+                        >
+                            Continue
+                        </ModalButton>
+                    </View>
+                    <View>
+                        <Link
+                            style={{ ...getFont('sans', 0.9, 'bold') }}
+                            href="https://www.theguardian.com/help/identity-faq"
+                        >
+                            Need help signing in?
+                        </Link>
+                    </View>
                 </View>
-                <ModalButton
-                    onPress={() => {
-                        close()
-                        onLoginPress()
-                    }}
-                >
-                    Continue
-                </ModalButton>
-                <ModalButton
-                    onPress={() => {
-                        close()
-                        onDismiss()
-                    }}
-                >
-                    Close
-                </ModalButton>
             </>
         }
         explainerTitle="Not subscribed yet?"
-        explainerSubtitle="Get a free trial with our Digital Pack, on our website"
+        explainerSubtitle={
+            Platform.OS === 'ios'
+                ? 'To get a free trial with our Digital Pack, visit our website'
+                : 'Get a free trial with our Digital Pack'
+        }
+        bottomExplainerContent={
+            <>
+                <ModalButton
+                    onPress={() => {
+                        if (Platform.OS === 'android') {
+                            Linking.openURL(
+                                'https://support.theguardian.com/uk/subscribe/digital',
+                            )
+                        }
+                    }}
+                    buttonAppearance={ButtonAppearance.dark}
+                >
+                    {Platform.OS === 'ios'
+                        ? 'Learn more'
+                        : 'Get your free 14 day trial'}
+                </ModalButton>
+            </>
+        }
     />
 )
 

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { Platform, Linking } from 'react-native'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { ModalButton } from './modal-button'
+import { ButtonAppearance } from './button/button'
 
 const SubNotFoundModalCard = ({
     close,
@@ -14,9 +16,19 @@ const SubNotFoundModalCard = ({
     onDismiss: () => void
 }) => (
     <OnboardingCard
-        title="Subscription not found"
+        title="Already a subscriber?"
         appearance={CardAppearance.blue}
         size="small"
+        explainerTitle="Not subscribed yet?"
+        onDismissThisCard={() => {
+            close()
+            onDismiss()
+        }}
+        explainerSubtitle={
+            Platform.OS === 'ios'
+                ? 'To get a free trial with our Digital Pack, visit our website'
+                : 'Get a free trial with our Digital Pack'
+        }
         bottomContent={
             <>
                 <ModalButton
@@ -35,18 +47,28 @@ const SubNotFoundModalCard = ({
                 >
                     Activate with subscriber ID
                 </ModalButton>
+            </>
+        }
+        bottomExplainerContent={
+            <>
                 <ModalButton
                     onPress={() => {
-                        close()
-                        onDismiss()
+                        if (Platform.OS === 'android') {
+                            Linking.openURL(
+                                'https://support.theguardian.com/uk/subscribe/digital',
+                            )
+                        }
                     }}
+                    buttonAppearance={ButtonAppearance.dark}
                 >
-                    Close
+                    {Platform.OS === 'ios'
+                        ? 'Learn more'
+                        : 'Get your free 14 day trial'}
                 </ModalButton>
             </>
         }
     >
-        We were unable to find a subscription with that account
+        {}
     </OnboardingCard>
 )
 

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -4,10 +4,10 @@ import {
     OnboardingCard,
     CardAppearance,
 } from 'src/components/onboarding/onboarding-card'
-import { Button, ButtonAppearance } from 'src/components/button/button'
-import { metrics } from 'src/theme/spacing'
+import { ButtonAppearance } from 'src/components/button/button'
 import { FEEDBACK_EMAIL } from 'src/helpers/words'
 import { useGdprSwitches } from 'src/hooks/use-settings'
+import { ModalButton } from 'src/components/modal-button'
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
     <View
@@ -23,11 +23,10 @@ const Aligner = ({ children }: { children: React.ReactNode }) => (
 )
 
 const styles = StyleSheet.create({
-    card: {},
-    sbs: {
+    consentButtonContainer: {
+        display: 'flex',
         flexDirection: 'row',
-        justifyContent: 'center',
-        marginTop: metrics.horizontal * 2,
+        alignItems: 'center',
     },
 })
 
@@ -35,21 +34,24 @@ const OnboardingIntro = ({ onContinue }: { onContinue: () => void }) => {
     return (
         <Aligner>
             <OnboardingCard
-                style={styles.card}
+                appearance={CardAppearance.blue}
                 title="Welcome to the Guardian daily"
                 explainerTitle="Thank you for being a beta user"
+                bottomExplainerContent={
+                    <>
+                        <ModalButton
+                            onPress={() => {
+                                onContinue()
+                            }}
+                            buttonAppearance={ButtonAppearance.dark}
+                        >
+                            Start
+                        </ModalButton>
+                    </>
+                }
             >
                 {`Send us your thoughts and bugs to ${FEEDBACK_EMAIL}`}
             </OnboardingCard>
-            <View style={styles.sbs}>
-                <Button
-                    appearance={ButtonAppearance.tomato}
-                    onPress={onContinue}
-                    style={{ marginLeft: 'auto' }} // keep the button to the right
-                >
-                    Start
-                </Button>
-            </View>
         </Aligner>
     )
 }
@@ -65,30 +67,41 @@ const OnboardingConsent = ({
     return (
         <Aligner>
             <OnboardingCard
-                style={styles.card}
-                appearance={CardAppearance.apricot}
+                appearance={CardAppearance.blue}
                 title="We care about your privacy"
                 explainerTitle="We won’t share your data without asking"
+                bottomExplainerContent={
+                    <>
+                        <View style={styles.consentButtonContainer}>
+                            <View>
+                                <ModalButton
+                                    onPress={() => {
+                                        onOpenGdprConsent()
+                                    }}
+                                    buttonAppearance={
+                                        ButtonAppearance.skeletonBlue
+                                    }
+                                >
+                                    My options
+                                </ModalButton>
+                            </View>
+                            <View>
+                                <ModalButton
+                                    onPress={() => {
+                                        enableNulls()
+                                        onContinue()
+                                    }}
+                                    buttonAppearance={ButtonAppearance.dark}
+                                >
+                                    {`I'm okay with that`}
+                                </ModalButton>
+                            </View>
+                        </View>
+                    </>
+                }
             >
-                {`(temporary copy) By clicking agree you are agreeing to The Guardian’s privacy policy and data usage`}
+                {`We use cookies and similar technology to improve your experience and also to allow us to improve our service. To find out more, read our privacy policy and cookie policy.`}
             </OnboardingCard>
-            <View style={styles.sbs}>
-                <Button
-                    appearance={ButtonAppearance.apricot}
-                    onPress={onOpenGdprConsent}
-                >
-                    Customize
-                </Button>
-                <Button
-                    appearance={ButtonAppearance.apricot}
-                    onPress={() => {
-                        enableNulls()
-                        onContinue()
-                    }}
-                >
-                    Agree
-                </Button>
-            </View>
         </Aligner>
     )
 }

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -161,6 +161,12 @@ const scale = {
                 lineHeight: 50,
             },
         },
+        2.25: {
+            0: {
+                fontSize: 55,
+                lineHeight: 55,
+            },
+        },
         2.5: {
             0: {
                 fontSize: 60,


### PR DESCRIPTION
## Screenshots

<img width="378" alt="Screenshot 2019-08-23 at 11 24 02" src="https://user-images.githubusercontent.com/8861681/63593606-38d46080-c5ac-11e9-821e-76c0d0f004ed.png">
<img width="378" alt="Screenshot 2019-08-23 at 11 58 59" src="https://user-images.githubusercontent.com/8861681/63593607-396cf700-c5ac-11e9-9987-2ab555c1b1da.png">

![image](https://user-images.githubusercontent.com/8861681/63593631-44278c00-c5ac-11e9-8a0b-ebf8da3809ff.png)
