### PR TITLE
render images inside articles from correct source

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -40,6 +40,7 @@
         "@react-native-community/masked-view": "^0.1.1",
         "@react-native-community/netinfo": "^3.2.1",
         "@react-native-community/push-notification-ios": "^1.0.2",
+        "@types/ramda": "^0.26.22",
         "chalk": "^2.4.2",
         "convert-svg-to-png": "^0.5.0",
         "deepmerge": "^4.0.0",

--- a/projects/Mallard/src/components/article/html/images.ts
+++ b/projects/Mallard/src/components/article/html/images.ts
@@ -164,6 +164,7 @@ const ImageBase = ({
     credit?: string
     role?: ImageElement['role']
 }) => {
+    console.log(path)
     const figcaption = renderCaption({ caption, credit })
     return html`
         <figure class="image" data-role="${role || 'inline'}">
@@ -178,15 +179,15 @@ const ImageBase = ({
     `
 }
 
-const Image = ({ imageElement }: { imageElement: ImageElement }) => {
+const Image = ({
+    imageElement,
+    path,
+}: {
+    imageElement: ImageElement
+    path: string
+}) => {
     //When you fix this pleas alter image.ts in background to not alert (unless we ship this 😱)
     const backend = backends[1].value //get PROD preview because we're faking the issue id
-    const path = `${backend}${mediaPath(
-        'fakeIssue/fake',
-        'phone',
-        imageElement.src.source,
-        imageElement.src.path,
-    )}`
 
     return ImageBase({ path, ...imageElement })
 }

--- a/projects/Mallard/src/components/article/html/images.ts
+++ b/projects/Mallard/src/components/article/html/images.ts
@@ -186,9 +186,6 @@ const Image = ({
     imageElement: ImageElement
     path: string
 }) => {
-    //When you fix this pleas alter image.ts in background to not alert (unless we ship this 😱)
-    const backend = backends[1].value //get PROD preview because we're faking the issue id
-
     return ImageBase({ path, ...imageElement })
 }
 

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -3,6 +3,7 @@ import {
     ArticlePillar,
     BlockElement,
     MediaAtomElement,
+    Image as ImageT,
 } from 'src/common'
 import { getPillarColors } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
@@ -97,11 +98,13 @@ export const render = (
         features,
         wrapLayout,
         showMedia,
+        imagePathLookup,
     }: {
         pillar: ArticlePillar
         features: ArticleFeatures[]
         wrapLayout: WrapLayout
         showMedia: boolean
+        imagePathLookup: [ImageT, string | undefined][]
     },
 ) => {
     const content = article
@@ -122,12 +125,18 @@ export const render = (
                 case 'media-atom':
                     return showMedia ? renderMediaAtom(el) : ''
                 case 'image':
-                    return showMedia ? Image({ imageElement: el }) : ''
+                    const imagePath = imagePathLookup.find(
+                        ([{ source, path }]) =>
+                            path == el.src.path && source == el.src.source,
+                    )
+                    const path = imagePath && imagePath[1]
+                    return showMedia && path !== undefined
+                        ? Image({ imageElement: el, path })
+                        : ''
                 case 'pullquote':
                     return Pullquote({
                         cite: el.html,
                         role: el.role || 'inline',
-                        ...el,
                     })
                 default:
                     return ''

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -137,6 +137,7 @@ export const render = (
                     return Pullquote({
                         cite: el.html,
                         role: el.role || 'inline',
+                        ...el,
                     })
                 default:
                     return ''

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import { Dimensions, Linking, Platform, View, StyleSheet } from 'react-native'
 import { WebView } from 'react-native-webview'
-import { ArticleFeatures, BlockElement } from 'src/common'
+import { ArticleFeatures, BlockElement, notNull } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
 import { Fader } from '../../layout/animators/fader'
@@ -11,6 +11,8 @@ import { PropTypes as StandfirstPropTypes } from '../article-standfirst'
 import { EMBED_DOMAIN, render } from '../html/render'
 import { Wrap, WrapLayout } from '../wrap/wrap'
 import { useNetInfo } from '@react-native-community/netinfo'
+import { useImagesPaths } from 'src/hooks/use-image-paths'
+import { zip } from 'ramda'
 
 const urlIsNotAnEmbed = (url: string) =>
     !(
@@ -50,17 +52,27 @@ const ArticleWebview = ({
     const { isConnected } = useNetInfo()
     const [height, setHeight] = useState(Dimensions.get('window').height)
     const [, { pillar }] = useArticle()
+    const images = article
+        .map(a =>
+            a.id === 'image'
+                ? a.src
+                : a.id === 'media-atom'
+                ? a.image
+                : undefined,
+        )
+        .filter(notNull)
 
-    const html = useMemo(
-        () =>
-            render(article, {
-                pillar,
-                features,
-                wrapLayout,
-                showMedia: isConnected,
-            }),
-        [article, pillar, wrapLayout, isConnected],
-    )
+    const imagePaths = useImagesPaths(images)
+    const imagePathLookup = zip(images, imagePaths)
+    console.log('HELO I AM RENDER')
+    console.log(imagePaths)
+    const html = render(article, {
+        pillar,
+        features,
+        wrapLayout,
+        showMedia: isConnected,
+        imagePathLookup,
+    })
 
     return (
         <>

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -64,8 +64,6 @@ const ArticleWebview = ({
 
     const imagePaths = useImagesPaths(images)
     const imagePathLookup = zip(images, imagePaths)
-    console.log('HELO I AM RENDER')
-    console.log(imagePaths)
     const html = render(article, {
         pillar,
         features,

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -6,7 +6,7 @@ import { Image, Issue } from '../../../common/src'
 import { useIssueCompositeKey } from './use-issue-id'
 import { useSettingsValue } from './use-settings'
 
-const selectImagePath = async (
+export const selectImagePath = async (
     apiUrl: string,
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
@@ -24,30 +24,28 @@ const selectImagePath = async (
 }
 
 /**
- * A simple helper to get image paths.
- * This will asynchronously try the cache, otherwise will return the API url
- * if not available in the cache.
+ * A simple helper to get image paths in order to try from the cache,
+ * then the API if the error handler is called, otherwise returns `undefined`
+ * if none are found
  *
- * Until the cache lookup has resolved, this will return undefined.
- * When the lookup resolves, a rerender should be triggered.
- *
- *  */
+ * TODO: cache these paths in a context in order not to check every time
+ */
 
-const useImagePath = (image?: Image) => {
+export const useImagePath = (image?: Image) => {
     const key = useIssueCompositeKey()
 
-    const [paths, setPaths] = useState<string | undefined>()
+    const [path, setPath] = useState<string | undefined>()
     const apiUrl = useSettingsValue.apiUrl()
     useEffect(() => {
         if (key && image) {
             const { localIssueId, publishedIssueId } = key
             selectImagePath(apiUrl, localIssueId, publishedIssueId, image).then(
-                setPaths,
+                setPath,
             )
         }
     }, [apiUrl, image, key])
     if (image === undefined) return undefined
-    return paths
+    return path
 }
 
-export { useImagePath, selectImagePath }
+export const useImagesPaths = (images: Image[]) => images.map(useImagePath)

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -24,10 +24,12 @@ export const selectImagePath = async (
 }
 
 /**
- * A simple helper to get image paths in order to try from the cache,
- * then the API if the error handler is called, otherwise returns `undefined`
- * if none are found
+ * A simple helper to get image paths.
+ * This will asynchronously try the cache, otherwise will return the API url
+ * if not available in the cache.
  *
+ * Until the cache lookup has resolved, this will return undefined.
+ * When the lookup resolves, a rerender should be triggered.
  * TODO: cache these paths in a context in order not to check every time
  */
 

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1080,6 +1080,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
+"@types/ramda@^0.26.22":
+  version "0.26.22"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.22.tgz#4506cf76b53191d17fce473bc3de529ece6f4886"
+  integrity sha512-TfX4BwgjMSXFuyb1QZsY2D8KEsJfiWolzJHYzFWyB/0UGiyX6BFvWX05IzzrMAsZpB4uN0GXAL5QcJHTKnBxoQ==
+  dependencies:
+    ts-toolbelt "^3.8.75"
+
 "@types/react-native-push-notification@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-native-push-notification/-/react-native-push-notification-3.0.6.tgz#07fe6b0b45dc1128949d2925d8e9ae4ed35c4790"
@@ -6628,6 +6635,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+ts-toolbelt@^3.8.75:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-3.12.0.tgz#557d0a2d354c1a59e430382fe0bdae4c454131dd"
+  integrity sha512-aGjQpudHKhQmKXTwYYa0Mt2zFtaT+FY9IAzdKO/ldTnOCWjJcwgwpgv+UjZBew2TMrs64h4l5qQZatjvOQyfmw==
 
 tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
## Why are you doing this?
supercedes https://github.com/guardian/editions/pull/489
<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
This fixes the image source  for in body images by using the hook.