### PR TITLE
Fix fronts memory leeks

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -165,11 +165,13 @@ const FrontWithResponse = React.memo(
                     // These three props are responsible for the majority of
                     // performance improvements
                     initialNumToRender={2}
-                    windowSize={5}
+                    windowSize={3}
                     maxToRenderPerBatch={2}
                     showsVerticalScrollIndicator={false}
                     scrollEventThrottle={1}
                     horizontal={true}
+                    removeClippedSubviews={true}
+                    style={{ overflow: 'hidden' }}
                     decelerationRate="fast"
                     snapToInterval={card.width}
                     ref={flatListRef}

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, FunctionComponent, useMemo } from 'react'
-import { Animated, View } from 'react-native'
+import { Animated, View, StyleSheet } from 'react-native'
 import { CollectionPage, PropTypes } from './collection-page'
 import { Slider, SliderSkeleton } from '../slider'
 import { Spinner } from '../spinner'
@@ -86,6 +86,8 @@ const CollectionPageInFront = ({
     )
 }
 
+const styles = StyleSheet.create({ overflow: { overflow: 'hidden' } })
+
 const FrontWithResponse = React.memo(
     ({
         frontData,
@@ -171,7 +173,7 @@ const FrontWithResponse = React.memo(
                     scrollEventThrottle={1}
                     horizontal={true}
                     removeClippedSubviews={true}
-                    style={{ overflow: 'hidden' }}
+                    style={styles.overflow}
                     decelerationRate="fast"
                     snapToInterval={card.width}
                     ref={flatListRef}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -52,6 +52,9 @@ const styles = StyleSheet.create({
     sideBySideFeed: {
         paddingTop: metrics.vertical,
     },
+    overflow: {
+        overflow: 'hidden',
+    },
 })
 
 const ScreenHeader = withNavigation(
@@ -129,7 +132,7 @@ const IssueFronts = ({
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
         <ScrollView
-            style={[style, { overflow: 'hidden' }]}
+            style={[style, styles.overflow]}
             key={width}
             removeClippedSubviews={true}
         >

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -128,7 +128,11 @@ const IssueFronts = ({
     const { width } = useDimensions()
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
-        <ScrollView style={style} key={width}>
+        <ScrollView
+            style={[style, { overflow: 'hidden' }]}
+            key={width}
+            removeClippedSubviews={true}
+        >
             {ListHeaderComponent}
             {issue.fronts.map(key => (
                 <Front


### PR DESCRIPTION
we were rendering a lot of offscreen views with a ton of images, this keeps them under check. In lower-end devices it means there will be a bit of a stutter'' when scrolling, this is good – it means the main thread is unloading images behind the scenes and freeing up memory!

on an iPad 4 this is the difference bw crashing after a minute and running smoothly