### PR TITLE
Fix bad memoisation

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -105,7 +105,8 @@ const FrontWithResponse = ({
             frontName: frontData.displayName || '',
         }
         return [flatCollections, navigator]
-    }, [frontData.collections.map(({ key }) => key).join(',')]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [localIssueId, publishedIssueId, frontData])
+
     const stops = cards.length
     const { card, container } = useIssueScreenSize()
 


### PR DESCRIPTION
## Why are you doing this?

This fixes issues rendering the wrong things on the wrong date. This now makes the loading of a new issue a bit gross as if they're both in the cache you get a moment where you see the old one. TBC how to fix this.

[**Trello Card ->**](https://trello.com/c/bw4bCapf/591-wrong-edition-shown-for-selected-issue-date)

