### PR TITLE
Improve rendering of app on small phones.

### DIFF
--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -131,7 +131,7 @@ const Header = ({
     )
 }
 
-const IssueHeader = ({
+const IssuePickerHeader = ({
     issue,
     ...headerProps
 }: { issue?: Issue } & Omit<HeaderProps, 'children'> &
@@ -139,9 +139,13 @@ const IssueHeader = ({
     const { date, weekday } = useIssueDate(issue)
     return (
         <Header {...headerProps}>
-            <IssueTitle {...headerProps} title={weekday} subtitle={date} />
+            <IssueTitle
+                {...headerProps}
+                title={`Recent`}
+                subtitle={`Editions`}
+            />
         </Header>
     )
 }
 
-export { Header, IssueHeader }
+export { Header, IssuePickerHeader }

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -124,7 +124,7 @@ const WeatherIconView = ({
         />
         <Text numberOfLines={1} ellipsizeMode="clip" style={styles.temperature}>
             {Math.round(forecast.Temperature.Value) +
-                ' ' +
+                '°' +
                 forecast.Temperature.Unit}
         </Text>
         <Text numberOfLines={1} ellipsizeMode="clip" style={styles.dateTime}>

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -11,7 +11,7 @@ import { Button, ButtonAppearance } from 'src/components/button/button'
 import { IssueRow } from 'src/components/issue/issue-row'
 import { GridRowSplit } from 'src/components/issue/issue-title'
 import { FlexCenter } from 'src/components/layout/flex-center'
-import { IssueHeader } from 'src/components/layout/header/header'
+import { IssuePickerHeader } from 'src/components/layout/header/header'
 import { ScrollContainer } from 'src/components/layout/ui/container'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { Heading } from 'src/components/layout/ui/row'
@@ -71,12 +71,14 @@ const HomeScreenHeader = withNavigation(
             />
         )
         return response({
-            error: () => <IssueHeader leftAction={settings} action={action} />,
+            error: () => (
+                <IssuePickerHeader leftAction={settings} action={action} />
+            ),
             pending: () => (
-                <IssueHeader leftAction={settings} action={action} />
+                <IssuePickerHeader leftAction={settings} action={action} />
             ),
             success: issue => (
-                <IssueHeader
+                <IssuePickerHeader
                     leftAction={settings}
                     issue={issue}
                     accessibilityHint={'Return to issue'}

--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -190,14 +190,14 @@ const Login = ({
                         {!hasInputEmail ? emailProgressText : submitText}
                     </LoginButton>
                 </View>
-                <View style={loginStyles.actionRow}>
+                <View style={loginStyles.actionsContainer}>
                     {hasInputEmail && (
-                        <Link style={loginStyles.resetLink} href={resetLink}>
+                        <Link style={[loginStyles.resetLink]} href={resetLink}>
                             Forgot password?
                         </Link>
                     )}
                     <LinkNav
-                        style={loginStyles.resetLink}
+                        style={[loginStyles.resetLink]}
                         onPress={onHelpPress}
                     >
                         Have a subscription but cannot sign in?

--- a/projects/Mallard/src/theme/breakpoints.ts
+++ b/projects/Mallard/src/theme/breakpoints.ts
@@ -8,7 +8,7 @@ export enum Breakpoints {
 /*
     Minimum breakpoint is currently 375 as this is what we initially started off with.
 */
-export const MINIMUM_BREAKPOINT: number = Breakpoints.phone
+export const MINIMUM_BREAKPOINT: number = Breakpoints.smallPhone
 
 export interface BreakpointList<T> {
     [fromSize: number]: T

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -47,8 +47,8 @@ const scale = {
     sans: {
         [0.5]: {
             [Breakpoints.smallPhone]: {
-                fontSize: 13,
-                lineHeight: 13,
+                fontSize: 11,
+                lineHeight: 11,
             },
             [Breakpoints.phone]: {
                 fontSize: 13,
@@ -57,8 +57,8 @@ const scale = {
         },
         [0.9]: {
             [Breakpoints.smallPhone]: {
-                fontSize: 15,
-                lineHeight: 18,
+                fontSize: 13,
+                lineHeight: 16,
             },
             [Breakpoints.phone]: {
                 fontSize: 15,
@@ -67,8 +67,8 @@ const scale = {
         },
         1: {
             [Breakpoints.smallPhone]: {
-                fontSize: 17,
-                lineHeight: 21,
+                fontSize: 14,
+                lineHeight: 19,
             },
             [Breakpoints.phone]: {
                 fontSize: 17,
@@ -93,8 +93,8 @@ const scale = {
         },
         1: {
             [Breakpoints.smallPhone]: {
-                fontSize: 16,
-                lineHeight: 20,
+                fontSize: 14,
+                lineHeight: 18,
             },
             [Breakpoints.phone]: {
                 fontSize: 16,
@@ -107,8 +107,8 @@ const scale = {
         },
         1.25: {
             [Breakpoints.smallPhone]: {
-                fontSize: 18,
-                lineHeight: 22,
+                fontSize: 15,
+                lineHeight: 19,
             },
             [Breakpoints.phone]: {
                 fontSize: 18,
@@ -137,8 +137,8 @@ const scale = {
         },
         1: {
             [Breakpoints.smallPhone]: {
-                fontSize: 18,
-                lineHeight: 20,
+                fontSize: 15,
+                lineHeight: 17,
             },
             [Breakpoints.phone]: {
                 fontSize: 18,
@@ -165,8 +165,8 @@ const scale = {
         },
         1.5: {
             [Breakpoints.smallPhone]: {
-                fontSize: 26,
-                lineHeight: 27,
+                fontSize: 21,
+                lineHeight: 22,
             },
             [Breakpoints.phone]: {
                 fontSize: 26,
@@ -219,8 +219,8 @@ const scale = {
         },
         1.25: {
             [Breakpoints.smallPhone]: {
-                fontSize: 24,
-                lineHeight: 26,
+                fontSize: 20,
+                lineHeight: 22,
             },
             [Breakpoints.phone]: {
                 fontSize: 24,
@@ -229,8 +229,8 @@ const scale = {
         },
         1.5: {
             [Breakpoints.smallPhone]: {
-                fontSize: 30,
-                lineHeight: 33,
+                fontSize: 25,
+                lineHeight: 28,
             },
             [Breakpoints.phone]: {
                 fontSize: 30,
@@ -239,8 +239,8 @@ const scale = {
         },
         2: {
             [Breakpoints.smallPhone]: {
-                fontSize: 45,
-                lineHeight: 50,
+                fontSize: 38,
+                lineHeight: 43,
             },
             [Breakpoints.phone]: {
                 fontSize: 45,
@@ -249,8 +249,8 @@ const scale = {
         },
         2.25: {
             [Breakpoints.smallPhone]: {
-                fontSize: 50,
-                lineHeight: 55,
+                fontSize: 38,
+                lineHeight: 42,
             },
             [Breakpoints.phone]: {
                 fontSize: 50,
@@ -259,8 +259,8 @@ const scale = {
         },
         2.5: {
             [Breakpoints.smallPhone]: {
-                fontSize: 60,
-                lineHeight: 66,
+                fontSize: 50,
+                lineHeight: 56,
             },
             [Breakpoints.phone]: {
                 fontSize: 60,


### PR DESCRIPTION
This PR makes some small improvements to font sizes at the breakpoint targeting smaller phones in order
avoid the design of the app on such devices looking obviously broken. This is not exhaustive.

This PR also sets the minimum breakpoint within the app to point to smaller phones by default as opposed to larger phones.

Also:

- Add missing degree icon to weather.
- Change issue picker title to 'Recent Editions'

Some Screenshots on a 5S:

<img width="380" alt="Screenshot 2019-09-10 at 21 08 41" src="https://user-images.githubusercontent.com/8861681/64688211-c5738f80-d483-11e9-9162-2e5be4e572d3.png">
<img width="380" alt="Screenshot 2019-09-10 at 21 08 55" src="https://user-images.githubusercontent.com/8861681/64689584-8b57bd00-d486-11e9-9fcc-a537a94c0e81.png">
<img width="380" alt="Screenshot 2019-09-10 at 21 09 05" src="https://user-images.githubusercontent.com/8861681/64689585-8b57bd00-d486-11e9-99e2-c334b25cd4ff.png">
<img width="380" alt="Screenshot 2019-09-10 at 21 09 16" src="https://user-images.githubusercontent.com/8861681/64689586-8b57bd00-d486-11e9-9581-4ef28ff325cf.png">
<img width="380" alt="Screenshot 2019-09-10 at 21 09 33" src="https://user-images.githubusercontent.com/8861681/64689587-8bf05380-d486-11e9-8244-b3364bf25a51.png">

