### PR TITLE
Use FlatList to split webviews for BlockElements

### DIFF
--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -90,52 +90,58 @@ const renderMediaAtom = (mediaAtomElement: MediaAtomElement) => {
     `
 }
 
-export const render = (
-    article: BlockElement[],
+const getElementHTML = (
+    el: BlockElement,
     {
-        pillar,
+        index,
         features,
-        wrapLayout,
         showMedia,
     }: {
+        index: number
+        features: ArticleFeatures[]
+        showMedia: boolean
+    },
+) => {
+    switch (el.id) {
+        case 'html':
+            if (index === 0 && features.includes(ArticleFeatures.HasDropCap)) {
+                return html`
+                    <div class="drop-cap">
+                        ${el.html}
+                    </div>
+                `
+            }
+            return el.html
+        case 'media-atom':
+            return showMedia ? renderMediaAtom(el) : ''
+        case 'image':
+            return showMedia ? Image({ imageElement: el }) : ''
+        case 'pullquote':
+            return Pullquote({
+                cite: el.html,
+                role: el.role || 'inline',
+                ...el,
+            })
+        default:
+            return ''
+    }
+}
+
+export const render = (
+    element: BlockElement,
+    options: {
+        index: number
         pillar: ArticlePillar
         features: ArticleFeatures[]
         wrapLayout: WrapLayout
         showMedia: boolean
     },
 ) => {
-    const content = article
-        .map((el, i) => {
-            switch (el.id) {
-                case 'html':
-                    if (
-                        i === 0 &&
-                        features.includes(ArticleFeatures.HasDropCap)
-                    ) {
-                        return html`
-                            <div class="drop-cap">
-                                ${el.html}
-                            </div>
-                        `
-                    }
-                    return el.html
-                case 'media-atom':
-                    return showMedia ? renderMediaAtom(el) : ''
-                case 'image':
-                    return showMedia ? Image({ imageElement: el }) : ''
-                case 'pullquote':
-                    return Pullquote({
-                        cite: el.html,
-                        role: el.role || 'inline',
-                        ...el,
-                    })
-                default:
-                    return ''
-            }
-        })
-        .join('')
-
-    const styles = makeCss({ colors: getPillarColors(pillar), wrapLayout })
+    const content = getElementHTML(element, options)
+    const styles = makeCss({
+        colors: getPillarColors(options.pillar),
+        wrapLayout: options.wrapLayout,
+    })
     const body = html`
         <main>${content}</main>
     `

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { Dimensions, Linking, Platform, View, StyleSheet } from 'react-native'
+import { Linking, Platform, StyleSheet, FlatList } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { ArticleFeatures, BlockElement } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
@@ -26,9 +26,6 @@ const styles = StyleSheet.create({
         padding: metrics.horizontal,
         paddingVertical: metrics.vertical,
     },
-    webviewWrap: {
-        ...StyleSheet.absoluteFillObject,
-    },
     webview: {
         backgroundColor: 'transparent',
         width: '100%',
@@ -40,6 +37,42 @@ const styles = StyleSheet.create({
     },
 })
 
+const BlockWebview = React.memo(({ blockString }: { blockString: string }) => {
+    const [height, setHeight] = useState(100)
+
+    return (
+        <WebView
+            originWhitelist={['*']}
+            scrollEnabled={false}
+            useWebKit={false}
+            source={{ html: blockString }}
+            onShouldStartLoadWithRequest={event => {
+                if (
+                    Platform.select({
+                        ios: event.navigationType === 'click',
+                        android: urlIsNotAnEmbed(event.url), // android doesn't have 'click' types so check for our embed types
+                    })
+                ) {
+                    Linking.openURL(event.url)
+                    return false
+                }
+                return true
+            }}
+            onMessage={event => {
+                if (parseInt(event.nativeEvent.data) > height) {
+                    setHeight(parseInt(event.nativeEvent.data))
+                }
+            }}
+            style={[
+                styles.webview,
+                {
+                    minHeight: height,
+                },
+            ]}
+        />
+    )
+})
+
 const ArticleWebview = ({
     article,
     wrapLayout,
@@ -48,58 +81,29 @@ const ArticleWebview = ({
     wrapLayout: WrapLayout
 }) => {
     const { isConnected } = useNetInfo()
-    const [height, setHeight] = useState(Dimensions.get('window').height)
     const [, { pillar }] = useArticle()
 
-    const html = useMemo(
+    const blockStrings = useMemo(
         () =>
-            render(article, {
-                pillar,
-                features,
-                wrapLayout,
-                showMedia: isConnected,
-            }),
+            article.map((el, index) => ({
+                string: render(el, {
+                    pillar,
+                    features,
+                    wrapLayout,
+                    showMedia: isConnected,
+                    index,
+                }),
+                key: index.toString(),
+            })),
         [article, pillar, wrapLayout, isConnected],
     )
 
     return (
-        <>
-            <Wrap>
-                <View style={{ minHeight: height }}></View>
-            </Wrap>
-
-            <View style={[styles.webviewWrap]}>
-                <WebView
-                    originWhitelist={['*']}
-                    scrollEnabled={false}
-                    useWebKit={false}
-                    source={{ html: html }}
-                    onShouldStartLoadWithRequest={event => {
-                        if (
-                            Platform.select({
-                                ios: event.navigationType === 'click',
-                                android: urlIsNotAnEmbed(event.url), // android doesn't have 'click' types so check for our embed types
-                            })
-                        ) {
-                            Linking.openURL(event.url)
-                            return false
-                        }
-                        return true
-                    }}
-                    onMessage={event => {
-                        if (parseInt(event.nativeEvent.data) > height) {
-                            setHeight(parseInt(event.nativeEvent.data))
-                        }
-                    }}
-                    style={[
-                        styles.webview,
-                        {
-                            minHeight: height,
-                        },
-                    ]}
-                />
-            </View>
-        </>
+        <FlatList
+            data={blockStrings}
+            initialNumToRender={2}
+            renderItem={info => <BlockWebview blockString={info.item.string} />}
+        />
     )
 }
 


### PR DESCRIPTION
## Why are you doing this?

Render articles on Android 😱 

This seems to work on the test device I have ... it may not work on others but it definitely seems like an improvement. If this gets ok'd I'll ship it and will be looking for feedback!

## More info

After looking into the lack of Android rendering, this it seemed to be down to resource consumption and rendering issues on Android. Removing elements from a broken article caused the article to render successfully. Crucially, as long as a certain amount of content was removed it didn't matter _which_ elements where removed so that ruled out having some problematic character etc. Additionally, you could still select text on a broken article, it was just invisible, which again pointed to a rendering bug rather than something before that like invalid input.

In order to keep the scrolling behaviour the same but ensure we weren't rendering as much, this PR moves each element into a separate web view that will only be rendered when the parent FlatList deems it appropriate. This will ultimately drop the amount of rendered elements to ~5 in this implementation.