### PR TITLE
Add link to already subscribed

### DIFF
--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -163,6 +163,9 @@ const AuthSwitcherScreen = ({
             password={password}
             isLoading={isLoading}
             onDismiss={() => navigation.goBack()}
+            onHelpPress={() =>
+                navigation.navigate(routeNames.AlreadySubscribed)
+            }
             onFacebookPress={() =>
                 handleAuthClick(
                     () => facebookAuthWithDeepRedirect(validatorString),

--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -4,7 +4,7 @@ import { TitlepieceText } from 'src/components/styled-text'
 import { Button } from 'src/components/button/button'
 import { metrics } from 'src/theme/spacing'
 import { color } from 'src/theme/color'
-import { Link } from 'src/components/link'
+import { Link, LinkNav } from 'src/components/link'
 import { getFont } from 'src/theme/typography'
 import { FormField } from 'src/hooks/use-form-field'
 import { LoginLayout } from 'src/components/login/login-layout'
@@ -90,6 +90,7 @@ const Login = ({
     emailProgressText,
     submitText,
     resetLink,
+    onHelpPress,
 }: {
     title: string
     onFacebookPress: () => void
@@ -103,6 +104,7 @@ const Login = ({
     emailProgressText: string
     submitText: string
     resetLink: string
+    onHelpPress: () => void
 }) => {
     const [hasInputEmail, setHasInputEmail] = useState(false)
     const [showError, setShowError] = useState(false)
@@ -194,6 +196,12 @@ const Login = ({
                             Forgot password?
                         </Link>
                     )}
+                    <LinkNav
+                        style={loginStyles.resetLink}
+                        onPress={onHelpPress}
+                    >
+                        Have a subscription but cannot sign in?
+                    </LinkNav>
                 </View>
             </View>
         </LoginLayout>


### PR DESCRIPTION
## Why are you doing this?

As pre Trello card, simple link to the "Already subscribed" route.

[**Trello Card ->**](https://trello.com/c/5x4IGQX8/586-activation-flow-add-a-link-to-im-already-subscribed-to-both-sign-in-screens)