### PR TITLE
Optimize onWrapLayout calls

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -51,12 +51,16 @@ const ArticleWebview = ({
     const [height, setHeight] = useState(Dimensions.get('window').height)
     const [, { pillar }] = useArticle()
 
-    const html = render(article, {
-        pillar,
-        features,
-        wrapLayout,
-        showMedia: isConnected,
-    })
+    const html = useMemo(
+        () =>
+            render(article, {
+                pillar,
+                features,
+                wrapLayout,
+                showMedia: isConnected,
+            }),
+        [article, pillar, wrapLayout, isConnected],
+    )
 
     return (
         <>


### PR DESCRIPTION
## Why are you doing this?

When heights were being updated the `Wrap` component would call `onWrapLayout` which would force re-renders. This will not not call the handler if the measurements are the same.

