### PR TITLE
Don't re-render on all nav changes

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -173,88 +173,93 @@ const handlePending = () => (
     </>
 )
 
-const IssueScreenWithPath = ({ path }: { path: PathToIssue }) => {
-    const response = useIssueResponse(path)
-    return response({
-        error: handleError,
-        pending: handlePending,
-        success: (issue, { retry }) => {
-            sendPageViewEvent({
-                path: `editions/uk/daily/${issue.key}`,
-            })
-            return (
-                <>
-                    <PreviewReloadButton
-                        onPress={() => {
-                            clearCache()
-                            retry()
-                        }}
-                    />
-                    <ScreenHeader issue={issue} />
+const IssueScreenWithPath = React.memo(
+    ({ path }: { path: PathToIssue }) => {
+        const response = useIssueResponse(path)
+        return response({
+            error: handleError,
+            pending: handlePending,
+            success: (issue, { retry }) => {
+                sendPageViewEvent({
+                    path: `editions/uk/daily/${issue.key}`,
+                })
+                return (
+                    <>
+                        <PreviewReloadButton
+                            onPress={() => {
+                                clearCache()
+                                retry()
+                            }}
+                        />
+                        <ScreenHeader issue={issue} />
 
-                    <WithBreakpoints>
-                        {{
-                            0: () => (
-                                <WithLayoutRectangle>
-                                    {metrics => (
-                                        <WithIssueScreenSize
-                                            value={[
-                                                PageLayoutSizes.mobile,
-                                                metrics,
-                                            ]}
-                                        >
-                                            <IssueFronts
-                                                ListHeaderComponent={
-                                                    <View
-                                                        style={
-                                                            styles.weatherWide
-                                                        }
-                                                    >
-                                                        <Weather />
-                                                    </View>
-                                                }
-                                                issue={issue}
-                                            />
-                                        </WithIssueScreenSize>
-                                    )}
-                                </WithLayoutRectangle>
-                            ),
-                            [Breakpoints.tabletVertical]: () => (
-                                <View
-                                    style={{
-                                        flexDirection: 'row',
-                                    }}
-                                >
-                                    <View style={styles.sideWeather}>
-                                        <Weather />
-                                    </View>
-
+                        <WithBreakpoints>
+                            {{
+                                0: () => (
                                     <WithLayoutRectangle>
                                         {metrics => (
                                             <WithIssueScreenSize
                                                 value={[
-                                                    PageLayoutSizes.tablet,
+                                                    PageLayoutSizes.mobile,
                                                     metrics,
                                                 ]}
                                             >
                                                 <IssueFronts
-                                                    style={
-                                                        styles.sideBySideFeed
+                                                    ListHeaderComponent={
+                                                        <View
+                                                            style={
+                                                                styles.weatherWide
+                                                            }
+                                                        >
+                                                            <Weather />
+                                                        </View>
                                                     }
                                                     issue={issue}
                                                 />
                                             </WithIssueScreenSize>
                                         )}
                                     </WithLayoutRectangle>
-                                </View>
-                            ),
-                        }}
-                    </WithBreakpoints>
-                </>
-            )
-        },
-    })
-}
+                                ),
+                                [Breakpoints.tabletVertical]: () => (
+                                    <View
+                                        style={{
+                                            flexDirection: 'row',
+                                        }}
+                                    >
+                                        <View style={styles.sideWeather}>
+                                            <Weather />
+                                        </View>
+
+                                        <WithLayoutRectangle>
+                                            {metrics => (
+                                                <WithIssueScreenSize
+                                                    value={[
+                                                        PageLayoutSizes.tablet,
+                                                        metrics,
+                                                    ]}
+                                                >
+                                                    <IssueFronts
+                                                        style={
+                                                            styles.sideBySideFeed
+                                                        }
+                                                        issue={issue}
+                                                    />
+                                                </WithIssueScreenSize>
+                                            )}
+                                        </WithLayoutRectangle>
+                                    </View>
+                                ),
+                            }}
+                        </WithBreakpoints>
+                    </>
+                )
+            },
+        })
+    },
+    (prev, next) =>
+        prev.path.localIssueId === next.path.localIssueId &&
+        prev.path.publishedIssueId === next.path.publishedIssueId,
+)
 
 export const IssueScreen = () => {
     const response = useIssueCompositeKeyHandler()

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -173,6 +173,11 @@ const handlePending = () => (
     </>
 )
 
+/** used to memoize the IssueScreenWithPath */
+const pathsAreEqual = (a: PathToIssue, b: PathToIssue) =>
+    a.localIssueId === b.localIssueId &&
+    a.publishedIssueId === b.publishedIssueId
+
 const IssueScreenWithPath = React.memo(
     ({ path }: { path: PathToIssue }) => {
         const response = useIssueResponse(path)
@@ -256,9 +261,7 @@ const IssueScreenWithPath = React.memo(
             },
         })
     },
-    (prev, next) =>
-        prev.path.localIssueId === next.path.localIssueId &&
-        prev.path.publishedIssueId === next.path.publishedIssueId,
+    (prev, next) => pathsAreEqual(prev.path, next.path),
 )
 
 export const IssueScreen = () => {


### PR DESCRIPTION
## Why are you doing this?

When we opened / closed the issue picker we would always re-render the whole issue screen. There are many sub-issues here - not least of which, issue screen could probably be quicker to render than it is (more memoization of the most often rendered components would help here).

Not sure this will totally fix the issue but it'll definitely help as we were re-rendering the issue screen when _opening_ the issue picker, which probably caused issues on slower devices.