### PR TITLE
Ensure we always have an issue id in context

### DIFF
--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -44,7 +44,14 @@ const WebviewWithArticle = ({
                     (issueCompositeKey && issueCompositeKey.publishedIssueId) ||
                     null,
             }),
-        [article, pillar, wrapLayout, isConnected, paddingTop],
+        [
+            article,
+            pillar,
+            wrapLayout,
+            isConnected,
+            paddingTop,
+            issueCompositeKey,
+        ],
     )
 
     return (

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode } from 'react'
 import { StyleSheet, View, StatusBar } from 'react-native'
-import { Issue } from 'src/common'
 import { Highlight } from 'src/components/highlight'
 import { GridRowSplit, IssueTitle } from 'src/components/issue/issue-title'
-import { useIssueDate } from 'src/helpers/issues'
 import { useInsets } from 'src/hooks/use-screen'
 import { WithAppAppearance } from 'src/theme/appearance'
 import { color } from 'src/theme/color'
@@ -131,12 +129,9 @@ const Header = ({
     )
 }
 
-const IssuePickerHeader = ({
-    issue,
-    ...headerProps
-}: { issue?: Issue } & Omit<HeaderProps, 'children'> &
-    TouchableHeaderProps) => {
-    const { date, weekday } = useIssueDate(issue)
+const IssuePickerHeader = (
+    headerProps: Omit<HeaderProps, 'children'> & TouchableHeaderProps,
+) => {
     return (
         <Header {...headerProps}>
             <IssueTitle

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -8,7 +8,6 @@ import {
 } from 'src/helpers/transform'
 import { ERR_404_REMOTE } from 'src/helpers/words'
 import { APIPaths, FSPaths, PathToArticle } from 'src/paths'
-import { getLatestIssue } from './use-api'
 import { useCachedOrPromise } from './use-cached-or-promise'
 
 export const useIssueWithResponse = <T>(
@@ -33,15 +32,13 @@ export const getIssueResponse = (
     )
 }
 
-export const useIssueOrLatestResponse = (issue?: {
+export const useIssueResponse = (issue: {
     localIssueId: Issue['localId']
     publishedIssueId: Issue['publishedId']
 }) =>
     useIssueWithResponse(
-        issue
-            ? getIssueResponse(issue.localIssueId, issue.publishedIssueId)
-            : getLatestIssue(),
-        [issue || 'latest'],
+        getIssueResponse(issue.localIssueId, issue.publishedIssueId),
+        [issue],
     )
 
 export const getFrontsResponse = (

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -6,7 +6,7 @@ import {
     NavigationScreenProp,
     withNavigation,
 } from 'react-navigation'
-import { Issue, IssueSummary } from 'src/common'
+import { IssueSummary } from 'src/common'
 import { Button, ButtonAppearance } from 'src/components/button/button'
 import { IssueRow } from 'src/components/issue/issue-row'
 import { GridRowSplit } from 'src/components/issue/issue-title'
@@ -22,7 +22,6 @@ import {
     REFRESH_BUTTON_TEXT,
 } from 'src/helpers/words'
 import { useIssueSummary } from 'src/hooks/use-api'
-import { useIssueOrLatestResponse } from 'src/hooks/use-issue'
 import { useMediaQuery } from 'src/hooks/use-screen'
 import { useSettingsValue } from 'src/hooks/use-settings'
 import {
@@ -38,14 +37,9 @@ import { ApiState } from './settings/api-screen'
 
 const HomeScreenHeader = withNavigation(
     ({
-        issue,
         navigation,
         onReturn,
     }: {
-        issue?: {
-            localIssueId: Issue['localId']
-            publishedIssueId: Issue['publishedId']
-        }
         onReturn: () => void
         onSettings: () => void
     } & NavigationInjectedProps) => {
@@ -60,7 +54,6 @@ const HomeScreenHeader = withNavigation(
                 onPress={onReturn}
             />
         )
-        const response = useIssueOrLatestResponse(issue)
         const settings = (
             <Button
                 icon={'\uE040'}
@@ -71,23 +64,14 @@ const HomeScreenHeader = withNavigation(
                 appearance={ButtonAppearance.skeleton}
             />
         )
-        return response({
-            error: () => (
-                <IssuePickerHeader leftAction={settings} action={action} />
-            ),
-            pending: () => (
-                <IssuePickerHeader leftAction={settings} action={action} />
-            ),
-            success: issue => (
-                <IssuePickerHeader
-                    leftAction={settings}
-                    issue={issue}
-                    accessibilityHint={'Return to issue'}
-                    onPress={onReturn}
-                    action={action}
-                />
-            ),
-        })
+        return (
+            <IssuePickerHeader
+                leftAction={settings}
+                accessibilityHint={'Return to issue'}
+                onPress={onReturn}
+                action={action}
+            />
+        )
     },
 )
 
@@ -169,7 +153,6 @@ export const HomeScreen = ({
             />
             <ScrollContainer>
                 <HomeScreenHeader
-                    issue={issue}
                     onSettings={() => {
                         navigation.navigate('Settings')
                     }}


### PR DESCRIPTION
## Why are you doing this?

Prior to this change `useIssueCompositeKey` would only return the key from the navigator. This wasn't necessarily the key that was being displayed, as we may not have a key in the navigator but our fetch strategy went and decided on an issue anyway.

This ensures that `useIssueCompositeKey` is the sole place where "issue picking' takes place. Then both our fetcher and consumers of the hook have the same value.

This could definitely do with a refactor but, given the fetching primitives that exist for this data are largely wrapped in hook-like constructs, it will take a bit longer than I'm prepared to give it right now.

I've also remove some unused issue dependencies from some components.

[**Trello Card ->**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
