### PR TITLE
(SH & MK) switch to use trailImage on fronts cards

### DIFF
--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -52,13 +52,13 @@ const ImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     }
     return (
         <ItemTappable {...tappableProps} {...{ article }}>
-            {'image' in article && article.image ? (
+            {'trailImage' in article && article.trailImage ? (
                 <ImageResource
                     style={[
                         imageStyles.image,
                         { height: getImageHeight(size) },
                     ]}
-                    image={article.image}
+                    image={article.trailImage}
                 />
             ) : null}
             {pillar === 'sport' && isFullWidthItem(size) ? (
@@ -134,7 +134,7 @@ A smaller hero
 */
 const SidekickImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     const [colors, { pillar }] = useArticle()
-    if (!article.image) {
+    if (!article.trailImage) {
         return <SmallItem {...{ article, size, ...tappableProps }} />
     }
     if (pillar === 'sport') {
@@ -146,7 +146,7 @@ const SidekickImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
             <View style={squareStyles.cover}>
                 <ImageResource
                     style={[StyleSheet.absoluteFill]}
-                    image={article.image}
+                    image={article.trailImage}
                 />
                 <View
                     style={[
@@ -208,10 +208,10 @@ const SplitImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
                     headline={article.headline}
                     {...{ size }}
                 />
-                {'image' in article && article.image ? (
+                {'trailImage' in article && article.trailImage ? (
                     <ImageResource
                         style={[splitImageStyles.image]}
-                        image={article.image}
+                        image={article.trailImage}
                     />
                 ) : null}
             </View>

--- a/projects/Mallard/src/components/front/items/items.tsx
+++ b/projects/Mallard/src/components/front/items/items.tsx
@@ -39,10 +39,10 @@ const CoverItem = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }}>
             <View style={coverStyles.cover}>
-                {'image' in article && article.image ? (
+                {'trailImage' in article && article.trailImage ? (
                     <ImageResource
                         style={coverStyles.cover}
-                        image={article.image}
+                        image={article.trailImage}
                     />
                 ) : null}
                 <TextBlock

--- a/projects/Mallard/src/components/front/items/super-items.tsx
+++ b/projects/Mallard/src/components/front/items/super-items.tsx
@@ -50,10 +50,10 @@ const superHeroImageStyles = StyleSheet.create({
 const NormalSuper = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
-            {'image' in article && article.image ? (
+            {'trailImage' in article && article.trailImage ? (
                 <ImageResource
                     style={[superHeroImageStyles.image]}
-                    image={article.image}
+                    image={article.trailImage}
                 />
             ) : null}
             <TextBlock
@@ -86,10 +86,10 @@ const sportSuperStyles = StyleSheet.create({
 const SportSuper = ({ article, size, ...tappableProps }: PropTypes) => {
     return (
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
-            {'image' in article && article.image ? (
+            {'trailImage' in article && article.trailImage ? (
                 <ImageResource
                     style={[superHeroImageStyles.image]}
-                    image={article.image}
+                    image={article.trailImage}
                 />
             ) : null}
             <TextBlock


### PR DESCRIPTION
## Why are you doing this?
In #553 PR we introduced `trailImage` (to be used on fronts) as distinct from `image` (to be used in content). This PR switches to use `article.trailImage` on fronts cards instead of  `article.image`.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/Y9de0IDo)

## Screenshots

example:
![image](https://user-images.githubusercontent.com/10913420/65518180-c375eb80-dedb-11e9-9f6a-099482691f16.png)

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
