### PR TITLE
Add setUserId function for Ophan

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
@@ -12,24 +12,33 @@ import java.io.File;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import ophan.OphanApi;
 
 class RNOphanModule extends ReactContextBaseJavaModule {
 
-    private final OphanApi ophanApi;
+    @Nonnull
+    private final File recordStoreDir;
+
+    @Nonnull
+    private OphanApi ophanApi;
 
     public RNOphanModule(@Nonnull ReactApplicationContext reactContext) {
         super(reactContext);
-        final File recordStoreDir = new File(reactContext.getCacheDir(), "ophan");
-        ophanApi = new OphanApi(
+        recordStoreDir = new File(reactContext.getCacheDir(), "ophan");
+        ophanApi = newOphanApi(null);
+    }
+
+    private OphanApi newOphanApi(@Nullable String userId) {
+        return new OphanApi(
                 "Android Editions",
                 BuildConfig.VERSION_NAME,
                 Build.VERSION.RELEASE,
                 Build.MODEL,
                 Build.MANUFACTURER,
                 "testDeviceId",
-                "testUserId",
+                userId,
                 new LogcatLogger(),
                 recordStoreDir.getAbsolutePath()
         );
@@ -39,6 +48,16 @@ class RNOphanModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "Ophan";
+    }
+
+    @ReactMethod
+    public void setUserId(@Nullable String userId, Promise promise) {
+        try {
+            ophanApi = newOphanApi(userId);
+            promise.resolve(userId);
+        } catch (Throwable e) {
+            promise.reject(e);
+        }
     }
 
     @ReactMethod

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.m
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.m
@@ -11,11 +11,12 @@
 @interface RCT_EXTERN_MODULE(Ophan, NSObject)
 
 RCT_EXTERN_METHOD(sendTestAppScreenEvent: (NSString)screenName
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject
-                  )
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(setUserId: (NSString)userId)
+RCT_EXTERN_METHOD(setUserId: (NSString)userId
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
                   
 
 @end

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.m
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.m
@@ -14,6 +14,8 @@ RCT_EXTERN_METHOD(sendTestAppScreenEvent: (NSString)screenName
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   )
+
+RCT_EXTERN_METHOD(setUserId: (NSString)userId)
                   
 
 @end

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
@@ -33,11 +33,10 @@ class Ophan: NSObject {
   }
   
   private func newOphanApi(userId: String?) -> OphanApi {
-  
     let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
     
-    // TODO: Antonio has an objective-C snippet for this but I need his help to turn it into Swiftt
+    // This snippet gets the current device's model name
     var systemInfo = utsname()
     uname(&systemInfo)
     let modelCode = withUnsafePointer(to: &systemInfo.machine) {

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
@@ -58,9 +58,10 @@ class Ophan: NSObject {
     )
   }
   
-  @objc(setUserId:)
-  func setUserId(_ userId: String) -> Void {
+  @objc(setUserId:resolver:rejecter:)
+  func setUserId(_ userId: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock) -> Void {
     ophanApi = newOphanApi(userId: userId)
+    resolve(userId)
   }
 
   @objc(sendTestAppScreenEvent:resolver:rejecter:)

--- a/projects/Mallard/ophan/build.gradle
+++ b/projects/Mallard/ophan/build.gradle
@@ -35,7 +35,7 @@ kotlin {
                 implementation kotlin('stdlib-common')
                 implementation("io.ktor:ktor-client-core:1.2.3")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.3.0-RC")
-                api 'com.gu.kotlin:multiplatform-ophan:0.1.3'
+                api 'com.gu.kotlin:multiplatform-ophan:0.1.5'
             }
         }
         androidMain {

--- a/projects/Mallard/ophan/src/commonMain/kotlin/ophan/Ophan.kt
+++ b/projects/Mallard/ophan/src/commonMain/kotlin/ophan/Ophan.kt
@@ -22,7 +22,7 @@ class OphanApi(
             deviceName: String,
             deviceManufacturer: String,
             deviceId: String,
-            userId: String,
+            userId: String?,
             logger: Logger,
             recordStorePath: String
     ) : this(OphanDispatcher(

--- a/projects/Mallard/ophan/src/iosMain/kotlin/ophan/Ophan.kt
+++ b/projects/Mallard/ophan/src/iosMain/kotlin/ophan/Ophan.kt
@@ -10,7 +10,7 @@ fun getThreadSafeOphanApi(
         deviceName: String,
         deviceManufacturer: String,
         deviceId: String,
-        userId: String,
+        userId: String?,
         logger: Logger,
         recordStorePath: String
 ): OphanApi = OphanApi(appFamily, appVersion, appOsVersion, deviceName, deviceManufacturer, deviceId, userId, logger, recordStorePath).freeze()

--- a/projects/Mallard/src/services/ophan.ts
+++ b/projects/Mallard/src/services/ophan.ts
@@ -1,0 +1,9 @@
+import { NativeModules } from 'react-native'
+
+type UserId = string | null
+
+const setUserId = (userId: UserId): Promise<UserId> => {
+    return NativeModules.Ophan.setUserId(userId)
+}
+
+export { setUserId }


### PR DESCRIPTION
## Why are you doing this?

So that tracking calls made by Ophan can be properly attributed to signed-in users.

[**Trello Card ->**](https://trello.com/c/Gk4RDfwf/525-ophan-initialiser)

## Changes

* Add `setUserId` function to both Android and iOS versions of the Ophan native module. This function takes a single string argument which is the new user ID to be used for subsequent tracking calls, and returns a promise which is either resolved with that ID (?) or rejected with an error.
* This function is not used from React Native land yet, but it should be called:
  1. when the user logs in, and
  2. immediately on app start, if the user is already logged in.