### PR TITLE
Supply app/os/device details when initialising Ophan

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
@@ -1,9 +1,12 @@
 package com.guardian.editions.ophan;
 
+import android.os.Build;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.guardian.editions.BuildConfig;
 
 import java.io.File;
 import java.util.UUID;
@@ -20,10 +23,11 @@ class RNOphanModule extends ReactContextBaseJavaModule {
         super(reactContext);
         final File recordStoreDir = new File(reactContext.getCacheDir(), "ophan");
         ophanApi = new OphanApi(
-                "0.0.1",
-                "Android",
-                "Unknown",
-                "Unknown",
+                "Android Editions",
+                BuildConfig.VERSION_NAME,
+                Build.VERSION.RELEASE,
+                Build.MODEL,
+                Build.MANUFACTURER,
                 "testDeviceId",
                 "testUserId",
                 new LogcatLogger(),

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
@@ -15,57 +15,62 @@
 */
 
 import Foundation
-// import ophan
+import ophan
 
 @objc(Ophan)
 class Ophan: NSObject {
+  
+  let ophanApi: OphanApi
 
-//   let ophanApi = OphanKt_.getThreadSafeOphanApi (
-//     appVersion: "0.0.1",
-//     appOs: "iOS",
-//     deviceName: "Unknown",
-//     deviceManufacturer: "Apple",
-//     deviceId: "testDeviceId",
-//     userId: "testUserId",
-//     logger: SimpleLogger(),
-//     recordStorePath: "ophan"
-//   )
+  override init() {
+    print("Initialising new Ophan instance on thread \(Thread.current)")
+    
+    let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+    
+    // TODO: Antonio has an objective-C snippet for this but I need his help to turn it into Swiftt
+    let deviceName = "Unknown"
+    
+    ophanApi = OphanKt_.getThreadSafeOphanApi (
+      appFamily: "iOS Editions",
+      appVersion: appVersion + " (" + buildNumber + ")",
+      appOsVersion: UIDevice.current.systemVersion,
+      deviceName: deviceName,
+      deviceManufacturer: "Apple",
+      deviceId: "testDeviceId",
+      userId: "testUserId",
+      logger: SimpleLogger(),
+      recordStorePath: "ophan"
+    )
+    
+    super.init()
+  }
 
-//   override init() {
-//     super.init()
-//     print("Initialising new Ophan instance on thread \(Thread.current)")
-//   }
+  deinit {
+    print("Deinitialising Ophan instance on thread \(Thread.current)")
+  }
 
-//   deinit {
-//     print("Deinitialising Ophan instance on thread \(Thread.current)")
-//   }
-
-//   @objc(sendTestAppScreenEvent:resolver:rejecter:)
-
-//   func sendTestAppScreenEvent(_ screenName: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock) -> Void {
-
-//     print("Current thread \(Thread.current)")
-
-//     do {
-//       DispatchQueue.main.async {
-//         print("Current thread \(Thread.current)")
-//         self.ophanApi.sendTestAppScreenEvent(screenName: screenName, eventId: UUID().uuidString)
-//         resolve(screenName)
-//       }
-//     } catch let error {
-//       reject("whoops - ios Ophan is sad", "blah", nil)
-//     }
-
-//   }
+  @objc(sendTestAppScreenEvent:resolver:rejecter:)
+  func sendTestAppScreenEvent(_ screenName: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock) -> Void {
+    print("Current thread \(Thread.current)")
+    do {
+      DispatchQueue.main.async {
+      print("Current thread \(Thread.current)")
+        self.ophanApi.sendTestAppScreenEvent(screenName: screenName, eventId: UUID().uuidString)
+        resolve(screenName)
+      }
+    } catch let error {
+      reject("whoops - ios Ophan is sad", "blah", nil)
+    }
+  }
 }
 
-// class SimpleLogger: Multiplatform_ophanLogger {
-//   func debug(tag: String, message: String) {
-//     print("D: " + tag + ": " + message + "\n")
-//   }
-
-//   func warn(tag: String, message: String, error: KotlinThrowable?) {
-//     print("W: " + tag + ": " + message + "\n")
-//   }
-
-// }
+class SimpleLogger: Multiplatform_ophanLogger {
+  func debug(tag: String, message: String) {
+    print("D: " + tag + ": " + message + "\n")
+  }
+  
+  func warn(tag: String, message: String, error: KotlinThrowable?) {
+    print("W: " + tag + ": " + message + "\n")
+  }
+}

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
@@ -29,7 +29,12 @@ class Ophan: NSObject {
     let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
     
     // TODO: Antonio has an objective-C snippet for this but I need his help to turn it into Swiftt
-    let deviceName = "Unknown"
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let modelCode = withUnsafePointer(to: &systemInfo.machine) {
+        $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(validatingUTF8: $0) }
+    }
+    let deviceName = modelCode ?? "Unrecognised model"
     
     ophanApi = OphanKt_.getThreadSafeOphanApi (
       appFamily: "iOS Editions",

--- a/projects/Mallard/ophan/src/commonMain/kotlin/ophan/Ophan.kt
+++ b/projects/Mallard/ophan/src/commonMain/kotlin/ophan/Ophan.kt
@@ -16,8 +16,9 @@ class OphanApi(
 ) {
 
     constructor(
+            appFamily: String,
             appVersion: String,
-            appOs: String,
+            appOsVersion: String,
             deviceName: String,
             deviceManufacturer: String,
             deviceId: String,
@@ -25,8 +26,16 @@ class OphanApi(
             logger: Logger,
             recordStorePath: String
     ) : this(OphanDispatcher(
-            App(appVersion, "TestEditions", appOs, Edition.UK),
-            Device(deviceName, deviceManufacturer),
+            App(
+                    version = appVersion,
+                    family = appFamily,
+                    os = appOsVersion,
+                    edition = Edition.UK
+            ),
+            Device(
+                    name = deviceName,
+                    manufacturer = deviceManufacturer
+            ),
             deviceId,
             userId,
             logger,

--- a/projects/Mallard/ophan/src/iosMain/kotlin/ophan/Ophan.kt
+++ b/projects/Mallard/ophan/src/iosMain/kotlin/ophan/Ophan.kt
@@ -4,12 +4,13 @@ import com.gu.ophan.Logger
 import kotlin.native.concurrent.freeze
 
 fun getThreadSafeOphanApi(
+        appFamily: String,
         appVersion: String,
-        appOs: String,
+        appOsVersion: String,
         deviceName: String,
         deviceManufacturer: String,
         deviceId: String,
         userId: String,
         logger: Logger,
         recordStorePath: String
-): OphanApi = OphanApi(appVersion, appOs, deviceName, deviceManufacturer, deviceId, userId, logger, recordStorePath).freeze()
+): OphanApi = OphanApi(appFamily, appVersion, appOsVersion, deviceName, deviceManufacturer, deviceId, userId, logger, recordStorePath).freeze()


### PR DESCRIPTION
## Why are you doing this?

To fill in some of the missing details we need to send to Ophan to properly attribute page views and other tracking calls.

Subsequent PRs will be required to fill in the details marked **TODO** in the table below.

[**Trello Card ->**](https://trello.com/c/Gk4RDfwf/525-ophan-initialiser)

## Changes

Field | Android value | iOS value
--- | --- | ---
App version | `BuildConfig.VERSION_NAME` (which takes value from `defaultConfig.versionName` in app/build.gradle) | `Bundle.main.infoDictionary?["CFBundleShortVersionString"]` and `Bundle.main.infoDictionary?["CFBundleVersion"]` (not sure where these values come from)
App family | Fixed: `"Android Editions"` | Fixed: `"iOS Editions"`
App OS version | `Build.VERSION.RELEASE`  | `UIDevice.current.systemVersion`
App edition | Fixed: `Edition.UK` | Fixed: `Edition.UK`
Device name | `Build.MODEL` | **TODO**
Device manufacturer | `Build.MANUFACTURER` | Fixed: `"Apple"`
Device id | **TODO** | **TODO**
User id | **TODO** | **TODO**