### PR TITLE
Remove hardcoded zip prefix

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -62,7 +62,6 @@ export interface DevSettings {
     isUsingProdDevtools: boolean
     useNewWebview: boolean
     notificationServiceRegister: string
-    zipUrl: string
     cacheClearUrl: string
     deprecationWarningUrl: string
     contentPrefix: string

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -63,7 +63,6 @@ export const defaultSettings: Settings = {
     notificationServiceRegister: __DEV__
         ? notificationServiceRegister.code
         : notificationServiceRegister.prod,
-    zipUrl: apiUrl + 'zips',
     cacheClearUrl: apiUrl + 'cache-clear',
     deprecationWarningUrl: apiUrl + 'deprecation-warning',
     contentPrefix: 'daily-edition',


### PR DESCRIPTION
## Why are you doing this?
The zip prefix is currently hardcoded but doesn't need to be and restricts how we arrange the file space by doing so. Not having that gives more flexibility.
