### PR TITLE
Fix iOS build using a "universal" ophan framework

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		2D16E6881FA4F8E400B85C8A /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D16E6891FA4F8E400B85C8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* MallardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* MallardTests.m */; };
 		30A65E2732C54D5E94DFE6CD /* GuardianWeatherIcons-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1B8F9A4ED48041FBB588FDD5 /* GuardianWeatherIcons-Regular.ttf */; };
-		4F62AA3223198F8B0052ADBA /* ophan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA3123198F8B0052ADBA /* ophan.framework */; };
-		4F62AA3323198F8B0052ADBA /* ophan.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA3123198F8B0052ADBA /* ophan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4F62AA36231E8D660052ADBA /* ophan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA35231E8D660052ADBA /* ophan.framework */; };
+		4F62AA37231E8D660052ADBA /* ophan.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA35231E8D660052ADBA /* ophan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7836FF3F0ADEA9274CAD15ED /* libPods-Mallard-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C512E12ECC343D6E33F7A1 /* libPods-Mallard-tvOSTests.a */; };
 		950E1C012317E06F00F38B92 /* Ophan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950E1C002317E06F00F38B92 /* Ophan.swift */; };
 		95CB9F1B2316B6E900F2F6B0 /* Ophan.m in Sources */ = {isa = PBXBuildFile; fileRef = 95CB9F192316B6E900F2F6B0 /* Ophan.m */; };
@@ -98,13 +98,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		4F62AA3423198F8B0052ADBA /* Embed Frameworks */ = {
+		4F62AA38231E8D660052ADBA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4F62AA3323198F8B0052ADBA /* ophan.framework in Embed Frameworks */,
+				4F62AA37231E8D660052ADBA /* ophan.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -144,6 +144,7 @@
 		49D58390ADA01A9FBA2F96DD /* Pods-Mallard-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mallard-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Mallard-tvOSTests/Pods-Mallard-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4F62AA2D23198E500052ADBA /* ophan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ophan.framework; path = "../ophan/build/fat-framework/debug/ophan.framework"; sourceTree = "<group>"; };
 		4F62AA3123198F8B0052ADBA /* ophan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ophan.framework; path = "../ophan/build/fat-framework/debug/ophan.framework"; sourceTree = "<group>"; };
+		4F62AA35231E8D660052ADBA /* ophan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ophan.framework; path = ../ophan/build/bin/ios/universalFramework/ophan.framework; sourceTree = "<group>"; };
 		5025F485D71B4A288ED193B0 /* GuardianTextSans-RegularItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextSans-RegularItalic.ttf"; path = "../src/assets/fonts/GuardianTextSans-RegularItalic.ttf"; sourceTree = "<group>"; };
 		574E262EB3A24AA6AA8027CA /* GuardianTextSans-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextSans-Regular.ttf"; path = "../src/assets/fonts/GuardianTextSans-Regular.ttf"; sourceTree = "<group>"; };
 		5DA07BFB0DCC824DF7C94988 /* Pods-Mallard-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mallard-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Mallard-tvOSTests/Pods-Mallard-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -196,7 +197,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BBB47E16F9C3A412F678A92 /* libPods-Mallard.a in Frameworks */,
-				4F62AA3223198F8B0052ADBA /* ophan.framework in Frameworks */,
+				4F62AA36231E8D660052ADBA /* ophan.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,6 +325,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				4F62AA35231E8D660052ADBA /* ophan.framework */,
 				A10F237623191F62004C70CC /* ReleaseStream */,
 				4F62AA2D23198E500052ADBA /* ophan.framework */,
 				4F62AA3123198F8B0052ADBA /* ophan.framework */,
@@ -412,7 +414,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				9A2F30EB4995BA18D2B5CA7D /* [CP] Copy Pods Resources */,
-				4F62AA3423198F8B0052ADBA /* Embed Frameworks */,
+				4F62AA38231E8D660052ADBA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -699,7 +701,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\"                      \\\n-Pkotlin.target=\"$KOTLIN_TARGET\"\n";
+			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\"\n";
 		};
 		9A2F30EB4995BA18D2B5CA7D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -887,7 +889,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/fat-framework/debug";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/bin/ios/universalFramework";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				KOTLIN_BUILD_TYPE = DEBUG;
@@ -916,7 +918,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/fat-framework/release";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/bin/ios/universalFramework";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				KOTLIN_BUILD_TYPE = RELEASE;

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -20,11 +20,11 @@
 		2D16E6881FA4F8E400B85C8A /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D16E6891FA4F8E400B85C8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* MallardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* MallardTests.m */; };
 		30A65E2732C54D5E94DFE6CD /* GuardianWeatherIcons-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1B8F9A4ED48041FBB588FDD5 /* GuardianWeatherIcons-Regular.ttf */; };
+		4F62AA3223198F8B0052ADBA /* ophan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA3123198F8B0052ADBA /* ophan.framework */; };
+		4F62AA3323198F8B0052ADBA /* ophan.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4F62AA3123198F8B0052ADBA /* ophan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7836FF3F0ADEA9274CAD15ED /* libPods-Mallard-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C512E12ECC343D6E33F7A1 /* libPods-Mallard-tvOSTests.a */; };
 		950E1C012317E06F00F38B92 /* Ophan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950E1C002317E06F00F38B92 /* Ophan.swift */; };
 		95CB9F1B2316B6E900F2F6B0 /* Ophan.m in Sources */ = {isa = PBXBuildFile; fileRef = 95CB9F192316B6E900F2F6B0 /* Ophan.m */; };
-		95CB9F222316C60F00F2F6B0 /* ophan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95CB9F1D2316C53F00F2F6B0 /* ophan.framework */; };
-		95CB9F232316C60F00F2F6B0 /* ophan.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95CB9F1D2316C53F00F2F6B0 /* ophan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9BBB47E16F9C3A412F678A92 /* libPods-Mallard.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC9F542F9A3CB816E7750C23 /* libPods-Mallard.a */; };
 		A13D0DC22316783B00505524 /* ReleaseStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13D0DC12316783B00505524 /* ReleaseStream.swift */; };
 		A13D0DC423167BB400505524 /* ReleaseStream.m in Sources */ = {isa = PBXBuildFile; fileRef = A13D0DC323167BB400505524 /* ReleaseStream.m */; };
@@ -98,13 +98,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		95CB9F242316C60F00F2F6B0 /* Embed Frameworks */ = {
+		4F62AA3423198F8B0052ADBA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				95CB9F232316C60F00F2F6B0 /* ophan.framework in Embed Frameworks */,
+				4F62AA3323198F8B0052ADBA /* ophan.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -142,6 +142,8 @@
 		3DA2FD0EC69B436384494394 /* GHGuardianHeadline-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GHGuardianHeadline-BoldItalic.ttf"; path = "../src/assets/fonts/GHGuardianHeadline-BoldItalic.ttf"; sourceTree = "<group>"; };
 		49561E0DB7FA414FA55A9C83 /* GHGuardianHeadline-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GHGuardianHeadline-Black.ttf"; path = "../src/assets/fonts/GHGuardianHeadline-Black.ttf"; sourceTree = "<group>"; };
 		49D58390ADA01A9FBA2F96DD /* Pods-Mallard-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mallard-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Mallard-tvOSTests/Pods-Mallard-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4F62AA2D23198E500052ADBA /* ophan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ophan.framework; path = "../ophan/build/fat-framework/debug/ophan.framework"; sourceTree = "<group>"; };
+		4F62AA3123198F8B0052ADBA /* ophan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ophan.framework; path = "../ophan/build/fat-framework/debug/ophan.framework"; sourceTree = "<group>"; };
 		5025F485D71B4A288ED193B0 /* GuardianTextSans-RegularItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextSans-RegularItalic.ttf"; path = "../src/assets/fonts/GuardianTextSans-RegularItalic.ttf"; sourceTree = "<group>"; };
 		574E262EB3A24AA6AA8027CA /* GuardianTextSans-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextSans-Regular.ttf"; path = "../src/assets/fonts/GuardianTextSans-Regular.ttf"; sourceTree = "<group>"; };
 		5DA07BFB0DCC824DF7C94988 /* Pods-Mallard-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mallard-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Mallard-tvOSTests/Pods-Mallard-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -194,7 +196,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BBB47E16F9C3A412F678A92 /* libPods-Mallard.a in Frameworks */,
-				95CB9F222316C60F00F2F6B0 /* ophan.framework in Frameworks */,
+				4F62AA3223198F8B0052ADBA /* ophan.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -323,6 +325,8 @@
 			isa = PBXGroup;
 			children = (
 				A10F237623191F62004C70CC /* ReleaseStream */,
+				4F62AA2D23198E500052ADBA /* ophan.framework */,
+				4F62AA3123198F8B0052ADBA /* ophan.framework */,
 				95CB9F182316B6E900F2F6B0 /* Ophan */,
 				13B07FAE1A68108700A75B9A /* Mallard */,
 				00E356EF1AD99517003FC87E /* MallardTests */,
@@ -408,7 +412,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				9A2F30EB4995BA18D2B5CA7D /* [CP] Copy Pods Resources */,
-				95CB9F242316C60F00F2F6B0 /* Embed Frameworks */,
+				4F62AA3423198F8B0052ADBA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -695,7 +699,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\"                      \\\n-Pkotlin.target=\"$KOTLIN_TARGET\"\n";
+			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\"                      \\\n-Pkotlin.target=\"$KOTLIN_TARGET\"\n";
 		};
 		9A2F30EB4995BA18D2B5CA7D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -883,7 +887,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$(SRCROOT)/../ophan/build/bin/ios/debugFramework";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/fat-framework/debug";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				KOTLIN_BUILD_TYPE = DEBUG;
@@ -896,6 +900,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -911,7 +916,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$(SRCROOT)/../ophan/build/bin/ios/releaseFramework";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../ophan/build/fat-framework/release";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				KOTLIN_BUILD_TYPE = RELEASE;
@@ -923,6 +928,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Mallard-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
@@ -80,7 +80,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
@@ -80,7 +80,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
@@ -35,11 +35,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForTesting = "NO"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "00E356ED1AD99517003FC87E"
@@ -56,16 +56,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
-               BuildableName = "MallardTests.xctest"
-               BlueprintName = "MallardTests"
-               ReferencedContainer = "container:Mallard.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -80,7 +70,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -58,7 +58,7 @@ kotlin {
 task fatFramework(type: FatFrameworkTask) {
     def buildType = project.findProperty('kotlin.build.type') ?: 'DEBUG'
     baseName = "ophan"
-    destinationDir = file("$buildDir/fat-framework/${buildType.toLowerCase()}")
+    destinationDir = file("$buildDir/bin/ios/universalFramework")
     from(
             kotlin.targets.ios.binaries.getFramework(buildType),
             kotlin.targets.ios32.binaries.getFramework(buildType),
@@ -94,8 +94,6 @@ task copyFatFramework {
     doLast {
         def srcFile = tasks.fatFramework.outputs.files
         def targetDir = getProperty('configuration.build.dir')
-        println("srcFile=$srcFile")
-        println("targetDir=$targetDir")
         copy {
             from srcFile
             into targetDir

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -55,16 +55,6 @@ kotlin {
     }
 }
 
-task debugFatFramework(type: FatFrameworkTask) {
-    baseName = "ophan"
-    destinationDir = file("$buildDir/fat-framework/debug")
-    from(
-            kotlin.targets.ios.binaries.getFramework("DEBUG"),
-            kotlin.targets.ios32.binaries.getFramework("DEBUG"),
-            kotlin.targets.ios64.binaries.getFramework("DEBUG")
-    )
-}
-
 task fatFramework(type: FatFrameworkTask) {
     def buildType = project.findProperty('kotlin.build.type') ?: 'DEBUG'
     baseName = "ophan"

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -68,7 +68,7 @@ task debugFatFramework(type: FatFrameworkTask) {
 task fatFramework(type: FatFrameworkTask) {
     def buildType = project.findProperty('kotlin.build.type') ?: 'DEBUG'
     baseName = "ophan"
-    destinationDir = file("$buildDir/fat-framework/debug")
+    destinationDir = file("$buildDir/fat-framework/${buildType.toLowerCase()}")
     from(
             kotlin.targets.ios.binaries.getFramework(buildType),
             kotlin.targets.ios32.binaries.getFramework(buildType),

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
+
 plugins {
     id 'org.jetbrains.kotlin.multiplatform' version '1.3.41'
 }
@@ -12,17 +14,28 @@ kotlin {
     // This is for iPhone emulator
     // Switch here to iosArm64 (or iosArm32) to build library for iPhone device
     iosX64("ios") {
-        binaries {
-            framework()
+        binaries.framework {
+            baseName = "ophan"
         }
     }
+    iosArm64("ios64") {
+        binaries.framework {
+            baseName = "ophan"
+        }
+    }
+    iosArm32("ios32") {
+        binaries.framework {
+            baseName = "ophan"
+        }
+    }
+
     sourceSets {
         commonMain {
             dependencies {
                 implementation kotlin('stdlib-common')
                 implementation("io.ktor:ktor-client-core:1.2.3")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.3.0-RC")
-                api 'com.gu.kotlin:multiplatform-ophan:0.1.1'
+                api 'com.gu.kotlin:multiplatform-ophan:0.1.3'
             }
         }
         androidMain {
@@ -32,11 +45,35 @@ kotlin {
             }
         }
         iosMain {
-            dependencies {
-
-            }
+        }
+        ios64Main {
+            dependsOn iosMain
+        }
+        ios32Main {
+            dependsOn iosMain
         }
     }
+}
+
+task debugFatFramework(type: FatFrameworkTask) {
+    baseName = "ophan"
+    destinationDir = file("$buildDir/fat-framework/debug")
+    from(
+            kotlin.targets.ios.binaries.getFramework("DEBUG"),
+            kotlin.targets.ios32.binaries.getFramework("DEBUG"),
+            kotlin.targets.ios64.binaries.getFramework("DEBUG")
+    )
+}
+
+task fatFramework(type: FatFrameworkTask) {
+    def buildType = project.findProperty('kotlin.build.type') ?: 'DEBUG'
+    baseName = "ophan"
+    destinationDir = file("$buildDir/fat-framework/debug")
+    from(
+            kotlin.targets.ios.binaries.getFramework(buildType),
+            kotlin.targets.ios32.binaries.getFramework(buildType),
+            kotlin.targets.ios64.binaries.getFramework(buildType)
+    )
 }
 
 // This task attaches native framework built from ios module to Xcode project
@@ -57,6 +94,21 @@ task copyFramework {
             into targetDir
             include 'app.framework/**'
             include 'app.framework.dSYM'
+        }
+    }
+}
+
+task copyFatFramework {
+    dependsOn tasks.fatFramework
+
+    doLast {
+        def srcFile = tasks.fatFramework.outputs.files
+        def targetDir = getProperty('configuration.build.dir')
+        println("srcFile=$srcFile")
+        println("targetDir=$targetDir")
+        copy {
+            from srcFile
+            into targetDir
         }
     }
 }


### PR DESCRIPTION
## Why are you doing this?

We have a problem trying to build the iOS app under its "Release" scheme. This scheme currently involves building the app for no fewer than **four** CPU architectures, two that are applicable to real iPhones: `arm64` and `arm7` (32-bit), and two that are for simulators: `x86_64` and `i386` (32-bit). This is a problem because the `ophan` Kotlin module is only currently set up to produce a framework for one of these architectures at a time and it cannot easily produce a framework for the `i386` architecture at all.

## Changes

* Modified the "Valid architectures" settings such that only the 64-bit simulator architecture gets built, this shouldn't be a big limitation to us as far as I can tell. 

<img width="654" alt="image" src="https://user-images.githubusercontent.com/951849/64160626-2a036e80-ce34-11e9-8a88-27825ba28878.png">

(Note: Xcode/`xcodebuild` will still build both 64-bit and 32-bit versions for real devices)

* The changes in the `ophan/build.gradle` allow the Kotlin module to produce a single framework compatible with all three remaining CPU architectures. This is what's called a "universal" or "fat" framework. AFAIK it's a single binary file with all three sub-binaries stuck together inside it and consumers can take whichever bits of it they want. The universal framework gets built to a different folder.

CC @alfavata - thanks for your help with understanding the frameworks.