### PR TITLE
Add cache control headers to files uploaded to S3

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -17,7 +17,7 @@ export const backends = [
     },
     {
         title: 'CODE published',
-        value: 'https://editions-store-code.s3-eu-west-1.amazonaws.com/',
+        value: 'https://editions.code.dev-guardianapis.com/',
         preview: false,
     },
     {

--- a/projects/archiver/media.ts
+++ b/projects/archiver/media.ts
@@ -10,7 +10,7 @@ import {
     IssueCompositeKey,
 } from './common'
 import { getColours, getImage } from './src/downloader'
-import { upload } from './src/upload'
+import { upload, ONE_WEEK } from './src/upload'
 
 const getImageFromElement = (element: BlockElement): Image | undefined => {
     switch (element.id) {
@@ -59,7 +59,7 @@ export const getAndUploadColours = async (
         console.error(JSON.stringify(colours))
         return colours
     }
-    return attempt(upload(colourPath, colours, 'application/json', 3600))
+    return attempt(upload(colourPath, colours, 'application/json', ONE_WEEK))
 }
 
 export const getAndUploadImage = async (
@@ -69,5 +69,5 @@ export const getAndUploadImage = async (
 ) => {
     const [path, data] = await getImage(publishedId, image, size)
     if (hasFailed(data)) return data
-    return upload(path, data, 'image/jpeg', 3600)
+    return upload(path, data, 'image/jpeg', ONE_WEEK)
 }

--- a/projects/archiver/media.ts
+++ b/projects/archiver/media.ts
@@ -59,7 +59,7 @@ export const getAndUploadColours = async (
         console.error(JSON.stringify(colours))
         return colours
     }
-    return attempt(upload(colourPath, colours, 'application/json'))
+    return attempt(upload(colourPath, colours, 'application/json', 3600))
 }
 
 export const getAndUploadImage = async (
@@ -69,5 +69,5 @@ export const getAndUploadImage = async (
 ) => {
     const [path, data] = await getImage(publishedId, image, size)
     if (hasFailed(data)) return data
-    return upload(path, data, 'image/jpeg')
+    return upload(path, data, 'image/jpeg', 3600)
 }

--- a/projects/archiver/src/frontTask.ts
+++ b/projects/archiver/src/frontTask.ts
@@ -30,7 +30,7 @@ export const handler: Handler<IssueTaskOutput, FrontTaskOutput> = async ({
     const images = unnest(getImagesFromFront(maybeFront))
 
     const frontUpload = await attempt(
-        upload(frontPath(publishedId, frontId), maybeFront, 'application/json'),
+        upload(frontPath(publishedId, frontId), maybeFront, 'application/json', 60),
     )
 
     if (hasFailed(frontUpload)) {

--- a/projects/archiver/src/frontTask.ts
+++ b/projects/archiver/src/frontTask.ts
@@ -30,7 +30,12 @@ export const handler: Handler<IssueTaskOutput, FrontTaskOutput> = async ({
     const images = unnest(getImagesFromFront(maybeFront))
 
     const frontUpload = await attempt(
-        upload(frontPath(publishedId, frontId), maybeFront, 'application/json', ONE_WEEK),
+        upload(
+            frontPath(publishedId, frontId),
+            maybeFront,
+            'application/json',
+            ONE_WEEK,
+        ),
     )
 
     if (hasFailed(frontUpload)) {

--- a/projects/archiver/src/frontTask.ts
+++ b/projects/archiver/src/frontTask.ts
@@ -6,7 +6,7 @@ import { getImagesFromFront } from '../media'
 import { getFront } from './downloader'
 import { IssueTaskOutput } from './issueTask'
 import { bucket } from './s3'
-import { upload } from './upload'
+import { upload, ONE_WEEK } from './upload'
 
 export interface FrontTaskOutput extends IssueTaskOutput {
     images: Image[]
@@ -30,7 +30,7 @@ export const handler: Handler<IssueTaskOutput, FrontTaskOutput> = async ({
     const images = unnest(getImagesFromFront(maybeFront))
 
     const frontUpload = await attempt(
-        upload(frontPath(publishedId, frontId), maybeFront, 'application/json', 60),
+        upload(frontPath(publishedId, frontId), maybeFront, 'application/json', ONE_WEEK),
     )
 
     if (hasFailed(frontUpload)) {

--- a/projects/archiver/src/generateIndexTask.ts
+++ b/projects/archiver/src/generateIndexTask.ts
@@ -15,7 +15,7 @@ export const handler: Handler<IndexTaskOutput> = async ({ issueId }) => {
         console.error(index)
         throw new Error('Could not generate index.')
     }
-    await upload('issues', index, 'application/json')
+    await upload('issues', index, 'application/json', 60)
     return {
         issueId,
         index,

--- a/projects/archiver/src/generateIndexTask.ts
+++ b/projects/archiver/src/generateIndexTask.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda'
 import { attempt, hasFailed } from '../../backend/utils/try'
 import { IssueCompositeKey, IssueSummary } from '../common'
 import { indexer } from './indexer/summary'
-import { upload } from './upload'
+import { upload, ONE_MINUTE } from './upload'
 
 export interface IndexTaskOutput {
     issueId: IssueCompositeKey
@@ -15,7 +15,7 @@ export const handler: Handler<IndexTaskOutput> = async ({ issueId }) => {
         console.error(index)
         throw new Error('Could not generate index.')
     }
-    await upload('issues', index, 'application/json', 60)
+    await upload('issues', index, 'application/json', ONE_MINUTE)
     return {
         issueId,
         index,

--- a/projects/archiver/src/indexer/summary.ts
+++ b/projects/archiver/src/indexer/summary.ts
@@ -3,7 +3,7 @@ import { attempt, hasFailed } from '../../../backend/utils/try'
 import { ImageSize, imageSizes } from '../../../common/src'
 import { IssueSummary, notNull } from '../../common'
 import { bucket, s3 } from '../s3'
-import { upload } from '../upload'
+import { upload, ONE_MINUTE } from '../upload'
 
 const zips = 'zips/'
 
@@ -119,6 +119,6 @@ export const summary = async () => {
         console.error('Could not fetch index')
         return
     }
-    await upload('issues', index, 'application/json', 60)
+    await upload('issues', index, 'application/json', ONE_MINUTE)
     return
 }

--- a/projects/archiver/src/indexer/summary.ts
+++ b/projects/archiver/src/indexer/summary.ts
@@ -119,6 +119,6 @@ export const summary = async () => {
         console.error('Could not fetch index')
         return
     }
-    await upload('issues', index, 'application/json')
+    await upload('issues', index, 'application/json', 60)
     return
 }

--- a/projects/archiver/src/issueUploadTask.ts
+++ b/projects/archiver/src/issueUploadTask.ts
@@ -15,7 +15,7 @@ export const handler: Handler<MediaTaskOutput, UploadTaskOutput> = async ({
 }) => {
     const { publishedId } = issue
     const issueUpload = await attempt(
-        upload(issuePath(publishedId), issue, 'application/json'),
+        upload(issuePath(publishedId), issue, 'application/json', 60),
     )
     if (hasFailed(issueUpload)) {
         console.error(JSON.stringify(issueUpload))

--- a/projects/archiver/src/issueUploadTask.ts
+++ b/projects/archiver/src/issueUploadTask.ts
@@ -3,7 +3,7 @@ import { attempt, hasFailed } from '../../backend/utils/try'
 import { issuePath } from '../common'
 import { MediaTaskOutput } from './imageTask'
 import { IssueTaskOutput } from './issueTask'
-import { upload } from './upload'
+import { upload, ONE_WEEK } from './upload'
 
 export type UploadTaskOutput = Pick<
     IssueTaskOutput,
@@ -15,7 +15,7 @@ export const handler: Handler<MediaTaskOutput, UploadTaskOutput> = async ({
 }) => {
     const { publishedId } = issue
     const issueUpload = await attempt(
-        upload(issuePath(publishedId), issue, 'application/json', 60),
+        upload(issuePath(publishedId), issue, 'application/json', ONE_WEEK),
     )
     if (hasFailed(issueUpload)) {
         console.error(JSON.stringify(issueUpload))

--- a/projects/archiver/src/upload.ts
+++ b/projects/archiver/src/upload.ts
@@ -1,9 +1,17 @@
 import { s3, bucket } from './s3'
 
+function cacheControlHeader(maxAge: number | undefined): string {
+    if (maxAge) {
+        return `max-age=${maxAge}`
+    }
+    return 'private'
+}
+
 export const upload = (
     key: string,
     body: {} | Buffer,
     mime: 'image/jpeg' | 'application/json' | 'application/zip',
+    maxAge: number | undefined,
 ): Promise<{ etag: string }> => {
     return new Promise((resolve, reject) => {
         s3.upload(
@@ -13,6 +21,7 @@ export const upload = (
                 Key: `${key}`,
                 ACL: 'public-read',
                 ContentType: mime,
+                CacheControl: cacheControlHeader(maxAge),
             },
             (err, data) => {
                 if (err) {

--- a/projects/archiver/src/upload.ts
+++ b/projects/archiver/src/upload.ts
@@ -7,6 +7,9 @@ function cacheControlHeader(maxAge: number | undefined): string {
     return 'private'
 }
 
+export const ONE_WEEK = 3600 * 24 * 7
+export const ONE_MINUTE = 60
+
 export const upload = (
     key: string,
     body: {} | Buffer,

--- a/projects/archiver/zipper.ts
+++ b/projects/archiver/zipper.ts
@@ -29,6 +29,10 @@ export const zip = async (
             Prefix: prefix,
         })
         .promise()
+    // TODO: deal with paginating S3 responses
+    if (objects.IsTruncated) {
+        console.error("Object list from S3 was truncated which we don't currently deal with")
+    }
     const files = (objects.Contents || []).map(obj => obj.Key).filter(notNull)
 
     console.log('Got file names')

--- a/projects/archiver/zipper.ts
+++ b/projects/archiver/zipper.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from 'stream'
 import archiver = require('archiver')
 import { s3, bucket } from './src/s3'
+import { ONE_WEEK } from './src/upload'
 
 const notNull = <T>(value: T | null | undefined): value is T =>
     value !== null && value !== undefined
@@ -18,7 +19,7 @@ export const zip = async (
             Body: output,
             ACL: 'public-read',
             ContentType: 'application/zip',
-            CacheControl: 'max-age=604800', // one week
+            CacheControl: `max-age=${ONE_WEEK}`,
         })
         .promise()
 

--- a/projects/archiver/zipper.ts
+++ b/projects/archiver/zipper.ts
@@ -31,7 +31,9 @@ export const zip = async (
         .promise()
     // TODO: deal with paginating S3 responses
     if (objects.IsTruncated) {
-        console.error("Object list from S3 was truncated which we don't currently deal with")
+        console.error(
+            "Object list from S3 was truncated which we don't currently deal with",
+        )
     }
     const files = (objects.Contents || []).map(obj => obj.Key).filter(notNull)
 

--- a/projects/archiver/zipper.ts
+++ b/projects/archiver/zipper.ts
@@ -17,6 +17,8 @@ export const zip = async (
             Key: `zips/${name}.zip`,
             Body: output,
             ACL: 'public-read',
+            ContentType: 'application/zip',
+            CacheControl: 'max-age=604800', // one week
         })
         .promise()
 


### PR DESCRIPTION
## Why are you doing this?
We need to introduce a CDN in the path between app and S3 bucket for perfomance/cost reasons but primarily so that we can point the app at a domain we control rather than directly at a bucket.

The `maxAge` we have selected here is one week for everything except the `issues` index in the root which is one minute. One minute might prove to be frustrating so happy to lower this (or send a PURGE when we write it). One week should be fine as the paths all contain a version which is unique and will never be modified.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/a9oY1ITn)

## Changes

* Add CacheControl field to all locations we use s3 upload in archiver
* Add mime type to the zip uploader as it was missing