### PR TITLE
Fix image alignments on new webviews

### DIFF
--- a/projects/Mallard/src/components/article/html/images.ts
+++ b/projects/Mallard/src/components/article/html/images.ts
@@ -83,7 +83,7 @@ const imageStyles = ({ colors, wrapLayout }: CssProps) => css`
         .image[data-role='thumbnail'] {
             width: ${px(wrapLayout.rail.contentWidth)};
             position: absolute;
-            right: ${px(metrics.article.sides)};
+            right: ${px(metrics.article.sides * 0.5)};
         }
     }
 

--- a/projects/Mallard/src/components/article/html/images.ts
+++ b/projects/Mallard/src/components/article/html/images.ts
@@ -83,7 +83,7 @@ const imageStyles = ({ colors, wrapLayout }: CssProps) => css`
         .image[data-role='thumbnail'] {
             width: ${px(wrapLayout.rail.contentWidth)};
             position: absolute;
-            right: ${px(metrics.article.sides * 0.5)};
+            right: 0;
         }
     }
 

--- a/projects/Mallard/src/components/article/html/line.ts
+++ b/projects/Mallard/src/components/article/html/line.ts
@@ -4,6 +4,7 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { WrapLayout } from '../wrap/wrap'
 import { metrics } from 'src/theme/spacing'
+import { breakOut } from './helpers/layout'
 
 export const lineStyles = ({
     colors,
@@ -19,9 +20,7 @@ export const lineStyles = ({
             height: '100%';
             background: ${color.line};
             top: 0;
-            right: ${wrapLayout.width -
-                wrapLayout.content.width -
-                metrics.sides.sides / 2};
+            right: ${breakOut(wrapLayout)};
             bottom: 0;
             display: block;
             z-index: 99999;


### PR DESCRIPTION
## Why are you doing this?
they were over the line and now they aren't

![Screenshot 2019-10-02 at 12 18 54](https://user-images.githubusercontent.com/11539094/66040229-d35e8280-e50e-11e9-981a-691fb5a7fce0.png)
