### PR TITLE
Fix back button on IssueList

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-id.tsx
+++ b/projects/Mallard/src/hooks/use-issue-id.tsx
@@ -26,6 +26,12 @@ export const useIssueCompositeKeyHandler = () => {
         'issue',
     )
 
+    // This will mean that any page that has come "from" an issue (that is not
+    // itself an issue), will have this previous issue marked as it's current
+    // issue, in order to facilitate actions to go back to or modals that
+    // require that information
+    const from: { path?: PathToIssue } | undefined = nav.getParam('from')
+
     // this is currently the easiest way to get to a value for the issue summar
     // could do with a refactor in to a service
     const response = useCachedOrPromise(getIssueSummary())
@@ -44,6 +50,15 @@ export const useIssueCompositeKeyHandler = () => {
             localIssueId: localId,
             publishedIssueId: publishedId,
         }
+    }
+
+    if (from && from.path) {
+        const { localIssueId, publishedIssueId } = from.path
+        if (localIssueId && publishedIssueId)
+            fromNav = fromNav || {
+                localIssueId,
+                publishedIssueId,
+            }
     }
 
     return <R extends any>({

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -28,12 +28,12 @@ import {
     navigateToIssue,
     navigateToSettings,
 } from 'src/navigation/helpers/base'
-import { PathToIssue } from 'src/paths'
 import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan'
 import { WithAppAppearance } from 'src/theme/appearance'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { ApiState } from './settings/api-screen'
+import { useIssueCompositeKey } from 'src/hooks/use-issue-id'
 
 const HomeScreenHeader = withNavigation(
     ({
@@ -140,10 +140,8 @@ export const HomeScreen = ({
     navigation: NavigationScreenProp<{}>
 }) => {
     const { response: issueSummary, retry } = useIssueSummary()
-    const from = navigation.getParam('from', undefined)
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
-    const issue: PathToIssue =
-        from && from.path && (from.path.issue as PathToIssue)
+    const issue = useIssueCompositeKey()
     return (
         <WithAppAppearance value={'tertiary'}>
             <NavigationEvents


### PR DESCRIPTION
## Why are you doing this?

Fix a regression where the back button on the issue list would always take you to the most recent issue.

[**Trello Card ->**](https://trello.com/c/Ievsx3zu/749-issue-picker-if-one-clicks-the-shevron-and-goes-back-doesnt-go-back-to-the-ediotion-that-someone-was-previously-looking-loads-th)
