### PR TITLE
Rahb/main credit

### DIFF
--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -1,19 +1,36 @@
-import React, { ReactNode } from 'react'
-import { StyleSheet, ImageBackground, View } from 'react-native'
-import { Image as ImageT } from '../../common'
+import React, { ReactNode, useState } from 'react'
+import { StyleSheet, ImageBackground, View, Text } from 'react-native'
+import { CreditedImage } from '../../common'
 import { useMediaQuery } from 'src/hooks/use-screen'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { useImagePath } from 'src/hooks/use-image-paths'
+import { Button } from '../button/button'
+import { useArticle } from 'src/hooks/use-article'
+import { color } from 'src/theme/color'
+import { UiBodyCopy } from '../styled-text'
 
 const styles = StyleSheet.create({
-    image: {
+    wrapper: {
+        backgroundColor: 'black',
+        padding: 10,
         width: '100%',
+    },
+    credit: {
+        color: color.palette.neutral[100],
+    },
+    button: {
+        position: 'absolute',
+        bottom: 10,
+        right: 10,
+    },
+    buttonText: {
+        color: color.palette.neutral[100],
     },
     proxy: { position: 'absolute', bottom: 0, left: 0 },
 })
 
 interface PropTypes {
-    image: ImageT
+    image: CreditedImage
     style?: {}
     proxy?: ReactNode
     aspectRatio?: number
@@ -28,22 +45,58 @@ const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
 
     const path = useImagePath(image)
 
+    const [showCredit, setShowCredit] = useState(false)
+    const toggleCredit = () => setShowCredit(curr => !curr)
+    const [colors] = useArticle()
+
     return (
-        <ImageBackground
-            resizeMethod={'resize'}
+        <View
             style={[
-                styles.image,
                 style,
-                {
-                    aspectRatio: aspectRatio ? aspectRatio : defaultAspectRatio,
-                },
+                styles.wrapper,
+                { aspectRatio: aspectRatio ? aspectRatio : defaultAspectRatio },
             ]}
-            source={{
-                uri: path,
-            }}
         >
-            {proxy && <View style={styles.proxy}>{proxy}</View>}
-        </ImageBackground>
+            {image.credit && (
+                <UiBodyCopy
+                    weight="bold"
+                    style={[
+                        styles.credit,
+                        {
+                            display: showCredit ? 'flex' : 'none',
+                        },
+                    ]}
+                >
+                    {image.credit}
+                </UiBodyCopy>
+            )}
+            <ImageBackground
+                resizeMethod={'resize'}
+                style={[
+                    StyleSheet.absoluteFillObject,
+                    {
+                        display: showCredit ? 'none' : 'flex',
+                    },
+                ]}
+                source={{
+                    uri: path,
+                }}
+            >
+                {proxy && <View style={styles.proxy}>{proxy}</View>}
+            </ImageBackground>
+            {image.credit && (
+                <Button
+                    alt="Toggle credit"
+                    icon={showCredit ? '' : ''}
+                    onPress={toggleCredit}
+                    style={styles.button}
+                    buttonStyles={{
+                        backgroundColor: colors.bright,
+                    }}
+                    textStyles={styles.buttonText}
+                />
+            )}
+        </View>
     )
 }
 
@@ -51,15 +104,7 @@ const CoverImage = ({
     small,
     ...props
 }: Omit<PropTypes, 'style' | 'aspectRatio'> & { small?: boolean }) => {
-    return (
-        <ArticleImage
-            {...props}
-            aspectRatio={small ? 1.18 : 0.95}
-            style={{
-                width: '100%',
-            }}
-        />
-    )
+    return <ArticleImage {...props} aspectRatio={small ? 1.18 : 0.95} />
 }
 
 export { ArticleImage, CoverImage }

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -16,7 +16,7 @@ import {
     BufferedTransport,
     CompactProtocol,
 } from '@creditkarma/thrift-server-core'
-import { getImage } from './assets'
+import { getImage, getCreditedImage } from './assets'
 import { elementParser } from './elements'
 import fetch from 'node-fetch'
 import { cleanupHtml } from '../utils/html'
@@ -25,6 +25,8 @@ import { kickerPicker } from './kickerPicker'
 import { getBylineImages } from './byline'
 import { rationaliseAtoms } from './atoms'
 import { articleTypePicker } from './articleTypePicker'
+import { CreditedImage } from '../../common/src'
+import { oc } from 'ts-optchain'
 
 type NotInCAPI =
     | 'key'
@@ -60,6 +62,28 @@ const truncateDateTime = (date: CapiDateTime64): CapiDateTime32 => ({
     dateTime: date.dateTime.toNumber(),
 })
 
+const getMainImage = (result: IContent): CreditedImage | undefined => {
+    const maybeMainImage = oc(result).blocks.main.elements[0]()
+    const maybeThumbnailElement =
+        result.elements &&
+        result.elements.find(element => element.relation === 'thumbnail')
+    const maybeThumbnailImage =
+        maybeThumbnailElement && getImage(maybeThumbnailElement.assets)
+
+    if (!maybeMainImage) {
+        console.warn(
+            `No main image in ${
+                result.id
+            } using thumbnail (${maybeThumbnailImage &&
+                maybeThumbnailImage.path}).`,
+        )
+    }
+
+    return maybeMainImage
+        ? getCreditedImage(maybeMainImage)
+        : maybeThumbnailImage
+}
+
 const parseArticleResult = async (
     result: IContent,
 ): Promise<[number, CAPIContent]> => {
@@ -88,27 +112,7 @@ const parseArticleResult = async (
     const byline = result.fields && result.fields.byline
     const bylineImages = getBylineImages(result)
 
-    const maybeMainImage =
-        result.blocks &&
-        result.blocks.main &&
-        result.blocks.main.elements &&
-        result.blocks.main.elements[0].assets &&
-        getImage(result.blocks.main.elements[0].assets)
-
-    const maybeThumbnailElement =
-        result.elements &&
-        result.elements.find(element => element.relation === 'thumbnail')
-    const maybeThumbnailImage =
-        maybeThumbnailElement && getImage(maybeThumbnailElement.assets)
-    const maybeImage = maybeMainImage || maybeThumbnailImage
-    if (maybeMainImage == null) {
-        console.warn(
-            `No main image in ${
-                result.id
-            } using thumbnail (${maybeThumbnailImage &&
-                maybeThumbnailImage.path}).`,
-        )
-    }
+    const maybeImage = getMainImage(result)
 
     const starRating = result.fields && result.fields.starRating
 

--- a/projects/backend/capi/assets.ts
+++ b/projects/backend/capi/assets.ts
@@ -1,6 +1,8 @@
-import { IAsset } from '@guardian/capi-ts'
+import { IAsset, IBlockElement } from '@guardian/capi-ts'
 import { Image } from '../common'
 import { getImageFromURL } from '../image'
+import { CreditedImage } from '../../common/src'
+import { oc } from 'ts-optchain'
 
 const extractImage: (
     assetArray: IAsset[],
@@ -35,4 +37,16 @@ export const getImage: (
         return
     }
     return getImageFromURL(asset.file)
+}
+
+export const getCreditedImage: (
+    element: IBlockElement,
+) => CreditedImage | undefined = element => {
+    const asset = extractImage(element.assets)
+    if (!(asset && asset.file)) {
+        console.warn('Image asset potentially invalid.', JSON.stringify(asset))
+        return
+    }
+    const image = getImageFromURL(asset.file)
+    return image && { ...image, credit: oc(element).imageTypeData.credit() }
 }

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -84,7 +84,7 @@ export interface Content extends WithKey {
     kicker: string
     articleType?: ArticleType
     trail: string
-    image?: Image
+    image?: CreditedImage
     standfirst?: string
     byline?: string
     bylineImages?: { thumbnail?: Image; cutout?: Image }
@@ -96,7 +96,6 @@ export interface Content extends WithKey {
 }
 export interface Article extends Content {
     type: 'article'
-    image?: Image
     byline: string
     standfirst: string
     elements: BlockElement[]
@@ -300,6 +299,10 @@ export const issueSummaryPath = () => 'issues'
 export interface Image {
     source: string
     path: string
+}
+
+export interface CreditedImage extends Image {
+    credit?: string
 }
 export interface Palette {
     //the palette from node-vibrant


### PR DESCRIPTION
## Why are you doing this?

This adds a toggle in the bottom corner of the main media whenever the image has a credit available.

[**Trello Card ->**](https://trello.com/c/bPElWriT/451-make-sure-credits-are-displayed-on-main-media-in-article)

## Changes

* Include data in backend model
* Add `CreditedImage` type
* Add toggle in front end

## Screenshots

<img src="https://user-images.githubusercontent.com/1652187/64432363-3f86cb80-d0b4-11e9-918b-387996f76ae0.gif" width="200" />

