### PR TITLE
Re-enable landscape orientation.

### DIFF
--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -116,6 +116,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
From the external beta we have had lots of feedback from existing users that landscape orientation is very important to them.
For this reason we have decided to add it back (acknowledging it's currently not perfect). This will help us raise defects against it during the beta and understand just how much work we have here.

<img width="754" alt="Screenshot 2019-10-01 at 13 09 45" src="https://user-images.githubusercontent.com/8861681/65961321-3a683280-e44e-11e9-878a-e54bb55a1b9b.png">
