### PR TITLE
We also need to provide the legacy index location for preview

### DIFF
--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -28,6 +28,10 @@ app.use((req, res, next) => {
     next()
 })
 
+// this next line supports legacy clients and can be removed after beta
+// it should return the issues list for the daily-edition
+app.get('/issues', issuesSummaryController)
+
 app.get('/' + issueSummaryPath('daily-edition'), issuesSummaryController)
 app.get('/' + issuePath(issueId), issueController)
 console.log('/' + issuePath(issueId))


### PR DESCRIPTION
## Why are you doing this?
#602 dealt with supporting existing clients for published endpoints but not preview endpoints. This ensures that existing clients will continue to work.

