### PR TITLE
Potentially re-authenticate after identity sign out

### DIFF
--- a/projects/Mallard/src/authentication/auth-context.tsx
+++ b/projects/Mallard/src/authentication/auth-context.tsx
@@ -201,10 +201,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
                 // and try to run authentication again
                 // otherwise, their identity sign in didn't affect their auth status
                 // so leave their auth status as is
-                if (
-                    isAuthed(authAttempt.status) &&
-                    isIdentity(authAttempt.status.data)
-                ) {
+                if (isIdentity(authAttempt.status)) {
                     setAuthAttempt(createAuthAttempt(unauthed, 'live'))
                     await runAuth()
                 }


### PR DESCRIPTION
## Why are you doing this?

Rather than _always_ removing authentication from a user when they sign out, we should try to re-authenticate a user if their successful authentication was down to their identity account. I.e., rerun the credential provider chain (knowing the identity part will fail) and see if they authenticate with either CAS or IAP (or any new methods of auth added in future). Only if they fail will they be unauthenticated.