### PR TITLE
fix: remove the warning for Ophan in iOS

### DIFF
--- a/projects/Mallard/ios/Mallard/Ophan/Ophan.m
+++ b/projects/Mallard/ios/Mallard/Ophan/Ophan.m
@@ -10,6 +10,11 @@
 
 @interface RCT_EXTERN_MODULE(Ophan, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 RCT_EXTERN_METHOD(setUserId: (NSString)userId
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
## Why are you doing this?

Yellow warning box complains about Ophan. This fix is what is suggested in the RN docs.