### PR TITLE
Render more cards

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -141,8 +141,8 @@ const FrontWithResponse = ({
         >
             <Animated.FlatList
                 showsHorizontalScrollIndicator={false}
-                windowSize={3}
-                maxToRenderPerBatch={1}
+                windowSize={6}
+                maxToRenderPerBatch={3}
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
                 horizontal={true}


### PR DESCRIPTION
## Why are you doing this?
Should fix the iOS bug where cards stop appearing at the expense of android being a bit slower - I wish i could tell you WHY, I just know it does it :(