### PR TITLE
chore: Hide downloaded issues menu

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -210,7 +210,7 @@ export const HomeScreen = ({
                             </FlexCenter>
                         ),
                 })}
-                {files.length > 0 && (
+                {files.length > 0 && __DEV__ && (
                     <>
                         <Heading>Issues on device</Heading>
                         <List


### PR DESCRIPTION
## Why are you doing this?

There's a small menu detailing issues on the device. This is for debug purposes and not on the designs.

## Changes

* Make this menu only appear in dev mode
