### PR TITLE
Rahb/aspect ratio

### DIFF
--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -1,13 +1,12 @@
 import React, { ReactNode, useState } from 'react'
-import { StyleSheet, ImageBackground, View, Text } from 'react-native'
-import { CreditedImage } from '../../common'
-import { useMediaQuery } from 'src/hooks/use-screen'
-import { Breakpoints } from 'src/theme/breakpoints'
-import { useImagePath } from 'src/hooks/use-image-paths'
-import { Button } from '../button/button'
+import { ImageBackground, StyleSheet, View } from 'react-native'
 import { useArticle } from 'src/hooks/use-article'
+import { useImagePath } from 'src/hooks/use-image-paths'
 import { color } from 'src/theme/color'
+import { CreditedImage } from '../../common'
+import { Button } from '../button/button'
 import { UiBodyCopy } from '../styled-text'
+import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 
 const styles = StyleSheet.create({
     wrapper: {
@@ -41,13 +40,8 @@ interface PropTypes {
 }
 
 const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
-    const isLandscape = useMediaQuery(
-        width => width >= Breakpoints.tabletLandscape,
-    )
-
-    const defaultAspectRatio = isLandscape ? 2 : 1.5
-
     const path = useImagePath(image)
+    const defaultAspectRatio = useAspectRatio(path)
 
     const [showCredit, setShowCredit] = useState(false)
     const toggleCredit = () => setShowCredit(curr => !curr)

--- a/projects/Mallard/src/components/article/types/cartoon.tsx
+++ b/projects/Mallard/src/components/article/types/cartoon.tsx
@@ -4,7 +4,7 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { GalleryHeader } from '../article-header/gallery-header'
 import { MaxWidthWrap } from '../wrap/max-width'
-import { AutoSizedImageResource } from 'src/components/front/image-resource'
+import { ImageResource } from 'src/components/front/image-resource'
 import { PictureArticle } from '../../../../../common/src'
 
 const Cartoon = ({ article }: { article: PictureArticle }) => (
@@ -26,9 +26,10 @@ const Cartoon = ({ article }: { article: PictureArticle }) => (
         >
             {article.image && (
                 <MaxWidthWrap>
-                    <AutoSizedImageResource
+                    <ImageResource
                         style={{ width: '100%' }}
                         image={article.image}
+                        setAspectRatio
                     />
                 </MaxWidthWrap>
             )}

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react'
-import { Image as IImage } from '../../../../common/src'
-import { Image, StyleProp, ImageStyle, ImageProps } from 'react-native'
+import React from 'react'
+import { Image, ImageProps, ImageStyle, StyleProp } from 'react-native'
+import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 import { useImagePath } from 'src/hooks/use-image-paths'
+import { Image as IImage } from '../../../../common/src'
 
 /**
  * This component abstracts away the endpoint for images
@@ -15,54 +16,28 @@ import { useImagePath } from 'src/hooks/use-image-paths'
 type ImageResourceProps = {
     image: IImage
     style?: StyleProp<ImageStyle>
-    onGetPath?: (path: string) => void
+    setAspectRatio?: boolean
 } & Omit<ImageProps, 'source'>
 
 const ImageResource = ({
     image,
     style,
-    onGetPath,
+    setAspectRatio = false,
     ...props
 }: ImageResourceProps) => {
     const path = useImagePath(image)
-    useEffect(() => {
-        onGetPath && path && onGetPath(path)
-    }, [path, onGetPath])
+    const aspectRatio = useAspectRatio(path)
     return (
         <Image
             resizeMethod={'resize'}
             {...props}
-            style={style}
+            style={[
+                style,
+                setAspectRatio && aspectRatio ? { aspectRatio } : {},
+            ]}
             source={{ uri: path }}
         />
     )
 }
 
-const AutoSizedImageResource = ({
-    ...props
-}: Omit<ImageResourceProps, 'onGetPath'>) => {
-    const [aspectRatio, setRatio] = useState(1)
-
-    return (
-        <ImageResource
-            {...props}
-            style={[
-                {
-                    aspectRatio,
-                },
-                props.style,
-            ]}
-            onGetPath={path => {
-                Image.getSize(
-                    path,
-                    (width, height) => {
-                        setRatio(width / height)
-                    },
-                    () => {},
-                )
-            }}
-        />
-    )
-}
-
-export { ImageResource, AutoSizedImageResource }
+export { ImageResource }

--- a/projects/Mallard/src/components/front/items/items.tsx
+++ b/projects/Mallard/src/components/front/items/items.tsx
@@ -2,14 +2,12 @@ import React from 'react'
 import { StyleSheet, View } from 'react-native'
 import { HeadlineCardText } from 'src/components/styled-text'
 import { metrics } from 'src/theme/spacing'
-import { ImageResource, AutoSizedImageResource } from '../image-resource'
+import { ImageResource } from '../image-resource'
 import { ItemTappable, PropTypes } from './helpers/item-tappable'
 import { TextBlock } from './helpers/text-block'
 import { ImageItem, SplitImageItem, SidekickImageItem } from './image-items'
 import { SmallItem, SmallItemLargeText } from './small-items'
 import { SuperHeroImageItem } from './super-items'
-import { WithBreakpoints } from 'src/components/layout/ui/sizing/with-breakpoints'
-import { Breakpoints } from 'src/theme/breakpoints'
 import { Image } from '../../../../../common/src'
 import { PageLayoutSizes } from '../helpers/helpers'
 
@@ -100,9 +98,10 @@ const SplashImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
             <View style={splashImageStyles.overflow}>
-                <AutoSizedImageResource
+                <ImageResource
                     style={[splashImageStyles.image]}
                     image={cardImage}
+                    setAspectRatio
                 />
             </View>
             <HeadlineCardText style={[splashImageStyles.hidden]}>

--- a/projects/Mallard/src/hooks/use-aspect-ratio.ts
+++ b/projects/Mallard/src/hooks/use-aspect-ratio.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+import { Image } from 'react-native'
+import { useMediaQuery } from 'src/hooks/use-screen'
+import { Breakpoints } from 'src/theme/breakpoints'
+
+const useAspectRatio = (path?: string) => {
+    const isLandscape = useMediaQuery(
+        width => width >= Breakpoints.tabletLandscape,
+    )
+
+    const [ratio, setRatio] = useState(isLandscape ? 2 : 1.5)
+
+    useEffect(() => {
+        if (path) {
+            Image.getSize(
+                path,
+                (w, h) => {
+                    setRatio(w / h)
+                },
+                () => {},
+            )
+        }
+    }, [path])
+
+    return ratio
+}
+
+export { useAspectRatio }


### PR DESCRIPTION
## Why are you doing this?

This uses the correct aspect ratio for main media as per the Trello card.

[**Trello Card ->**](https://trello.com/c/t4ABIp7j/490-main-media-that-isnt-the-expected-aspect-ratio-should-be-scaled-to-fit)

## Changes

* Add `useAspectRatio` hook.
* Allow `ImageResource` to leverage this hook with a prop
* Remove `AutoSizedImageResource`
* Use hook with article `ImageBackground`

## Screenshots

![Screen Shot 2019-09-20 at 14 16 30](https://user-images.githubusercontent.com/1652187/65329960-7c24ed80-dbb1-11e9-8eb2-0e660fb054e1.png)

