### PR TITLE
Support Review article headers on news pillar articles

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -40,6 +40,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
+                else if (isReview) return ArticleType.Review
                 else return ArticleType.Article
 
             case 'sport':


### PR DESCRIPTION
## Why are you doing this?

To support the application of the review template on article's whose pillar is news.

