### PR TITLE
fix: Shaddow Warning

### DIFF
--- a/projects/Mallard/src/navigation/navigators/underlay.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay.tsx
@@ -90,15 +90,6 @@ const createUnderlayNavigator = (
         defaultNavigationOptions: {
             gesturesEnabled: false,
         },
-        cardStyle: {
-            shadowOffset: {
-                width: 0,
-                height: 0,
-            },
-            overflow: 'visible',
-            shadowOpacity: 0.2,
-            shadowRadius: 8,
-        },
         headerMode: 'none',
         ...(supportsTransparentCards()
             ? {


### PR DESCRIPTION
## Why are you doing this?

In an effort to improve performance, im looking through some of the warnings. This warning came up a lot on iOS and it was particularly focused on this piece of code that has been removed.

It looks like its never used, but would like @walaura to check.

Checked on both iOS and Android and there is no visual regression.