### PR TITLE
Rahb/in app browser

### DIFF
--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -11,6 +11,8 @@ buildscript {
         supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
         googlePlayServicesVersion = "17.1.0"
         firebaseVersion = "19.0.1"
+        androidXAnnotation = "1.1.0"
+        androidXBrowser = "1.0.0"
     }
     repositories {
         google()

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -114,6 +114,8 @@ PODS:
   - RNImageFilterKit (0.5.18):
     - Bolts (= 1.9.0)
     - React
+  - RNInAppBrowser (3.0.1):
+    - React
   - RNKeychain (3.1.3):
     - React
   - RNScreens (1.0.0-alpha.23):
@@ -171,6 +173,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNIap (from `../node_modules/react-native-iap`)
   - RNImageFilterKit (from `../node_modules/react-native-image-filter-kit`)
+  - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -254,6 +257,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-iap"
   RNImageFilterKit:
     :path: "../node_modules/react-native-image-filter-kit"
+  RNInAppBrowser:
+    :path: "../node_modules/react-native-inappbrowser-reborn"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
   RNScreens:
@@ -304,6 +309,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNImageFilterKit: 5383a4dcde9177624eb25ce20e12c6cc4805e74c
+  RNInAppBrowser: 24abaaff1fe1d8bea2492537ca32e455b14ef030
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   RNSVG: ff9b094e39dd4a437ebe17d1c7ceed286e75f426

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -60,6 +60,7 @@
         "react-native-iap": "^3.3.9",
         "react-native-image-filter-kit": "^0.5.18",
         "react-native-in-app-utils": "^6.0.1",
+        "react-native-inappbrowser-reborn": "^3.0.1",
         "react-native-keychain": "^3.1.3",
         "react-native-progress-circle": "^2.0.1",
         "react-native-push-notification": "^3.1.7",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -96,7 +96,6 @@ export default class App extends React.Component<{}, {}> {
         return (
             <ErrorBoundary>
                 <WithProviders>
-                    <ModalRenderer />
                     <StatusBar
                         animated={true}
                         barStyle="light-content"
@@ -106,6 +105,7 @@ export default class App extends React.Component<{}, {}> {
                         <RootNavigator {...rootNavigationProps} />
                         <NetInfoAutoToast />
                     </View>
+                    <ModalRenderer />
                 </WithProviders>
             </ErrorBoundary>
         )

--- a/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
@@ -1,5 +1,6 @@
 import { authWithDeepRedirect } from '../deep-link-auth'
 import { EventEmitter } from 'events'
+import { BrowserResult } from 'react-native-inappbrowser-reborn'
 
 const createListener = (): EventEmitter & {
     addEventListener: EventEmitter['addListener']
@@ -11,83 +12,263 @@ const createListener = (): EventEmitter & {
     return ee
 }
 
+const createInAppBrowser = ({
+    available = true,
+    cancel = false,
+}: {
+    available?: boolean
+    cancel?: boolean
+} = {}) => ({
+    open: () =>
+        new Promise<BrowserResult>(res => cancel && res({ type: 'cancel' })),
+    close: jest.fn(() => {}),
+    isAvailable: () => Promise.resolve(available),
+})
+
 describe('deep-link-auth', () => {
     describe('authWithDeepRedirect', () => {
-        it('waits for a deep link with a token before resolving', async () => {
-            const linking = Object.assign(createListener(), {
-                openURL: () => {},
-            })
-            const appState = createListener()
-            const validator = jest.fn(async () => 'token')
+        describe('external link', () => {
+            it('waits for a deep link with a token before resolving', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => 'token')
 
-            const promise = authWithDeepRedirect(
-                'https://authurl.com/auth',
-                validator,
-                linking,
-                appState,
-            )
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: false }),
+                )
 
-            linking.emit('url', { url: 'myurl' })
-
-            const val = await promise
-
-            expect(val).toBe('token')
-            expect(validator).toBeCalledWith('myurl')
-        })
-
-        it('will throw if the app is opened without a deep link', async () => {
-            const linking = Object.assign(createListener(), {
-                openURL: () => {},
-            })
-            const appState = createListener()
-            const validator = jest.fn(async () => 'token')
-
-            const promise = authWithDeepRedirect(
-                'https://authurl.com/auth',
-                validator,
-                linking,
-                appState,
-            )
-
-            let error
-
-            // there's probably a better way to do this with jest!
-            try {
-                appState.emit('change', 'active')
-                await promise
-            } catch (e) {
-                error = e
-            }
-
-            await expect(error).toBe('Sign-in cancelled')
-        })
-
-        it('will throw if the validator throws', async () => {
-            const linking = Object.assign(createListener(), {
-                openURL: () => {},
-            })
-            const appState = createListener()
-            const validator = jest.fn(async () => {
-                throw 'hi'
-            })
-
-            const promise = authWithDeepRedirect(
-                'https://authurl.com/auth',
-                validator,
-                linking,
-                appState,
-            )
-
-            let error
-
-            try {
                 linking.emit('url', { url: 'myurl' })
-                await promise
-            } catch (e) {
-                error = e
-            }
 
-            await expect(error).toBe('hi')
+                const val = await promise
+
+                expect(val).toBe('token')
+                expect(validator).toBeCalledWith('myurl')
+            })
+
+            it('will throw if the app is foregrounded without a deep link', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => 'token')
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: false }),
+                )
+
+                // wait the in app browser check
+                await Promise.resolve()
+
+                let error
+
+                // there's probably a better way to do this with jest!
+                try {
+                    appState.emit('change', 'active')
+                    // this should not be able to save us, the error should already be fired
+                    linking.emit('url', { url: 'myurl' })
+                    await promise
+                } catch (e) {
+                    error = e
+                }
+
+                expect(error).toBe('Sign-in cancelled')
+            })
+
+            it('ignores the app being backgrounded and continues to wait for a deep link with a token before resolving', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => 'token')
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: false }),
+                )
+
+                appState.emit('change', 'inactive')
+                linking.emit('url', { url: 'myurl' })
+
+                const val = await promise
+
+                expect(val).toBe('token')
+                expect(validator).toBeCalledWith('myurl')
+            })
+
+            it('will throw if the validator throws', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => {
+                    throw 'hi'
+                })
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: false }),
+                )
+
+                // wait the in app browser check
+                await Promise.resolve()
+
+                let error
+
+                try {
+                    linking.emit('url', { url: 'myurl' })
+                    await promise
+                } catch (e) {
+                    error = e
+                }
+
+                expect(error).toBe('hi')
+            })
+        })
+
+        describe('in app browser', () => {
+            it('waits for a deep link with a token before resolving, and then closes browser', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => 'token')
+                const browser = createInAppBrowser({ available: true })
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    browser,
+                )
+
+                linking.emit('url', { url: 'myurl' })
+
+                const val = await promise
+
+                expect(val).toBe('token')
+                expect(validator).toBeCalledWith('myurl')
+                expect(browser.close).toBeCalled()
+            })
+
+            it('will not throw if the app is foregrounded without a deep link but will wait for link emit', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => 'token')
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: true }),
+                )
+
+                // wait the in app browser check
+                await Promise.resolve()
+
+                let error
+
+                try {
+                    // fire this first, which would ordinarly trigger an error without an
+                    // in app browser
+                    appState.emit('change', 'active')
+                    linking.emit('url', { url: 'myurl' })
+                    await promise
+                } catch (e) {
+                    error = e
+                }
+
+                expect(error).toBeUndefined()
+            })
+
+            it('will throw if the validator throws, and will close the in app browser', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => {
+                    throw 'hi'
+                })
+                const browser = createInAppBrowser({ available: true })
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    browser,
+                )
+
+                // wait the in app browser check
+                await Promise.resolve()
+
+                let error
+
+                try {
+                    linking.emit('url', { url: 'myurl' })
+                    await promise
+                } catch (e) {
+                    error = e
+                }
+
+                expect(error).toBe('hi')
+                expect(browser.close).toBeCalled()
+            })
+
+            it('will throw if the in app browser is closed', async () => {
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {},
+                })
+                const appState = createListener()
+                const validator = jest.fn(async () => {
+                    throw 'hi'
+                })
+                const browser = createInAppBrowser({
+                    available: true,
+                    cancel: true,
+                })
+
+                const promise = authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    validator,
+                    linking,
+                    appState,
+                    browser,
+                )
+
+                // wait the in app browser check
+                await Promise.resolve()
+
+                let error
+
+                try {
+                    await promise
+                } catch (e) {
+                    error = e
+                }
+
+                expect(error).toBe('Sign-in cancelled')
+                expect(browser.close).toBeCalled()
+            })
         })
     })
 })

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -39,7 +39,7 @@ const authWithDeepRedirect = async (
     inAppBrowserImpl: IInAppBrowser = InAppBrowser,
 ): Promise<string> => {
     return new Promise(async (res, rej) => {
-        let unlisteners: (() => void)[] = []
+        const unlisteners: (() => void)[] = []
 
         const onFinish = async (url?: string) => {
             inAppBrowserImpl.close()

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -1,9 +1,34 @@
 import { Linking, AppState } from 'react-native'
+import InAppBrowser from 'react-native-inappbrowser-reborn'
 
 interface Emitter<T> {
     addEventListener(type: string, cb: (e: T) => void): void
     removeEventListener(type: string, cb: Function): void
 }
+
+type IAppState = Emitter<string>
+
+const createAppChangeListener = (
+    fn: (state: string) => void,
+    appStateEmitter: IAppState,
+) => {
+    appStateEmitter.addEventListener('change', fn)
+    return () => appStateEmitter.removeEventListener('change', fn)
+}
+
+type ILinking = Emitter<{ url: string }> & {
+    openURL: (url: string) => void
+}
+
+const createLinkListener = (
+    fn: (event: { url: string }) => void,
+    linkingImpl: ILinking,
+) => {
+    linkingImpl.addEventListener('url', fn)
+    return () => linkingImpl.removeEventListener('url', fn)
+}
+
+type IInAppBrowser = Pick<typeof InAppBrowser, 'close' | 'open' | 'isAvailable'>
 
 /**
  * This function will open an auth url and wait for the first navigation back to the app
@@ -12,42 +37,72 @@ interface Emitter<T> {
  * in the case where someone redirects to the app without a token and then attempts the login
  * flow again (which would have created two listeners)
  */
-const authWithDeepRedirect = (
+const authWithDeepRedirect = async (
     authUrl: string,
     extractTokenAndValidateState: (url: string) => Promise<string>,
     /* mocks for testing */
-    linkingEmitter: Emitter<{ url: string }> & {
-        openURL: (url: string) => void
-    } = Linking,
-    appStateEmitter: Emitter<string> = AppState,
+    linkingImpl: ILinking = Linking,
+    appStateImpl: IAppState = AppState,
+    inAppBrowserImpl: IInAppBrowser = InAppBrowser,
 ): Promise<string> => {
-    Linking.openURL(authUrl)
     return new Promise(async (res, rej) => {
-        const linkHandler = async ({ url }: { url: string }) => {
-            linkingEmitter.removeEventListener('url', linkHandler)
-            // eslint-disable-next-line
-            appStateEmitter.removeEventListener('change', appChangeHandler)
+        let unlisteners: (() => void)[] = []
 
-            try {
-                res(await extractTokenAndValidateState(url))
-            } catch (e) {
-                rej(e)
+        const onFinish = async (url?: string) => {
+            inAppBrowserImpl.close()
+
+            let unlistener
+            while ((unlistener = unlisteners.pop())) {
+                unlistener()
             }
-        }
 
-        const appChangeHandler = (currentState: string) => {
-            if (currentState === 'active') {
-                // make sure the link handler is removed whenever we come back to the app
-                // url is called first in the happy path so the promise will have resolved by then
-                // otherwise, if they navigate back without authenticating, remove the listener and cancel the login
-                linkingEmitter.removeEventListener('url', linkHandler)
-                AppState.removeEventListener('change', appChangeHandler)
+            if (!url) {
                 rej('Sign-in cancelled')
+            } else {
+                res(await extractTokenAndValidateState(url))
             }
         }
 
-        linkingEmitter.addEventListener('url', linkHandler)
-        appStateEmitter.addEventListener('change', appChangeHandler)
+        const unlistenLink = createLinkListener((event: { url: string }) => {
+            // eslint-disable-next-line
+            onFinish(event.url)
+        }, linkingImpl)
+
+        unlisteners.push(unlistenLink)
+
+        if (await inAppBrowserImpl.isAvailable()) {
+            await inAppBrowserImpl.open(authUrl, {
+                // iOS Properties
+                dismissButtonStyle: 'cancel',
+                // Android Properties
+                showTitle: false,
+                enableUrlBarHiding: true,
+                enableDefaultShare: true,
+            })
+            // The deep link handler is called before the `InAppBrowser.open` promise resolves
+            // so we can tidy up happily here, in case there was a cancelled event
+            // this call may end up rejecting the promise _again_ (after it's already been
+            // resolved / rejected) but this is basically a noop
+            onFinish()
+        } else {
+            const unlistenAppState = createAppChangeListener(
+                (currentState: string) => {
+                    if (currentState === 'active') {
+                        // This is being run when
+                        // make sure the link handler is removed whenever we come back to the app
+                        // url is called first in the happy path so the promise will have resolved by then
+                        // otherwise, if they navigate back without authenticating, remove the listener and cancel the login
+
+                        // eslint-disable-next-line
+                        onFinish()
+                    }
+                },
+                appStateImpl,
+            )
+            unlisteners.push(unlistenAppState)
+            // open in the browser if in app browsers are not supported
+            linkingImpl.openURL(authUrl)
+        }
     })
 }
 

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -59,7 +59,11 @@ const authWithDeepRedirect = async (
             if (!url) {
                 rej('Sign-in cancelled')
             } else {
-                res(await extractTokenAndValidateState(url))
+                try {
+                    res(await extractTokenAndValidateState(url))
+                } catch (e) {
+                    rej(e)
+                }
             }
         }
 
@@ -80,8 +84,8 @@ const authWithDeepRedirect = async (
                 enableDefaultShare: true,
             })
             // The deep link handler is called before the `InAppBrowser.open` promise resolves
-            // so we can tidy up happily here, in case there was a cancelled event
-            // this call may end up rejecting the promise _again_ (after it's already been
+            // so we can tidy up happily here in case there was a cancelled event.
+            // This call may end up rejecting the promise _again_ (after it's already been
             // resolved / rejected) but this is basically a noop
             onFinish()
         } else {

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -4946,6 +4946,11 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opn@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -5500,6 +5505,14 @@ react-native-in-app-utils@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.1.tgz#e8469804d7ceb8ad2b368dc2cc9b824c98ca387a"
   integrity sha512-DHWgQTR+SSmVy+eLEXFJNOfsdvfHmU6y5k91W34x+pt4y/q2wo5++2RQZD/KDpHm89LYKDN1XKCojHFM6//xWQ==
+
+react-native-inappbrowser-reborn@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.0.1.tgz#85f973fd821b9f67359681147d004ef9cf690b4d"
+  integrity sha512-W1aYWm9/bR6bOWWDJFo6c8w1ivnOC8Z+juUDTAXjH+COaDR5opXHHx8+KL0HZZW6CeyGcnbU/l7l1R2TO7GXBQ==
+  dependencies:
+    invariant "^2.2.4"
+    opencollective-postinstall "^2.0.2"
 
 react-native-keychain@^3.1.3:
   version "3.1.3"

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -42,6 +42,7 @@
     "node-fetch": "^2.6.0",
     "node-vibrant": "^3.1.3",
     "ramda": "^0.26.1",
+    "react-native-inappbrowser-reborn": "^3.0.1",
     "striptags": "^3.1.1",
     "ts-optchain": "^0.1.8",
     "utility-types": "^3.7.0"

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -3452,6 +3452,11 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -3845,6 +3850,14 @@ react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-native-inappbrowser-reborn@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.0.1.tgz#85f973fd821b9f67359681147d004ef9cf690b4d"
+  integrity sha512-W1aYWm9/bR6bOWWDJFo6c8w1ivnOC8Z+juUDTAXjH+COaDR5opXHHx8+KL0HZZW6CeyGcnbU/l7l1R2TO7GXBQ==
+  dependencies:
+    invariant "^2.2.4"
+    opencollective-postinstall "^2.0.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Why are you doing this?

This adds an in-app browser for the social flows for supporting devices, otherwise it falls back to the external browser.

Additionally, this fixes Modals being rendered "underneath" transparent cards on Android ... again ...

[**Trello Card ->**](https://trello.com/c/CJn25tOl/446-in-app-browser-for-social-login-flows)

## Screenshots

### iOS
<img src="https://user-images.githubusercontent.com/1652187/64192067-c39d4100-ce71-11e9-9176-ccd63514c11e.gif" width="200" />

### Android
<img src="https://user-images.githubusercontent.com/1652187/64240619-19b5c700-cefa-11e9-8c90-1552371f9245.gif" width="200" />


