### PR TITLE
fix: Remove yellow box warning for ReleaseStream

### DIFF
--- a/projects/Mallard/ios/ReleaseStream.m
+++ b/projects/Mallard/ios/ReleaseStream.m
@@ -9,6 +9,14 @@
 #import <Foundation/Foundation.h>
 #import "React/RCTBridgeModule.h"
 
+
 @interface RCT_EXTERN_REMAP_MODULE(RNReleaseStream, ReleaseStream, NSObject)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
+
 @end
 


### PR DESCRIPTION
## Why are you doing this?

Remove the noise in the warnings.