### PR TITLE
Add bug button in beta

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/services/ophan'
 import { NavigationState } from 'react-navigation'
 import { AuthStatus, isIdentity } from './authentication/credentials-chain'
+import { BugButton } from './components/BugButton'
 
 // useScreens is not a hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -165,6 +166,7 @@ export default class App extends React.Component<{}, {}> {
                             <NetInfoAutoToast />
                         </View>
                         <ModalRenderer />
+                        <BugButton />
                     </AuthProvider>
                 </WithProviders>
             </ErrorBoundary>

--- a/projects/Mallard/src/components/BugButton.tsx
+++ b/projects/Mallard/src/components/BugButton.tsx
@@ -11,6 +11,7 @@ const styles = StyleSheet.create({
         position: 'absolute',
         bottom: 20,
         right: 20,
+        zIndex: 9999,
     },
 })
 

--- a/projects/Mallard/src/components/BugButton.tsx
+++ b/projects/Mallard/src/components/BugButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { useContext } from 'react'
+import { AuthContext } from 'src/authentication/auth-context'
+import { createMailtoHandler } from 'src/helpers/diagnostics'
+import { Button } from './button/button'
+import { isInBeta } from 'src/helpers/release-stream'
+
+const BugButton = () => {
+    const { status } = useContext(AuthContext)
+    return isInBeta() ? (
+        <Button
+            style={{
+                position: 'absolute',
+                bottom: 20,
+                right: 20,
+            }}
+            onPress={createMailtoHandler('Report a bug', '', status)}
+            alt="Report a bug"
+            icon=""
+        />
+    ) : null
+}
+
+export { BugButton }

--- a/projects/Mallard/src/components/BugButton.tsx
+++ b/projects/Mallard/src/components/BugButton.tsx
@@ -4,16 +4,21 @@ import { AuthContext } from 'src/authentication/auth-context'
 import { createMailtoHandler } from 'src/helpers/diagnostics'
 import { Button } from './button/button'
 import { isInBeta } from 'src/helpers/release-stream'
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+    button: {
+        position: 'absolute',
+        bottom: 20,
+        right: 20,
+    },
+})
 
 const BugButton = () => {
     const { status } = useContext(AuthContext)
     return isInBeta() ? (
         <Button
-            style={{
-                position: 'absolute',
-                bottom: 20,
-                right: 20,
-            }}
+            style={styles.button}
             onPress={createMailtoHandler('Report a bug', '', status)}
             alt="Report a bug"
             icon=""

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -89,6 +89,25 @@ const openSupportMailto = (text: string, releaseURL: string, body?: string) => {
     )
 }
 
+const createMailtoHandler = (
+    text: string,
+    releaseURL: string,
+    authStatus: AuthStatus,
+) => () =>
+    runActionSheet(DIAGNOSTICS_REQUEST, [
+        {
+            text: 'Include',
+            onPress: async () => {
+                const diagnostics = await getDiagnosticInfo(authStatus)
+                openSupportMailto(text, releaseURL, diagnostics)
+            },
+        },
+        {
+            text: `Don't include`,
+            onPress: () => openSupportMailto(text, releaseURL),
+        },
+    ])
+
 const createSupportMailto = (
     text: string,
     releaseURL: string,
@@ -98,22 +117,8 @@ const createSupportMailto = (
     title: text,
     linkWeight: 'regular' as const,
     data: {
-        onPress: () =>
-            runActionSheet(DIAGNOSTICS_REQUEST, [
-                {
-                    text: 'Include',
-                    onPress: async () => {
-                        const diagnostics = await getDiagnosticInfo(authStatus)
-                        console.log(diagnostics)
-                        openSupportMailto(text, releaseURL, diagnostics)
-                    },
-                },
-                {
-                    text: `Don't include`,
-                    onPress: () => openSupportMailto(text, releaseURL),
-                },
-            ]),
+        onPress: createMailtoHandler(text, releaseURL, authStatus),
     },
 })
 
-export { createSupportMailto }
+export { createSupportMailto, createMailtoHandler }

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1080,11 +1080,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
-"@types/react-native-permissions@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/react-native-permissions/-/react-native-permissions-1.1.1.tgz#297f39ed19234045e1dc1cd0abd85b86bdf9c606"
-  integrity sha512-+xLVH6kefg9hpJKxQhRcaYHckhbQCxDrU6HEaTzf3gMbn4I4aunjxkqeSMAofrHFNOnOS/phnsTbifoDATjk3w==
-
 "@types/react-native-push-notification@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-native-push-notification/-/react-native-push-notification-3.0.6.tgz#07fe6b0b45dc1128949d2925d8e9ae4ed35c4790"


### PR DESCRIPTION
## Why are you doing this?

This adds a bug button to be displayed in beta. It will use the action card to ask whether or not to include diagnostics (as with the help buttons in the help menu)

[**Trello Card ->**](https://trello.com/c/nXsogFxn/532-add-a-floating-bug-report-tool-like-we-have-on-the-live-app-betas)

<img width="200" alt="Screenshot 2019-09-11 at 10 38 35" src="https://user-images.githubusercontent.com/1652187/64686345-70824a00-d480-11e9-93ef-8260e4eb400f.png">
