### PR TITLE
Rahb/fix error validation

### DIFF
--- a/projects/Mallard/src/hooks/use-form-field.ts
+++ b/projects/Mallard/src/hooks/use-form-field.ts
@@ -16,18 +16,16 @@ const useFormField = (
         onSet?: (value: string) => void
     },
 ): FormField => {
-    const [hasInput, setHasInput] = useState(false)
     const [value, setValue] = useState(initialValue)
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
-        hasInput && setError(validator(value))
-    }, [hasInput, validator, value])
+        setError(validator(value))
+    }, [validator, value])
 
     return {
         value,
         setValue: value => {
-            setHasInput(true)
             onSet && onSet(value)
             setValue(value)
         },

--- a/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
+++ b/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
@@ -26,6 +26,8 @@ const CasSignInScreen = ({
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const [isLoading, setIsLoading] = useState(false)
 
+    const [shouldShowError, setShouldShowError] = useState(false)
+
     const subscriberID = useFormField('', {
         validator: subId => (subId ? null : 'Please enter a subscriber ID'),
         onSet: () => setErrorMessage(null),
@@ -37,6 +39,10 @@ const CasSignInScreen = ({
     })
 
     const handleSubmit = async () => {
+        if (subscriberID.error || password.error) {
+            setShouldShowError(true)
+            return
+        }
         try {
             const expiry = await fetchAndPersistCASExpiry(
                 subscriberID.value,
@@ -63,14 +69,14 @@ const CasSignInScreen = ({
         >
             <View>
                 <LoginInput
-                    error={subscriberID.error}
+                    error={shouldShowError ? subscriberID.error : null}
                     onChangeText={subscriberID.setValue}
                     label="Subscriber ID (including all zeros)"
                     accessibilityLabel="subscriber id input"
                     value={subscriberID.value}
                 />
                 <LoginInput
-                    error={password.error}
+                    error={shouldShowError ? password.error : null}
                     onChangeText={password.setValue}
                     label="Postcode or surname"
                     accessibilityLabel="postcode or surname input"

--- a/projects/Mallard/src/services/id-service.ts
+++ b/projects/Mallard/src/services/id-service.ts
@@ -1,5 +1,6 @@
 import { ID_API_URL, ID_ACCESS_TOKEN } from 'src/constants'
 import qs from 'query-string'
+import { GENERIC_ERROR } from 'src/helpers/words'
 
 interface ErrorReponse {
     errors: { message: string; description: string }[]
@@ -9,7 +10,12 @@ const hasErrorsArray = (json: any): json is ErrorReponse =>
     json && Array.isArray(json.errors)
 
 const maybeThrowErrors = async (res: Response) => {
-    const json = await res.json()
+    let json: any
+    try {
+        json = await res.json()
+    } catch (e) {
+        throw __DEV__ ? e : new Error(GENERIC_ERROR)
+    }
 
     if (res.status !== 200) {
         throw new Error(


### PR DESCRIPTION
## Why are you doing this?

This ensures that errors are set _immediately_ on form fields. Initially they were set only after a user had input some text but the field may have (and did) start out in an invalid state.

This fixes that and, at the same time if we have a JSON parse error in the identity service. We show a less techy error.