### PR TITLE
Move the index file to be namespaced ready for multiple editions

### DIFF
--- a/projects/Mallard/src/hooks/use-api.ts
+++ b/projects/Mallard/src/hooks/use-api.ts
@@ -2,12 +2,16 @@ import { IssueSummary, issueSummaryPath } from 'src/common'
 import { fetchFromApi } from 'src/helpers/fetch'
 import { withResponse } from 'src/helpers/response'
 import { useCachedOrPromise } from './use-cached-or-promise'
+import { defaultSettings } from 'src/helpers/settings/defaults'
 
 export const getIssueSummary = () =>
-    fetchFromApi<IssueSummary[]>(issueSummaryPath(), {
-        cached: false,
-        validator: res => res.length > 0,
-    })
+    fetchFromApi<IssueSummary[]>(
+        issueSummaryPath(defaultSettings.contentPrefix),
+        {
+            cached: false,
+            validator: res => res.length > 0,
+        },
+    )
 
 export const useIssueSummary = () => {
     const response = useCachedOrPromise(getIssueSummary())

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -35,6 +35,15 @@ export const handler: Handler<
         ...otherIssueSummaries,
     ])
 
+    await upload(
+        `${issuePublication.edition}/issues`,
+        allIssues,
+        'application/json',
+        FIVE_SECONDS,
+    )
+
+    // Also upload the index into the root for older clients
+    // TODO: this can be removed once we are happy that the clients are consuming the namespaced index
     await upload('issues', allIssues, 'application/json', FIVE_SECONDS)
 
     console.log('Uploaded new issues file')

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -44,7 +44,9 @@ export const handler: Handler<
 
     // Also upload the index into the root for older clients
     // TODO: this can be removed once we are happy that the clients are consuming the namespaced index
-    await upload('issues', allIssues, 'application/json', FIVE_SECONDS)
+    if (issuePublication.edition === 'daily-edition') {
+        await upload('issues', allIssues, 'application/json', FIVE_SECONDS)
+    }
 
     console.log('Uploaded new issues file')
 

--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -28,7 +28,7 @@ app.use((req, res, next) => {
     next()
 })
 
-app.get('/' + issueSummaryPath(), issuesSummaryController)
+app.get('/' + issueSummaryPath('daily-edition'), issuesSummaryController)
 app.get('/' + issuePath(issueId), issueController)
 console.log('/' + issuePath(issueId))
 app.get('/' + frontPath(issueId, '*?'), frontController)

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -393,7 +393,7 @@ export const mediaPath = (
 export const coloursPath = (issue: string, source: string, path: string) =>
     `${issueDir(issue)}/colours/${source}/${path}`
 
-export const issueSummaryPath = () => 'issues'
+export const issueSummaryPath = (edition: string) => `${edition}/issues`
 export interface Image {
     source: string
     path: string


### PR DESCRIPTION
## Why are you doing this?
The AUS and UK editions are in our rear view mirror but we currently have only one issue index location. Having one index for each separate edition makes more sense so this makes that change.

For backwards compatibility we put a copy of the index in the old location for now so that we don't unnecessarily break clients.

An issue will need to be republished to create the new index after deployment.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com)