### PR TITLE
Update PROD preview endpoint to use guardian domain name

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -12,7 +12,7 @@ export const backends = [
     },
     {
         title: 'PROD preview',
-        value: 'https://d2cf1ljtg904cv.cloudfront.net/',
+        value: 'https://preview.editions.guardianapis.com/',
         preview: true,
     },
     {


### PR DESCRIPTION
## Why are you doing this?
#466 is now out and working as expected in CODE. This changes the PROD preview to point to a guardianapis.com domain too.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/a9oY1ITn/652-proper-domain-names-for-backend)

## Changes

* Change PROD preview cloudfront location to use the API gateway custom domain


<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
