### PR TITLE
Populate trailImage instead of image with crossword card images

### DIFF
--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -33,7 +33,7 @@ const getCrosswordImage = (type: CrosswordType) => {
 
 type CrosswordArticleOverrides = Pick<
     CAPIArticle,
-    'headline' | 'kicker' | 'image'
+    'headline' | 'kicker' | 'trailImage'
 > &
     Pick<CrosswordArticle, 'crossword'>
 
@@ -44,7 +44,7 @@ export const getCrosswordArticleOverrides = (
     return {
         headline: getCrosswordName(type),
         kicker: getCrosswordKicker(article.crossword),
-        image: getCrosswordImage(type),
+        trailImage: getCrosswordImage(type),
         crossword: article.crossword,
     }
 }


### PR DESCRIPTION
## Why are you doing this?
This fixes the images on fronts for crossword cards which was broken when `trailImage` was introduced in #565. The crossword card images are explicitly set in the backend but were overriding `image` instead of `trailImage`.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/nN2ql7qK)

## Screenshots

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
![unnamed](https://user-images.githubusercontent.com/1236466/65786307-47370e80-e14e-11e9-946d-b7798f7f92d3.jpg)
