### PR TITLE
Fix make script to try make regardless

### DIFF
--- a/script/make
+++ b/script/make
@@ -6,8 +6,9 @@ if [ -n "$USE_GMAKE" ]; then
     exec gmake "$@"
 else
     if [ "$UNAME" == "Darwin" ]; then
-        echo "ERROR: make on macOS is not sophisticated enough for our needs, please 'brew install make' to get gmake"
-        exit 1
+        echo "ERROR: make on macOS is not sophisticated enough for our needs"
+        echo "       We'll try and use it anyway in case you've replaced the system make"
+        echo "       If it doesn't work please 'brew install make' to get gmake"
     fi
     exec make "$@"
 fi


### PR DESCRIPTION
## Why are you doing this?
Change the make script to fallback to using make regardless of whether we think it should be new enough.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
