### PR TITLE
fix: Double Android Icon

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -43,16 +43,6 @@
     </service>
 
       <activity
-        android:name=".SplashActivity"
-        android:theme="@style/SplashTheme"
-        android:label="@string/app_name">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-
-      <activity
         android:name=".MainActivity"
         android:launchMode="singleTask"
         android:label="@string/app_name"


### PR DESCRIPTION
## Why are you doing this?

Splash screen activity added as a result of a tutorial meant a duplicate icon. Activity removed and down to one icon.

For reference: https://stackoverflow.com/questions/47823186/why-there-are-show-two-icon-after-installed-in-the-android