### PR TITLE
Remove virtual listviews on issue screen, reduce jank all over

### DIFF
--- a/projects/Mallard/src/components/front/helpers/wrapper.tsx
+++ b/projects/Mallard/src/components/front/helpers/wrapper.tsx
@@ -9,6 +9,7 @@ const styles = StyleSheet.create({
         paddingRight: metrics.horizontal,
         marginBottom: 0,
         marginTop: 0,
+        height: metrics.fronts.sliderRadius * 2,
     },
 })
 

--- a/projects/Mallard/src/components/layout/ui/sizing/with-layout-rectangle.tsx
+++ b/projects/Mallard/src/components/layout/ui/sizing/with-layout-rectangle.tsx
@@ -4,7 +4,8 @@ import { LayoutRectangle, View } from 'react-native'
 const WithLayoutRectangle: FunctionComponent<{
     children: (l: LayoutRectangle) => ReactNode
     minHeight?: number
-}> = ({ children, minHeight }) => {
+    fallback?: ReactNode
+}> = ({ children, minHeight, fallback }) => {
     const [metrics, setMetrics] = useState<LayoutRectangle | null>(null)
     return (
         <View
@@ -13,6 +14,7 @@ const WithLayoutRectangle: FunctionComponent<{
                 setMetrics(ev.nativeEvent.layout)
             }}
         >
+            {!metrics && fallback}
             {metrics && children(metrics)}
         </View>
     )

--- a/projects/Mallard/src/components/slider/draw/background.tsx
+++ b/projects/Mallard/src/components/slider/draw/background.tsx
@@ -4,6 +4,7 @@ import Svg, { Circle, Line } from 'react-native-svg'
 import { View } from 'react-native'
 import { WithBreakpoints } from '../../layout/ui/sizing/with-breakpoints'
 import { WithLayoutRectangle } from 'src/components/layout/ui/sizing/with-layout-rectangle'
+import { UiBodyCopy } from 'src/components/styled-text'
 
 const Stop = ({
     fill,
@@ -30,7 +31,7 @@ const Background = ({
     height: number
     radius: number
 }) => {
-    const stopElements = (width: number) => {
+    const stopElements = () => {
         const elements = [
             <Stop
                 key={-2}
@@ -41,7 +42,7 @@ const Background = ({
             <Stop
                 key={-1}
                 style={{ transform: { translateX: radius * -1 } }}
-                cx={width}
+                cx={'100%'}
                 {...{ fill, height, radius }}
             />,
         ]
@@ -51,7 +52,7 @@ const Background = ({
             elements.push(
                 <Stop
                     key={i}
-                    cx={width * cx}
+                    cx={cx * 100 + '%'}
                     style={{ transform: { translateX } }}
                     {...{ fill, height, radius }}
                 />,
@@ -60,27 +61,17 @@ const Background = ({
         return elements
     }
     return (
-        <WithLayoutRectangle>
-            {({ width }) => (
-                <Svg
-                    width={width}
-                    height={height * 2}
-                    style={{
-                        overflow: 'visible',
-                        position: 'absolute',
-                    }}
-                >
-                    <Line
-                        x1="0"
-                        y1={height}
-                        x2={width}
-                        y2={height}
-                        stroke={fill}
-                    />
-                    {stopElements(width)}
-                </Svg>
-            )}
-        </WithLayoutRectangle>
+        <Svg
+            width={'100%'}
+            height={height * 2}
+            style={{
+                overflow: 'visible',
+                position: 'absolute',
+            }}
+        >
+            <Line x1="0" y1={height} x2={'100%'} y2={height} stroke={fill} />
+            {stopElements()}
+        </Svg>
     )
 }
 

--- a/projects/Mallard/src/components/slider/index.tsx
+++ b/projects/Mallard/src/components/slider/index.tsx
@@ -14,7 +14,6 @@ const stopRadius = 4
 const styles = StyleSheet.create({
     root: {
         height: metrics.fronts.sliderRadius * 2,
-        width: '100%',
     },
     background: {
         marginHorizontal: metrics.fronts.sliderRadius - stopRadius,
@@ -94,7 +93,10 @@ const Slider = ({
             : undefined
 
     return (
-        <WithLayoutRectangle minHeight={metrics.fronts.sliderRadius}>
+        <WithLayoutRectangle
+            fallback={<SliderSkeleton />}
+            minHeight={metrics.fronts.sliderRadius}
+        >
             {({ width }) => (
                 <View
                     {...(isScrubbable ? panResponder.panHandlers : {})}

--- a/projects/Mallard/src/components/spinner.tsx
+++ b/projects/Mallard/src/components/spinner.tsx
@@ -31,9 +31,9 @@ const Ball = ({ color, jump }: { color: string; jump: Animated.Value }) => {
                 {
                     transform: [
                         {
-                            translateY: jump.interpolate({
+                            scale: jump.interpolate({
                                 inputRange: safeInterpolation([0, 1]),
-                                outputRange: safeInterpolation([-5, 5]),
+                                outputRange: safeInterpolation([0.8, 1]),
                             }),
                         },
                     ],

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -49,6 +49,7 @@ export interface PathToIssue {
 const styles = StyleSheet.create({
     weatherWide: {
         marginHorizontal: metrics.horizontal,
+        height: 78,
     },
     sideWeather: {
         width: 78,

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -39,6 +39,8 @@ import {
     REFRESH_BUTTON_TEXT,
 } from 'src/helpers/words'
 import { sendPageViewEvent } from 'src/services/ophan'
+import { ScrollView } from 'react-native-gesture-handler'
+import { UiBodyCopy } from 'src/components/styled-text'
 
 export interface PathToIssue {
     issue: Issue['key']
@@ -122,38 +124,13 @@ const IssueFronts = ({
     const { container } = useIssueScreenSize()
 
     return (
-        <FlatList
-            // this is horrible but in the worst case where we get duplicate ids
-            // (which we have done in the past) then we shouldn't break the rendering
-            // even if it does mean showing the same front twice
-            // we could filter out duplicates but in this case it'd probably be more
-            // obvious for someone previewing if we did render it twice
-            data={issue.fronts.map((key, index) => ({
-                key,
-                index,
-            }))}
-            extraData={{
-                ...container,
-            }}
-            windowSize={3}
-            style={style}
-            removeClippedSubviews={true}
-            ListHeaderComponent={ListHeaderComponent}
-            ListFooterComponent={() => (
-                <View style={{ height: container.height / 2 }} />
-            )}
-            keyExtractor={item => `${item.index}::${item.key}`}
-            getItemLayout={(_, index) => ({
-                length: container.height,
-                offset: container.height * index,
-                index,
-            })}
-            renderItem={({ item }) => (
-                <View style={{ height: container.height, overflow: 'hidden' }}>
-                    <Front issue={issue.key} front={item.key} />
-                </View>
-            )}
-        />
+        <ScrollView style={style} removeClippedSubviews>
+            {ListHeaderComponent}
+            {issue.fronts.map((key, index) => (
+                <Front issue={issue.key} front={key} key={key} />
+            ))}
+            <View style={{ height: container.height / 2 }} />
+        </ScrollView>
     )
 }
 


### PR DESCRIPTION
## Why are you doing this?
Reduce jank across the issue screen via

- Removing the nested flatlists (which weren;'t reliable)
- setting heights for slider & weather
- tweaking the loading dots animation to be more subtle
- Reducing slider visual jank

This overall makes the issue loading feel a bit smoother