### PR TITLE
Remove overflow

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -52,9 +52,6 @@ const styles = StyleSheet.create({
     sideBySideFeed: {
         paddingTop: metrics.vertical,
     },
-    overflow: {
-        overflow: 'hidden',
-    },
 })
 
 const ScreenHeader = withNavigation(
@@ -131,11 +128,7 @@ const IssueFronts = ({
     const { width } = useDimensions()
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
-        <ScrollView
-            style={[style, styles.overflow]}
-            key={width}
-            removeClippedSubviews={true}
-        >
+        <ScrollView style={style} key={width} removeClippedSubviews={true}>
             {ListHeaderComponent}
             {issue.fronts.map(key => (
                 <Front


### PR DESCRIPTION
## Why are you doing this?

The `overflow: hidden` broke scrolling on Android. @walaura I'm assuming this was put in to try and solve the performance issues, but I'm assuming `renderClippedSubviews` will more than account for this so it seems safe to remove.