### PR TITLE
Switch to use the byline image for opinion

### DIFF
--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -102,10 +102,12 @@ const RoundImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
                 headline={article.headline}
                 {...{ size }}
             />
-            {'image' in article && article.image ? (
+            {'bylineImages' in article &&
+            article.bylineImages &&
+            article.bylineImages.cutout ? (
                 <ImageResource
                     style={[imageStyles.roundImage]}
-                    image={article.image}
+                    image={article.bylineImages.cutout}
                 />
             ) : null}
         </ItemTappable>


### PR DESCRIPTION
## Why are you doing this?
The opinion cards were mistakenly bringing in the main media when they should show contributor cutouts. Note that this doesn't have a fallback which results in many cards not having an image at all.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/Y9de0IDo)

## Changes

* Switch to use byline cutout

## Screenshots
**Before**:
![image](https://user-images.githubusercontent.com/1236466/65447191-f19cf200-de2d-11e9-80c9-234b31789334.png)


**After**:
![image](https://user-images.githubusercontent.com/1236466/65446922-573cae80-de2d-11e9-8dda-2e94fe5303f0.png)
