### PR TITLE
Remove unused thumbnail which makes it easier to override cutout

### DIFF
--- a/projects/Mallard/src/components/article/article-header/types.ts
+++ b/projects/Mallard/src/components/article/article-header/types.ts
@@ -7,5 +7,5 @@ export interface ArticleHeaderProps {
     image?: Image | null
     standfirst: string
     starRating?: Article['starRating']
-    bylineImages?: { thumbnail?: Image; cutout?: Image }
+    bylineImages?: { cutout?: Image }
 }

--- a/projects/archiver/media.ts
+++ b/projects/archiver/media.ts
@@ -27,11 +27,7 @@ export const getImagesFromArticle = (article: CAPIArticle): Image[] => {
     const elements = article.type !== 'crossword' ? article.elements : []
     const cardImages = [article.cardImage, article.cardImageTablet]
     const bylineImages =
-        (article.bylineImages && [
-            article.bylineImages.cutout,
-            article.bylineImages.thumbnail,
-        ]) ||
-        []
+        (article.bylineImages && [article.bylineImages.cutout]) || []
 
     const images = elements.map(getImageFromElement)
 

--- a/projects/backend/capi/__tests__/byline.spec.ts
+++ b/projects/backend/capi/__tests__/byline.spec.ts
@@ -60,10 +60,6 @@ describe('byline image extractor', () => {
         const article = createArticleLike(tagSpecs, 'Name')
         const images = getBylineImages(article)
         expect(images).toStrictEqual({
-            thumbnail: {
-                source: 'test',
-                path: 'image',
-            },
             cutout: {
                 source: 'test',
                 path: 'image2',

--- a/projects/backend/capi/byline.ts
+++ b/projects/backend/capi/byline.ts
@@ -4,26 +4,23 @@ import { Image } from '../common'
 
 export const getBylineImages = (
     article: IContent,
-): { thumbnail?: Image; cutout?: Image } | undefined => {
+): { cutout?: Image } | undefined => {
     const byline = article.fields && article.fields.byline
     if (byline == null) return undefined
     // We could be more clever here, but multiple contributer tags wouldn't be displayed.
     const tags = article.tags
 
     const contributor = tags.find(
-        tag => tag.type == TagType.CONTRIBUTOR && byline.includes(tag.webTitle),
+        tag =>
+            tag.type == TagType.CONTRIBUTOR &&
+            byline.includes(tag.webTitle) &&
+            tag.bylineLargeImageUrl,
     )
     if (contributor == null) return
-    const { bylineImageUrl, bylineLargeImageUrl } = contributor
+    const { bylineLargeImageUrl } = contributor
     const cutout =
         bylineLargeImageUrl !== undefined
             ? getImageFromURL(bylineLargeImageUrl)
             : undefined
-
-    const thumbnail =
-        bylineImageUrl !== undefined
-            ? getImageFromURL(bylineImageUrl)
-            : undefined
-
-    return { cutout, thumbnail }
+    return { cutout }
 }

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -160,7 +160,7 @@ export interface Content extends WithKey {
     cardImageTablet?: Image
     standfirst?: string
     byline?: string
-    bylineImages?: { thumbnail?: Image; cutout?: Image }
+    bylineImages?: { cutout?: Image }
     showByline: boolean
     showQuotedHeadline: boolean
     mediaType: MediaType


### PR DESCRIPTION
## Why are you doing this?
When a cutout is overriden or set by the fronts tool `thumbnail` is not available. Also, `thumbnail` is not used. Finally it is largely a legacy field in CAPI that isn't really used by dotcom either. This removes it from our code base.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/Y9de0IDo)

## Changes

* Remove `thumbnail` from `bylineImages`
* Add extra filter to only look for images that have a cutout

