### PR TITLE
Add Cookie and Privacy policy links to onboarding screen.

### DIFF
--- a/projects/Mallard/src/components/onboarding/onboarding-card.tsx
+++ b/projects/Mallard/src/components/onboarding/onboarding-card.tsx
@@ -89,7 +89,7 @@ const OnboardingCard = ({
     size = 'big',
     maxSize = 500,
 }: {
-    children?: string
+    children?: React.ReactNode
     title: string
     subtitle?: string
     bottomContent?: React.ReactNode

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -67,9 +67,7 @@ const SubNotFoundModalCard = ({
                 </ModalButton>
             </>
         }
-    >
-        {}
-    </OnboardingCard>
+    ></OnboardingCard>
 )
 
 export { SubNotFoundModalCard }

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -5,9 +5,10 @@ import {
     CardAppearance,
 } from 'src/components/onboarding/onboarding-card'
 import { ButtonAppearance } from 'src/components/button/button'
-import { FEEDBACK_EMAIL } from 'src/helpers/words'
+import { FEEDBACK_EMAIL, COOKIE_LINK, PRIVACY_LINK } from 'src/helpers/words'
 import { useGdprSwitches } from 'src/hooks/use-settings'
 import { ModalButton } from 'src/components/modal-button'
+import { Link } from 'src/components/link'
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
     <View
@@ -100,7 +101,15 @@ const OnboardingConsent = ({
                     </>
                 }
             >
-                {`We use cookies and similar technology to improve your experience and also to allow us to improve our service. To find out more, read our privacy policy and cookie policy.`}
+                {
+                    <>
+                        We use cookies and similar technology to improve your
+                        experience and also to allow us to improve our service.
+                        To find out more, read our{' '}
+                        <Link href={PRIVACY_LINK}>privacy policy</Link> and{' '}
+                        <Link href={COOKIE_LINK}>cookie policy</Link>.
+                    </>
+                }
             </OnboardingCard>
         </Aligner>
     )


### PR DESCRIPTION
Links: 
<img width="379" alt="Screenshot 2019-08-30 at 12 37 03" src="https://user-images.githubusercontent.com/8861681/64018316-0682b000-cb24-11e9-8a5b-f85e31c9b257.png">

Privacy policy opens in browser, going here: 

<img width="379" alt="Screenshot 2019-08-30 at 12 36 54" src="https://user-images.githubusercontent.com/8861681/64018340-18645300-cb24-11e9-9470-d9a338dc7cdb.png">

Cookie policy opens in browser, going here:

<img width="379" alt="Screenshot 2019-08-30 at 12 36 59" src="https://user-images.githubusercontent.com/8861681/64018364-27e39c00-cb24-11e9-80f0-487fc35c8652.png">

