### PR TITLE
Properly set Ophan deviceId

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.guardian.editions.BuildConfig;
 
 import java.io.File;
@@ -28,11 +29,16 @@ class RNOphanModule extends ReactContextBaseJavaModule {
                 Build.VERSION.RELEASE,
                 Build.MODEL,
                 Build.MANUFACTURER,
-                "testDeviceId",
+                getDeviceId(),
                 "testUserId",
                 new LogcatLogger(),
                 recordStoreDir.getAbsolutePath()
         );
+    }
+
+    @Nonnull
+    private static String getDeviceId() {
+        return FirebaseInstanceId.getInstance().getId();
     }
 
     @Nonnull

--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.swift
@@ -42,7 +42,7 @@ class Ophan: NSObject {
       appOsVersion: UIDevice.current.systemVersion,
       deviceName: deviceName,
       deviceManufacturer: "Apple",
-      deviceId: "testDeviceId",
+      deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "",
       userId: "testUserId",
       logger: SimpleLogger(),
       recordStorePath: "ophan"


### PR DESCRIPTION
## Why are you doing this?

So that events sent to Ophan are each attributable to a particular device.

[**Trello Card ->**](https://trello.com/c/Gk4RDfwf/525-ophan-initialiser)

## Changes

* On iOS set the `deviceId` to `UIDevice.current.identifierForVendor`
* On Android set the `deviceId` to `FirebaseInstanceId.getInstance().getId()`