### PR TITLE
Disable react navigation URL handling

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -158,6 +158,7 @@ export default class App extends React.Component<{}, {}> {
                         <View style={styles.appContainer}>
                             <RootNavigator
                                 {...rootNavigationProps}
+                                enableURLHandling={false}
                                 onNavigationStateChange={
                                     onNavigationStateChange
                                 }


### PR DESCRIPTION
## Why are you doing this?

We don't want react navigation to handle _any_ deep links. As a precaution I'm explicitly turning it off as it _may_ have caused some of the social sign in issues we had earlier today.

As per the docs: https://reactnavigation.org/docs/en/deep-linking.html#disable-deep-linking