### PR TITLE
Massive memory gainz

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -59,6 +59,8 @@ PODS:
   - React-jsinspector (0.60.4)
   - react-native-config (0.11.7):
     - React
+  - react-native-image-resizer (1.0.1):
+    - React
   - react-native-in-app-utils (6.0.2):
     - React
   - react-native-netinfo (3.2.1):
@@ -144,6 +146,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-config (from `../node_modules/react-native-config`)
+  - react-native-image-resizer (from `../node_modules/react-native-image-resizer`)
   - react-native-in-app-utils (from `../node_modules/react-native-in-app-utils`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - "react-native-safe-area-insets (from `../node_modules/@delightfulstudio/react-native-safe-area-insets`)"
@@ -205,6 +208,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-image-resizer:
+    :path: "../node_modules/react-native-image-resizer"
   react-native-in-app-utils:
     :path: "../node_modules/react-native-in-app-utils"
   react-native-netinfo:
@@ -278,6 +283,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 7549641e48bafae7bfee3f3ea19bf4901639c5de
   React-jsinspector: 73f24a02fa684ed6a2b828ba116874a2191ded88
   react-native-config: 55548054279d92e0e4566ea15a8b9b81028ec342
+  react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
   react-native-netinfo: 0da34082d2cec3100c9b5073bb217e35f1142bdd
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
@@ -312,4 +318,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c499c44aed47275a8e1f036511ecda7d7450e47a
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.6.1

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -58,6 +58,7 @@
         "react-native-device-info": "^3.1.4",
         "react-native-gesture-handler": "^1.3.0",
         "react-native-iap": "^3.3.9",
+        "react-native-image-resizer": "^1.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.0.1",
         "react-native-keychain": "^3.1.3",

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -8,7 +8,7 @@ import {
     PixelRatio,
 } from 'react-native'
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { useImagePath, useScaledImage } from 'src/hooks/use-image-paths'
 import { Image as IImage } from '../../../../common/src'
 
 /**
@@ -26,38 +26,47 @@ type ImageResourceProps = {
     setAspectRatio?: boolean
 } & Omit<ImageProps, 'source'>
 
-const ImageResourceWithWidth = ({
-    image,
+const ScaledImageResource = ({
+    imagePath,
     style,
-    setAspectRatio = false,
     width,
     ...props
-}: ImageResourceProps & { width: number }) => {
-    const path = useImagePath(image, width)
-    const aspectRatio = useAspectRatio(path)
+}: {
+    width: number
+    imagePath: string
+    style?: StyleProp<ImageStyle>
+}) => {
+    const uri = useScaledImage(imagePath, width)
     return (
         <Image
             resizeMethod={'resize'}
             {...props}
-            style={[
-                style,
-                setAspectRatio && aspectRatio ? { aspectRatio } : {},
-            ]}
-            source={{ uri: path }}
+            style={style}
+            source={{ uri }}
         />
     )
 }
 
-const ImageResource = (props: ImageResourceProps) => {
+const ImageResource = ({
+    image,
+    style,
+    setAspectRatio = false,
+    ...props
+}: ImageResourceProps) => {
     const [width, setWidth] = useState<number | null>(null)
-    return width ? (
-        <ImageResourceWithWidth
+    const imagePath = useImagePath(image)
+    const aspectRatio = useAspectRatio(imagePath)
+    const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
+    return width && imagePath ? (
+        <ScaledImageResource
             width={width}
+            imagePath={imagePath}
+            style={styles}
             {...props}
-        ></ImageResourceWithWidth>
+        ></ScaledImageResource>
     ) : (
         <View
-            style={[props.style]}
+            style={styles}
             onLayout={ev => {
                 setWidth(
                     PixelRatio.getPixelSizeForLayoutSize(

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -57,6 +57,7 @@ const ImageResource = (props: ImageResourceProps) => {
         ></ImageResourceWithWidth>
     ) : (
         <View
+            style={[props.style]}
             onLayout={ev => {
                 setWidth(
                     PixelRatio.getPixelSizeForLayoutSize(

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,5 +1,12 @@
-import React from 'react'
-import { Image, ImageProps, ImageStyle, StyleProp } from 'react-native'
+import React, { useState } from 'react'
+import {
+    Image,
+    ImageProps,
+    ImageStyle,
+    StyleProp,
+    View,
+    PixelRatio,
+} from 'react-native'
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 import { useImagePath } from 'src/hooks/use-image-paths'
 import { Image as IImage } from '../../../../common/src'
@@ -19,13 +26,14 @@ type ImageResourceProps = {
     setAspectRatio?: boolean
 } & Omit<ImageProps, 'source'>
 
-const ImageResource = ({
+const ImageResourceWithWidth = ({
     image,
     style,
     setAspectRatio = false,
+    width,
     ...props
-}: ImageResourceProps) => {
-    const path = useImagePath(image)
+}: ImageResourceProps & { width: number }) => {
+    const path = useImagePath(image, width)
     const aspectRatio = useAspectRatio(path)
     return (
         <Image
@@ -37,6 +45,26 @@ const ImageResource = ({
             ]}
             source={{ uri: path }}
         />
+    )
+}
+
+const ImageResource = (props: ImageResourceProps) => {
+    const [width, setWidth] = useState<number | null>(null)
+    return width ? (
+        <ImageResourceWithWidth
+            width={width}
+            {...props}
+        ></ImageResourceWithWidth>
+    ) : (
+        <View
+            onLayout={ev => {
+                setWidth(
+                    PixelRatio.getPixelSizeForLayoutSize(
+                        ev.nativeEvent.layout.width,
+                    ),
+                )
+            }}
+        ></View>
     )
 }
 

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -47,23 +47,16 @@ const compressImagePath = async (path: string, width: number) => {
  *
  *  */
 
-const useImagePath = (image?: Image, width?: number) => {
+const useImagePath = (image?: Image) => {
     const key = useIssueCompositeKey()
 
     const [paths, setPaths] = useState<string | undefined>()
     const apiUrl = useSettingsValue.apiUrl()
     useEffect(() => {
         if (key && image) {
-            console.log([apiUrl, image, key])
             const { localIssueId, publishedIssueId } = key
             selectImagePath(apiUrl, localIssueId, publishedIssueId, image).then(
-                path => {
-                    if (width) {
-                        compressImagePath(path, width).then(setPaths)
-                    } else {
-                        setPaths(path)
-                    }
-                },
+                setPaths,
             )
         }
     }, [
@@ -71,7 +64,6 @@ const useImagePath = (image?: Image, width?: number) => {
         image,
         key ? key.publishedIssueId : undefined,
         key ? key.localIssueId : undefined,
-        width,
     ])
     if (image === undefined) return undefined
     return paths

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -71,6 +71,7 @@ const useImagePath = (image?: Image, width?: number) => {
         image,
         key ? key.publishedIssueId : undefined,
         key ? key.localIssueId : undefined,
+        width,
     ])
     if (image === undefined) return undefined
     return paths

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -77,4 +77,12 @@ const useImagePath = (image?: Image, width?: number) => {
     return paths
 }
 
-export { useImagePath, selectImagePath }
+const useScaledImage = (largePath: string, width: number) => {
+    const [path, setPath] = useState<string | undefined>()
+    useEffect(() => {
+        compressImagePath(largePath, width).then(setPath)
+    }, [largePath, width])
+    return path
+}
+
+export { useImagePath, useScaledImage, selectImagePath }

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -5477,6 +5477,11 @@ react-native-iap@^3.3.9:
   dependencies:
     dooboolab-welcome "^1.1.0"
 
+react-native-image-resizer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-image-resizer/-/react-native-image-resizer-1.0.1.tgz#e9eeb7f81596ffc490f822897952b046c07ee95c"
+  integrity sha512-upBF/9TIs4twg19dSkSaDW/MzMpNbysEXtPuapu3GqvOuGIYHKQ30v6httDn7rIb6uCcNIWL1BwZJM2cDt/C9Q==
+
 react-native-in-app-utils@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.2.tgz#b44498c7cce772fe1cebb00af082ff7bf4000a55"


### PR DESCRIPTION
Team, turns out we were using HUGE images all over the place

## THE METHODOLOGIZ

With this PR we now scale images before sending them off to RAM, not doing so was hurting older end devices, especially iPads with their huge screens. The resizer scales them down to the exact width (accounting for retina displays) that they will be displayed at. This all happens on device so we don't get network gains or anything, we just free up ram.

There's a tradeoff involved: scaling down the images causes a super minor CPU spike and calculating the width means that we will, in the best case scenario, miss a frame when rendering images. In real world use the CPU spike is insignificant compared to everything else going on in first load (plus its native code so uses a different thread) and the frame dropped is insignificant when added to the time it takes images to render

## THE NUMBERZ

The performance diff is just bananas and it's a change between crashing and running smoothly. In both cases i scrolled all the way to the bottom, then went up and stopped at a front with 1 image, then swiped to a front with 3+ images. You can see on the after image that our memory remains pretty much flat now as the images are TINY

![Screenshot 2019-10-03 at 13 54 16](https://user-images.githubusercontent.com/11539094/66129643-3c65f900-e5e8-11e9-9a53-530d6f8bd324.png)

![Screenshot 2019-10-03 at 13 56 10](https://user-images.githubusercontent.com/11539094/66129719-60c1d580-e5e8-11e9-876a-523a61af827d.png)

## THE ALLOCATIONZ

The first screenshot is from before #631, if you compare persistent memory you can see we went from 400MB to 3MB (holy shit) – but what's fair for the scope of this PR is the total memory. The total memory our images ever use is now halved (440 to 220) which is AMAZEBALLS, these 2 PRs make the app super snappy on older deevs

![Screenshot 2019-10-03 at 14 27 06](https://user-images.githubusercontent.com/11539094/66130658-f873f380-e5e9-11e9-84e7-8bbc0c6eb0bd.png)
![Screenshot 2019-10-03 at 14 27 13](https://user-images.githubusercontent.com/11539094/66130666-fb6ee400-e5e9-11e9-84e0-47feaea046d6.png)
