### PR TITLE
Render issue when revisiting the issue

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -149,7 +149,6 @@ const FrontWithResponse = ({
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
                 horizontal={true}
-                removeClippedSubviews={true}
                 decelerationRate="fast"
                 snapToInterval={card.width}
                 ref={(flatList: AnimatedFlatListRef) =>

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -178,7 +178,6 @@ const ArticleSlider = ({
                 keyExtractor={(item: ArticleNavigator['articles'][0]) =>
                     item.article
                 }
-                removeClippedSubviews={true}
                 data={
                     isInScroller
                         ? articleNavigator.articles

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect } from 'react'
+import React, { ReactElement } from 'react'
 import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import {

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useEffect } from 'react'
 import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import {
@@ -120,9 +120,9 @@ const IssueFronts = ({
     const { container } = useIssueScreenSize()
 
     return (
-        <ScrollView style={style} removeClippedSubviews>
+        <ScrollView style={style}>
             {ListHeaderComponent}
-            {issue.fronts.map((key, index) => (
+            {issue.fronts.map(key => (
                 <Front
                     localIssueId={issue.localId}
                     publishedIssueId={issue.publishedId}


### PR DESCRIPTION
## Why are you doing this?

Fixes the the attached trello card.

[**Trello Card ->**](https://trello.com/c/qpmxzFNN/622-issue-invisible-until-scroll-then-incorrect-issue-date-visible)

If this degrades performance then it seems to be to do with how the custom `transitionConfig` in underlay is working here: https://github.com/guardian/editions/blob/65465eaccd54dac4524135a7e5d5d4b617ae0627/projects/Mallard/src/navigation/navigators/underlay.tsx#L108

I'm assuming that the custom animation is causing the articles to be considered "clipped" in some way and the scrollview isn't detecting when the translation back on screen.