### PR TITLE
Changing the pecking order of template application

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -11,15 +11,15 @@ const articleTypePicker = (article: IContent): ArticleType => {
 
     const isImmersive: boolean =
         (article.fields && article.fields.displayHint === 'immersive') || false
-    const isLongRead: boolean =
-        isTagPresent('theguardian/journal/the-long-read') && isImmersive
+    const isLongRead: boolean = isTagPresent(
+        'theguardian/journal/the-long-read',
+    )
     const isSeries: boolean = isTagPresent('tone/special-report') && isImmersive
     const isInterview: boolean = isTagPresent('tone/interview')
     const isObituary: boolean = isTagPresent('tone/obituaries')
     const isAnalysis: boolean = isTagPresent('tone/analysis')
     const isComment: boolean = isTagPresent('tone/comment')
-    const isLetter: boolean =
-        isTagPresent('tone/lettertotheeditor') && isImmersive
+    const isLetter: boolean = isTagPresent('tone/lettertotheeditor')
     const isFeature: boolean = isTagPresent('tone/features')
     const isGallery: boolean = isTagPresent('type/gallery')
     const isReview: boolean = isTagPresent('tone/reviews')
@@ -32,39 +32,45 @@ const articleTypePicker = (article: IContent): ArticleType => {
     if (article.pillarName) {
         switch (article.pillarName.toLowerCase()) {
             case 'news':
-                if (isLongRead) return ArticleType.Longread
-                else if (isSeries) return ArticleType.Series
+                if (isSeries) return ArticleType.Series
+                else if (isImmersive) return ArticleType.Immersive
                 else if (isInterview) return ArticleType.Interview
-                else if (isAnalysis) return ArticleType.Analysis
+                else if (isLongRead) return ArticleType.Longread
                 else if (isObituary) return ArticleType.Obituary
+                else if (isAnalysis) return ArticleType.Analysis
                 else return ArticleType.Article
 
             case 'sport':
-                if (isMatchResult) return ArticleType.MatchResult
+                if (isSeries) return ArticleType.Series
+                else if (isImmersive) return ArticleType.Immersive
                 else if (isInterview) return ArticleType.Interview
                 else if (isLongRead) return ArticleType.Longread
-                else if (isAnalysis) return ArticleType.Analysis
+                else if (isMatchResult) return ArticleType.MatchResult
                 else if (isObituary) return ArticleType.Obituary
+                else if (isAnalysis) return ArticleType.Analysis
                 else return ArticleType.Article
 
             case 'opinion':
             case 'journal':
-                if (isComment) return ArticleType.Opinion
+                if (isSeries) return ArticleType.Series
+                else if (isImmersive) return ArticleType.Immersive
                 else if (isLongRead) return ArticleType.Longread
-                else if (isLetter) return ArticleType.Letter
                 else if (isObituary) return ArticleType.Obituary
                 else if (isAnalysis) return ArticleType.Analysis
+                else if (isLetter) return ArticleType.Letter
+                else if (isComment) return ArticleType.Opinion
                 else return ArticleType.Article
 
             case 'lifestyle':
-                if (isRecipe) return ArticleType.Recipe
-                else if (isInterview) return ArticleType.Interview
-                else if (isObituary) return ArticleType.Obituary
+                if (isImmersive) return ArticleType.Immersive
                 else if (isReview) return ArticleType.Review
-                else if (isGallery) return ArticleType.Gallery
+                else if (isRecipe) return ArticleType.Recipe
+                else if (isInterview) return ArticleType.Interview
+                else if (isLongRead) return ArticleType.Longread
+                else if (isObituary) return ArticleType.Obituary
                 else if (isAnalysis) return ArticleType.Analysis
+                else if (isGallery) return ArticleType.Gallery
                 else if (isFeature) return ArticleType.Feature
-                else if (isImmersive) return ArticleType.Immersive
                 else return ArticleType.Article
 
             case 'culture':
@@ -76,10 +82,12 @@ const articleTypePicker = (article: IContent): ArticleType => {
             case 'classical':
             case 'arts':
                 if (isReview) return ArticleType.Review
-                else if (isObituary) return ArticleType.Obituary
-                else if (isFeature) return ArticleType.Feature
-                else if (isAnalysis) return ArticleType.Analysis
                 else if (isImmersive) return ArticleType.Immersive
+                else if (isInterview) return ArticleType.Interview
+                else if (isLongRead) return ArticleType.Longread
+                else if (isObituary) return ArticleType.Obituary
+                else if (isAnalysis) return ArticleType.Analysis
+                else if (isFeature) return ArticleType.Feature
                 else return ArticleType.Article
 
             default:


### PR DESCRIPTION
Based on review with Ana P this is to address some issues with articleType being set sub-optimally.

## Why are you doing this?

[**Trello Card ->**](https://trello.com/c/Puvf7hXs/592-incorrect-articletype-assigned-to-stories)

## Changes

* Removed the need for immersive to be applied to select longread and letters
* Changed the application logic for each 'pillar' to meet design
* Added additional templates to some 'pillars' that were previously excluded.
