### PR TITLE
Change subject for diagnostics

### DIFF
--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -48,6 +48,7 @@ The information below will help us to better understand your query:
 -App-
 Product: Daily App
 App Version: ${DeviceInfo.getVersion()} ${DeviceInfo.getBuildNumber()}
+Commit id: ${getVersionInfo().commitId}
 Release Channel: ${isInBeta() ? 'BETA' : 'RELEASE'}
 App Edition: UK
 First app start: ${DeviceInfo.getFirstInstallTime()}
@@ -80,7 +81,7 @@ const openSupportMailto = (text: string, releaseURL: string, body?: string) => {
 
     const subject = `${text} - ${
         Platform.OS
-    } Daily App, ${DeviceInfo.getVersion()} / ${getVersionInfo().commitId}`
+    } Daily App, ${DeviceInfo.getVersion()} ${DeviceInfo.getBuildNumber()}`
 
     return Linking.openURL(
         `mailto:${email}?subject=${encodeURIComponent(subject)}${


### PR DESCRIPTION
## Why are you doing this?

After speaking with Gwyn on the user help team, it was deemed more helpful to have the Build number rather than commit id in the subject.