### PR TITLE
Fix dep length to 1

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -84,27 +84,25 @@ const FrontWithResponse = ({
 
     const [scrollX] = useState(() => new Animated.Value(0))
     const flatListRef = useRef<AnimatedFlatListRef | undefined>()
-    const [cards, articleNavigator]: [FlatCard[], ArticleNavigator] = useMemo(
-        () => {
-            const flatCollections = flattenCollectionsToCards(
-                frontData.collections,
-            )
-            const navigator = {
-                articles: flattenFlatCardsToFront(flatCollections).map(
-                    ({ article, collection }) => ({
-                        collection: collection.key,
-                        front: frontData.key,
-                        article: article.key,
-                        issue,
-                    }),
-                ),
-                appearance: frontData.appearance,
-                frontName: frontData.displayName || '',
-            }
-            return [flatCollections, navigator]
-        },
-        frontData.collections.map(({ key }) => key), // eslint-disable-line react-hooks/exhaustive-deps
-    )
+    const [cards, articleNavigator]: [
+        FlatCard[],
+        ArticleNavigator,
+    ] = useMemo(() => {
+        const flatCollections = flattenCollectionsToCards(frontData.collections)
+        const navigator = {
+            articles: flattenFlatCardsToFront(flatCollections).map(
+                ({ article, collection }) => ({
+                    collection: collection.key,
+                    front: frontData.key,
+                    article: article.key,
+                    issue,
+                }),
+            ),
+            appearance: frontData.appearance,
+            frontName: frontData.displayName || '',
+        }
+        return [flatCollections, navigator]
+    }, [frontData.collections.map(({ key }) => key).join(',')]) // eslint-disable-line react-hooks/exhaustive-deps
     const stops = cards.length
     const { card, container } = useIssueScreenSize()
 


### PR DESCRIPTION
## Why are you doing this?

React seems to crap out when the length of dependencies change, this change fixes the length of dependencies to 1 so that React doesn't error, while preserving the same semantics.