### PR TITLE
Memoize cards and add debug helper

### DIFF
--- a/projects/Mallard/src/components/front/helpers/helpers.ts
+++ b/projects/Mallard/src/components/front/helpers/helpers.ts
@@ -9,7 +9,7 @@ import { Rectangle, Size } from 'src/helpers/sizes'
 import { PropTypes } from '../items/helpers/item-tappable'
 import { safeInterpolation } from 'src/helpers/math'
 
-type Item = FunctionComponent<PropTypes>
+export type Item = FunctionComponent<PropTypes>
 
 export interface AnimatedFlatListRef {
     _component: FlatList<Front['collections'][0]>

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -45,11 +45,15 @@ const CollectionPageInFront = ({
     scrollX: Animated.Value
 } & PropTypes) => {
     const { card, size } = useIssueScreenSize()
-    const translate = getTranslateForPage(
-        card.width,
-        scrollX,
-        index,
-        size === PageLayoutSizes.mobile ? 1 : 0.5,
+    const translate = useMemo(
+        () =>
+            getTranslateForPage(
+                card.width,
+                scrollX,
+                index,
+                size === PageLayoutSizes.mobile ? 1 : 0.5,
+            ),
+        [card.width, scrollX, index, size],
     )
     return (
         <Animated.View

--- a/projects/Mallard/src/helpers/debug.ts
+++ b/projects/Mallard/src/helpers/debug.ts
@@ -9,13 +9,14 @@ type DiffEntry<Props, K extends keyof Props> = {
 type Diff<Props extends object> = DiffEntry<Props, keyof Props>[]
 
 /**
- * This will help to log the difference between props on subsequen renders.
+ * This will help to log the difference between props on subsequent renders.
  *
- * You use it just as you would use React.memo, except the second argument
- * will pass you the prev / next props _and_ the array of diffs to log.
+ * It (ab)uses, React.memo to get access to the prev / next props and you
+ * use it just as you would use React.memo, except the second argument
+ * passes through those prev / next props _and_ an array of diffs to log.
  *
- * If you only want to log the diffs of one specific component you can
- * use the props to and log conditionally e.g. and article id
+ * If you only want to log the diffs of one specific component instance you can
+ * use the props to log conditionally e.g. comparing against a specific article id
  */
 const logPropDiff = <T extends object>(
     component: SFC<T>,

--- a/projects/Mallard/src/helpers/debug.ts
+++ b/projects/Mallard/src/helpers/debug.ts
@@ -1,0 +1,48 @@
+import { memo, SFC } from 'react'
+
+type DiffEntry<Props, K extends keyof Props> = {
+    key: K
+    prev: Props[K]
+    next: Props[K]
+}
+
+type Diff<Props extends object> = DiffEntry<Props, keyof Props>[]
+
+/**
+ * This will help to log the difference between props on subsequen renders.
+ *
+ * You use it just as you would use React.memo, except the second argument
+ * will pass you the prev / next props _and_ the array of diffs to log.
+ *
+ * If you only want to log the diffs of one specific component you can
+ * use the props to and log conditionally e.g. and article id
+ */
+const logPropDiff = <T extends object>(
+    component: SFC<T>,
+    log: (prevProps: T, nextProps: T, diff: Diff<T>) => boolean = () => true,
+) =>
+    memo(component, (prevProps, nextProps) => {
+        const allKeys = Object.keys(prevProps).concat(
+            Object.keys(nextProps),
+        ) as (keyof T)[]
+
+        const diff: Diff<T> = []
+
+        for (const key of allKeys) {
+            const prev = prevProps[key]
+            const next = nextProps[key]
+            if (!Object.is(prev, next)) {
+                diff.push({
+                    key,
+                    prev,
+                    next,
+                })
+            }
+        }
+
+        log(prevProps, nextProps, diff)
+
+        return false
+    })
+
+export { logPropDiff }


### PR DESCRIPTION
## Why are you doing this?

This ensures cards render only once (instead of twice previously) on a normal issue load.

Additionally added a helper for debugging prop diffs.

Because of `Context`, things may still be re-rendering further down in the tree but will check this separately from this PR.