### PR TITLE
Hide card overflow

### DIFF
--- a/projects/Mallard/src/components/front/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page.tsx
@@ -44,6 +44,7 @@ const styles = StyleSheet.create({
         marginBottom: metrics.fronts.sides * 1.5,
     },
     itemHolder: {
+        overflow: 'hidden',
         position: 'absolute',
     },
     multiline: {


### PR DESCRIPTION
## Why are you doing this?

Largely this is to solve images overflowing the card but it will stop anything overflowing a card which seems like a 👍 

[**Trello Card ->**](https://trello.com/c/84Y6zDQf/742-cover-card-depth-issues)
