### PR TITLE
chore: Issue Summary type change

### DIFF
--- a/projects/archiver/src/indexer/summary.ts
+++ b/projects/archiver/src/indexer/summary.ts
@@ -69,17 +69,17 @@ export const indexer = async (): Promise<IssueSummary[]> => {
                     .filter(notNull),
             )
 
-            const images: { [key in ImageSize]?: string[] } = fromPairs(
+            const images: { [key in ImageSize]?: string } = fromPairs(
                 imageSizes
-                    .map((breakpoint): [ImageSize, string[]] | null => {
+                    .map((breakpoint): [ImageSize, string] | null => {
                         const asset = assetFiles[breakpoint]
                         if (asset == null) return null
-                        return [breakpoint, [asset]]
+                        return [breakpoint, asset]
                     })
                     .filter(notNull),
             )
 
-            const data = [assetFiles.data]
+            const data = assetFiles.data
             if (data == null) {
                 console.log(`No data for ${issue}`)
                 return null

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -142,8 +142,8 @@ export interface IssueSummary extends WithKey, IssueCompositeKey {
     name: string
     date: string
     assets?: {
-        [P in ImageSize]?: string[]
-    } & { data: string[] }
+        [P in ImageSize]?: string
+    } & { data: string }
 }
 
 export interface Issue extends IssueSummary, WithKey {


### PR DESCRIPTION
## Why are you doing this?

For downloads, we want to read from the assets object in the issue summary. This currently under each breakpoint has an array of paths. After discussion with @AWare, it was clear that this wont be an array but be one path. It makes more sense to make this change at the type level and it means we wont need logic to manage arrays.