### PR TITLE
Restore 'cover card fronts' to Life after front name change.

### DIFF
--- a/projects/common/src/collection/card-layouts.ts
+++ b/projects/common/src/collection/card-layouts.ts
@@ -163,7 +163,7 @@ export const getCardsForFront = (
                 0: [],
                 1: [2],
             }
-        case 'Lifestyle':
+        case 'Life':
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage, true)
         case 'Food':


### PR DESCRIPTION
## Why are you doing this?

We've changed the name of front "Lifestyle" to life.
This PR is to restore cover cards for the front which were picked by frontName.
