### PR TITLE
Rahb/trail fixes

### DIFF
--- a/projects/backend/__tests__/fronts.spec.ts
+++ b/projects/backend/__tests__/fronts.spec.ts
@@ -1,0 +1,45 @@
+import { patchArticle } from '../fronts'
+import { Article, PublishedFurniture } from './helpers/fixtures'
+
+describe('fronts', () => {
+    describe('patchArticle', () => {
+        describe('trail and standfirst', () => {
+            it('takes the furniture value for trail if it exists', () => {
+                const patched = patchArticle(
+                    Article({ key: 'my-article', trail: 'article' }),
+                    PublishedFurniture({ trailTextOverride: 'furniture' }),
+                )[1]
+                expect(patched.trail).toBe('furniture')
+                expect(patched.trail).toBe(patched.standfirst)
+            })
+
+            it('takes the article value for trail when furniture is falsey', () => {
+                const p1 = patchArticle(
+                    Article({ key: 'my-article', trail: 'article' }),
+                    PublishedFurniture({ trailTextOverride: '' }),
+                )[1]
+                expect(p1.trail).toBe('article')
+                expect(p1.trail).toBe(p1.standfirst)
+
+                const p2 = patchArticle(
+                    Article({ key: 'my-article', trail: 'article' }),
+                    PublishedFurniture(),
+                )[1]
+                expect(p2.trail).toBe(p2.standfirst)
+            })
+
+            it('strips html tags from the fields', () => {
+                const patched = patchArticle(
+                    Article({
+                        key: 'my-article',
+                        trail:
+                            '<strong>here is <em>something</em> important</strong>',
+                    }),
+                    PublishedFurniture({ trailTextOverride: '' }),
+                )[1]
+                expect(patched.trail).toBe('here is something important')
+                expect(patched.trail).toBe(patched.standfirst)
+            })
+        })
+    })
+})

--- a/projects/backend/__tests__/helpers/fixtures.ts
+++ b/projects/backend/__tests__/helpers/fixtures.ts
@@ -1,0 +1,130 @@
+import {
+    ArticleType,
+    MediaType,
+    Image,
+    Content as IContent,
+    BlockElement,
+} from '../../../common/src'
+import {
+    PublishedImage,
+    PublishedFurtniture as IPublishedFurtniture,
+} from '../../fronts/issue'
+import { CArticle } from '../../capi/articles'
+
+interface ContentFields {
+    key: string
+    type?: string
+    headline?: string
+    kicker?: string
+    articleType?: ArticleType
+    trail?: string
+    image?: Image
+    standfirst?: string
+    byline?: string
+    bylineImages?: { thumbnail?: Image; cutout?: Image }
+    showByline?: boolean
+    showQuotedHeadline?: boolean
+    mediaType?: MediaType
+    slideshowImages?: Image[]
+    sportScore?: string
+}
+
+const Content = <T extends string>(
+    type: T,
+    {
+        key,
+        headline = 'My amazing story',
+        kicker = 'Big news',
+        articleType,
+        trail = 'Read this',
+        image = { source: '', path: '' },
+        standfirst,
+        byline,
+        bylineImages,
+        showByline = true,
+        showQuotedHeadline = false,
+        mediaType = 'Image',
+        slideshowImages,
+        sportScore,
+    }: ContentFields,
+): IContent & { type: T } => ({
+    key,
+    type,
+    headline,
+    kicker,
+    articleType,
+    trail,
+    image,
+    standfirst,
+    byline,
+    bylineImages,
+    showByline,
+    showQuotedHeadline,
+    mediaType,
+    slideshowImages,
+    sportScore,
+})
+
+type ArticleFields = {
+    image?: Image
+    byline?: string
+    standfirst?: string
+    elements?: BlockElement[]
+    starRating?: number
+} & ContentFields
+
+const Article = ({
+    image,
+    byline = 'Mr CAPI',
+    standfirst = 'This story is great',
+    elements = [],
+    starRating,
+    ...contentFields
+}: ArticleFields): CArticle => ({
+    ...Content('article', contentFields),
+    path: contentFields.key,
+    image,
+    byline,
+    standfirst,
+    elements,
+    starRating,
+})
+
+interface PublishedFurnitureFields {
+    kicker?: string
+    headlineOverride?: string
+    trailTextOverride?: string
+    bylineOverride?: string
+    showByline?: boolean
+    showQuotedHeadline?: boolean
+    mediaType?: MediaType
+    imageSrcOverride?: PublishedImage
+    slideshowImages?: PublishedImage[]
+    sportScore?: string
+}
+
+const PublishedFurniture = ({
+    kicker,
+    headlineOverride,
+    trailTextOverride,
+    bylineOverride,
+    showByline = true,
+    showQuotedHeadline = false,
+    mediaType = 'Image',
+    imageSrcOverride,
+    slideshowImages,
+    sportScore,
+}: PublishedFurnitureFields = {}): IPublishedFurtniture => ({
+    kicker,
+    headlineOverride,
+    trailTextOverride,
+    bylineOverride,
+    showByline,
+    showQuotedHeadline,
+    mediaType,
+    imageSrcOverride,
+    slideshowImages,
+    sportScore,
+})
+
+export { Article, PublishedFurniture }

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -40,20 +40,20 @@ interface CAPIExtras {
     path: string
 }
 
-type CArticle = Omit<Article, NotInCAPI | OptionalInCAPI> &
+export type CArticle = Omit<Article, NotInCAPI | OptionalInCAPI> &
     Partial<Pick<Article, OptionalInCAPI>> &
     CAPIExtras
-type CGallery = Omit<GalleryArticle, NotInCAPI | OptionalInCAPI> &
+export type CGallery = Omit<GalleryArticle, NotInCAPI | OptionalInCAPI> &
     Partial<Pick<Article, OptionalInCAPI>> &
     CAPIExtras
-type CPicture = Omit<PictureArticle, NotInCAPI | OptionalInCAPI> &
+export type CPicture = Omit<PictureArticle, NotInCAPI | OptionalInCAPI> &
     Partial<Pick<Article, OptionalInCAPI>> &
     CAPIExtras
 export type CCrossword = Omit<CrosswordArticle, NotInCAPI | OptionalInCAPI> &
     Partial<Pick<Article, OptionalInCAPI>> &
     CAPIExtras
 
-type CAPIContent = CArticle | CGallery | CCrossword | CPicture
+export type CAPIContent = CArticle | CGallery | CCrossword | CPicture
 
 const truncateDateTime = (date: CapiDateTime64): CapiDateTime32 => ({
     iso8601: date.iso8601,

--- a/projects/backend/jest.config.js
+++ b/projects/backend/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     preset: 'ts-jest/presets/default',
     setupFilesAfterEnv: ['./jest-matchers.ts'],
+    testMatch: ['**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
 }


### PR DESCRIPTION
## Why are you doing this?

Set standfirst to be equal to the trail text. As a side effect this strips the html tags (as it was already stripped on the trail, just not on the standfirst).

Additionally, I've slightly refactored this to make it easier to do the right thing when we add another article type.