### PR TITLE
Deal with the difference between make and gmake

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "scripts": {
         "upload": "node-riffraff-artifact",
-        "validate": "make validate -j8 -Orecurse",
-        "fix": "make fix -j8 -Orecurse",
-        "build": "make build -j8 -Orecurse",
-        "test": "make test -j8 -Orecurse",
-        "install-mallard": "make install",
-        "validate-mallard": "make validate-Mallard",
+        "validate": "script/make validate -j8 -Orecurse",
+        "fix": "script/make fix -j8 -Orecurse",
+        "build": "script/make build -j8 -Orecurse",
+        "test": "script/make test -j8 -Orecurse",
+        "install-mallard": "script/make install",
+        "validate-mallard": "script/make validate-Mallard",
         "validate-mallard-tsc": "echo 'no longer used'",
-        "test-mallard": "make test-Mallard"
+        "test-mallard": "script/make test-Mallard"
     },
     "devDependencies": {
         "@guardian/node-riffraff-artifact": "0.0.15",

--- a/projects/archiver/package.json
+++ b/projects/archiver/package.json
@@ -22,8 +22,8 @@
         "build": "ncc build main.ts -o dist -m",
         "start": "AWS_DEFAULT_PROFILE='frontend' ts-node local.ts",
         "start:index": "AWS_DEFAULT_PROFILE='frontend' ts-node src/indexer/local.ts",
-        "validate": "cd ../.. && make validate-archiver",
-        "fix": "cd ../.. && yarn fix-archiver",
+        "validate": "cd ../.. && script/make validate-archiver",
+        "fix": "cd ../.. && script/make fix-archiver",
         "test": "jest --coverage",
         "test:watch": "jest --watch"
     },

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -20,8 +20,8 @@
     "build": "ncc build index.ts -o dist -m",
     "start": "ts-node-dev --ignore-watch node_modules index.ts",
     "preview": "publicationStage=preview yarn start",
-    "validate": "cd ../.. && make validate-backend",
-    "fix": "cd ../.. && make fix-backend",
+    "validate": "cd ../.. && script/make validate-backend",
+    "fix": "cd ../.. && script/make fix-backend",
     "test": "jest --coverage",
     "test:watch": "jest --watch"
   },

--- a/script/make
+++ b/script/make
@@ -1,0 +1,13 @@
+#!/bin/bash
+# A bash script that calls gmake or make as available on your system
+USE_GMAKE=$(which gmake)
+UNAME=$(uname)
+if [ -n "$USE_GMAKE" ]; then
+    exec gmake "$@"
+else
+    if [ "$UNAME" == "Darwin" ]; then
+        echo "ERROR: make on macOS is not sophisticated enough for our needs, please 'brew install make' to get gmake"
+        exit 1
+    fi
+    exec make "$@"
+fi


### PR DESCRIPTION
## Why are you doing this?
The build relies on GNU make but only ever tries to use `make` rather than `gmake`, which is where GNU make lives when brew installed opn macOS. 

This script tries both and prints a helpful error if you don't have `gmake` but are on macOS.
