### PR TITLE
Fix android beta build

### DIFF
--- a/projects/Mallard/Makefile
+++ b/projects/Mallard/Makefile
@@ -1,3 +1,5 @@
+export JAVA_OPTS = -Xmx4096m -Dsun.jnu.encoding=UTF-8
+
 debug-android:
 	mkdir -p android/app/src/main/assets
 	yarn jetify
@@ -20,3 +22,5 @@ beta-android:
 	yarn bundle-android
 	cd android && ./gradlew clean && cd ..
 	fastlane android beta
+
+PHONY: beta-android beta-ios debug-android debug-ios

--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 29
         supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX
+        androidXVersion = '1.0.2' // This is for react-native-inappbrowser
         mediaCompatVersion = '1.0.1' // Do not specify if using old libraries, specify '1.0.1' or similar for androidx.media:media dependency
         supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
         googlePlayServicesVersion = "17.1.0"

--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 29
         supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX
-        androidXVersion = '1.0.2' // This is for react-native-inappbrowser
+        androidXVersion = '1.0.2' // This is for react-native-inappbrowser-reborn
         mediaCompatVersion = '1.0.1' // Do not specify if using old libraries, specify '1.0.1' or similar for androidx.media:media dependency
         supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
         googlePlayServicesVersion = "17.1.0"


### PR DESCRIPTION
## Why are you doing this?

beta was not building

## Changes

- This adds a version required by react-native-inappbrowser-reborn to work with androidx. 
- This adds more memory to gradle and notes that the makefile targets are "phony" as they do not relate to filenames.