### PR TITLE
Change fb app id to new Editions app

### DIFF
--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -26,10 +26,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>fb180444840287</string>
+			<string>fb528503751025697</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>fb180444840287</string>
+				<string>fb528503751025697</string>
 			</array>
 		</dict>
 		<dict>

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -11,7 +11,7 @@ const {
     ANDROID_RELEASE_STREAM,
 } = Config
 
-const FACEBOOK_CLIENT_ID = '180444840287'
+const FACEBOOK_CLIENT_ID = '528503751025697'
 
 const AUTH_TTL = 86400000 // ms in a day
 


### PR DESCRIPTION
## Why are you doing this?

I've created a new app id in the Guardian FB account. This change goes along with that to move the app over to that new id for authentication. It seems to work ...