### PR TITLE
backend README simplifying for copy paste lovers

### DIFF
--- a/projects/backend/README.md
+++ b/projects/backend/README.md
@@ -11,9 +11,7 @@ Ensure you have Janus credentials for `cmsFronts`.
 Then ensure you have some environment variables set, to do it in your current shell just run:
 
 ```
-export stage=prod;
-export psurl=https://preview.content.guardianapis.com/content/print-sent;
-export CAPI_KEY=test;
+export stage=prod && export psurl=https://preview.content.guardianapis.com/content/print-sent && export CAPI_KEY=test;
 ```
 
 `stage` is `prod` due to the fact that you get more results that way! The CAPI key is the canonical testing key ... if this, for whatever reason, doesn't work in future you can change it to a valid one.


### PR DESCRIPTION
## Why are you doing this?

that will simplify the procedure of running backend locally, so that command which set env variables can be copy pasted and executed in one line

