### PR TITLE
Tweaks to consent management screens.

### DIFF
--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -42,7 +42,11 @@ const essentials: EssentialGdprSwitch = {
 const GdprConsent = ({
     shouldShowDismissableHeader = false,
     navigation,
-}: { shouldShowDismissableHeader?: boolean } & NavigationInjectedProps) => {
+    continueText,
+}: {
+    shouldShowDismissableHeader?: boolean
+    continueText: string
+} & NavigationInjectedProps) => {
     const setSetting = useSettings()
     const settings = useOtherSettingsValues()
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
@@ -75,11 +79,9 @@ const GdprConsent = ({
     }
 
     const onDismiss = () => {
-        if (
-            settings.gdprAllowFunctionality &&
-            settings.gdprAllowFunctionality
-        ) {
-            navigation.goBack(null)
+        if (settings.gdprAllowFunctionality && settings.gdprAllowPerformance) {
+            showToast(PREFS_SAVED_MSG)
+            navigation.navigate('App')
         } else {
             Alert.alert(
                 'Before you go',
@@ -87,7 +89,7 @@ const GdprConsent = ({
                 [
                     { text: 'Manage preferences', onPress: () => {} },
                     {
-                        text: 'Enable all and continue',
+                        text: continueText,
                         onPress: () => onEnableAllAndContinue(),
                         style: 'cancel',
                     },
@@ -125,7 +127,7 @@ const GdprConsent = ({
                         appearance={ButtonAppearance.skeleton}
                         onPress={() => onEnableAllAndContinue()}
                     >
-                        Enable all and continue
+                        {continueText}
                     </Button>
                 }
             ></TallRow>
@@ -177,7 +179,10 @@ const GdprConsent = ({
 const GdprConsentScreen = ({ navigation }: NavigationInjectedProps) => (
     <WithAppAppearance value={'settings'}>
         <ScrollContainer>
-            <GdprConsent navigation={navigation}></GdprConsent>
+            <GdprConsent
+                navigation={navigation}
+                continueText={'Enable all'}
+            ></GdprConsent>
         </ScrollContainer>
     </WithAppAppearance>
 )
@@ -189,6 +194,7 @@ const GdprConsentScreenForOnboarding = ({
         <ScrollContainer>
             <GdprConsent
                 shouldShowDismissableHeader={true}
+                continueText={'Enable all aand continue'}
                 navigation={navigation}
             ></GdprConsent>
         </ScrollContainer>


### PR DESCRIPTION
Done - Users should be able to close the screen after choosing their preferences for performance and functionality. By tapping close, they should be taken to the home screen of the app.

Done - On Settings > Privacy settings (not from onboarding), the button should be "Enable all", not "Enable all and continue"