### PR TITLE
making Editions backend self documenting API

### DIFF
--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -9,6 +9,7 @@ import { imageController, imageColourController } from './controllers/image'
 import { ImageSize, coloursPath } from '../common/src/index'
 import { issuePath, mediaPath, frontPath, issueSummaryPath } from './common'
 import { isPreview } from './preview'
+import listEndpoints from 'express-list-endpoints'
 
 const app = express()
 
@@ -44,9 +45,13 @@ app.get(
 
 app.get('/' + coloursPath(issueId, ':source', '*?'), imageColourController)
 
-app.get('/', (req, res) => {
+const endpoints = listEndpoints(app)
+
+const rootPath = '/'
+
+app.get(rootPath, (req, res) => {
     res.setHeader('Content-Type', 'application/json')
-    res.send(JSON.stringify({ client: '🦆' }))
+    res.send(endpoints)
 })
 
 export const handler: Handler = (event, context) => {
@@ -60,7 +65,8 @@ export const handler: Handler = (event, context) => {
 if (require.main === module) {
     const port = 3131
 
-    app.listen(port, () =>
-        console.log(`Editions backend listening on port ${port}!`),
-    )
+    app.listen(port, () => {
+        console.log(`Editions backend listening on port ${port}!`)
+        console.log('Editions backend endpoints list available at root path')
+    })
 }

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -37,6 +37,7 @@
     "aws-serverless-express": "^3.3.6",
     "encoding": "^0.1.12",
     "express": "^4.17.1",
+    "express-list-endpoints": "^4.0.1",
     "jest": "^24.8.0",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0",

--- a/projects/backend/types/express-list-endpoints.d.ts
+++ b/projects/backend/types/express-list-endpoints.d.ts
@@ -1,0 +1,1 @@
+declare module 'express-list-endpoints'

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -1682,6 +1682,11 @@ expect@^24.8.0:
     jest-message-util "^24.8.0"
     jest-regex-util "^24.3.0"
 
+express-list-endpoints@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/express-list-endpoints/-/express-list-endpoints-4.0.1.tgz#f83ec9de4df21b904cfba523bc913aee4c17e9db"
+  integrity sha512-KjY7frYk72/Jwk2VgqyvuXlTPslEkWkzjUXPUMCUguVmAWqd6fh60VHr+sEfqJgMAOE3hKhUjm/7tLASVaE2Qg==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
## Why are you doing this?
I want to easily check which endpoints are supported by Editions backend 
For documentation and testing purposes
<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->


## Changes

* adding `express-list-endpoints` library
* making root path `/` as Editions backend docs (endpoints lists)

## Screenshots
![Screenshot 2019-10-03 at 11 37 33](https://user-images.githubusercontent.com/10913420/66121590-71b51b80-e5d5-11e9-9328-7fe66d1aa51d.png)

You can run app locally and access: http://localhost:3131/docs
<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
