### PR TITLE
Stabilise transitions

### DIFF
--- a/projects/Mallard/src/components/front/helpers/helpers.ts
+++ b/projects/Mallard/src/components/front/helpers/helpers.ts
@@ -7,6 +7,7 @@ import { Front } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
 import { useAppAppearance } from 'src/theme/appearance'
 import { Rectangle, Size } from 'src/helpers/sizes'
+import { safeInterpolation } from 'src/helpers/math'
 
 type Item = FunctionComponent<PropTypes>
 
@@ -94,12 +95,16 @@ export const getTranslateForPage = (
     multiplier: number = 1,
 ) => {
     return scrollX.interpolate({
-        inputRange: [width * (page - 1), width * page, width * (page + 1)],
-        outputRange: [
+        inputRange: safeInterpolation([
+            width * (page - 1),
+            width * page,
+            width * (page + 1),
+        ]),
+        outputRange: safeInterpolation([
             metrics.fronts.sides * (-1.75 * multiplier),
             0,
             metrics.fronts.sides * (1.75 * multiplier),
-        ],
+        ]),
     })
 }
 

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -28,6 +28,7 @@ import { useFrontsResponse } from 'src/hooks/use-issue'
 import { ArticleNavigator } from '../../screens/article-screen'
 import { WithArticle, getAppearancePillar } from '../../hooks/use-article'
 import { useIssueScreenSize } from 'src/screens/issue/use-size'
+import { safeInterpolation } from 'src/helpers/math'
 
 const CollectionPageInFront = ({
     index,
@@ -135,7 +136,7 @@ const FrontWithResponse = ({
                             card.width * (stops <= 0 ? stops : stops - 1) +
                                 0.001,
                         ],
-                        outputRange: [0, 1],
+                        outputRange: safeInterpolation([0, 1]),
                     })}
                 />
             }

--- a/projects/Mallard/src/components/front/items/item.tsx
+++ b/projects/Mallard/src/components/front/items/item.tsx
@@ -36,6 +36,7 @@ import { ImageResource } from '../image-resource'
 import { TextBlock } from './text-block'
 import { supportsTransparentCards } from 'src/helpers/features'
 import { ariaHidden } from 'src/helpers/a11y'
+import { safeInterpolation } from 'src/helpers/math'
 
 interface TappablePropTypes {
     style?: StyleProp<ViewStyle>
@@ -157,8 +158,8 @@ const ItemTappable = withNavigation(
                         {
                             backgroundColor: color.dimBackground,
                             opacity: opacity.interpolate({
-                                inputRange: [0, 1],
-                                outputRange: [1, 0],
+                                inputRange: safeInterpolation([0, 1]),
+                                outputRange: safeInterpolation([1, 0]),
                             }),
                         },
                     ]}

--- a/projects/Mallard/src/components/layout/animators/clipFromTop.tsx
+++ b/projects/Mallard/src/components/layout/animators/clipFromTop.tsx
@@ -3,6 +3,7 @@ import { Animated, Dimensions, StyleSheet } from 'react-native'
 import MaskedView from '@react-native-community/masked-view'
 import { supportsAnimatedClipView } from 'src/helpers/features'
 import { metrics } from 'src/theme/spacing'
+import { safeInterpolation } from 'src/helpers/math'
 
 /*
 This is part of the transition from articles to fronts
@@ -41,7 +42,10 @@ const MaskClipFromTop = ({ children, from, easing }: PropTypes) => {
                         {
                             borderRadius: easing.interpolate({
                                 inputRange: [0, 1],
-                                outputRange: [0, metrics.radius],
+                                outputRange: safeInterpolation([
+                                    0,
+                                    metrics.radius,
+                                ]),
                             }),
                         },
                         {
@@ -49,21 +53,21 @@ const MaskClipFromTop = ({ children, from, easing }: PropTypes) => {
                                 {
                                     translateY: easing.interpolate({
                                         inputRange: [0, 0.5, 1],
-                                        outputRange: [
+                                        outputRange: safeInterpolation([
                                             (windowHeight - from) / -2,
                                             (windowHeight - from) / -2,
                                             0,
-                                        ],
+                                        ]),
                                     }),
                                 },
                                 {
                                     scaleY: easing.interpolate({
                                         inputRange: [0, 0.5, 1],
-                                        outputRange: [
+                                        outputRange: safeInterpolation([
                                             targetHeightScale,
                                             targetHeightScale,
                                             1,
-                                        ],
+                                        ]),
                                     }),
                                 },
                             ],

--- a/projects/Mallard/src/components/layout/animators/fader.tsx
+++ b/projects/Mallard/src/components/layout/animators/fader.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import { Animated, Dimensions, StyleSheet, View } from 'react-native'
-import { clamp } from 'src/helpers/math'
+import { clamp, safeInterpolation } from 'src/helpers/math'
 import { useNavigatorPosition } from 'src/navigation/helpers/transition'
 
 /*
@@ -43,12 +43,12 @@ const Fader = ({ children }: PropTypes) => {
                         /*
                         we wanna prevent any value except the final
                         one to be 1 because otherwise the animation will throw */
-                        inputRange: [
+                        inputRange: safeInterpolation([
                             clamp(0.2 + buildOrder.current / 10, 0, 1),
                             clamp(0.4 + buildOrder.current / 10, 0.4, 1),
                             1,
-                        ],
-                        outputRange: [0, 1, 1],
+                        ]),
+                        outputRange: safeInterpolation([0, 1, 1]),
                     }),
                 },
                 faderStyles.wrapper,

--- a/projects/Mallard/src/components/layout/slide-card/header.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/header.tsx
@@ -8,6 +8,7 @@ import {
 import { Chevron } from '../../chevron'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
+import { safeInterpolation } from 'src/helpers/math'
 
 const styles = StyleSheet.create({
     headerContainer: {
@@ -50,11 +51,11 @@ const Header = ({
                             transform: [
                                 {
                                     translateY: scrollY.interpolate({
-                                        inputRange: [0, 100],
-                                        outputRange: [
+                                        inputRange: safeInterpolation([0, 100]),
+                                        outputRange: safeInterpolation([
                                             metrics.headerHeight / -10,
                                             0,
-                                        ],
+                                        ]),
                                         extrapolate: 'clamp',
                                     }),
                                 },

--- a/projects/Mallard/src/components/layout/slide-card/index.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, ReactNode, useRef } from 'react'
 import { Animated, StyleSheet, View, PanResponder } from 'react-native'
 import { Header } from './header'
 import { dismissAt } from './helpers'
+import { safeInterpolation } from 'src/helpers/math'
 
 /*
 This is the swipey contraption that contains an article.
@@ -36,8 +37,8 @@ export const SlideCard = ({
     useEffect(() => {
         Animated.timing(getPosition(), {
             toValue: scrollY.interpolate({
-                inputRange: [0, 60],
-                outputRange: [1, 0.8],
+                inputRange: safeInterpolation([0, 60]),
+                outputRange: safeInterpolation([1, 0.8]),
             }) as Animated.Value,
             duration: 0,
             useNativeDriver: true,
@@ -88,8 +89,11 @@ export const SlideCard = ({
                     transform: [
                         {
                             translateY: scrollY.interpolate({
-                                inputRange: [dismissAt * -1, 0],
-                                outputRange: [dismissAt, 0],
+                                inputRange: safeInterpolation([
+                                    dismissAt * -1,
+                                    0,
+                                ]),
+                                outputRange: safeInterpolation([dismissAt, 0]),
                                 extrapolate: 'clamp',
                             }),
                         },

--- a/projects/Mallard/src/components/layout/ui/modal-for-tablet.tsx
+++ b/projects/Mallard/src/components/layout/ui/modal-for-tablet.tsx
@@ -4,6 +4,7 @@ import { AnimatedValue } from 'react-navigation'
 import { WithBreakpoints } from 'src/components/layout/ui/sizing/with-breakpoints'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
+import { safeInterpolation } from 'src/helpers/math'
 
 const modalStyles = StyleSheet.create({
     root: {
@@ -47,8 +48,16 @@ const ModalForTablet = ({
                                 modalStyles.bg,
                                 {
                                     opacity: position.interpolate({
-                                        inputRange: [0, 0.9, 1],
-                                        outputRange: [0, 0, 1],
+                                        inputRange: safeInterpolation([
+                                            0,
+                                            0.9,
+                                            1,
+                                        ]),
+                                        outputRange: safeInterpolation([
+                                            0,
+                                            0,
+                                            1,
+                                        ]),
                                     }),
                                 },
                             ]}

--- a/projects/Mallard/src/components/modal.tsx
+++ b/projects/Mallard/src/components/modal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useContext, useCallback } from 'react'
 import { Animated, StyleSheet } from 'react-native'
 import { useAlphaIn } from 'src/hooks/use-alpha-in'
+import { safeInterpolation } from 'src/helpers/math'
 
 type ModalRenderer = (close: () => void) => React.ReactNode
 
@@ -86,8 +87,8 @@ const ModalRenderer = () => {
                             transform: [
                                 {
                                     translateY: val.interpolate({
-                                        inputRange: [0, 1],
-                                        outputRange: [20, 0],
+                                        inputRange: safeInterpolation([0, 1]),
+                                        outputRange: safeInterpolation([20, 0]),
                                     }),
                                 },
                             ],

--- a/projects/Mallard/src/components/slider/draw/lozenge.tsx
+++ b/projects/Mallard/src/components/slider/draw/lozenge.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, ReactNode } from 'react'
 
 import { color } from 'src/theme/color'
 import { Animated, Text, StyleSheet, View } from 'react-native'
-import { clamp } from 'src/helpers/math'
+import { clamp, safeInterpolation } from 'src/helpers/math'
 import { ariaHidden } from 'src/helpers/a11y'
 import { metrics } from 'src/theme/spacing'
 
@@ -75,15 +75,24 @@ const LozengeBigHeader = ({
                     width &&
                         position && {
                             opacity: position.interpolate({
-                                inputRange: [0, fadeLozengeAt],
-                                outputRange: [1, 0],
+                                inputRange: safeInterpolation([
+                                    0,
+                                    fadeLozengeAt,
+                                ]),
+                                outputRange: safeInterpolation([1, 0]),
                                 extrapolate: 'clamp',
                             }),
                             transform: [
                                 {
                                     translateX: position.interpolate({
-                                        inputRange: [0, width],
-                                        outputRange: [0, width * -0.5],
+                                        inputRange: safeInterpolation([
+                                            0,
+                                            width,
+                                        ]),
+                                        outputRange: safeInterpolation([
+                                            0,
+                                            width * -0.5,
+                                        ]),
                                         extrapolate: 'clamp',
                                     }),
                                 },
@@ -108,12 +117,12 @@ const LozengeBigHeader = ({
                         },
                         position && {
                             opacity: position.interpolate({
-                                inputRange: [
+                                inputRange: safeInterpolation([
                                     0,
                                     fadeLozengeAt - 1,
                                     fadeLozengeAt,
-                                ],
-                                outputRange: [1, 1, 0],
+                                ]),
+                                outputRange: safeInterpolation([1, 1, 0]),
                                 extrapolate: 'clamp',
                             }),
                         },
@@ -121,20 +130,26 @@ const LozengeBigHeader = ({
                             transform: [
                                 {
                                     translateX: position.interpolate({
-                                        inputRange: [0, fadeLozengeAt],
-                                        outputRange: [
+                                        inputRange: safeInterpolation([
+                                            0,
+                                            fadeLozengeAt,
+                                        ]),
+                                        outputRange: safeInterpolation([
                                             0,
                                             fadeLozengeAt * -1 -
                                                 width / 2 +
                                                 metrics.fronts.sliderRadius,
-                                        ],
+                                        ]),
                                         extrapolate: 'clamp',
                                     }),
                                 },
                                 {
                                     scaleX: position.interpolate({
-                                        inputRange: [0, fadeLozengeAt],
-                                        outputRange: [1, 0],
+                                        inputRange: safeInterpolation([
+                                            0,
+                                            fadeLozengeAt,
+                                        ]),
+                                        outputRange: safeInterpolation([1, 0]),
                                         extrapolate: 'clamp',
                                     }),
                                 },
@@ -149,7 +164,7 @@ const LozengeBigHeader = ({
                         width &&
                             position && {
                                 opacity: position.interpolate({
-                                    inputRange: [
+                                    inputRange: safeInterpolation([
                                         0,
                                         clamp(
                                             width / 2 -
@@ -158,20 +173,23 @@ const LozengeBigHeader = ({
                                             width / 2,
                                         ),
                                         width / 2,
-                                    ],
-                                    outputRange: [1, 1, 0],
+                                    ]),
+                                    outputRange: safeInterpolation([1, 1, 0]),
                                 }),
                                 transform: [
                                     {
                                         translateX: position.interpolate({
-                                            inputRange: [0, fadeLozengeAt],
-                                            outputRange: [
+                                            inputRange: safeInterpolation([
+                                                0,
+                                                fadeLozengeAt,
+                                            ]),
+                                            outputRange: safeInterpolation([
                                                 0,
                                                 fadeLozengeAt * -1 -
                                                     (width -
                                                         metrics.fronts
                                                             .sliderRadius),
-                                            ],
+                                            ]),
                                             extrapolate: 'clamp',
                                         }),
                                     },
@@ -243,8 +261,8 @@ const LozengeWrapper = ({
                     transform: [
                         {
                             translateX: position.interpolate({
-                                inputRange: [0, 100],
-                                outputRange: [0, 100],
+                                inputRange: safeInterpolation([0, 100]),
+                                outputRange: safeInterpolation([0, 100]),
                                 extrapolateLeft: 'clamp',
                             }),
                         },
@@ -274,8 +292,8 @@ const Lozenge = ({
                     fill={fill}
                     style={{
                         opacity: position.interpolate({
-                            inputRange: [0, 10],
-                            outputRange: [0, 1],
+                            inputRange: safeInterpolation([0, 10]),
+                            outputRange: safeInterpolation([0, 1]),
                             extrapolate: 'clamp',
                         }),
                     }}

--- a/projects/Mallard/src/components/slider/index.tsx
+++ b/projects/Mallard/src/components/slider/index.tsx
@@ -7,6 +7,7 @@ import { Background } from './draw/background'
 import { WithBreakpoints } from '../layout/ui/sizing/with-breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { WithLayoutRectangle } from '../layout/ui/sizing/with-layout-rectangle'
+import { safeInterpolation } from 'src/helpers/math'
 
 const stopRadius = 4
 
@@ -84,8 +85,11 @@ const Slider = ({
     const lozengePosition = (width: number) =>
         isScrollable
             ? position.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [0, width - metrics.fronts.sliderRadius * 2],
+                  inputRange: safeInterpolation([0, 1]),
+                  outputRange: safeInterpolation([
+                      0,
+                      width - metrics.fronts.sliderRadius * 2,
+                  ]),
               })
             : undefined
 

--- a/projects/Mallard/src/components/spinner.tsx
+++ b/projects/Mallard/src/components/spinner.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { View, Animated, StyleSheet } from 'react-native'
 import { ariaHidden } from 'src/helpers/a11y'
 import { color } from 'src/theme/color'
+import { safeInterpolation } from 'src/helpers/math'
 
 const styles = StyleSheet.create({
     ball: {
@@ -31,8 +32,8 @@ const Ball = ({ color, jump }: { color: string; jump: Animated.Value }) => {
                     transform: [
                         {
                             translateY: jump.interpolate({
-                                inputRange: [0, 1],
-                                outputRange: [-5, 5],
+                                inputRange: safeInterpolation([0, 1]),
+                                outputRange: safeInterpolation([-5, 5]),
                             }),
                         },
                     ],

--- a/projects/Mallard/src/components/toast/toast.tsx
+++ b/projects/Mallard/src/components/toast/toast.tsx
@@ -8,6 +8,7 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
 import { UiBodyCopy } from '../styled-text'
+import { safeInterpolation } from 'src/helpers/math'
 
 export interface ToastProps {
     title: string
@@ -42,8 +43,8 @@ const Toast = ({ title, subtitle }: ToastProps) => {
                     transform: [
                         {
                             translateY: position.interpolate({
-                                inputRange: [0, 1],
-                                outputRange: [50, 0],
+                                inputRange: safeInterpolation([0, 1]),
+                                outputRange: safeInterpolation([50, 0]),
                             }),
                         },
                     ],

--- a/projects/Mallard/src/helpers/math.ts
+++ b/projects/Mallard/src/helpers/math.ts
@@ -3,3 +3,26 @@ export const clamp = (number: number, min: number, max: number) => {
     if (number < min) return min
     return number
 }
+
+export const isSafeValue = (value: unknown): value is number => {
+    if (!isFinite(value as number)) {
+        return false
+    }
+    return true
+}
+
+export const safeValue = (value: unknown, fallback: number): number => {
+    if (!isSafeValue(value)) {
+        return fallback
+    }
+    return value
+}
+
+export const safeInterpolation = (values: unknown[]): number[] => {
+    for (let value of values) {
+        if (!isSafeValue(value)) {
+            return [...new Array(values.length - 1).fill(0), 1]
+        }
+    }
+    return values as number[]
+}

--- a/projects/Mallard/src/navigation/navigators/article.tsx
+++ b/projects/Mallard/src/navigation/navigators/article.tsx
@@ -23,6 +23,7 @@ import {
 } from '../helpers/transition'
 import { routeNames } from '../routes'
 import { articleScreenMotion, screenInterpolator } from './article/transition'
+import { safeInterpolation, safeValue } from 'src/helpers/math'
 
 type DismissStateChangedFn = (dismissable: boolean) => void
 export interface ArticleNavigatorInjectedProps {
@@ -143,16 +144,19 @@ const wrapInSlideCard: NavigatorWrapper = (navigator, getPosition) => {
                             transform: [
                                 {
                                     translateY: position.interpolate({
-                                        inputRange: [0, 1],
-                                        outputRange: [200, 0],
+                                        inputRange: safeInterpolation([0, 1]),
+                                        outputRange: safeInterpolation([
+                                            200,
+                                            0,
+                                        ]),
                                     }),
                                 },
                             ],
                         },
                         {
                             opacity: position.interpolate({
-                                inputRange: [0, 0.5],
-                                outputRange: [0, 1],
+                                inputRange: safeInterpolation([0, 0.5]),
+                                outputRange: safeInterpolation([0, 1]),
                             }),
                         },
                     ]}
@@ -164,7 +168,6 @@ const wrapInSlideCard: NavigatorWrapper = (navigator, getPosition) => {
                 </Animated.View>
             )
         }
-
         return (
             <Animated.View
                 style={[
@@ -181,7 +184,7 @@ const wrapInSlideCard: NavigatorWrapper = (navigator, getPosition) => {
                             {
                                 opacity: opacityOuter,
                                 borderRadius,
-                                minHeight: height / scaler,
+                                minHeight: safeValue(height / scaler, 1000),
                             },
                         ]}
                     >

--- a/projects/Mallard/src/navigation/navigators/article/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/article/transition.tsx
@@ -3,6 +3,7 @@ import { NavigationTransitionProps } from 'react-navigation'
 import { minOpacity, minScale, radius } from 'src/navigation/helpers/transition'
 import { routeNames } from 'src/navigation/routes'
 import { metrics } from 'src/theme/spacing'
+import { safeInterpolation } from 'src/helpers/math'
 
 const getScaleForArticle = (width: LayoutRectangle['width']) => {
     return width / Dimensions.get('window').width
@@ -17,18 +18,22 @@ const issueScreenInterpolator = (sceneProps: NavigationTransitionProps) => {
     these ones r easy
     */
     const scale = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 0.1, sceneIndex + 1],
-        outputRange: [1, 1, minScale],
+        inputRange: safeInterpolation([
+            sceneIndex,
+            sceneIndex + 0.1,
+            sceneIndex + 1,
+        ]),
+        outputRange: safeInterpolation([1, 1, minScale]),
     })
     const borderRadius = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
         extrapolate: 'clamp',
-        outputRange: [0, radius],
+        outputRange: safeInterpolation([0, radius]),
     })
     const opacity = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 0.1],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 0.1]),
         extrapolate: 'clamp',
-        outputRange: [1, minOpacity],
+        outputRange: safeInterpolation([1, minOpacity]),
     })
 
     /*
@@ -42,8 +47,8 @@ const issueScreenInterpolator = (sceneProps: NavigationTransitionProps) => {
     const finalTranslate = translateOffset + metrics.slideCardSpacing / 1.5
 
     const translateY = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
-        outputRange: [0, finalTranslate],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+        outputRange: safeInterpolation([0, finalTranslate]),
     })
 
     return {
@@ -80,13 +85,13 @@ const articleScreenMotion = ({
         and its card so it's a bit less jarring
         */
     const opacity = position.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, 1],
+        inputRange: safeInterpolation([0, 1]),
+        outputRange: safeInterpolation([0, 1]),
     })
 
     const opacityOuter = position.interpolate({
-        inputRange: [0, 0.1, 1],
-        outputRange: [0, 1, 1],
+        inputRange: safeInterpolation([0, 0.1, 1]),
+        outputRange: safeInterpolation([0, 1, 1]),
     })
 
     /*
@@ -96,8 +101,8 @@ const articleScreenMotion = ({
     const scaler = getScaleForArticle(width)
 
     const scale = position.interpolate({
-        inputRange: [0, 1],
-        outputRange: [scaler, 1],
+        inputRange: safeInterpolation([0, 1]),
+        outputRange: safeInterpolation([scaler, 1]),
     })
 
     /*
@@ -107,8 +112,8 @@ const articleScreenMotion = ({
     const distanceFromVCenter = y - windowHeight / 2
     const d = (windowHeight / 2) * scaler + distanceFromVCenter
     const translateY = position.interpolate({
-        inputRange: [0, 1],
-        outputRange: [d, metrics.slideCardSpacing],
+        inputRange: safeInterpolation([0, 1]),
+        outputRange: safeInterpolation([d, metrics.slideCardSpacing]),
     })
 
     /*
@@ -117,15 +122,15 @@ const articleScreenMotion = ({
         */
     const distanceFromCentre = width / 2 + x - windowWidth / 2
     const translateX = position.interpolate({
-        inputRange: [0, 1],
-        outputRange: [distanceFromCentre, 0],
+        inputRange: safeInterpolation([0, 1]),
+        outputRange: safeInterpolation([distanceFromCentre, 0]),
     })
 
     const transform = [{ translateX }, { translateY }, { scale }]
 
     const borderRadius = position.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, metrics.radius],
+        inputRange: safeInterpolation([0, 1]),
+        outputRange: safeInterpolation([0, metrics.radius]),
     })
 
     return {

--- a/projects/Mallard/src/navigation/navigators/modal.tsx
+++ b/projects/Mallard/src/navigation/navigators/modal.tsx
@@ -12,6 +12,7 @@ import { Animated } from 'react-native'
 import { ModalForTablet } from 'src/components/layout/ui/modal-for-tablet'
 import { addStaticRouter } from '../helpers/base'
 import { supportsTransparentCards } from 'src/helpers/features'
+import { safeInterpolation } from 'src/helpers/math'
 
 const addStaticRouterWithModal = (
     Navigator: NavigationContainer,
@@ -63,8 +64,8 @@ const createModalNavigator = (
             } = transitionProps
 
             animatedValue = position.interpolate({
-                inputRange: [index - 1, index, index + 1],
-                outputRange: [0, 1, 0],
+                inputRange: safeInterpolation([index - 1, index, index + 1]),
+                outputRange: safeInterpolation([0, 1, 0]),
             })
             return StackViewTransitionConfigs.defaultTransitionConfig(
                 transitionProps,

--- a/projects/Mallard/src/navigation/navigators/underlay.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay.tsx
@@ -16,6 +16,7 @@ import {
 } from '../helpers/transition'
 import { screenInterpolator } from './underlay/transition'
 import { addStaticRouter } from '../helpers/base'
+import { safeInterpolation } from 'src/helpers/math'
 
 const overlayStyles = StyleSheet.create({
     root: {
@@ -41,8 +42,8 @@ const addStaticRouterWithOverlay: NavigatorWrapper = (
                         overlayStyles.root,
                         {
                             opacity: posi.interpolate({
-                                inputRange: [0, 1],
-                                outputRange: [0, 0.33],
+                                inputRange: safeInterpolation([0, 1]),
+                                outputRange: safeInterpolation([0, 0.33]),
                             }),
                         },
                     ]}

--- a/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
@@ -3,6 +3,7 @@ import { NavigationTransitionProps } from 'react-navigation'
 import { minOpacity, minScale, radius } from 'src/navigation/helpers/transition'
 import { metrics } from 'src/theme/spacing'
 import { BreakpointList, Breakpoints } from 'src/theme/breakpoints'
+import { safeInterpolation } from 'src/helpers/math'
 
 const sidebarWidth = 360
 
@@ -15,12 +16,12 @@ const issueScreenToIssueList = (sceneProps: NavigationTransitionProps) => {
     const finalTranslate = windowHeight - 80
 
     const translateY = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
-        outputRange: [0, finalTranslate],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+        outputRange: safeInterpolation([0, finalTranslate]),
     })
     const translateX = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
-        outputRange: [0, -sidebarWidth],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+        outputRange: safeInterpolation([0, -sidebarWidth]),
     })
 
     const platformStyles = isTablet
@@ -33,15 +34,15 @@ const issueScreenToIssueList = (sceneProps: NavigationTransitionProps) => {
               shadowOpacity: 1,
               shadowRadius: 3.84,
               borderRadius: position.interpolate({
-                  inputRange: [sceneIndex, sceneIndex + 1],
-                  outputRange: [0, radius / 4],
+                  inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+                  outputRange: safeInterpolation([0, radius / 4]),
               }),
           }
         : {
               transform: [{ translateY }],
               borderRadius: position.interpolate({
-                  inputRange: [sceneIndex, sceneIndex + 1],
-                  outputRange: [0, radius],
+                  inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+                  outputRange: safeInterpolation([0, radius]),
               }),
           }
 
@@ -64,17 +65,21 @@ const IssueListToIssueScreen = (sceneProps: NavigationTransitionProps) => {
     these ones r easy
     */
     const scale = position.interpolate({
-        inputRange: [sceneIndex - 1, sceneIndex - 0.1, sceneIndex],
-        outputRange: [minScale, 1, 1],
+        inputRange: safeInterpolation([
+            sceneIndex - 1,
+            sceneIndex - 0.1,
+            sceneIndex,
+        ]),
+        outputRange: safeInterpolation([minScale, 1, 1]),
     })
     const borderRadius = position.interpolate({
-        inputRange: [sceneIndex - 1, sceneIndex],
+        inputRange: safeInterpolation([sceneIndex - 1, sceneIndex]),
         extrapolate: 'clamp',
-        outputRange: [radius, 0],
+        outputRange: safeInterpolation([radius, 0]),
     })
     const opacity = position.interpolate({
-        inputRange: [sceneIndex - 1, sceneIndex],
-        outputRange: [minOpacity, 1],
+        inputRange: safeInterpolation([sceneIndex - 1, sceneIndex]),
+        outputRange: safeInterpolation([minOpacity, 1]),
     })
 
     /*
@@ -88,8 +93,8 @@ const IssueListToIssueScreen = (sceneProps: NavigationTransitionProps) => {
     const finalTranslate = translateOffset + metrics.slideCardSpacing / 1.5
 
     const translateY = position.interpolate({
-        inputRange: [sceneIndex, sceneIndex + 1],
-        outputRange: [0, finalTranslate],
+        inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
+        outputRange: safeInterpolation([0, finalTranslate]),
     })
 
     const platformStyles = isTablet

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -25,6 +25,7 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { PathToArticle } from './article-screen'
 import { ArticleScreenBody } from './article/body'
+import { safeInterpolation } from 'src/helpers/math'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -116,8 +117,11 @@ const ArticleScreenWithProps = ({
         initialValue: 0,
         currentValue: current,
     }).interpolate({
-        inputRange: [0, articleNavigator.articles.length - 1],
-        outputRange: [0, 1],
+        inputRange: safeInterpolation([
+            0,
+            articleNavigator.articles.length - 1,
+        ]),
+        outputRange: safeInterpolation([0, 1]),
     })
 
     useEffect(() => {

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -126,7 +126,7 @@ const ArticleScreenWithProps = ({
                 index: current,
                 animated: false,
             })
-    }, [current, width])
+    }, [width])
 
     const preview = useIsPreview()
     const previewNotice = preview ? `${path.collection}:${current}` : undefined

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -32,6 +32,7 @@ import { metrics } from 'src/theme/spacing'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { Header } from 'src/components/layout/header/header'
 import { supportsTransparentCards } from 'src/helpers/features'
+import { safeInterpolation } from 'src/helpers/math'
 
 export interface PathToIssue {
     issue: Issue['key']
@@ -70,8 +71,8 @@ const ScreenHeader = withNavigation(
                         style={
                             supportsTransparentCards() && {
                                 opacity: position.interpolate({
-                                    inputRange: [0, 1],
-                                    outputRange: [1, 0],
+                                    inputRange: safeInterpolation([0, 1]),
+                                    outputRange: safeInterpolation([1, 0]),
                                 }),
                             }
                         }


### PR DESCRIPTION
Transition interpolations will crash at runtime if they get any values that aren't finite numbers. This is rare but can happen.

This fixes that by checking if they are finite numbers and if they aren't returning an empty interpolation - this means this crash will never happen but in certain scenarios where it would have happened transitions might get a bit weird? which is better I think