### PR TITLE
Change scheme back to debug

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
@@ -70,7 +70,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
## Why are you doing this?

When building locally, the build runs in `RELEASE` mode rather than `DEBUG`. @jimhunty this came in in cfd3d4e7c89e86dd58c786ad6eb4a47698c081ec - is there any reason this was committed or was it a mistake?