### PR TITLE
Limit reauths for now

### DIFF
--- a/projects/Mallard/src/authentication/auth-context.tsx
+++ b/projects/Mallard/src/authentication/auth-context.tsx
@@ -66,11 +66,7 @@ const AuthContext = createContext<{
 const needsReauth = (
     prevAttempt: AuthAttempt,
     { isConnected }: { isConnected: boolean | null },
-) =>
-    (prevAttempt.type === 'cached' && isConnected) ||
-    (isPending(prevAttempt.status) ||
-        (isAuthed(prevAttempt.status) &&
-            prevAttempt.time < Date.now() - AUTH_TTL))
+) => prevAttempt.type === 'cached' && isConnected
 
 const assertUnreachable = (x: never): never => {
     throw new Error('This should be unreachable')


### PR DESCRIPTION
## Why are you doing this?

If we are _ever_ unauthed we try to reauth at the end of every unsuccessful attempt. I need to think about this but for now we should only try to reauthenticate automatically if we were previously cached and have become connected.