### PR TITLE
test coverage for picking most recent valid issue version

### DIFF
--- a/projects/archiver/src/services/status.ts
+++ b/projects/archiver/src/services/status.ts
@@ -41,7 +41,7 @@ export const putStatus = (
 
 /* Given a published instance ID of an issue, return the instance status
  * from the status file - this contains the status and modified time */
-export const getStatus = async (
+const getStatus = async (
     issuePublication: IssuePublicationIdentifier,
 ): Promise<IssuePublicationWithStatus> => {
     console.log(`getStatus for ${JSON.stringify(issuePublication)}`)
@@ -80,7 +80,7 @@ export const getStatus = async (
 }
 
 /* Given an edition name and date provide a list of versions */
-export const getVersions = async (
+const getVersions = async (
     issue: IssueIdentifier,
 ): Promise<IssuePublicationIdentifier[]> => {
     console.log(`getVersions for ${JSON.stringify(issue)}`)
@@ -97,6 +97,8 @@ export const getVersions = async (
 export const getStatuses = async (
     issuePublication: IssueIdentifier,
 ): Promise<IssuePublicationWithStatus[]> => {
-    const allVersions = await getVersions(issuePublication)
+    const allVersions: IssuePublicationIdentifier[] = await getVersions(
+        issuePublication,
+    )
     return Promise.all(allVersions.map(getStatus))
 }

--- a/projects/archiver/src/tasks/indexer/helpers/get-published-version.spec.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-published-version.spec.ts
@@ -1,0 +1,139 @@
+import { getPublishedVersionInternal } from './get-published-version'
+import { IssuePublicationWithStatus } from '../../../services/status'
+import { IssueIdentifier } from '../../../../common'
+import moment = require('moment')
+
+const dt = '2019-09-30T16:45:23.699Z'
+
+const issue: IssueIdentifier = {
+    edition: 'daily-edition',
+    issueDate: '2019-09-09',
+}
+
+describe('getPublishedVersionInternal', () => {
+    it('should return most recent valid issue version', () => {
+        const publicationStatuses: IssuePublicationWithStatus[] = [
+            {
+                ...issue,
+                version: '2019-09-30T16:45:23.699Z',
+                status: 'bundled',
+                updated: moment(dt).toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T17:45:23.699Z',
+                status: 'indexed',
+                updated: moment(dt)
+                    .add(1, 'hours')
+                    .toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T18:45:23.699Z',
+                status: 'notified',
+                updated: moment(dt)
+                    .add(2, 'hours')
+                    .toDate(),
+            },
+        ]
+
+        const actual = getPublishedVersionInternal(publicationStatuses, issue)
+
+        const expected = {
+            ...issue,
+            version: '2019-09-30T18:45:23.699Z',
+            status: 'notified',
+            updated: moment(dt)
+                .add(2, 'hours')
+                .toDate(),
+        }
+
+        expect(actual).toStrictEqual(expected)
+    })
+    it('should return most recent valid issue version and ignore most recent entries which status was not of publish type', () => {
+        const publicationStatuses: IssuePublicationWithStatus[] = [
+            {
+                ...issue,
+                version: '2019-09-30T16:45:23.699Z',
+                status: 'bundled',
+                updated: moment(dt).toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T17:45:23.699Z',
+                status: 'indexed',
+                updated: moment(dt)
+                    .add(1, 'hours')
+                    .toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T18:45:23.699Z',
+                status: 'notified',
+                updated: moment(dt)
+                    .add(2, 'hours')
+                    .toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T19:45:23.699Z',
+                status: 'started',
+                updated: moment(dt)
+                    .add(3, 'hours')
+                    .toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T20:45:23.699Z',
+                status: 'assembled',
+                updated: moment(dt)
+                    .add(4, 'hours')
+                    .toDate(),
+            },
+        ]
+
+        const actual = getPublishedVersionInternal(publicationStatuses, issue)
+
+        const expected = {
+            ...issue,
+            version: '2019-09-30T18:45:23.699Z',
+            status: 'notified',
+            updated: moment(dt)
+                .add(2, 'hours')
+                .toDate(),
+        }
+
+        expect(actual).toStrictEqual(expected)
+    })
+
+    it('should return undefined if all statuses were not of publish type', () => {
+        const publicationStatuses: IssuePublicationWithStatus[] = [
+            {
+                ...issue,
+                version: '2019-09-30T16:45:23.699Z',
+                status: 'started',
+                updated: moment(dt).toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T17:45:23.699Z',
+                status: 'assembled',
+                updated: moment(dt)
+                    .add(1, 'hours')
+                    .toDate(),
+            },
+            {
+                ...issue,
+                version: '2019-09-30T18:45:23.699Z',
+                status: 'unknown',
+                updated: moment(dt)
+                    .add(2, 'hours')
+                    .toDate(),
+            },
+        ]
+
+        const actual = getPublishedVersionInternal(publicationStatuses, issue)
+
+        expect(actual).toBe(undefined)
+    })
+})

--- a/projects/archiver/src/tasks/indexer/helpers/get-published-version.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-published-version.ts
@@ -1,23 +1,14 @@
 import { IssuePublicationIdentifier, IssueIdentifier } from '../../../../common'
-import { getStatuses, isPublished } from '../../../services/status'
+import {
+    getStatuses,
+    isPublished,
+    IssuePublicationWithStatus,
+} from '../../../services/status'
 
-/* Given an edition name and date this will return the current publication instance ID
- * or undefined is there is no valid published instance. This is based on the status
- * of each instance, we are only interested in instances that are 'published'. Of the
- * instances that are valid we want the most recent one.
- * This also logs if there are more than one
- */
-export const getPublishedVersion = async (
+export const getPublishedVersionInternal = (
+    publicationStatuses: IssuePublicationWithStatus[],
     issue: IssueIdentifier,
-): Promise<IssuePublicationIdentifier | undefined> => {
-    const publicationStatuses = await getStatuses(issue)
-    console.log(
-        `getPublishedVersion: fetched list of publications for ${JSON.stringify(
-            issue,
-        )}`,
-        JSON.stringify(publicationStatuses),
-    )
-
+): IssuePublicationIdentifier | undefined => {
     const published = publicationStatuses.filter(({ status }) =>
         isPublished(status),
     )
@@ -44,4 +35,26 @@ export const getPublishedVersion = async (
     }
 
     return chosen
+}
+
+/* Given an edition name and date this will return the current publication instance ID
+ * or undefined is there is no valid published instance. This is based on the status
+ * of each instance, we are only interested in instances that are 'published'. Of the
+ * instances that are valid we want the most recent one.
+ * This also logs if there are more than one
+ */
+export const getPublishedVersion = async (
+    issue: IssueIdentifier,
+): Promise<IssuePublicationIdentifier | undefined> => {
+    const publicationStatuses: IssuePublicationWithStatus[] = await getStatuses(
+        issue,
+    )
+    console.log(
+        `getPublishedVersion: fetched list of publications for ${JSON.stringify(
+            issue,
+        )}`,
+        JSON.stringify(publicationStatuses),
+    )
+
+    return getPublishedVersionInternal(publicationStatuses, issue)
 }

--- a/projects/archiver/src/tasks/indexer/helpers/local.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/local.ts
@@ -1,11 +1,11 @@
-import { indexer } from './summary'
+import { getIssueSummaries } from './summary'
 import { attempt, hasFailed } from '../../../../../backend/utils/try'
 import { upload, ONE_MINUTE } from '../../../utils/s3'
 
 /* This file is for testing the indexer locally */
 
 export const summary = async () => {
-    const index = await attempt(indexer())
+    const index = await attempt(getIssueSummaries())
     if (hasFailed(index)) {
         console.error(index)
         console.error('Could not fetch index')

--- a/projects/archiver/src/tasks/indexer/helpers/summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/summary.ts
@@ -9,7 +9,7 @@ import { getPublishedVersion } from './get-published-version'
 import { oc } from 'ts-optchain'
 
 // currently publishing will remove this issue from the index, it should be generated in the indextask
-export const indexer = async (
+export const getIssueSummaries = async (
     currentlyPublishing?: IssuePublicationIdentifier,
 ): Promise<IssueSummary[]> => {
     const allIssues = await getIssues()

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -1,7 +1,7 @@
 import { Handler } from 'aws-lambda'
 import { IssueSummary, issueSummarySort } from '../../../common'
 import { getIssueSummary } from './helpers/get-issue-summary'
-import { indexer } from './helpers/summary'
+import { getIssueSummaries } from './helpers/summary'
 import { upload, FIVE_SECONDS } from '../../utils/s3'
 import { UploadTaskOutput } from '../upload'
 import { handleAndNotify } from '../../services/task-handler'
@@ -24,7 +24,7 @@ export const handler: Handler<
         throw new Error('No issue summary was generated for the current issue')
     }
 
-    const otherIssueSummaries = await indexer(issuePublication)
+    const otherIssueSummaries = await getIssueSummaries(issuePublication)
 
     console.log(
         `Creating index using the new and ${otherIssueSummaries.length} existing issue summaries`,


### PR DESCRIPTION
## Why are you doing this?

To review if we are picking the most recent valid issue version while publishing
This PR ads test coverage for that

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes
- adding unit tests for `getPublishedVersion` function
- small renames and refactor
