### PR TITLE
Create and use sign in failed card

### DIFF
--- a/projects/Mallard/src/components/sign-in-failed-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-failed-modal-card.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { View, StyleSheet } from 'react-native'
+import { ModalButton } from './modal-button'
+import { UiBodyCopy } from './styled-text'
+import { metrics } from 'src/theme/spacing'
+
+const styles = StyleSheet.create({
+    bottomContentContainer: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginTop: metrics.vertical * 2,
+    },
+})
+
+const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
+
+const SignInFailedModalCard = ({
+    close,
+    onLoginPress,
+    onOpenCASLogin,
+    onDismiss,
+    email,
+}: {
+    close: () => void
+    onLoginPress: () => void
+    onOpenCASLogin: () => void
+    onDismiss: () => void
+    email: string
+}) => (
+    <OnboardingCard
+        title="Already a subscriber?"
+        appearance={CardAppearance.blue}
+        onDismissThisCard={onDismiss}
+        size="small"
+        bottomContent={
+            <>
+                <UiBodyCopy weight="bold">{`We were unable to find a subscription associated with ${email}. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`}</UiBodyCopy>
+                <View style={styles.bottomContentContainer}>
+                    <View>
+                        <ModalButton
+                            onPress={() => {
+                                close()
+                                onLoginPress()
+                            }}
+                        >
+                            Try a different email
+                        </ModalButton>
+                        <ModalButton
+                            onPress={() => {
+                                close()
+                                onOpenCASLogin()
+                            }}
+                        >
+                            Activate with subscriber ID
+                        </ModalButton>
+                    </View>
+                </View>
+            </>
+        }
+    />
+)
+
+export { SignInFailedModalCard }

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -10,14 +10,14 @@ import { googleAuthWithDeepRedirect } from 'src/authentication/services/google'
 import { AuthContext } from 'src/authentication/auth-context'
 import { NavigationScreenProp } from 'react-navigation'
 import { useModal } from 'src/components/modal'
-import { SubNotFoundModalCard } from 'src/components/sub-not-found-modal-card'
+import { SignInFailedModalCard } from 'src/components/sign-in-failed-modal-card'
 import { routeNames } from 'src/navigation/routes'
 import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
 import { Login } from './log-in'
 import isEmail from 'validator/lib/isEmail'
 import { useFormField } from 'src/hooks/use-form-field'
 import { IdentityAuthStatus } from 'src/authentication/credentials-chain'
-import { withConsent, GdprSwitch } from 'src/helpers/settings'
+import { withConsent } from 'src/helpers/settings'
 import { Alert } from 'react-native'
 
 const useRandomState = () =>
@@ -110,7 +110,11 @@ const AuthSwitcherScreen = ({
                                 setStatus(IdentityAuthStatus(data))
                                 if (!canViewEdition(data)) {
                                     open(close => (
-                                        <SubNotFoundModalCard
+                                        <SignInFailedModalCard
+                                            email={
+                                                data.userDetails
+                                                    .primaryEmailAddress
+                                            }
                                             onDismiss={() =>
                                                 navigation.popToTop()
                                             }


### PR DESCRIPTION
## Why are you doing this?

This adds a new type of modal card for a failed sign in that will _only_ show after the sign in to Identity has failed. The existing one (with a bit more stuff about the digital pack) will show on any subsequent views.

[**Trello Card ->**](https://trello.com/c/H32H2eUN/464-update-paywall-screen-for-when-a-user-is-signed-in-but-do-not-have-a-subscription-ios-version-check-on-android-as-well)

<img width="200" src="https://user-images.githubusercontent.com/1652187/64125321-781b6200-cda1-11e9-9123-899626ccd57d.gif" />
