### PR TITLE
Make universal framework only support iPhoneOS OR iPhoneSimulator

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -701,7 +701,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\"\n";
+			shellScript = "\"$SRCROOT/../ophan/gradlew\" -p \"$SRCROOT/../ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\" \\\n-Pkotlin.valid.archs=\"$VALID_ARCHS\"\n";
 		};
 		9A2F30EB4995BA18D2B5CA7D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -57,13 +57,22 @@ kotlin {
 
 task fatFramework(type: FatFrameworkTask) {
     def buildType = project.findProperty('kotlin.build.type') ?: 'DEBUG'
+    def validArchs = project.findProperty('kotlin.valid.archs') ?: 'x86_64'
+    println("validArchs=" + validArchs)
     baseName = "ophan"
     destinationDir = file("$buildDir/bin/ios/universalFramework")
-    from(
-            kotlin.targets.ios.binaries.getFramework(buildType),
-            kotlin.targets.ios32.binaries.getFramework(buildType),
-            kotlin.targets.ios64.binaries.getFramework(buildType)
-    )
+    if (validArchs == 'x86_64') {
+        from(
+                kotlin.targets.ios.binaries.getFramework(buildType),
+                kotlin.targets.ios32.binaries.getFramework(buildType),
+                kotlin.targets.ios64.binaries.getFramework(buildType)
+        )
+    } else {
+        from(
+                kotlin.targets.ios32.binaries.getFramework(buildType),
+                kotlin.targets.ios64.binaries.getFramework(buildType)
+        )
+    }
 }
 
 // This task attaches native framework built from ios module to Xcode project


### PR DESCRIPTION
## Why are you doing this?

Fixes the build by using only the required architectures in the right places.