### PR TITLE
Switch PROD backend host and decrease index cache

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -7,7 +7,7 @@ This is a bit of a mess
 export const backends = [
     {
         title: 'PROD published',
-        value: 'https://editions-store-prod.s3-eu-west-1.amazonaws.com/',
+        value: 'https://editions.guardianapis.com/',
         preview: false,
     },
     {

--- a/projects/archiver/src/generateIndexTask.ts
+++ b/projects/archiver/src/generateIndexTask.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda'
 import { attempt, hasFailed } from '../../backend/utils/try'
 import { IssueCompositeKey, IssueSummary } from '../common'
 import { indexer } from './indexer/summary'
-import { upload, ONE_MINUTE } from './upload'
+import { upload, FIVE_SECONDS } from './upload'
 
 export interface IndexTaskOutput {
     issueId: IssueCompositeKey
@@ -15,7 +15,7 @@ export const handler: Handler<IndexTaskOutput> = async ({ issueId }) => {
         console.error(index)
         throw new Error('Could not generate index.')
     }
-    await upload('issues', index, 'application/json', ONE_MINUTE)
+    await upload('issues', index, 'application/json', FIVE_SECONDS)
     return {
         issueId,
         index,

--- a/projects/archiver/src/indexer/summary.ts
+++ b/projects/archiver/src/indexer/summary.ts
@@ -3,7 +3,7 @@ import { attempt, hasFailed } from '../../../backend/utils/try'
 import { ImageSize, imageSizes } from '../../../common/src'
 import { IssueSummary, notNull } from '../../common'
 import { bucket, s3 } from '../s3'
-import { upload, ONE_MINUTE } from '../upload'
+import { upload, FIVE_SECONDS } from '../upload'
 
 const zips = 'zips/'
 
@@ -119,6 +119,6 @@ export const summary = async () => {
         console.error('Could not fetch index')
         return
     }
-    await upload('issues', index, 'application/json', ONE_MINUTE)
+    await upload('issues', index, 'application/json', FIVE_SECONDS)
     return
 }

--- a/projects/archiver/src/upload.ts
+++ b/projects/archiver/src/upload.ts
@@ -9,6 +9,7 @@ function cacheControlHeader(maxAge: number | undefined): string {
 
 export const ONE_WEEK = 3600 * 24 * 7
 export const ONE_MINUTE = 60
+export const FIVE_SECONDS = 5
 
 export const upload = (
     key: string,


### PR DESCRIPTION
## Why are you doing this?
Follow up to #464 that switches the PROD API endpoint to use the new domain and CDN.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/a9oY1ITn)

## Changes

* Reduce `/issues` max age from `60` to `5`
* Switch PROD endpoint to own domain name


<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
