### PR TITLE
fix: iOS beta build

### DIFF
--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -116,5 +116,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Why are you doing this?

iOS Beta Build is broken because we need to set iPad to full screen. This disables multitasking. If multitasking is a required feature, then it should be looked at after launch