### PR TITLE
Finish up image fetching

### DIFF
--- a/projects/Mallard/src/components/article/types/gallery.tsx
+++ b/projects/Mallard/src/components/article/types/gallery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import {
     Image,
     ImageStyle,
@@ -12,7 +12,6 @@ import { GalleryArticle, Image as ImageType, ImageElement } from 'src/common'
 import { BigArrow } from 'src/components/icons/BigArrow'
 import { UiBodyCopy } from 'src/components/styled-text'
 import { useArticle } from 'src/hooks/use-article'
-import { APIPaths } from 'src/paths'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
@@ -24,10 +23,9 @@ import {
 import { Wrap } from '../wrap/wrap'
 import { Direction } from 'src/helpers/sizes'
 import { useImagePath } from 'src/hooks/use-image-paths'
-import { imageForScreenSize } from 'src/helpers/screen'
 import { useIssueCompositeKey } from 'src/hooks/use-issue-id'
 import { Issue } from '../../../common'
-import { defaultSettings } from 'src/helpers/settings/defaults'
+import { ImageResource } from 'src/components/front/image-resource'
 
 const galleryImageStyles = StyleSheet.create({
     root: { backgroundColor: color.skeleton },
@@ -36,44 +34,17 @@ const GalleryImage = ({
     src,
     accessibilityLabel,
     style,
-    publishedId,
 }: {
     src: ImageType
     accessibilityLabel?: string
     style: StyleProp<ImageStyle>
-    publishedId: Issue['publishedId']
 }) => {
-    const [aspectRatio, setRatio] = useState(1)
-    const backend = defaultSettings.apiUrl
-    // @TODO: This will need a refactor to work locally
-    const uri = `${backend}${APIPaths.media(
-        publishedId,
-        imageForScreenSize(),
-        src.source,
-        src.path,
-    )}`
-
-    useEffect(() => {
-        Image.getSize(
-            uri,
-            (width, height) => {
-                setRatio(width / height)
-            },
-            () => {},
-        )
-    }, [uri])
-
     return (
-        <Image
+        <ImageResource
+            image={src}
+            style={[style, galleryImageStyles.root]}
+            setAspectRatio={true}
             accessibilityLabel={accessibilityLabel}
-            source={{ uri }}
-            style={[
-                style,
-                galleryImageStyles.root,
-                {
-                    aspectRatio,
-                },
-            ]}
         />
     )
 }
@@ -117,13 +88,7 @@ const styles = StyleSheet.create({
     arrow: { position: 'absolute', top: 3, left: -2 },
 })
 
-const GalleryItem = ({
-    element,
-    publishedId,
-}: {
-    element: ImageElement
-    publishedId: Issue['publishedId']
-}) => {
+const GalleryItem = ({ element }: { element: ImageElement }) => {
     const [color] = useArticle()
     return (
         <Wrap
@@ -154,7 +119,6 @@ const GalleryItem = ({
         >
             <GalleryImage
                 accessibilityLabel={element.alt}
-                publishedId={publishedId}
                 src={element.src}
                 style={styles.image}
             />
@@ -210,12 +174,7 @@ const Gallery = ({ gallery }: { gallery: GalleryArticle }) => {
             <View style={[styles.background]}>
                 {gallery.elements.map((element, index) => {
                     if (element.id === 'image' && publishedId) {
-                        return (
-                            <GalleryItem
-                                element={element}
-                                publishedId={publishedId}
-                            />
-                        )
+                        return <GalleryItem element={element} />
                     }
                     return <Text key={index}>{element.id}</Text>
                 })}

--- a/projects/Mallard/src/paths/index.ts
+++ b/projects/Mallard/src/paths/index.ts
@@ -26,7 +26,6 @@ export const APIPaths = {
     issue: issuePath,
     front: frontPath,
     media: mediaPath,
-    mediaBackend: 'https://d2cf1ljtg904cv.cloudfront.net/', // TODO: Use s3 issue paths.
 }
 
 const issuesDir = `${RNFetchBlob.fs.dirs.DocumentDir}/issues`


### PR DESCRIPTION
## Why are you doing this?
There was some concern that image asset handling would not always get images from the correct location - in particular that it might fetch an asset directly from the image resizer.

An audit revealed that the `mediaBackend` field is no longer used 🍾 but that the `GalleryImage` component would not correctly load images when offline 😞

This PR removes the unused field and migrates GalleryImage to use ImageResource which deals with figuring out where an image should be loaded from.

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/hILDsCZK)

## Changes

* Remove unused field from `APIPaths`
* Change `GalleryImage` component to use `ImageResource`

