### PR TITLE
Remount crosswords on change

### DIFF
--- a/projects/Mallard/src/components/article/types/crossword.tsx
+++ b/projects/Mallard/src/components/article/types/crossword.tsx
@@ -12,6 +12,7 @@ const Crossword = ({
     crosswordArticle: CrosswordArticle
 }) => (
     <WebView
+        key={crosswordArticle.key}
         originWhitelist={['*']}
         source={{ uri: getBundleUri('crosswords') }}
         injectedJavaScript={`


### PR DESCRIPTION
## Why are you doing this?

This stops crosswords from rendering the data from the previous crossword.