### PR TITLE
Revert "Change android release to supply beta"

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -56,7 +56,7 @@ platform :android do
            }
     )
     supply(
-      track: 'beta',
+      track: 'internal',
       package_name: 'com.guardian.editions'
     )
   end


### PR DESCRIPTION
Reverts guardian/editions#579 - nothing to see here ... 🙄 

![Screen Shot 2019-09-27 at 09 29 29](https://user-images.githubusercontent.com/1652187/65754698-82631e80-e109-11e9-9eaf-b3fde34fbece.png)
