### PR TITLE
Allow a switch for builds to use iap sandbox

### DIFF
--- a/projects/Mallard/.env.production.js
+++ b/projects/Mallard/.env.production.js
@@ -6,6 +6,7 @@ ID_API_URL
 MEMBERS_DATA_API_URL
 SENTRY_DSN_URL
 ITUNES_CONNECT_SHARED_SECRET
+USE_SANDBOX_IAP
 `
 
 writeEnvVarsToFiles('android/sentry.properties', 'ios/sentry.properties')`

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -7,6 +7,7 @@ const {
     MEMBERS_DATA_API_URL,
     ID_ACCESS_TOKEN,
     ITUNES_CONNECT_SHARED_SECRET,
+    USE_SANDBOX_IAP: ENV_USE_SANDBOX_IAP,
 } = Config
 
 const FACEBOOK_CLIENT_ID = '180444840287'
@@ -26,6 +27,11 @@ const LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY = 'printSubscriberID'
 const LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY = 'printSubscriberPostcode'
 const LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY = `${DeviceInfo.getBundleId()}_expiryDict`
 
+// this allows us to ensure some prod build use the sanboxed IAP endpoints
+// e.g. the beta builds for testflight
+// we should never be using sandbox for __DEV__ builds, hence the `||`
+const USE_SANDBOX_IAP = ENV_USE_SANDBOX_IAP || __DEV__ ? true : false
+
 export {
     CAS_ENDPOINT_URL,
     ID_API_URL,
@@ -38,4 +44,5 @@ export {
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
     LEGACY_CAS_EXPIRY_USER_DEFAULTS_KEY,
     ITUNES_CONNECT_SHARED_SECRET,
+    USE_SANDBOX_IAP,
 }

--- a/projects/Mallard/src/services/iap.ts
+++ b/projects/Mallard/src/services/iap.ts
@@ -1,6 +1,6 @@
 import RNIAP, { Purchase } from 'react-native-iap'
 import { Platform } from 'react-native'
-import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants'
+import { ITUNES_CONNECT_SHARED_SECRET, USE_SANDBOX_IAP } from 'src/constants'
 import { ReceiptValidationResponse } from 'react-native-iap/apple'
 import { authTypeFromIAP } from 'src/authentication/credentials-chain'
 import { NativeModules } from 'react-native'
@@ -31,7 +31,7 @@ const fetchDecodeReceipt = (receipt: string) =>
             'receipt-data': receipt,
             password: ITUNES_CONNECT_SHARED_SECRET,
         },
-        __DEV__,
+        USE_SANDBOX_IAP,
     )
 
 const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {


### PR DESCRIPTION
## Why are you doing this?

Currently, when upgrading from the old app to the new app in TestFlight, IAP subscriptions don't persist.

I _think_ this is down to the fact that we were using the `__DEV__` flag to check which verify endpoint to use. The old DE app (correctly) used the sandbox endpoint. Currently, the new DE app uses the live endpoint due to `__DEV__` being `false` in the beta build.

This adds an environment variable to override back to sandbox for some build.

I've set these variables in TC for both android and iOS beta build.
