### PR TITLE
feat: Always fetch Issue Summary

### DIFF
--- a/projects/Mallard/src/hooks/use-api.ts
+++ b/projects/Mallard/src/hooks/use-api.ts
@@ -7,7 +7,7 @@ import { getIssueResponse } from './use-issue'
 
 export const getIssueSummary = () =>
     fetchFromApi<IssueSummary[]>(issueSummaryPath(), {
-        cached: true,
+        cached: false,
         validator: res => res.length > 0,
     })
 


### PR DESCRIPTION
## Why are you doing this?

As an interim solution, we do not use the cache to get the issue summary. This way we always get the latest. This screen will now not work offline.