### PR TITLE
Dont spawn lots of windows

### DIFF
--- a/projects/Mallard/scripts/watch-html.command
+++ b/projects/Mallard/scripts/watch-html.command
@@ -4,4 +4,3 @@
 cd `dirname $0`
 cd ..
 node ./scripts/watch-html.js
-read

--- a/projects/Mallard/scripts/watch-html.js
+++ b/projects/Mallard/scripts/watch-html.js
@@ -16,10 +16,16 @@ const startWatchers = async () => {
                 [`cd ../../projects/${project}`, watchScript].join(' && '),
                 (err, stdout, stderr) => {
                     if (err || stderr) {
+                        if (stderr.includes('SIGKILL')) {
+                            console.log('Process replaced.')
+                            process.exit(0)
+                        }
                         console.error(
                             chalk.red('Failed watching bundle ' + key),
                         )
                         console.error(stderr)
+
+                        fs.readFileSync(0) //Don't immediately exit, allow the user to read the message.
                         process.exit(1)
                         return
                     }


### PR DESCRIPTION
This prevents `watch-html` from endlessly spawning terminals.