### PR TITLE
Enusre modal is closed after failed sign in

### DIFF
--- a/projects/Mallard/src/components/sign-in-failed-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-failed-modal-card.tsx
@@ -33,7 +33,10 @@ const SignInFailedModalCard = ({
     <OnboardingCard
         title="Subscription not found"
         appearance={CardAppearance.blue}
-        onDismissThisCard={onDismiss}
+        onDismissThisCard={() => {
+            close()
+            onDismiss()
+        }}
         size="medium"
         bottomContent={
             <>


### PR DESCRIPTION
## Why are you doing this?

Modals weren't closing when clicking the close button after a failed sign in. This fixes that.