### PR TITLE
Rahb/improve issue list

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -48,21 +48,9 @@ enum ExistsStatus {
     doesNotExist,
 }
 
-const IssueRow = ({
-    issue,
-    onPress,
-}: {
-    issue: IssueSummary
-    onPress: () => void
-}) => {
-    const { date, weekday } = useMemo(() => renderIssueDate(issue.date), [
-        issue.date,
-    ])
-
-    const [dlStatus, setDlStatus] = useState<DLStatus | null>(null)
-
+const IssueButton = ({ issue }: { issue: IssueSummary }) => {
     const [exists, setExists] = useState<ExistsStatus>(ExistsStatus.pending)
-
+    const [dlStatus, setDlStatus] = useState<DLStatus | null>(null)
     const { showToast } = useToast()
 
     useEffect(() => {
@@ -98,44 +86,46 @@ const IssueRow = ({
     }
 
     return (
+        <ProgressCircle
+            percent={dlStatus ? getStatusPercentage(dlStatus) || 100 : 100}
+            radius={20}
+            bgColor={
+                exists === ExistsStatus.doesExist ? color.primary : undefined
+            }
+            borderWidth={1}
+            shadowColor="#ccc"
+            color={color.primary}
+        >
+            <Button
+                onPress={onDownloadIssue}
+                icon={exists === ExistsStatus.doesExist ? '\uE062' : '\uE077'}
+                alt={'Download'}
+                appearance={ButtonAppearance.skeleton}
+                textStyles={{
+                    color:
+                        exists !== ExistsStatus.doesExist
+                            ? color.primary
+                            : color.palette.neutral[100],
+                }}
+            />
+        </ProgressCircle>
+    )
+}
+
+const IssueRow = ({
+    issue,
+    onPress,
+}: {
+    issue: IssueSummary
+    onPress: () => void
+}) => {
+    const { date, weekday } = useMemo(() => renderIssueDate(issue.date), [
+        issue.date,
+    ])
+
+    return (
         <RowWrapper>
-            <GridRowSplit
-                proxy={
-                    <ProgressCircle
-                        percent={
-                            dlStatus
-                                ? getStatusPercentage(dlStatus) || 100
-                                : 100
-                        }
-                        radius={20}
-                        bgColor={
-                            exists === ExistsStatus.doesExist
-                                ? color.primary
-                                : undefined
-                        }
-                        borderWidth={1}
-                        shadowColor="#ccc"
-                        color={color.primary}
-                    >
-                        <Button
-                            onPress={onDownloadIssue}
-                            icon={
-                                exists === ExistsStatus.doesExist
-                                    ? '\uE062'
-                                    : '\uE077'
-                            }
-                            alt={'Download'}
-                            appearance={ButtonAppearance.skeleton}
-                            textStyles={{
-                                color:
-                                    exists !== ExistsStatus.doesExist
-                                        ? color.primary
-                                        : color.palette.neutral[100],
-                            }}
-                        />
-                    </ProgressCircle>
-                }
-            >
+            <GridRowSplit proxy={<IssueButton issue={issue} />}>
                 <View style={rowStyles.issueRow}>
                     <Highlight onPress={onPress}>
                         <IssueTitle

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { View } from 'react-native'
 import {
-    NavigationEvents,
     NavigationInjectedProps,
     NavigationScreenProp,
     withNavigation,
@@ -76,62 +75,64 @@ const HomeScreenHeader = withNavigation(
 )
 
 const IssueList = withNavigation(
-    ({
-        issueList,
-        navigation,
-    }: {
-        issueList: IssueSummary[]
-    } & NavigationInjectedProps) => {
-        const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
-        return (
-            <>
-                <BaseList
-                    style={{ paddingTop: 0 }}
-                    data={issueList}
-                    renderItem={({ item: issueSummary }) => (
-                        <IssueRow
-                            onPress={() => {
-                                navigateToIssue(navigation, {
-                                    path: {
-                                        localIssueId: issueSummary.localId,
-                                        publishedIssueId:
-                                            issueSummary.publishedId,
-                                    },
-                                })
-                                sendComponentEvent({
-                                    componentType: ComponentType.appButton,
-                                    action: Action.click,
-                                    value: 'issues_list_issue_clicked',
-                                })
-                            }}
-                            issue={issueSummary}
-                        />
-                    )}
-                />
-                {isUsingProdDevtools ? (
-                    <View
-                        style={{
-                            padding: metrics.horizontal,
-                            paddingVertical: metrics.vertical * 4,
-                        }}
-                    >
-                        <GridRowSplit>
-                            <Button
-                                appearance={ButtonAppearance.skeleton}
+    React.memo(
+        ({
+            issueList,
+            navigation,
+        }: {
+            issueList: IssueSummary[]
+        } & NavigationInjectedProps) => {
+            const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
+            return (
+                <>
+                    <BaseList
+                        style={{ paddingTop: 0 }}
+                        data={issueList}
+                        renderItem={({ item: issueSummary }) => (
+                            <IssueRow
                                 onPress={() => {
                                     navigateToIssue(navigation, {
-                                        path: undefined,
+                                        path: {
+                                            localIssueId: issueSummary.localId,
+                                            publishedIssueId:
+                                                issueSummary.publishedId,
+                                        },
+                                    })
+                                    sendComponentEvent({
+                                        componentType: ComponentType.appButton,
+                                        action: Action.click,
+                                        value: 'issues_list_issue_clicked',
                                     })
                                 }}
-                            >
-                                Go to latest
-                            </Button>
-                        </GridRowSplit>
-                    </View>
-                ) : null}
-            </>
-        )
-    },
+                                issue={issueSummary}
+                            />
+                        )}
+                    />
+                    {isUsingProdDevtools ? (
+                        <View
+                            style={{
+                                padding: metrics.horizontal,
+                                paddingVertical: metrics.vertical * 4,
+                            }}
+                        >
+                            <GridRowSplit>
+                                <Button
+                                    appearance={ButtonAppearance.skeleton}
+                                    onPress={() => {
+                                        navigateToIssue(navigation, {
+                                            path: undefined,
+                                        })
+                                    }}
+                                >
+                                    Go to latest
+                                </Button>
+                            </GridRowSplit>
+                        </View>
+                    ) : null}
+                </>
+            )
+        },
+    ),
 )
 
 export const HomeScreen = ({
@@ -139,16 +140,11 @@ export const HomeScreen = ({
 }: {
     navigation: NavigationScreenProp<{}>
 }) => {
-    const { response: issueSummary, retry } = useIssueSummary()
+    const { response: issueSummary } = useIssueSummary()
     const isUsingProdDevtools = useSettingsValue.isUsingProdDevtools()
     const issue = useIssueCompositeKey()
     return (
         <WithAppAppearance value={'tertiary'}>
-            <NavigationEvents
-                onDidFocus={() => {
-                    retry()
-                }}
-            />
             <ScrollContainer>
                 <HomeScreenHeader
                     onSettings={() => {


### PR DESCRIPTION
## Why are you doing this?

This improves the rendering the issue list in a few ways:

- It only makes the _button_ re-render when it finds out an issue already exists, rather than the whole issue row
- Additionally it memoizes the `IssueList` which was being re-rendered unnecessarily
- Finally, `retry` was being called on mount such that we were calling the `/issues` endpoint twice for every mount, also causing re-renders that would have broken the above memoization as we get two responses back from the issues endpoint. `retry` wasn't working as we'd hoped anyway and the broader case is being dealt with by another PR.