### PR TITLE
Get the right article types and present them

### DIFF
--- a/editions.code-workspace
+++ b/editions.code-workspace
@@ -31,6 +31,11 @@
             "javascriptreact",
             "typescript",
             "typescriptreact"
-        ]
+        ],
+        "search.exclude": {
+            "**/main.jsbundle": true,
+            "**/android/**/main.js": true,
+            "**/assets/**/main.js": true
+        }
     }
 }

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -3,7 +3,7 @@ import {
     HTMLElement,
     MediaAtomElement,
     ImageElement,
-    PillarFromPalette,
+    ArticlePillar,
 } from 'src/common'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
@@ -62,7 +62,7 @@ const renderImageElement = (imageElement: ImageElement) => {
 
 export const render = (
     article: BlockElement[],
-    { pillar }: { pillar: PillarFromPalette },
+    { pillar }: { pillar: ArticlePillar },
 ) => {
     const html = article
         .filter(

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '../spinner'
 import { FlexCenter } from '../layout/flex-center'
 import {
     Issue,
-    PillarFromPalette,
+    ArticlePillar,
     Front as FrontType,
     ArticleType,
 } from 'src/common'
@@ -36,7 +36,7 @@ const CollectionPageInFront = ({
     ...collectionPageProps
 }: {
     index: number
-    pillar: PillarFromPalette
+    pillar: ArticlePillar
     scrollX: Animated.Value
 } & PropTypes) => {
     const { card, size } = useIssueScreenSize()

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -142,6 +142,7 @@ const FrontWithResponse = ({
         >
             <Animated.FlatList
                 showsHorizontalScrollIndicator={false}
+                windowSize={3}
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
                 horizontal={true}

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -143,6 +143,7 @@ const FrontWithResponse = ({
             <Animated.FlatList
                 showsHorizontalScrollIndicator={false}
                 windowSize={3}
+                maxToRenderPerBatch={1}
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
                 horizontal={true}

--- a/projects/Mallard/src/hooks/article/dev-tools.tsx
+++ b/projects/Mallard/src/hooks/article/dev-tools.tsx
@@ -5,14 +5,6 @@ import { StyleSheet, View } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { Button, ButtonAppearance } from 'src/components/button/button'
 
-export const getEnumPosition = <T extends {}>(
-    value: T,
-    position: number,
-): T[keyof T] => {
-    const enumAsArray = Object.values(value)
-    return enumAsArray[position] as T[keyof T]
-}
-
 const getFirstLast = <T extends any>(arr: T[]): T[] => [
     arr[0],
     arr.slice(-1)[0],

--- a/projects/Mallard/src/hooks/article/dev-tools.tsx
+++ b/projects/Mallard/src/hooks/article/dev-tools.tsx
@@ -57,9 +57,6 @@ export const DevTools = ({
                         style={{ marginTop: metrics.vertical }}
                         onPress={() => {
                             setPillar(cur => {
-                                if (cur === firstPillar) {
-                                    return lastPillar
-                                }
                                 if (cur === lastPillar) {
                                     return firstPillar
                                 }
@@ -83,9 +80,6 @@ export const DevTools = ({
                                     if (cur === firstType) {
                                         return lastType
                                     }
-                                    if (cur === lastType) {
-                                        return firstType
-                                    }
                                     return types[types.indexOf(cur) - 1]
                                 })
                             }}
@@ -96,9 +90,6 @@ export const DevTools = ({
                             style={{ marginLeft: metrics.horizontal / 4 }}
                             onPress={() => {
                                 setType(cur => {
-                                    if (cur === firstType) {
-                                        return lastType
-                                    }
                                     if (cur === lastType) {
                                         return firstType
                                     }

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -20,16 +20,11 @@ interface PropTypes {
     children: Element
 }
 
-export const Providers = ({ type, pillar, children }: PropTypes) => {
-    const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
-    if (isUsingProdDevtools)
-        return <ProvidersAndDevtools {...{ type, pillar, children }} />
-    return (
-        <WithArticleType value={type}>
-            <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
-        </WithArticleType>
-    )
-}
+export const Providers = ({ type, pillar, children }: PropTypes) => (
+    <WithArticleType value={type}>
+        <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
+    </WithArticleType>
+)
 
 const ProvidersAndDevtools = ({ type, pillar, children }: PropTypes) => {
     const [modifiedPillar, setPillar] = useState(pillar)
@@ -52,6 +47,7 @@ const ProvidersAndDevtools = ({ type, pillar, children }: PropTypes) => {
 
 export const WithArticle = (props: PropTypes) => {
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
+
     if (isUsingProdDevtools) return <ProvidersAndDevtools {...props} />
     return <Providers {...props} />
 }

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -1,30 +1,61 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useState } from 'react'
 import { color } from '../theme/color'
-import { PillarFromPalette, ArticleType, Appearance } from '../common'
+import {
+    ArticlePillar,
+    ArticleType,
+    Appearance,
+    articlePillars,
+} from '../common'
 import { PillarColours } from '@guardian/pasteup/palette'
+import { useSettingsValue } from './use-settings'
+import { DevTools } from 'src/screens/article/dev-tools'
 
 /*
   Exports
  */
-const ArticlePillarContext = createContext<PillarFromPalette>('neutral')
+const ArticlePillarContext = createContext<ArticlePillar>('neutral')
 const ArticleTypeContext = createContext<ArticleType>(ArticleType.Article)
 
 export const WithArticlePillar = ArticlePillarContext.Provider
 export const WithArticleType = ArticleTypeContext.Provider
 
-export const WithArticle = ({
-    type,
-    pillar,
-    children,
-}: {
+interface PropTypes {
     type: ArticleType
-    pillar: PillarFromPalette
+    pillar: ArticlePillar
     children: Element
-}) => (
-    <WithArticleType value={type}>
-        <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
-    </WithArticleType>
-)
+}
+
+const WithArticleDevtools = ({ type, pillar, children }: PropTypes) => {
+    const [modifiedPillar, setPillar] = useState(pillar)
+    const [modifiedType, setType] = useState(type)
+
+    return (
+        <>
+            <DevTools
+                pillar={modifiedPillar}
+                type={modifiedType}
+                setPillar={setPillar}
+                setType={setType}
+            />
+            <WithArticleType value={modifiedType}>
+                <WithArticlePillar value={modifiedPillar}>
+                    {children}
+                </WithArticlePillar>
+            </WithArticleType>
+        </>
+    )
+}
+
+export const WithArticle = ({ type, pillar, children }: PropTypes) => {
+    const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
+    if (isUsingProdDevtools)
+        return <WithArticleDevtools {...{ type, pillar, children }} />
+    return (
+        <WithArticleType value={type}>
+            <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
+        </WithArticleType>
+    )
+}
 
 const neutrals: PillarColours = {
     dark: color.palette.neutral[7],
@@ -34,13 +65,13 @@ const neutrals: PillarColours = {
     faded: color.palette.neutral[97],
 }
 
-export const getPillarColors = (pillar: PillarFromPalette) =>
+export const getPillarColors = (pillar: ArticlePillar) =>
     pillar === 'neutral' ? neutrals : color.palette[pillar]
 
 export const useArticle = (): [
     PillarColours,
     {
-        pillar: PillarFromPalette
+        pillar: ArticlePillar
         type: ArticleType
     },
 ] => {

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -37,15 +37,15 @@ const ProvidersAndDevtools = ({ type, pillar, children }: PropTypes) => {
 
     return (
         <>
+            <Providers type={modifiedType} pillar={modifiedPillar}>
+                {children}
+            </Providers>
             <DevTools
                 pillar={modifiedPillar}
                 type={modifiedType}
                 setPillar={setPillar}
                 setType={setType}
             />
-            <Providers type={modifiedType} pillar={modifiedPillar}>
-                {children}
-            </Providers>
         </>
     )
 }

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -1,14 +1,9 @@
 import React, { createContext, useContext, useState } from 'react'
 import { color } from '../theme/color'
-import {
-    ArticlePillar,
-    ArticleType,
-    Appearance,
-    articlePillars,
-} from '../common'
+import { ArticlePillar, ArticleType, Appearance } from '../common'
 import { PillarColours } from '@guardian/pasteup/palette'
 import { useSettingsValue } from './use-settings'
-import { DevTools } from 'src/screens/article/dev-tools'
+import { DevTools } from 'src/hooks/article/dev-tools'
 
 /*
   Exports
@@ -25,7 +20,18 @@ interface PropTypes {
     children: Element
 }
 
-const WithArticleDevtools = ({ type, pillar, children }: PropTypes) => {
+export const Providers = ({ type, pillar, children }: PropTypes) => {
+    const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
+    if (isUsingProdDevtools)
+        return <ProvidersAndDevtools {...{ type, pillar, children }} />
+    return (
+        <WithArticleType value={type}>
+            <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
+        </WithArticleType>
+    )
+}
+
+const ProvidersAndDevtools = ({ type, pillar, children }: PropTypes) => {
     const [modifiedPillar, setPillar] = useState(pillar)
     const [modifiedType, setType] = useState(type)
 
@@ -37,24 +43,17 @@ const WithArticleDevtools = ({ type, pillar, children }: PropTypes) => {
                 setPillar={setPillar}
                 setType={setType}
             />
-            <WithArticleType value={modifiedType}>
-                <WithArticlePillar value={modifiedPillar}>
-                    {children}
-                </WithArticlePillar>
-            </WithArticleType>
+            <Providers type={modifiedType} pillar={modifiedPillar}>
+                {children}
+            </Providers>
         </>
     )
 }
 
-export const WithArticle = ({ type, pillar, children }: PropTypes) => {
+export const WithArticle = (props: PropTypes) => {
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
-    if (isUsingProdDevtools)
-        return <WithArticleDevtools {...{ type, pillar, children }} />
-    return (
-        <WithArticleType value={type}>
-            <WithArticlePillar value={pillar}>{children}</WithArticlePillar>
-        </WithArticleType>
-    )
+    if (isUsingProdDevtools) return <ProvidersAndDevtools {...props} />
+    return <Providers {...props} />
 }
 
 const neutrals: PillarColours = {

--- a/projects/Mallard/src/navigation/navigators/article.tsx
+++ b/projects/Mallard/src/navigation/navigators/article.tsx
@@ -217,7 +217,7 @@ const createArticleNavigator = (
     front: NavigationRouteConfig,
     article: NavigationRouteConfig,
 ) => {
-    let animatedValue = new Animated.Value(1)
+    let animatedValue = new Animated.Value(0)
 
     const navigation: { [key: string]: NavigationContainer } = {
         [routeNames.Issue]: addStaticRouterWithPosition(
@@ -226,7 +226,7 @@ const createArticleNavigator = (
         ),
         [routeNames.Article]: supportsTransparentCards()
             ? wrapInSlideCard(article, () => animatedValue)
-            : wrapInBasicCard(article, () => animatedValue),
+            : wrapInBasicCard(article, () => new Animated.Value(1)),
     }
 
     const transitionConfig = (transitionProps: NavigationTransitionProps) => {

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -204,6 +204,7 @@ const ArticleScreenWithProps = ({
                         keyExtractor={(item: ArticleNavigator['articles'][0]) =>
                             item.article
                         }
+                        removeClippedSubviews={true}
                         data={
                             isInScroller
                                 ? articleNavigator.articles

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { StyleSheet } from 'react-native'
 import { ScrollView } from 'react-navigation'
-import { articlePillars, ArticleType, PillarFromPalette } from 'src/common'
+import { articlePillars, ArticleType, ArticlePillar } from 'src/common'
 import { ArticleController } from 'src/components/article'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { UiBodyCopy } from 'src/components/styled-text'
@@ -26,14 +26,10 @@ const ArticleScreenBody = ({
 }: {
     path: PathToArticle
     onTopPositionChange: (isAtTop: boolean) => void
-    pillar: PillarFromPalette
+    pillar: ArticlePillar
     width: number
     previewNotice?: string
 }) => {
-    const [modifiedPillar, setPillar] = useState(
-        articlePillars.indexOf(pillar) || 0,
-    )
-    const [modifiedType, setType] = useState(0)
     const articleResponse = useArticleResponse(path)
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
 
@@ -66,25 +62,12 @@ const ArticleScreenBody = ({
                             {previewNotice && (
                                 <UiBodyCopy>{previewNotice}</UiBodyCopy>
                             )}
-                            {isUsingProdDevtools ? (
-                                <DevTools
-                                    pillar={modifiedPillar}
-                                    setPillar={setPillar}
-                                    type={modifiedType}
-                                    setType={setType}
-                                />
-                            ) : null}
                             <WithArticle
                                 type={
-                                    isUsingProdDevtools
-                                        ? getEnumPosition(
-                                              ArticleType,
-                                              modifiedType,
-                                          )
-                                        : article.article.articleType ||
-                                          ArticleType.Article
+                                    article.article.articleType ||
+                                    ArticleType.Article
                                 }
-                                pillar={articlePillars[modifiedPillar]}
+                                pillar={pillar}
                             >
                                 <ArticleController article={article.article} />
                             </WithArticle>

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -1,16 +1,14 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { StyleSheet } from 'react-native'
 import { ScrollView } from 'react-navigation'
-import { articlePillars, ArticleType, ArticlePillar } from 'src/common'
+import { ArticleType, ArticlePillar } from 'src/common'
 import { ArticleController } from 'src/components/article'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { UiBodyCopy } from 'src/components/styled-text'
 import { WithArticle } from 'src/hooks/use-article'
 import { useArticleResponse } from 'src/hooks/use-issue'
-import { useSettingsValue } from 'src/hooks/use-settings'
 import { color } from 'src/theme/color'
 import { PathToArticle } from '../article-screen'
-import { DevTools, getEnumPosition } from './dev-tools'
 import { ModalRenderer } from '../../components/modal'
 
 const styles = StyleSheet.create({
@@ -31,7 +29,6 @@ const ArticleScreenBody = ({
     previewNotice?: string
 }) => {
     const articleResponse = useArticleResponse(path)
-    const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
 
     return (
         <>

--- a/projects/Mallard/src/screens/article/dev-tools.tsx
+++ b/projects/Mallard/src/screens/article/dev-tools.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { articlePillars, ArticleType } from 'src/common'
+import { articlePillars, ArticleType, ArticlePillar } from 'src/common'
 import { StyleSheet, View } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { Button, ButtonAppearance } from 'src/components/button/button'
@@ -12,6 +12,11 @@ export const getEnumPosition = <T extends {}>(
     const enumAsArray = Object.values(value)
     return enumAsArray[position] as T[keyof T]
 }
+
+const getFirstLast = <T extends any>(arr: T[]): T[] => [
+    arr[0],
+    arr.slice(-1)[0],
+]
 
 const styles = StyleSheet.create({
     devTools: {
@@ -30,17 +35,24 @@ export const DevTools = ({
     setPillar,
     setType,
 }: {
-    pillar: number
-    type: number
-    setPillar: (p: (p: number) => number) => void
-    setType: (t: (t: number) => number) => void
+    pillar: ArticlePillar
+    type: ArticleType
+    setPillar: (p: (p: ArticlePillar) => ArticlePillar) => void
+    setType: (t: (t: ArticleType) => ArticleType) => void
 }) => {
     const [open, setOpen] = useState(false)
+    const [firstPillar, lastPillar] = getFirstLast(
+        (articlePillars as unknown) as ArticlePillar[],
+    )
+    const types: ArticleType[] = Object.values(ArticleType)
+    const [firstType, lastType] = getFirstLast(types)
+
     return (
         <View style={styles.devTools}>
             <Button
                 appearance={ButtonAppearance.skeletonActive}
                 alt={'open devtools'}
+                style={{ transform: [{ scale: 0.5 }] }}
                 onPress={() => {
                     setOpen(current => !current)
                 }}
@@ -52,15 +64,20 @@ export const DevTools = ({
                     <Button
                         style={{ marginTop: metrics.vertical }}
                         onPress={() => {
-                            setPillar(app => {
-                                if (app + 1 >= articlePillars.length) {
-                                    return 0
+                            setPillar(cur => {
+                                if (cur === firstPillar) {
+                                    return lastPillar
                                 }
-                                return app + 1
+                                if (cur === lastPillar) {
+                                    return firstPillar
+                                }
+                                return articlePillars[
+                                    articlePillars.indexOf(cur) + 1
+                                ]
                             })
                         }}
                     >
-                        {`PILLAR: ${articlePillars[pillar]}`}
+                        {`PILLAR: ${pillar}`}
                     </Button>
                     <View
                         style={{
@@ -70,29 +87,30 @@ export const DevTools = ({
                     >
                         <Button
                             onPress={() => {
-                                setType(app => {
-                                    if (app - 1 < 0) {
-                                        return (
-                                            Object.keys(ArticleType).length - 1
-                                        )
+                                setType(cur => {
+                                    if (cur === firstType) {
+                                        return lastType
                                     }
-                                    return app - 1
+                                    if (cur === lastType) {
+                                        return firstType
+                                    }
+                                    return types[types.indexOf(cur) - 1]
                                 })
                             }}
                         >
-                            {`👈 ${getEnumPosition(ArticleType, type)}`}
+                            {`👈 ${type}`}
                         </Button>
                         <Button
                             style={{ marginLeft: metrics.horizontal / 4 }}
                             onPress={() => {
-                                setType(app => {
-                                    if (
-                                        app + 1 >=
-                                        Object.keys(ArticleType).length
-                                    ) {
-                                        return 0
+                                setType(cur => {
+                                    if (cur === firstType) {
+                                        return lastType
                                     }
-                                    return app + 1
+                                    if (cur === lastType) {
+                                        return firstType
+                                    }
+                                    return types[types.indexOf(cur) + 1]
                                 })
                             }}
                         >

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -128,6 +128,7 @@ const IssueFronts = ({
             extraData={{
                 ...container,
             }}
+            windowSize={3}
             style={style}
             removeClippedSubviews={true}
             ListHeaderComponent={ListHeaderComponent}

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -31,7 +31,7 @@ export enum ArticleType {
     Immersive = 'immersive',
 }
 
-export type PillarFromPalette = typeof articlePillars[number]
+export type ArticlePillar = typeof articlePillars[number]
 
 export interface ColorAppearance {
     type: 'custom'
@@ -39,7 +39,7 @@ export interface ColorAppearance {
 }
 export interface PillarAppearance {
     type: 'pillar'
-    name: PillarFromPalette
+    name: ArticlePillar
 }
 
 export type Appearance = PillarAppearance | ColorAppearance


### PR DESCRIPTION
This picks up the article type from the backend and also refactors the devtools so they disappear completely if not in dev mode (less overhead) and the props just pass through

![Screenshot 2019-08-23 at 16 15 30](https://user-images.githubusercontent.com/11539094/63603946-89ef4f00-c5c2-11e9-9ecc-7e8e277b027a.png)
![Screenshot 2019-08-23 at 16 18 48](https://user-images.githubusercontent.com/11539094/63603950-8b207c00-c5c2-11e9-8957-07b0a483a9f1.png)
