### PR TITLE
Stop net info re-renders on mount

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -32,6 +32,7 @@ import { IdentityAuth } from './authentication/credentials-chain'
 import { BugButton } from './components/BugButton'
 import SplashScreen from 'react-native-splash-screen'
 import { UpdateIpAddress } from './components/update-ip-address'
+import { NetInfoProvider } from './hooks/use-net-info'
 
 // useScreens is not a hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -114,10 +115,15 @@ const onNavigationStateChange = (
 const isReactNavPersistenceError = (e: Error) =>
     __DEV__ && e.message.includes('There is no route defined for')
 
-const WithProviders = nestProviders(SettingsProvider, Modal, ToastProvider)
-
 const handleIdStatus = (data: IdentityAuth | null) =>
     setUserId(data && data.info.userDetails.id)
+
+const WithProviders = nestProviders(
+    SettingsProvider,
+    Modal,
+    ToastProvider,
+    NetInfoProvider,
+)
 
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -115,15 +115,15 @@ const onNavigationStateChange = (
 const isReactNavPersistenceError = (e: Error) =>
     __DEV__ && e.message.includes('There is no route defined for')
 
-const handleIdStatus = (data: IdentityAuth | null) =>
-    setUserId(data && data.info.userDetails.id)
-
 const WithProviders = nestProviders(
     SettingsProvider,
     Modal,
     ToastProvider,
     NetInfoProvider,
 )
+
+const handleIdStatus = (data: IdentityAuth | null) =>
+    setUserId(data && data.info.userDetails.id)
 
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {

--- a/projects/Mallard/src/__mocks__/@react-native-community/netinfo.js
+++ b/projects/Mallard/src/__mocks__/@react-native-community/netinfo.js
@@ -2,4 +2,7 @@ module.exports = {
     getCurrentState: jest.fn(() => Promise.resolve()),
     addListener: jest.fn(),
     removeListeners: jest.fn(),
+    NetInfoStateType: {
+        unknown: 'unknown',
+    },
 }

--- a/projects/Mallard/src/authentication/auth-context.tsx
+++ b/projects/Mallard/src/authentication/auth-context.tsx
@@ -7,7 +7,7 @@ import React, {
     useCallback,
 } from 'react'
 import { signOutIdentity } from '../helpers/storage'
-import { useNetInfo } from '@react-native-community/netinfo'
+import { useNetInfo } from 'src/hooks/use-net-info'
 import {
     nonIdentityAuthChain,
     cachedNonIdentityAuthChain,

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -15,7 +15,6 @@ import {
     wireScrollBarToDismiss,
     OnTopPositionChangeFn,
 } from 'src/screens/article/helpers'
-import { UiBodyCopy } from 'src/components/styled-text'
 
 const styles = StyleSheet.create({
     block: {

--- a/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
+++ b/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
@@ -1,4 +1,4 @@
-import { useNetInfo } from '@react-native-community/netinfo'
+import { useNetInfo } from 'src/hooks/use-net-info'
 import { useEffect } from 'react'
 import { useToast } from 'src/hooks/use-toast'
 

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext } from 'react'
+import {
+    useNetInfo as originalUseNetInfo,
+    NetInfoState,
+    NetInfoStateType,
+} from '@react-native-community/netinfo'
+
+const StableNetInfoContext = createContext<NetInfoState>({
+    type: NetInfoStateType.unknown,
+    isConnected: false,
+    details: null,
+})
+
+const NetInfoProvider = ({ children }: { children: React.ReactNode }) => (
+    <StableNetInfoContext.Provider value={originalUseNetInfo()}>
+        {children}
+    </StableNetInfoContext.Provider>
+)
+
+const useNetInfo = () => useContext(StableNetInfoContext)
+
+export { NetInfoProvider, useNetInfo }


### PR DESCRIPTION
## Why are you doing this?

While debugging some Android issues I noticed that the `useNetInfo` hook forces a re-render on mount for any component that uses it. This changes fixes that by storing the `NetInfoState` in one place in the context and as such ensures that this re-render only happens on app load and never again.