### PR TITLE
Allow modal to be clickable on Android

### DIFF
--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -32,7 +32,6 @@ const ArticleScreenBody = ({
 
     return (
         <>
-            <ModalRenderer />
             <ScrollView
                 scrollEventThrottle={8}
                 onScroll={ev => {
@@ -72,6 +71,7 @@ const ArticleScreenBody = ({
                     ),
                 })}
             </ScrollView>
+            <ModalRenderer />
         </>
     )
 }


### PR DESCRIPTION
## Why are you doing this?

Fixes a bug where login modals were not clickable on android

