### PR TITLE
Slight tweaks to flatlist

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -159,16 +159,17 @@ const FrontWithResponse = ({
         >
             <Animated.FlatList
                 showsHorizontalScrollIndicator={false}
-                windowSize={6}
-                maxToRenderPerBatch={3}
+                // These three props are responsible for the majority of
+                // performance improvements
+                initialNumToRender={2}
+                windowSize={5}
+                maxToRenderPerBatch={2}
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
                 horizontal={true}
                 decelerationRate="fast"
                 snapToInterval={card.width}
-                ref={(flatList: AnimatedFlatListRef) =>
-                    (flatListRef.current = flatList)
-                }
+                ref={flatListRef}
                 getItemLayout={(_: never, index: number) => ({
                     length: card.width,
                     offset: card.width * index,
@@ -196,11 +197,9 @@ const FrontWithResponse = ({
                     ],
                     { useNativeDriver: true },
                 )}
-                extraData={{
-                    ...card,
-                    cw: container.width,
-                    ch: container.height,
-                }}
+                // this needs to be referential equal or will trigger
+                // a re-render
+                extraData={`${container.width}:${container.height}`}
                 data={cards}
                 renderItem={({
                     item,


### PR DESCRIPTION
## Why are you doing this?

The main fix here is `initialNumberToRender`, without this number set, for some reason it was rendering 6 cards for each front, essentially making the FlatList redundant 🤷‍♂ 

Also, `windowSize` should well be odd as means the amount of things rendering are the window (which is equal to one of the 5 units) plus `n` either side.

`maxToRenderPerBatch` seems fine at 2 but can push that back up if needs be

and `extraData` would cause a re-render of this list every single time as it compares by reference equality. It's essentially a sentinel as to whether to change or not, comparing by reference equality.