### PR TITLE
tweaked sizes back

### DIFF
--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -86,8 +86,8 @@ const scale = {
                 lineHeight: 18,
             },
             [Breakpoints.phone]: {
-                fontSize: 15,
-                lineHeight: 19,
+                fontSize: 14,
+                lineHeight: 16,
             },
             [Breakpoints.tabletVertical]: {
                 fontSize: 18,
@@ -144,8 +144,8 @@ const scale = {
                 lineHeight: 17,
             },
             [Breakpoints.phone]: {
-                fontSize: 16,
-                lineHeight: 19,
+                fontSize: 17,
+                lineHeight: 20,
             },
             [Breakpoints.tabletVertical]: {
                 fontSize: 24,
@@ -172,8 +172,8 @@ const scale = {
                 lineHeight: 22,
             },
             [Breakpoints.phone]: {
-                fontSize: 26,
-                lineHeight: 29,
+                fontSize: 24,
+                lineHeight: 26,
             },
             [Breakpoints.tabletVertical]: {
                 fontSize: 36,


### PR DESCRIPTION
Reverting the change to the small headline size. 

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
