### PR TITLE
Rahb/selective drop cap

### DIFF
--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -1,9 +1,4 @@
-import {
-    ArticleFeatures,
-    ArticlePillar,
-    BlockElement,
-    MediaAtomElement,
-} from 'src/common'
+import { ArticlePillar, BlockElement, MediaAtomElement } from 'src/common'
 import { getPillarColors } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
 import {
@@ -47,7 +42,7 @@ export const makeCss = ({ colors, wrapLayout }: CssProps) => css`
         display: inline-block;
         transform: scale(1.335) translateY(1px) translateX(-2px);
         transform-origin: left center;
-        margin-right: 25px;
+        margin-bottom: 25px;
     }
     :root {
         ${getScaledFontCss('text', 1)}
@@ -105,14 +100,12 @@ export const render = (
     article: BlockElement[],
     {
         pillar,
-        features,
         wrapLayout,
         showMedia,
         height,
         publishedId,
     }: {
         pillar: ArticlePillar
-        features: ArticleFeatures[]
         wrapLayout: WrapLayout
         showMedia: boolean
         height: number
@@ -123,10 +116,7 @@ export const render = (
         .map((el, i) => {
             switch (el.id) {
                 case 'html':
-                    if (
-                        i === 0 &&
-                        features.includes(ArticleFeatures.HasDropCap)
-                    ) {
+                    if (el.hasDropCap) {
                         return html`
                             <div class="drop-cap">
                                 ${el.html}

--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -42,7 +42,7 @@ export const makeCss = ({ colors, wrapLayout }: CssProps) => css`
         display: inline-block;
         transform: scale(1.335) translateY(1px) translateX(-2px);
         transform-origin: left center;
-        margin-bottom: 25px;
+        margin-right: 25px;
     }
     :root {
         ${getScaledFontCss('text', 1)}

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -2,7 +2,7 @@ import { useNetInfo } from '@react-native-community/netinfo'
 import React, { useMemo } from 'react'
 import { Animated, Linking, Platform, WebViewProps } from 'react-native'
 import { WebView } from 'react-native-webview'
-import { ArticleFeatures, BlockElement } from 'src/common'
+import { BlockElement } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
 import { useIssueCompositeKey } from 'src/hooks/use-issue-id'
 import { EMBED_DOMAIN, render } from '../../html/render'
@@ -13,8 +13,6 @@ const urlIsNotAnEmbed = (url: string) =>
         url.startsWith(EMBED_DOMAIN) ||
         url.startsWith('https://www.youtube.com/embed')
     )
-
-const features: ArticleFeatures[] = [ArticleFeatures.HasDropCap]
 
 const AniWebview = Animated.createAnimatedComponent(WebView)
 
@@ -36,7 +34,6 @@ const WebviewWithArticle = ({
         () =>
             render(article, {
                 pillar,
-                features,
                 wrapLayout,
                 showMedia: isConnected,
                 height: paddingTop,

--- a/projects/backend/__tests__/fronts.spec.ts
+++ b/projects/backend/__tests__/fronts.spec.ts
@@ -1,4 +1,4 @@
-import { patchArticle, getImages } from '../fronts'
+import { patchArticle, getImages, patchArticleElements } from '../fronts'
 import { Article, PublishedFurniture } from './helpers/fixtures'
 import { CAPIContent } from '../capi/articles'
 import {
@@ -6,7 +6,7 @@ import {
     PublishedImage,
     PublishedCardImage,
 } from '../fronts/issue'
-import { CreditedImage, Image } from '../../common/src'
+import { CreditedImage, Image, ArticleType } from '../../common/src'
 
 describe('fronts', () => {
     describe('patchArticle', () => {
@@ -46,6 +46,40 @@ describe('fronts', () => {
                 )[1]
                 expect(patched.trail).toBe('here is something important')
                 expect(patched.trail).toBe(patched.standfirst)
+            })
+        })
+    })
+
+    describe('patchArticleElements', () => {
+        it('should add drop caps for the first html element only in certain `articleType`s', () => {
+            const els = patchArticleElements({
+                articleType: ArticleType.Feature,
+                elements: [
+                    { id: 'html', html: '<p>hi</p>' },
+                    { id: 'html', html: '<p>hi</p>' },
+                ],
+            })
+
+            expect(els[0]).toMatchObject({
+                hasDropCap: true,
+            })
+        })
+
+        it('should ignore non-html elements in first position', () => {
+            const els = patchArticleElements({
+                articleType: ArticleType.Feature,
+                elements: [
+                    { id: 'unknown' },
+                    { id: 'html', html: '<p>hi</p>' },
+                ],
+            })
+
+            expect(els[0]).not.toMatchObject({
+                hasDropCap: true,
+            })
+
+            expect(els[1]).not.toMatchObject({
+                hasDropCap: true,
             })
         })
     })

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -1,6 +1,6 @@
 import striptags from 'striptags'
 import { oc } from 'ts-optchain'
-import { BlockElement } from '../common/src'
+import { BlockElement, ArticleType } from '../common/src'
 import { CAPIContent, CArticle, getArticles } from './capi/articles'
 import {
     CAPIArticle,
@@ -135,7 +135,10 @@ const commonFields = (article: CAPIContent, furniture: PublishedFurtniture) => {
     }
 }
 
-const patchArticleElements = (article: CArticle): BlockElement[] => {
+export const patchArticleElements = (article: {
+    articleType?: ArticleType
+    elements: BlockElement[]
+}): BlockElement[] => {
     const [head, ...tail] = article.elements
     return !articleShouldHaveDropCap(article) || !isHTMLElement(head)
         ? article.elements

--- a/projects/backend/utils/article.ts
+++ b/projects/backend/utils/article.ts
@@ -1,5 +1,4 @@
 import { ArticleType, BlockElement, HTMLElement } from '../../common/src'
-import { CArticle } from '../capi/articles'
 
 const DROP_CAP_ARTICLE_TYPES: ArticleType[] = [
     ArticleType.Feature,
@@ -7,8 +6,11 @@ const DROP_CAP_ARTICLE_TYPES: ArticleType[] = [
     ArticleType.Longread,
 ]
 
-const articleShouldHaveDropCap = ({ articleType }: CArticle) =>
-    articleType && DROP_CAP_ARTICLE_TYPES.includes(articleType)
+const articleShouldHaveDropCap = ({
+    articleType,
+}: {
+    articleType?: ArticleType
+}) => articleType && DROP_CAP_ARTICLE_TYPES.includes(articleType)
 
 const isHTMLElement = (el?: BlockElement): el is HTMLElement =>
     !!el && el.id === 'html'

--- a/projects/backend/utils/article.ts
+++ b/projects/backend/utils/article.ts
@@ -1,0 +1,16 @@
+import { ArticleType, BlockElement, HTMLElement } from '../../common/src'
+import { CArticle } from '../capi/articles'
+
+const DROP_CAP_ARTICLE_TYPES: ArticleType[] = [
+    ArticleType.Feature,
+    ArticleType.Immersive,
+    ArticleType.Longread,
+]
+
+const articleShouldHaveDropCap = ({ articleType }: CArticle) =>
+    articleType && DROP_CAP_ARTICLE_TYPES.includes(articleType)
+
+const isHTMLElement = (el?: BlockElement): el is HTMLElement =>
+    !!el && el.id === 'html'
+
+export { articleShouldHaveDropCap, isHTMLElement }

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -31,11 +31,6 @@ export enum ArticleType {
     Immersive = 'immersive',
 }
 
-export enum ArticleFeatures {
-    HasDropCap = 'HAS-DROP-CAP',
-    HasFancyDropCap = 'HAS-FANCY-DROP-CAP',
-}
-
 export type ArticlePillar = typeof articlePillars[number]
 
 export interface ColorAppearance {
@@ -249,6 +244,7 @@ export interface UnknownElement {
 export interface HTMLElement {
     id: 'html'
     html: string
+    hasDropCap?: boolean
 }
 
 type ImageRoles = 'supporting' | 'immersive' | 'showcase' | 'thumbnail' | string


### PR DESCRIPTION
## Why are you doing this?

Only render drop caps on the first element in certain article types.

This touches items in `common` but it adds it as an optional field so all that will happen is some old editions will not show drop caps where they potentially should.

[**Trello Card ->**](https://trello.com/c/kfcab6vH/726-bug-drop-caps-show-on-all-article-types-need-to-appear-only-on-long-read-immersive-and-feature)

[**Trello Card ->**](https://trello.com/c/5rZiNYGQ/740-bug-overuse-of-drop-caps)

