### PR TITLE
Add a custom domain to the preview API gateway

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -22,7 +22,7 @@ export const backends = [
     },
     {
         title: 'CODE preview',
-        value: 'https://d2mztzjulnpyb8.cloudfront.net/',
+        value: 'https://preview.editions.code.dev-guardianapis.com/',
         preview: true,
     },
     {

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -190,7 +190,7 @@ export class EditionsStack extends cdk.Stack {
 
         previewDomainName.addBasePathMapping(previewApi)
 
-        new CfnOutput(this, 'Preview-API-hostname', {
+        new CfnOutput(this, 'Preview-Api-Target-Hostname', {
             description: 'hostname',
             value: `${previewDomainName.domainNameAliasDomainName}`,
         })

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -107,19 +107,23 @@ export class EditionsStack extends cdk.Stack {
 
         const previewHostname = new cdk.CfnParameter(this, 'preview-hostname', {
             type: 'String',
-            description: 'Hostname of the preview endpoint'
+            description: 'Hostname of the preview endpoint',
         })
 
-        const previewCertificateArn = new cdk.CfnParameter(this, 'preview-certificate-arn', {
-            type: 'String',
-            description: 'ARN of ACM certificate for preview endpoint'
-        })
+        const previewCertificateArn = new cdk.CfnParameter(
+            this,
+            'preview-certificate-arn',
+            {
+                type: 'String',
+                description: 'ARN of ACM certificate for preview endpoint',
+            },
+        )
 
         const previewCertificate = acm.Certificate.fromCertificateArn(
             this,
             'preview-certificate',
             previewCertificateArn.valueAsString,
-            )
+        )
 
         const backendProps = (
             publicationStage: 'preview' | 'published',

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -8,6 +8,7 @@ import cloudfront = require('@aws-cdk/aws-cloudfront')
 import { CfnOutput, Duration } from '@aws-cdk/core'
 
 import { archiverStepFunction } from './step-function'
+import acm = require('@aws-cdk/aws-certificatemanager')
 export class EditionsStack extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props)
@@ -104,6 +105,22 @@ export class EditionsStack extends cdk.Stack {
             description: 'lambda access',
         })
 
+        const previewHostname = new cdk.CfnParameter(this, 'preview-hostname', {
+            type: 'String',
+            description: 'Hostname of the preview endpoint'
+        })
+
+        const previewCertificateArn = new cdk.CfnParameter(this, 'preview-certificate-arn', {
+            type: 'String',
+            description: 'ARN of ACM certificate for preview endpoint'
+        })
+
+        const previewCertificate = acm.Certificate.fromCertificateArn(
+            this,
+            'preview-certificate',
+            previewCertificateArn.valueAsString,
+            )
+
         const backendProps = (
             publicationStage: 'preview' | 'published',
         ): FunctionProps => ({
@@ -149,14 +166,32 @@ export class EditionsStack extends cdk.Stack {
             backendProps('published'),
         )
 
-        const gateway = new apigateway.LambdaRestApi(
+        const previewApi = new apigateway.LambdaRestApi(
             this,
             'editions-preview-backend-apigateway',
             {
                 handler: previewBackend,
             },
         )
-        const publishedGateway = new apigateway.LambdaRestApi(
+
+        const previewDomainName = new apigateway.DomainName(
+            this,
+            'preview-domain-name',
+            {
+                domainName: previewHostname.valueAsString,
+                certificate: previewCertificate,
+                endpointType: apigateway.EndpointType.REGIONAL,
+            },
+        )
+
+        previewDomainName.addBasePathMapping(previewApi)
+
+        new CfnOutput(this, 'Preview-API-hostname', {
+            description: 'hostname',
+            value: `${previewDomainName.domainNameAliasDomainName}`,
+        })
+
+        const publishedApi = new apigateway.LambdaRestApi(
             this,
             'editions-published-backend-apigateway',
             {
@@ -164,12 +199,12 @@ export class EditionsStack extends cdk.Stack {
             },
         )
 
-        const gatewayId = gateway.restApiId
-        const publishedGatewayId = publishedGateway.restApiId
+        const previewGatewayId = previewApi.restApiId
+        const publishedGatewayId = publishedApi.restApiId
 
         const backendURL = `${publishedGatewayId}.execute-api.eu-west-1.amazonaws.com/prod/` //Yes, this (the region) really should not be hard coded.
 
-        const dist = new cloudfront.CloudFrontWebDistribution(
+        const previewDist = new cloudfront.CloudFrontWebDistribution(
             this,
             'backend-cloudfront-distribution',
             {
@@ -185,7 +220,7 @@ export class EditionsStack extends cdk.Stack {
                             },
                         ],
                         customOriginSource: {
-                            domainName: `${gatewayId}.execute-api.eu-west-1.amazonaws.com`, //Yes, this (the region) really should not be hard coded.
+                            domainName: `${previewGatewayId}.execute-api.eu-west-1.amazonaws.com`, //Yes, this (the region) really should not be hard coded.
                         },
                     },
                 ],
@@ -193,7 +228,7 @@ export class EditionsStack extends cdk.Stack {
         )
         new CfnOutput(this, 'Cloudfront-distribution', {
             description: 'URL for distribution',
-            value: `https://${dist.domainName}`,
+            value: `https://${previewDist.domainName}`,
         })
 
         const archive = s3.Bucket.fromBucketName(


### PR DESCRIPTION
## Why are you doing this?
The main aim of this is to use a guardian owned domain rather than baking cloudfront domains into the app. At present this completely removes cloudfront from the loop but this could be added again later.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/a9oY1ITn/652-proper-domain-names-for-backend) 

## Changes

* Take preview domain and ACM cert as parameters
* Create custom domain and attach to API gateway endpoint

## Screenshots

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
