### PR TITLE
Don't re-render after netinfo update

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -16,7 +16,7 @@ import { FSPaths } from 'src/paths'
 import ProgressCircle from 'react-native-progress-circle'
 import { color } from 'src/theme/color'
 import { imageForScreenSize } from 'src/helpers/screen'
-import { useNetInfo } from '@react-native-community/netinfo'
+import { fetch } from '@react-native-community/netinfo'
 import { useToast } from 'src/hooks/use-toast'
 import { DOWNLOAD_ISSUE_MESSAGE_OFFLINE } from 'src/helpers/words'
 
@@ -41,11 +41,6 @@ const getStatusPercentage = (status: DLStatus): number | null => {
     return null
 }
 
-const getBGTransparency = (dlStatus: DLStatus | null) =>
-    dlStatus && dlStatus.type === 'download'
-        ? (getStatusPercentage(dlStatus) || 100) / 100
-        : 0
-
 const IssueRow = ({
     issue,
     onPress,
@@ -63,16 +58,14 @@ const IssueRow = ({
 
     const { showToast } = useToast()
 
-    const { isConnected } = useNetInfo()
-
     useEffect(() => {
         // we probably need a better check for this
         // e.g. do we have issue json and images?
         RNFetchBlob.fs.exists(FSPaths.issue(issue.key)).then(setExists)
     }, [issue.key])
 
-    const onDownloadIssue = () => {
-        if (isConnected && !dlStatus) {
+    const onDownloadIssue = async () => {
+        if ((await fetch()).isConnected && !dlStatus) {
             downloadAndUnzipIssue(issue.key, imageForScreenSize(), status => {
                 setDlStatus(status)
                 if (status.type === 'success') {


### PR DESCRIPTION
## Why are you doing this?

Nothing in the React tree actually depends on `isConnected`, we only care about it when the download callback runs. However, because we had a hook, every connection status change would force a re-render of the `IssueRow`.

This change removes the hook that causes the update and uses `fetch` to get the status in the callback.