### PR TITLE
Improve privacy policy in onboarding.

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
     },
 })
 
-const persistenceKey = 'dev-nav-key-232asdf1asdfa347'
+const persistenceKey = 'dev-nav-key-232asdf1asdfa3410'
 
 const persistNavigationState = async (navState: any) => {
     try {

--- a/projects/Mallard/src/components/link.tsx
+++ b/projects/Mallard/src/components/link.tsx
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
     },
 })
 
-export const Link = ({
+const Link = ({
     children,
     style,
     href,
@@ -27,3 +27,19 @@ export const Link = ({
         {children}
     </Text>
 )
+
+const LinkNav = ({
+    children,
+    style,
+    onPress,
+}: {
+    children: string
+    style?: TextProps['style']
+    onPress: () => void
+}) => (
+    <Text style={[styles.link, style]} onPress={onPress}>
+        {children}
+    </Text>
+)
+
+export { Link, LinkNav }

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -19,5 +19,6 @@ export const ERR_404_REMOTE = `Couldn't find item`
 export const PREFS_SAVED_MSG = 'Your preferences are saved.'
 
 export const PRIVACY_SETTINGS_HEADER_TITLE = 'Privacy Settings'
+export const PRIVACY_POLICY_HEADER_TITLE = 'Privacy Policy'
 export const REFRESH_BUTTON_TEXT = 'Refresh'
 export const DOWNLOAD_ISSUE_MESSAGE_OFFLINE = `You're currently offline. You can download it when you go online`

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -4,6 +4,8 @@ import {
     createStackNavigator,
     createSwitchNavigator,
     NavigationScreenProp,
+    StackViewTransitionConfigs,
+    NavigationTransitionProps,
 } from 'react-navigation'
 import { shouldShowOnboarding } from 'src/helpers/settings'
 import { useOtherSettingsValues } from 'src/hooks/use-settings'
@@ -23,7 +25,10 @@ import {
     GdprConsentScreenForOnboarding,
 } from 'src/screens/settings/gdpr-consent-screen'
 import { HelpScreen } from 'src/screens/settings/help-screen'
-import { PrivacyPolicyScreen } from 'src/screens/settings/privacy-policy-screen'
+import {
+    PrivacyPolicyScreen,
+    PrivacyPolicyScreenForOnboarding,
+} from 'src/screens/settings/privacy-policy-screen'
 import { TermsAndConditionsScreen } from 'src/screens/settings/terms-and-conditions-screen'
 import { color } from 'src/theme/color'
 import { ArticleScreen } from '../screens/article-screen'
@@ -43,6 +48,30 @@ const navOptionsWithGraunHeader = {
         borderBottomColor: color.text,
     },
     headerTintColor: color.textOverPrimary,
+}
+
+/* The screens you add to IOS_MODAL_ROUTES will have the modal transition. I.e they will slide up from the bottom. */
+const IOS_MODAL_ROUTES = [
+    routeNames.onboarding.PrivacyPolicyInline,
+    routeNames.onboarding.OnboardingConsentInline,
+]
+
+const dynamicModalTransition = (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps: NavigationTransitionProps,
+) => {
+    const isModal = IOS_MODAL_ROUTES.some(
+        screenName =>
+            screenName === transitionProps.scene.route.routeName ||
+            (prevTransitionProps &&
+                screenName === prevTransitionProps.scene.route.routeName),
+    )
+
+    return StackViewTransitionConfigs.defaultTransitionConfig(
+        transitionProps,
+        prevTransitionProps,
+        isModal,
+    )
 }
 
 const AppStack = createModalNavigator(
@@ -97,15 +126,25 @@ const OnboardingStack = createModalNavigator(
                                         routeNames.onboarding
                                             .OnboardingConsentInline,
                                     ),
+                                onOpenPrivacyPolicy: () =>
+                                    nav.navigate(
+                                        routeNames.onboarding
+                                            .PrivacyPolicyInline,
+                                    ),
                             }),
                         ),
                         navigationOptions: {
                             header: null,
                         },
                     },
+                    [routeNames.onboarding
+                        .OnboardingConsentInline]: GdprConsentScreenForOnboarding,
+                    [routeNames.onboarding
+                        .PrivacyPolicyInline]: PrivacyPolicyScreenForOnboarding,
                 },
                 {
-                    mode: 'modal',
+                    headerMode: 'none',
+                    transitionConfig: dynamicModalTransition,
                     defaultNavigationOptions: {
                         ...navOptionsWithGraunHeader,
                     },
@@ -116,14 +155,7 @@ const OnboardingStack = createModalNavigator(
             headerMode: 'none',
         },
     ),
-    {
-        [routeNames.onboarding.OnboardingConsentInline]: createStackNavigator(
-            {
-                GdprConsentScreenForOnboarding,
-            },
-            { headerMode: 'none' },
-        ),
-    },
+    {},
 )
 const RootNavigator = createAppContainer(
     createStackNavigator(

--- a/projects/Mallard/src/navigation/routes.ts
+++ b/projects/Mallard/src/navigation/routes.ts
@@ -18,5 +18,6 @@ export const routeNames = {
         OnboardingStart: 'OnboardingStart',
         OnboardingConsent: 'OnboardingConsent',
         OnboardingConsentInline: 'OnboardingConsentInline',
+        PrivacyPolicyInline: 'PrivacyPolicyInline',
     },
 }

--- a/projects/Mallard/src/screens/onboarding-screen.tsx
+++ b/projects/Mallard/src/screens/onboarding-screen.tsx
@@ -41,15 +41,20 @@ const OnboardingIntroScreen = ({ onContinue }: { onContinue: () => void }) => {
 const OnboardingConsentScreen = ({
     onOpenGdprConsent,
     onContinue,
+    onOpenPrivacyPolicy,
 }: {
     onOpenGdprConsent: () => void
     onContinue: () => void
+    onOpenPrivacyPolicy: () => void
 }) => {
     const setSetting = useSettings()
     return (
         <Frame>
             <OnboardingConsent
-                {...{ onOpenGdprConsent }}
+                {...{
+                    onOpenGdprConsent,
+                    onOpenPrivacyPolicy,
+                }}
                 onContinue={() => {
                     onOpenGdprConsent()
                     setSetting('hasOnboarded', true)

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -5,10 +5,10 @@ import {
     CardAppearance,
 } from 'src/components/onboarding/onboarding-card'
 import { ButtonAppearance } from 'src/components/button/button'
-import { FEEDBACK_EMAIL, COOKIE_LINK, PRIVACY_LINK } from 'src/helpers/words'
+import { FEEDBACK_EMAIL } from 'src/helpers/words'
 import { useGdprSwitches } from 'src/hooks/use-settings'
 import { ModalButton } from 'src/components/modal-button'
-import { Link } from 'src/components/link'
+import { LinkNav } from 'src/components/link'
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
     <View
@@ -60,9 +60,11 @@ const OnboardingIntro = ({ onContinue }: { onContinue: () => void }) => {
 const OnboardingConsent = ({
     onOpenGdprConsent,
     onContinue,
+    onOpenPrivacyPolicy,
 }: {
     onOpenGdprConsent: () => void
     onContinue: () => void
+    onOpenPrivacyPolicy: () => void
 }) => {
     const { enableNulls } = useGdprSwitches()
     return (
@@ -106,8 +108,10 @@ const OnboardingConsent = ({
                         We use cookies and similar technology to improve your
                         experience and also to allow us to improve our service.
                         To find out more, read our{' '}
-                        <Link href={PRIVACY_LINK}>privacy policy</Link> and{' '}
-                        <Link href={COOKIE_LINK}>cookie policy</Link>.
+                        <LinkNav onPress={onOpenPrivacyPolicy}>
+                            privacy policy
+                        </LinkNav>
+                        .
                     </>
                 }
             </OnboardingCard>

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
-import { FlatList, View, Alert } from 'react-native'
+import { FlatList, View, Alert, Text } from 'react-native'
 import { Button, ButtonAppearance } from 'src/components/button/button'
 import { ScrollContainer } from 'src/components/layout/ui/container'
 import { Footer, Separator, TallRow } from 'src/components/layout/ui/row'
 import { ThreeWaySwitch } from 'src/components/layout/ui/switch'
-import { Link } from 'src/components/link'
+import { LinkNav } from 'src/components/link'
 import { UiBodyCopy } from 'src/components/styled-text'
 import { GdprSwitchSettings } from 'src/helpers/settings'
 import {
-    COOKIE_LINK,
-    PRIVACY_LINK,
     PREFS_SAVED_MSG,
     PRIVACY_SETTINGS_HEADER_TITLE,
 } from 'src/helpers/words'
@@ -23,6 +21,7 @@ import { WithAppAppearance } from 'src/theme/appearance'
 import { useToast } from 'src/hooks/use-toast'
 import { LoginHeader } from 'src/components/login/login-layout'
 import { NavigationInjectedProps } from 'react-navigation'
+import { routeNames } from 'src/navigation/routes'
 
 interface GdprSwitch {
     key: keyof GdprSwitchSettings
@@ -104,7 +103,7 @@ const GdprConsent = ({
     return (
         <View>
             {shouldShowDismissableHeader ? (
-                <LoginHeader onDismiss={() => onDismiss()}>
+                <LoginHeader onDismiss={onDismiss}>
                     {PRIVACY_SETTINGS_HEADER_TITLE}
                 </LoginHeader>
             ) : (
@@ -118,10 +117,17 @@ const GdprConsent = ({
                         and similar technologies for this service. These
                         technologies are provided by us and by our third-party
                         partners. To find out more, read our{' '}
-                        <Link href={PRIVACY_LINK}>privacy policy</Link> and{' '}
-                        <Link href={COOKIE_LINK}>cookie policy</Link>. If you
-                        disable a category, you may need to restart the app for
-                        your changes to fully take effect.
+                        <LinkNav
+                            onPress={() =>
+                                navigation.navigate(
+                                    routeNames.onboarding.PrivacyPolicyInline,
+                                )
+                            }
+                        >
+                            privacy policy
+                        </LinkNav>
+                        . If you disable a category, you may need to restart the
+                        app for your changes to fully take effect.
                     </>
                 }
                 proxy={

--- a/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
+++ b/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import { DefaultInfoTextWebview } from './default-info-text-webview'
+import { LoginHeader } from 'src/components/login/login-layout'
+import { PRIVACY_POLICY_HEADER_TITLE } from 'src/helpers/words'
+import { NavigationInjectedProps } from 'react-navigation'
+import { routeNames } from 'src/navigation/routes'
 
 const privacyPolicyHtml = require('src/constants/settings/privacy-policy.json')
     .bodyHtml
@@ -9,7 +13,18 @@ const PrivacyPolicyScreen = () => (
 )
 
 PrivacyPolicyScreen.navigationOptions = {
-    title: 'Privacy Policy',
+    title: PRIVACY_POLICY_HEADER_TITLE,
 }
 
-export { PrivacyPolicyScreen }
+const PrivacyPolicyScreenForOnboarding = ({
+    navigation,
+}: NavigationInjectedProps) => (
+    <>
+        <LoginHeader onDismiss={() => navigation.goBack()}>
+            {PRIVACY_POLICY_HEADER_TITLE}
+        </LoginHeader>
+        <DefaultInfoTextWebview html={privacyPolicyHtml} />
+    </>
+)
+
+export { PrivacyPolicyScreen, PrivacyPolicyScreenForOnboarding }


### PR DESCRIPTION
 - Open privacy policy in a webview to prevent link being opened via deep linking by app.
 - Make card slide up from bottom on ios.
 - Remove cookie policy link (we don't have cookie policy, nor do we use cookies so removing for now)