### PR TITLE
fix: Android fix credit

### DIFF
--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -12,16 +12,20 @@ import { UiBodyCopy } from '../styled-text'
 const styles = StyleSheet.create({
     wrapper: {
         backgroundColor: 'black',
-        padding: 10,
         width: '100%',
     },
     credit: {
         color: color.palette.neutral[100],
+        zIndex: 1,
+        backgroundColor: 'black',
+        height: '100%',
+        padding: 10,
     },
     button: {
         position: 'absolute',
         bottom: 10,
         right: 10,
+        zIndex: 2,
     },
     buttonText: {
         color: color.palette.neutral[100],


### PR DESCRIPTION
## Why are you doing this?

Credits not showing on Article image on Android

[**Trello Card ->**](https://trello.com/c/bPElWriT/451-make-sure-credits-are-displayed-on-main-media-in-article)

## Screenshots

![Screen Shot 2019-09-11 at 11 47 13](https://user-images.githubusercontent.com/935975/64691499-adebd500-d48a-11e9-9dff-4293bbfbfae3.png)
