### PR TITLE
Don't display inline media offline for now

### DIFF
--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -96,10 +96,12 @@ export const render = (
         pillar,
         features,
         wrapLayout,
+        showInlineImages,
     }: {
         pillar: ArticlePillar
         features: ArticleFeatures[]
         wrapLayout: WrapLayout
+        showInlineImages: boolean
     },
 ) => {
     const content = article
@@ -120,7 +122,7 @@ export const render = (
                 case 'media-atom':
                     return renderMediaAtom(el)
                 case 'image':
-                    return Image({ imageElement: el })
+                    return showInlineImages ? Image({ imageElement: el }) : ''
                 case 'pullquote':
                     return Pullquote({
                         cite: el.html,

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -96,12 +96,12 @@ export const render = (
         pillar,
         features,
         wrapLayout,
-        showInlineImages,
+        showMedia,
     }: {
         pillar: ArticlePillar
         features: ArticleFeatures[]
         wrapLayout: WrapLayout
-        showInlineImages: boolean
+        showMedia: boolean
     },
 ) => {
     const content = article
@@ -120,9 +120,9 @@ export const render = (
                     }
                     return el.html
                 case 'media-atom':
-                    return renderMediaAtom(el)
+                    return showMedia ? renderMediaAtom(el) : ''
                 case 'image':
-                    return showInlineImages ? Image({ imageElement: el }) : ''
+                    return showMedia ? Image({ imageElement: el }) : ''
                 case 'pullquote':
                     return Pullquote({
                         cite: el.html,

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -10,7 +10,7 @@ import { ArticleHeaderProps } from '../article-header/types'
 import { PropTypes as StandfirstPropTypes } from '../article-standfirst'
 import { EMBED_DOMAIN, render } from '../html/render'
 import { Wrap, WrapLayout } from '../wrap/wrap'
-import { color } from 'src/theme/color'
+import { useNetInfo } from '@react-native-community/netinfo'
 
 const urlIsNotAnEmbed = (url: string) =>
     !(
@@ -47,10 +47,16 @@ const ArticleWebview = ({
     article: BlockElement[]
     wrapLayout: WrapLayout
 }) => {
+    const { isConnected } = useNetInfo()
     const [height, setHeight] = useState(Dimensions.get('window').height)
     const [, { pillar }] = useArticle()
 
-    const html = render(article, { pillar, features, wrapLayout })
+    const html = render(article, {
+        pillar,
+        features,
+        wrapLayout,
+        showInlineImages: isConnected,
+    })
 
     return (
         <>

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -80,7 +80,7 @@ const ArticleWebview = ({
                             Linking.openURL(event.url)
                             return false
                         }
-                        return isConnected // if we're not connected then don't try and load any resources
+                        return true
                     }}
                     onMessage={event => {
                         if (parseInt(event.nativeEvent.data) > height) {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -55,7 +55,7 @@ const ArticleWebview = ({
         pillar,
         features,
         wrapLayout,
-        showInlineImages: isConnected,
+        showMedia: isConnected,
     })
 
     return (

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -80,7 +80,7 @@ const ArticleWebview = ({
                             Linking.openURL(event.url)
                             return false
                         }
-                        return true
+                        return isConnected // if we're not connected then don't try and load any resources
                     }}
                     onMessage={event => {
                         if (parseInt(event.nativeEvent.data) > height) {


### PR DESCRIPTION
## Why are you doing this?

Only render images and media atoms when we're online (currently, for images, we don't adjust the URLs for offline viewing, this will be done in a separate PR in future).

This may also fix the `NSUrlError -1009` as it may stop the webkit trying to load anything when offline. It _seems_ to work but I want to test this in beta.

[**Trello Card 1 ->**](https://trello.com/c/tL8jQm02/664-inline-images-not-rendered-in-offline-mode)

[**Trello Card 2 ->**](https://trello.com/c/lKYpO1J5/640-bug-offline-mode-not-all-content-rendered)

