### PR TITLE
Add backed support for a 'special' swatch

### DIFF
--- a/projects/backend/fronts/issue.ts
+++ b/projects/backend/fronts/issue.ts
@@ -13,6 +13,7 @@ export type Swatch =
     | 'culture'
     | 'lifestyle'
     | 'sport'
+    | 'special'
 export interface PublishedFront {
     id: string
     name: string


### PR DESCRIPTION
A new swatch is to be supplied, called 'special' this will be used on the optional fronts that straddle "Top Stories". These fronts will be used for special reports, huge news, elections - that sort of thing. The fronts tool will be able to supply once: https://github.com/guardian/facia-tool/pull/989 is merged.

I don't yet have a definition of the swatch values from @blongden73

## Why are you doing this?

[**Trello for Editions ->**](https://trello.com/c/R0He87w9/339-big-news-special-news-design)
[**Trello for Tool Support ->**](https://trello.com/c/S5azk9Il/452-front-tool-support-for-big-news)

## Changes

* Adds "special" and an acceptable swatch value
