### PR TITLE
Editions backend: support multiple editions

### DIFF
--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -1,0 +1,88 @@
+import { Request, Response } from 'express'
+import { EditionsBackendControllers, createApp } from '../application'
+import chai from 'chai'
+import chaiHttp from 'chai-http'
+import * as http from 'http'
+
+// Configure chai
+chai.use(chaiHttp)
+chai.should()
+
+const stub = (req: Request, res: Response) => {
+    console.log(`endpoint: ${req.path} called`)
+    res.sendStatus(200)
+}
+
+const testStubControllers: EditionsBackendControllers = {
+    issuesSummaryController: stub,
+    issueController: stub,
+    frontController: stub,
+    imageController: stub,
+    imageColourController: stub,
+}
+
+const previewApp = createApp(testStubControllers, true)
+const versionedApp = createApp(testStubControllers, false)
+
+describe('Endpoints contract test for Preview Editions Backend application', () => {
+    it('should return 404 for non registered endpoints', done => {
+        chai.request(previewApp)
+            .get('/non-exisitent')
+            .end((err, res) => {
+                expect(res.status).toBe(404)
+                done()
+            })
+    })
+    it('should return 200 for registered GET paths', done => {
+        const expectedEndpoints = [
+            '/',
+            '/issues',
+            '/daily-edition/issues',
+            '/daily-edition/2019-09-17/preview/issue',
+            '/daily-edition/2019-09-17/preview/front/Top%20stories',
+            '/daily-edition/2019-09-17/preview/media/tablet/test/trail/asset.com',
+            '/daily-edition/2019-09-17/preview/media/colours/test/trail/asset.com',
+        ]
+
+        expectedEndpoints.forEach(path => {
+            chai.request(previewApp)
+                .get(path)
+                .end((err, res) => {
+                    expect(res.status).toBe(200)
+                    done()
+                })
+        })
+    })
+})
+
+describe('Endpoints contract test for Versioned Editions Backend application', () => {
+    const version = '2019-10-02T16:50:56.015Z'
+    it('should return 404 for non registered endpoints', done => {
+        chai.request(versionedApp)
+            .get('/non-exisitent')
+            .end((err, res) => {
+                expect(res.status).toBe(404)
+                done()
+            })
+    })
+    it('should return 200 for registered GET paths', done => {
+        const expectedEndpoints = [
+            '/',
+            '/issues',
+            `/daily-edition/issues`,
+            `/daily-edition/2019-09-17/${version}/issue`,
+            `/daily-edition/2019-09-17/${version}/front/Top%20stories`,
+            `/daily-edition/2019-09-17/${version}/media/tablet/test/trail/asset.com`,
+            `/daily-edition/2019-09-17/${version}/media/colours/test/trail/asset.com`,
+        ]
+
+        expectedEndpoints.forEach(path => {
+            chai.request(versionedApp)
+                .get(path)
+                .end((err, res) => {
+                    expect(res.status).toBe(200)
+                    done()
+                })
+        })
+    })
+})

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -2,9 +2,7 @@ import { Request, Response } from 'express'
 import { EditionsBackendControllers, createApp } from '../application'
 import chai from 'chai'
 import chaiHttp from 'chai-http'
-import * as http from 'http'
 
-// Configure chai
 chai.use(chaiHttp)
 chai.should()
 
@@ -21,10 +19,8 @@ const testStubControllers: EditionsBackendControllers = {
     imageColourController: stub,
 }
 
-const previewApp = createApp(testStubControllers, true)
-const versionedApp = createApp(testStubControllers, false)
-
 describe('Endpoints contract test for Preview Editions Backend application', () => {
+    const previewApp = createApp(testStubControllers, true)
     it('should return 404 for non registered endpoints', done => {
         chai.request(previewApp)
             .get('/non-exisitent')
@@ -56,6 +52,7 @@ describe('Endpoints contract test for Preview Editions Backend application', () 
 })
 
 describe('Endpoints contract test for Versioned Editions Backend application', () => {
+    const versionedApp = createApp(testStubControllers, false)
     const version = '2019-10-02T16:50:56.015Z'
     it('should return 404 for non registered endpoints', done => {
         chai.request(versionedApp)

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -1,0 +1,64 @@
+import express = require('express')
+import { Request, Response } from 'express'
+import { ImageSize, coloursPath } from '../common/src/index'
+import { issuePath, mediaPath, frontPath, issueSummaryPath } from './common'
+import listEndpoints from 'express-list-endpoints'
+
+export interface EditionsBackendControllers {
+    issuesSummaryController: (req: Request, res: Response) => void
+    issueController: (req: Request, res: Response) => void
+    frontController: (req: Request, res: Response) => void
+    imageController: (req: Request, res: Response) => void
+    imageColourController: (req: Request, res: Response) => void
+}
+
+export const createApp = (
+    controllers: EditionsBackendControllers,
+    asPreview: boolean,
+): express.Application => {
+    const app: express.Application = express()
+
+    if (asPreview) {
+        console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
+        console.log('🗞🗞🗞 HOT OFF THE PRESS THIS IS PREVIEW🗞🗞🗞')
+        console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
+    }
+
+    const issueId = asPreview
+        ? ':edition/:date/preview'
+        : ':edition/:date/:version'
+
+    app.use((req, res, next) => {
+        console.log(req.url)
+        console.log(JSON.stringify(req.params))
+        next()
+    })
+
+    app.get('/issues', controllers.issuesSummaryController)
+    app.get(
+        '/' + issueSummaryPath(':edition'),
+        controllers.issuesSummaryController,
+    )
+    app.get('/' + issuePath(issueId), controllers.issueController)
+    app.get('/' + frontPath(issueId, '*?'), controllers.frontController)
+
+    app.get(
+        '/' + mediaPath(issueId, ':size' as ImageSize, ':source', '*?'),
+        controllers.imageController,
+    )
+
+    app.get(
+        '/' + coloursPath(issueId, ':source', '*?'),
+        controllers.imageColourController,
+    )
+
+    const endpoints = listEndpoints(app)
+
+    const rootPath = '/'
+
+    app.get(rootPath, (req, res) => {
+        res.setHeader('Content-Type', 'application/json')
+        res.send(endpoints)
+    })
+    return app
+}

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express'
 import { ImageSize, coloursPath } from '../common/src/index'
 import { issuePath, mediaPath, frontPath, issueSummaryPath } from './common'
 import listEndpoints from 'express-list-endpoints'
+import { pickIssuePathSegments } from './utils/issue'
 
 export interface EditionsBackendControllers {
     issuesSummaryController: (req: Request, res: Response) => void
@@ -24,9 +25,7 @@ export const createApp = (
         console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
     }
 
-    const issueId = asPreview
-        ? ':edition/:date/preview'
-        : ':edition/:date/:version'
+    const issuePathSegments = pickIssuePathSegments(asPreview)
 
     app.use((req, res, next) => {
         console.log(req.url)
@@ -42,16 +41,20 @@ export const createApp = (
         '/' + issueSummaryPath(':edition'),
         controllers.issuesSummaryController,
     )
-    app.get('/' + issuePath(issueId), controllers.issueController)
-    app.get('/' + frontPath(issueId, '*?'), controllers.frontController)
+    app.get('/' + issuePath(issuePathSegments), controllers.issueController)
+    app.get(
+        '/' + frontPath(issuePathSegments, '*?'),
+        controllers.frontController,
+    )
 
     app.get(
-        '/' + mediaPath(issueId, ':size' as ImageSize, ':source', '*?'),
+        '/' +
+            mediaPath(issuePathSegments, ':size' as ImageSize, ':source', '*?'),
         controllers.imageController,
     )
 
     app.get(
-        '/' + coloursPath(issueId, ':source', '*?'),
+        '/' + coloursPath(issuePathSegments, ':source', '*?'),
         controllers.imageColourController,
     )
 

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -34,7 +34,10 @@ export const createApp = (
         next()
     })
 
+    // this next line supports legacy clients and can be removed after beta
+    // it should return the issues list for the daily-edition
     app.get('/issues', controllers.issuesSummaryController)
+
     app.get(
         '/' + issueSummaryPath(':edition'),
         controllers.issuesSummaryController,

--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -2,145 +2,147 @@ import { getIssuesSummary } from '../issue'
 import { IssueSummary } from '../../../common/src'
 import { LIVE_PAGE_SIZE, PREVIEW_PAGE_SIZE } from '../issue'
 
+const dailyEdition = 'daily-edition'
+
 const issueList = [
     {
-        key: 'daily-edition/2019-03-22/',
+        key: `${dailyEdition}/2019-03-22/`,
         lastModified: '2019-03-22',
     },
     {
-        key: 'daily-edition/2019-03-23/',
+        key: `${dailyEdition}/2019-03-23/`,
         lastModified: '2019-03-23',
     },
     {
-        key: 'daily-edition/2019-03-26/',
+        key: `${dailyEdition}/2019-03-26/`,
         lastModified: '2019-03-26',
     },
     {
-        key: 'daily-edition/2019-03-24/',
+        key: `${dailyEdition}/2019-03-24/`,
         lastModified: '2019-03-24',
     },
     {
-        key: 'daily-edition/2019-03-25/',
+        key: `${dailyEdition}/2019-03-25/`,
         lastModified: '2019-03-25',
     },
     {
-        key: 'daily-edition/2019-03-27/',
+        key: `${dailyEdition}/2019-03-27/`,
         lastModified: '2019-03-27',
     },
     {
-        key: 'daily-edition/2019-03-28/',
+        key: `${dailyEdition}/2019-03-28/`,
         lastModified: '2019-03-28',
     },
     {
-        key: 'daily-edition/2019-03-29/',
+        key: `${dailyEdition}/2019-03-29/`,
         lastModified: '2019-03-29',
     },
     {
-        key: 'daily-edition/2019-03-30/',
+        key: `${dailyEdition}/2019-03-30/`,
         lastModified: '2019-03-30',
     },
     {
-        key: 'daily-edition/2019-03-31/',
+        key: `${dailyEdition}/2019-03-31/`,
         lastModified: '2019-03-31',
     },
     {
-        key: 'daily-edition/2019-04-01/',
+        key: `${dailyEdition}/2019-04-01/`,
         lastModified: '2019-04-01',
     },
     {
-        key: 'daily-edition/2019-04-02/',
+        key: `${dailyEdition}/2019-04-02/`,
         lastModified: '2019-04-02',
     },
     {
-        key: 'daily-edition/2019-04-03/',
+        key: `${dailyEdition}/2019-04-03/`,
         lastModified: '2019-04-03',
     },
     {
-        key: 'daily-edition/2019-04-04/',
+        key: `${dailyEdition}/2019-04-04/`,
         lastModified: '2019-04-04',
     },
     {
-        key: 'daily-edition/2019-04-05/',
+        key: `${dailyEdition}/2019-04-05/`,
         lastModified: '2019-04-05',
     },
     {
-        key: 'daily-edition/2019-04-06/',
+        key: `${dailyEdition}/2019-04-06/`,
         lastModified: '2019-04-06',
     },
     {
-        key: 'daily-edition/2019-04-07/',
+        key: `${dailyEdition}/2019-04-07/`,
         lastModified: '2019-04-07',
     },
     {
-        key: 'daily-edition/2019-04-08/',
+        key: `${dailyEdition}/2019-04-08/`,
         lastModified: '2019-04-08',
     },
     {
-        key: 'daily-edition/2019-04-09/',
+        key: `${dailyEdition}/2019-04-09/`,
         lastModified: '2019-04-09',
     },
     {
-        key: 'daily-edition/2019-04-10/',
+        key: `${dailyEdition}/2019-04-10/`,
         lastModified: '2019-04-10',
     },
     {
-        key: 'daily-edition/2019-04-11/',
+        key: `${dailyEdition}/2019-04-11/`,
         lastModified: '2019-04-11',
     },
     {
-        key: 'daily-edition/2019-04-12/',
+        key: `${dailyEdition}/2019-04-12/`,
         lastModified: '2019-04-12',
     },
     {
-        key: 'daily-edition/2019-04-13/',
+        key: `${dailyEdition}/2019-04-13/`,
         lastModified: '2019-04-13',
     },
     {
-        key: 'daily-edition/2019-04-14/',
+        key: `${dailyEdition}/2019-04-14/`,
         lastModified: '2019-04-14',
     },
     {
-        key: 'daily-edition/2019-04-15/',
+        key: `${dailyEdition}/2019-04-15/`,
         lastModified: '2019-04-15',
     },
     {
-        key: 'daily-edition/2019-04-16/',
+        key: `${dailyEdition}/2019-04-16/`,
         lastModified: '2019-04-16',
     },
     {
-        key: 'daily-edition/2019-04-17/',
+        key: `${dailyEdition}/2019-04-17/`,
         lastModified: '2019-04-17',
     },
     {
-        key: 'daily-edition/2019-04-18/',
+        key: `${dailyEdition}/2019-04-18/`,
         lastModified: '2019-04-18',
     },
     {
-        key: 'daily-edition/2019-04-19/',
+        key: `${dailyEdition}/2019-04-19/`,
         lastModified: '2019-04-19',
     },
     {
-        key: 'daily-edition/2019-04-20/',
+        key: `${dailyEdition}/2019-04-20/`,
         lastModified: '2019-04-20',
     },
     {
-        key: 'daily-edition/2019-04-21/',
+        key: `${dailyEdition}/2019-04-21/`,
         lastModified: '2019-04-21',
     },
     {
-        key: 'daily-edition/2019-04-22/',
+        key: `${dailyEdition}/2019-04-22/`,
         lastModified: '2019-04-22',
     },
     {
-        key: 'daily-edition/2019-04-23/',
+        key: `${dailyEdition}/2019-04-23/`,
         lastModified: '2019-04-23',
     },
     {
-        key: 'daily-edition/2019-04-25/',
+        key: `${dailyEdition}/2019-04-25/`,
         lastModified: '2019-04-25',
     },
     {
-        key: 'daily-edition/2019-04-24/',
+        key: `${dailyEdition}/2019-04-24/`,
         lastModified: '2019-04-24',
     },
 ]
@@ -153,8 +155,6 @@ const getNthKey = (n: number) => {
     const [edition, key] = issueList[n].key.split('/')
     return `${edition}/${key}`
 }
-
-const dailyEdition = 'daily-edition'
 
 describe('getIssuesSummary', () => {
     it('returns the correct number of issues when on live stage', async () => {

--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -154,25 +154,27 @@ const getNthKey = (n: number) => {
     return `${edition}/${key}`
 }
 
+const dailyEdition = 'daily-edition'
+
 describe('getIssuesSummary', () => {
     it('returns the correct number of issues when on live stage', async () => {
         const isPreview = false
-        const issues = await getIssuesSummary(isPreview)
+        const issues = await getIssuesSummary(dailyEdition, isPreview)
         expect(issues).toHaveLength(7)
 
-        const issues2 = await getIssuesSummary(isPreview)
+        const issues2 = await getIssuesSummary(dailyEdition, isPreview)
         expect(issues2).toHaveLength(LIVE_PAGE_SIZE)
     })
 
     it('returns the correct numer of issues when in preview stage', async () => {
         const isPreview = true
-        const issues = await getIssuesSummary(isPreview)
+        const issues = await getIssuesSummary(dailyEdition, isPreview)
         expect(issues).toHaveLength(PREVIEW_PAGE_SIZE)
     })
 
     it('returns the most recent issues', async () => {
         const isPreview = false
-        const issues = await getIssuesSummary(isPreview)
+        const issues = await getIssuesSummary(dailyEdition, isPreview)
         expect(issues).not.toHaveFailed(issues)
         expect((issues as IssueSummary[]).map(i => i.key)).toEqual([
             getNthKey(33),

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -5,15 +5,16 @@ import { hasFailed } from '../utils/try'
 import { isPreview } from '../preview'
 
 export const frontController = (req: Request, res: Response) => {
-    const id: string = req.params[0]
-    const issue: string = req.params.date
+    const frontId: string = req.params[0]
+    const issueDate: string = req.params.date
     const version: string = decodeURIComponent(
         isPreview ? 'preview' : req.params.version,
     )
 
+    const edition = req.params.edition
     const [date, updater] = lastModified()
-    console.log(`Request for ${req.url} fetching front ${id}`)
-    getFront(issue, id, version, updater)
+    console.log(`Request for ${req.url} fetching front ${frontId}`)
+    getFront(edition, issueDate, frontId, version, updater)
         .then(data => {
             if (hasFailed(data)) {
                 console.error(`${req.url} threw ${JSON.stringify(data)}`)

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -4,14 +4,15 @@ import { getFront } from '../fronts'
 import { hasFailed } from '../utils/try'
 import { isPreview } from '../preview'
 import { IssuePublicationIdentifier } from '../common'
+import { decodeVersionOrPreview } from '../utils/issue'
 
 export const frontController = (req: Request, res: Response) => {
     const frontId: string = req.params[0]
     const issueDate: string = req.params.date
-    const version: string = decodeURIComponent(
-        isPreview ? 'preview' : req.params.version,
+    const version: string = decodeVersionOrPreview(
+        req.params.version,
+        isPreview,
     )
-
     const edition = req.params.edition
     const [date, updater] = lastModified()
     console.log(`Request for ${req.url} fetching front ${frontId}`)

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -3,6 +3,7 @@ import { lastModified } from '../lastModified'
 import { getFront } from '../fronts'
 import { hasFailed } from '../utils/try'
 import { isPreview } from '../preview'
+import { IssuePublicationIdentifier } from '../common'
 
 export const frontController = (req: Request, res: Response) => {
     const frontId: string = req.params[0]
@@ -14,7 +15,12 @@ export const frontController = (req: Request, res: Response) => {
     const edition = req.params.edition
     const [date, updater] = lastModified()
     console.log(`Request for ${req.url} fetching front ${frontId}`)
-    getFront(edition, issueDate, frontId, version, updater)
+    const issue: IssuePublicationIdentifier = {
+        issueDate,
+        version,
+        edition,
+    }
+    getFront(issue, frontId, updater)
         .then(data => {
             if (hasFailed(data)) {
                 console.error(`${req.url} threw ${JSON.stringify(data)}`)

--- a/projects/backend/controllers/image.ts
+++ b/projects/backend/controllers/image.ts
@@ -1,23 +1,26 @@
 import { Request, Response } from 'express'
 import { getImageURL, getPalette } from '../image'
 import { imageSizes } from '../../common/src/index'
+import { Image } from '../common'
+
 export const imageController = (req: Request, res: Response) => {
     const source = req.params.source
     const size = req.params.size
-    const path: string = req.params[0]
-    console.log(`Getting image redirect for ${source} ${size} ${path}`)
+    const lastPathParam: string = req.params[0]
+    const img: Image = { source, path: lastPathParam }
+    console.log(`Getting image redirect for ${source} ${size} ${lastPathParam}`)
     if (!imageSizes.includes(size)) {
         res.status(500)
         res.send('Invalid size')
     }
-    const redirect = getImageURL({ source, path }, size)
+    const redirect = getImageURL(img, size)
     res.redirect(redirect)
 }
 export const imageColourController = (req: Request, res: Response) => {
     const source = req.params.source
-
-    const path: string = req.params[0]
-    getPalette({ source, path })
+    const lastPathParam: string = req.params[0]
+    const img: Image = { source, path: lastPathParam }
+    getPalette(img)
         .then(data => {
             res.setHeader('Content-Type', 'application/json')
             res.send(JSON.stringify(data))

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -49,7 +49,6 @@ export const getIssuesSummary = async (
      */
     const edition = getEditionOrFallback(maybeEdition)
     const editionPath = buildEditionPath(maybeEdition, isPreview)
-    console.log('listing objects at path:', editionPath)
     const issueKeys = await s3List(editionPath)
 
     if (hasFailed(issueKeys)) {

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -8,6 +8,7 @@ import { Attempt, hasFailed } from '../utils/try'
 import {
     buildEditionRootPath as buildEditionPath,
     getEditionOrFallback,
+    decodeVersionOrPreview,
 } from '../utils/issue'
 
 export const LIVE_PAGE_SIZE = 7
@@ -15,8 +16,9 @@ export const PREVIEW_PAGE_SIZE = 35
 
 export const issueController = (req: Request, res: Response) => {
     const issueDate: string = req.params.date
-    const version: string = decodeURIComponent(
-        isPreviewStage ? 'preview' : req.params.version,
+    const version: string = decodeVersionOrPreview(
+        req.params.version,
+        isPreviewStage,
     )
     const edition = req.params.edition
     const issue: IssuePublicationIdentifier = {

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -15,11 +15,11 @@ export const issueController = (req: Request, res: Response) => {
     const version: string = decodeURIComponent(
         isPreviewStage ? 'preview' : req.params.version,
     )
-    const issueEdition = req.params.edition
+    const edition = req.params.edition
     const issue: IssuePublicationIdentifier = {
         issueDate,
         version,
-        edition: issueEdition,
+        edition,
     }
     console.log(`${req.url}: request for issue ${issueDate}`)
     getIssue(issue)

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -5,7 +5,10 @@ import { getIssue } from '../issue'
 import { isPreview as isPreviewStage } from '../preview'
 import { s3List } from '../s3'
 import { Attempt, hasFailed } from '../utils/try'
-import { getEditionOrFallback } from '../utils/issue'
+import {
+    buildEditionRootPath as buildEditionPath,
+    getEditionOrFallback,
+} from '../utils/issue'
 
 export const LIVE_PAGE_SIZE = 7
 export const PREVIEW_PAGE_SIZE = 35
@@ -45,10 +48,9 @@ export const getIssuesSummary = async (
      * TODO to delete in the future
      */
     const edition = getEditionOrFallback(maybeEdition)
-    const issueKeys = await s3List({
-        key: `${edition}/`,
-        bucket: isPreview ? 'preview' : 'published',
-    })
+    const editionPath = buildEditionPath(maybeEdition, isPreview)
+    console.log('listing objects at path:', editionPath)
+    const issueKeys = await s3List(editionPath)
 
     if (hasFailed(issueKeys)) {
         console.error('Error in issue index controller')

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -14,10 +14,11 @@ export const issueController = (req: Request, res: Response) => {
     const version: string = decodeURIComponent(
         isPreviewStage ? 'preview' : req.params.version,
     )
+    const issueEdition = req.params.edition
     const issueId: IssuePublicationIdentifier = {
         issueDate,
         version,
-        edition: 'daily-edition',
+        edition: issueEdition,
     }
     console.log(`${req.url}: request for issue ${issueDate}`)
     getIssue(issueId)
@@ -34,10 +35,11 @@ export const issueController = (req: Request, res: Response) => {
 }
 
 export const getIssuesSummary = async (
+    editionType: string,
     isPreview: boolean,
 ): Promise<Attempt<IssueSummary[]>> => {
     const issueKeys = await s3List({
-        key: 'daily-edition/',
+        key: `${editionType}/`,
         bucket: isPreview ? 'preview' : 'published',
     })
 
@@ -52,7 +54,7 @@ export const getIssuesSummary = async (
             const publicationDate = lastModified
             const version = filename.replace('.json', '')
             return {
-                edition: 'daily-edition',
+                edition: editionType,
                 issueDate,
                 version,
                 publicationDate,
@@ -96,7 +98,8 @@ export const getIssuesSummary = async (
 
 export const issuesSummaryController = (req: Request, res: Response) => {
     console.log('Issue summary requested.')
-    getIssuesSummary(isPreviewStage)
+    const issueEdition = req.params.edition
+    getIssuesSummary(issueEdition, isPreviewStage)
         .then(data => {
             if (hasFailed(data)) {
                 console.error(JSON.stringify(data))

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -34,12 +34,21 @@ export const issueController = (req: Request, res: Response) => {
         .catch(e => console.error(e))
 }
 
+const getEditionOrFallback = (editionType: string) =>
+    editionType ? editionType : 'daily-edition'
+
 export const getIssuesSummary = async (
     editionType: string,
     isPreview: boolean,
 ): Promise<Attempt<IssueSummary[]>> => {
+    /**
+     * fallbacks to 'daily-edition'
+     * to support /issues path
+     * TODO to delete in the future
+     */
+    const edition = getEditionOrFallback(editionType)
     const issueKeys = await s3List({
-        key: `${editionType}/`,
+        key: `${edition}/`,
         bucket: isPreview ? 'preview' : 'published',
     })
 

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -258,13 +258,14 @@ const getDisplayName = (front: string) => {
 }
 
 export const getFront = async (
-    issue: string,
+    edition: string,
+    issueDate: string,
     id: string,
     source: string,
     lastModifiedUpdater: LastModifiedUpdater,
 ): Promise<Attempt<Front>> => {
     const path: Path = {
-        key: `daily-edition/${issue}/${source}.json`,
+        key: `${edition}/${issueDate}/${source}.json`,
         bucket: isPreview ? 'preview' : 'published',
     }
     const resp = await s3fetch(path)
@@ -272,7 +273,7 @@ export const getFront = async (
     if (hasFailed(resp)) {
         return withFailureMessage(
             resp,
-            `Attempt to fetch ${issue} and ${id} failed.`,
+            `Attempt to fetch ${issueDate} and ${id} failed.`,
         )
     }
 
@@ -297,7 +298,7 @@ export const getFront = async (
 
     collections.filter(hasFailed).forEach(failedCollection => {
         console.error(
-            `silently removing collection from ${issue}/${id} ${JSON.stringify(
+            `silently removing collection from ${issueDate}/${id} ${JSON.stringify(
                 failedCollection,
             )}`,
         )

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -263,18 +263,10 @@ const getDisplayName = (front: string) => {
 }
 
 const fetchPublishedIssue = async (
-    edition: string,
-    issueDate: string,
+    issue: IssuePublicationIdentifier,
     frontId: string,
-    version: string,
     lastModifiedUpdater: LastModifiedUpdater,
 ): Promise<Attempt<PublishedIssue>> => {
-    const issue: IssuePublicationIdentifier = {
-        issueDate,
-        version,
-        edition,
-    }
-
     const path: Path = issueObjectPathBuilder(issue, isPreview)
 
     const issueData = await s3fetch(path)
@@ -282,7 +274,7 @@ const fetchPublishedIssue = async (
     if (hasFailed(issueData)) {
         return withFailureMessage(
             issueData,
-            `Attempt to fetch ${issueDate} and ${frontId} failed.`,
+            `Attempt to fetch ${issue.issueDate} and ${frontId} failed.`,
         )
     }
 
@@ -331,17 +323,13 @@ export const transformToFront = async (
 }
 
 export const getFront = async (
-    edition: string,
-    issueDate: string,
+    issue: IssuePublicationIdentifier,
     frontId: string,
-    source: string,
     lastModifiedUpdater: LastModifiedUpdater,
 ): Promise<Attempt<Front>> => {
     const publishedIssue = await fetchPublishedIssue(
-        edition,
-        issueDate,
+        issue,
         frontId,
-        source,
         lastModifiedUpdater,
     )
 

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -36,7 +36,7 @@ import {
     withFailureMessage,
 } from './utils/try'
 import { articleShouldHaveDropCap, isHTMLElement } from './utils/article'
-import { issueObjectPathBuilder } from './utils/issue'
+import { buildIssueObjectPath } from './utils/issue'
 
 // overrideArticleMainMedia may be false in most cases
 const getImage = (
@@ -267,7 +267,7 @@ const fetchPublishedIssue = async (
     frontId: string,
     lastModifiedUpdater: LastModifiedUpdater,
 ): Promise<Attempt<PublishedIssue>> => {
-    const path: Path = issueObjectPathBuilder(issue, isPreview)
+    const path: Path = buildIssueObjectPath(issue, isPreview)
 
     const issueData = await s3fetch(path)
 

--- a/projects/backend/index.ts
+++ b/projects/backend/index.ts
@@ -2,57 +2,22 @@ require('dotenv').config()
 
 import awsServerlessExpress from 'aws-serverless-express'
 import { Handler } from 'aws-lambda'
-import express = require('express')
 import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController, imageColourController } from './controllers/image'
-import { ImageSize, coloursPath } from '../common/src/index'
-import { issuePath, mediaPath, frontPath, issueSummaryPath } from './common'
+import { createApp, EditionsBackendControllers } from './application'
 import { isPreview } from './preview'
-import listEndpoints from 'express-list-endpoints'
 
-const app = express()
-
-if (isPreview) {
-    console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
-    console.log('🗞🗞🗞 HOT OFF THE PRESS THIS IS PREVIEW🗞🗞🗞')
-    console.log('🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞🗞')
+const runtimeControllers: EditionsBackendControllers = {
+    issuesSummaryController,
+    issueController,
+    frontController,
+    imageController,
+    imageColourController,
 }
 
-const issueId = isPreview
-    ? 'daily-edition/:date/preview'
-    : 'daily-edition/:date/:version'
-
-app.use((req, res, next) => {
-    console.log(req.url)
-    console.log(JSON.stringify(req.params))
-    next()
-})
-
-// this next line supports legacy clients and can be removed after beta
-// it should return the issues list for the daily-edition
-app.get('/issues', issuesSummaryController)
-
-app.get('/' + issueSummaryPath('daily-edition'), issuesSummaryController)
-app.get('/' + issuePath(issueId), issueController)
-console.log('/' + issuePath(issueId))
-app.get('/' + frontPath(issueId, '*?'), frontController)
-
-app.get(
-    '/' + mediaPath(issueId, ':size' as ImageSize, ':source', '*?'),
-    imageController,
-)
-
-app.get('/' + coloursPath(issueId, ':source', '*?'), imageColourController)
-
-const endpoints = listEndpoints(app)
-
-const rootPath = '/'
-
-app.get(rootPath, (req, res) => {
-    res.setHeader('Content-Type', 'application/json')
-    res.send(endpoints)
-})
+const asPreview = isPreview
+const app = createApp(runtimeControllers, asPreview)
 
 export const handler: Handler = (event, context) => {
     awsServerlessExpress.proxy(

--- a/projects/backend/issue.ts
+++ b/projects/backend/issue.ts
@@ -3,15 +3,14 @@ import { PublishedIssue } from './fronts/issue'
 import { isPreview } from './preview'
 import { Path, s3fetch } from './s3'
 import { hasFailed } from './utils/try'
+import { issueObjectPathBuilder } from './utils/issue'
 
 export const getIssue = async (
     issue: IssuePublicationIdentifier,
 ): Promise<Issue | 'notfound'> => {
     console.log('Attempting to get latest issue for', issue)
-    const path: Path = {
-        key: `${issue.edition}/${issue.issueDate}/${issue.version}.json`,
-        bucket: isPreview ? 'preview' : 'published',
-    }
+
+    const path: Path = issueObjectPathBuilder(issue, isPreview)
 
     console.log(`Fetching ${JSON.stringify(path)} for ${JSON.stringify(issue)}`)
 

--- a/projects/backend/issue.ts
+++ b/projects/backend/issue.ts
@@ -3,14 +3,14 @@ import { PublishedIssue } from './fronts/issue'
 import { isPreview } from './preview'
 import { Path, s3fetch } from './s3'
 import { hasFailed } from './utils/try'
-import { issueObjectPathBuilder } from './utils/issue'
+import { buildIssueObjectPath } from './utils/issue'
 
 export const getIssue = async (
     issue: IssuePublicationIdentifier,
 ): Promise<Issue | 'notfound'> => {
     console.log('Attempting to get latest issue for', issue)
 
-    const path: Path = issueObjectPathBuilder(issue, isPreview)
+    const path: Path = buildIssueObjectPath(issue, isPreview)
 
     console.log(`Fetching ${JSON.stringify(path)} for ${JSON.stringify(issue)}`)
 

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -14,7 +14,9 @@
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
     "ts-node-dev": "^1.0.0-pre.40",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "chai": "^4.1.2",
+    "chai-http": "^4.0.0"
   },
   "scripts": {
     "build": "ncc build index.ts -o dist -m",

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -1,0 +1,49 @@
+import { buildIssueObjectPath, getEditionOrFallback } from '../issue'
+import { IssuePublicationIdentifier } from '../../common'
+import { Path } from '../../s3'
+
+const issueDate = '2019-09-11'
+const version = '2019-10-04T11:28:04.07Z'
+const edition = 'daily-edition'
+
+const issue: IssuePublicationIdentifier = {
+    issueDate,
+    version,
+    edition,
+}
+
+describe('buildIssueObjectPath', () => {
+    it('should build preview path', () => {
+        const isPreview = true
+
+        const actual = buildIssueObjectPath(issue, isPreview)
+
+        const expected: Path = {
+            key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
+            bucket: 'preview',
+        }
+
+        expect(actual).toStrictEqual(expected)
+    })
+    it('should build published path', () => {
+        const isPreview = false
+
+        const actual = buildIssueObjectPath(issue, isPreview)
+
+        const expected: Path = {
+            key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
+            bucket: 'published',
+        }
+
+        expect(actual).toStrictEqual(expected)
+    })
+})
+
+describe('getEditionOrFallback', () => {
+    it('should get edition provided', () => {
+        expect(getEditionOrFallback('other-edition')).toBe('other-edition')
+    })
+    it('should fallback to daily-edition', () => {
+        expect(getEditionOrFallback('')).toBe('daily-edition')
+    })
+})

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -2,6 +2,7 @@ import {
     buildIssueObjectPath,
     buildEditionRootPath,
     decodeVersionOrPreview,
+    pickIssuePathSegments,
 } from '../issue'
 import { IssuePublicationIdentifier } from '../../common'
 import { Path } from '../../s3'
@@ -88,5 +89,20 @@ describe('decodeVersionOrPreview', () => {
         expect(
             decodeVersionOrPreview('some%20version', isPreviewStage),
         ).toStrictEqual('some version')
+    })
+})
+
+describe('pickIssuePathSegments', () => {
+    it('should fallback to preview', () => {
+        const isPreview = true
+        expect(pickIssuePathSegments(isPreview)).toStrictEqual(
+            ':edition/:date/preview',
+        )
+    })
+    it('should pick versioned path segments', () => {
+        const isPreview = false
+        expect(pickIssuePathSegments(isPreview)).toStrictEqual(
+            ':edition/:date/:version',
+        )
     })
 })

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -1,4 +1,4 @@
-import { buildIssueObjectPath, getEditionOrFallback } from '../issue'
+import { buildIssueObjectPath, buildEditionRootPath } from '../issue'
 import { IssuePublicationIdentifier } from '../../common'
 import { Path } from '../../s3'
 
@@ -15,35 +15,59 @@ const issue: IssuePublicationIdentifier = {
 describe('buildIssueObjectPath', () => {
     it('should build preview path', () => {
         const isPreview = true
-
         const actual = buildIssueObjectPath(issue, isPreview)
-
         const expected: Path = {
             key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
             bucket: 'preview',
         }
-
         expect(actual).toStrictEqual(expected)
     })
     it('should build published path', () => {
         const isPreview = false
-
         const actual = buildIssueObjectPath(issue, isPreview)
-
         const expected: Path = {
             key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
             bucket: 'published',
         }
-
         expect(actual).toStrictEqual(expected)
     })
 })
 
-describe('getEditionOrFallback', () => {
-    it('should get edition provided', () => {
-        expect(getEditionOrFallback('other-edition')).toBe('other-edition')
+describe('buildEditionRootPath', () => {
+    it('should get preview edition path for edition provided', () => {
+        const isPreview = true
+        const actual = buildEditionRootPath('other-edition', isPreview)
+        const expected: Path = {
+            key: 'other-edition/',
+            bucket: 'preview',
+        }
+        expect(actual).toStrictEqual(expected)
     })
-    it('should fallback to daily-edition', () => {
-        expect(getEditionOrFallback('')).toBe('daily-edition')
+    it('should get published edition path for edition provided', () => {
+        const isPreview = false
+        const actual = buildEditionRootPath('other-edition', isPreview)
+        const expected: Path = {
+            key: 'other-edition/',
+            bucket: 'published',
+        }
+        expect(actual).toStrictEqual(expected)
+    })
+    it('should get preview edition path with fallback to daily-edition', () => {
+        const isPreview = true
+        const actual = buildEditionRootPath('', isPreview)
+        const expected: Path = {
+            key: 'daily-edition/',
+            bucket: 'preview',
+        }
+        expect(actual).toStrictEqual(expected)
+    })
+    it('should get published edition path with fallback to daily-edition', () => {
+        const isPreview = false
+        const actual = buildEditionRootPath('', isPreview)
+        const expected: Path = {
+            key: 'daily-edition/',
+            bucket: 'published',
+        }
+        expect(actual).toStrictEqual(expected)
     })
 })

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -1,4 +1,8 @@
-import { buildIssueObjectPath, buildEditionRootPath } from '../issue'
+import {
+    buildIssueObjectPath,
+    buildEditionRootPath,
+    decodeVersionOrPreview,
+} from '../issue'
 import { IssuePublicationIdentifier } from '../../common'
 import { Path } from '../../s3'
 
@@ -69,5 +73,20 @@ describe('buildEditionRootPath', () => {
             bucket: 'published',
         }
         expect(actual).toStrictEqual(expected)
+    })
+})
+
+describe('decodeVersionOrPreview', () => {
+    it('should fallback to preview', () => {
+        const isPreviewStage = true
+        expect(
+            decodeVersionOrPreview('some%20version', isPreviewStage),
+        ).toStrictEqual('preview')
+    })
+    it('should decode version', () => {
+        const isPreviewStage = false
+        expect(
+            decodeVersionOrPreview('some%20version', isPreviewStage),
+        ).toStrictEqual('some version')
     })
 })

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -34,3 +34,7 @@ export const decodeVersionOrPreview = (
 ): string => {
     return decodeURIComponent(isPreviewStage ? 'preview' : version)
 }
+
+export const pickIssuePathSegments = (asPreview: boolean) => {
+    return asPreview ? ':edition/:date/preview' : ':edition/:date/:version'
+}

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,0 +1,16 @@
+import { IssuePublicationIdentifier } from '../common'
+import { Path } from '../s3'
+
+export const issueObjectPathBuilder = (
+    issue: IssuePublicationIdentifier,
+    asPreview: boolean,
+): Path => {
+    const { edition, issueDate, version } = issue
+    return {
+        key: `${edition}/${issueDate}/${version}.json`,
+        bucket: asPreview ? 'preview' : 'published',
+    }
+}
+
+export const getEditionOrFallback = (editionType: string) =>
+    editionType ? editionType : 'daily-edition'

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,6 +1,11 @@
 import { IssuePublicationIdentifier } from '../common'
 import { Path } from '../s3'
 
+const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
+
+export const getEditionOrFallback = (maybeEdition: string) =>
+    maybeEdition ? maybeEdition : 'daily-edition'
+
 export const buildIssueObjectPath = (
     issue: IssuePublicationIdentifier,
     asPreview: boolean,
@@ -8,9 +13,17 @@ export const buildIssueObjectPath = (
     const { edition, issueDate, version } = issue
     return {
         key: `${edition}/${issueDate}/${version}.json`,
-        bucket: asPreview ? 'preview' : 'published',
+        bucket: pickBucket(asPreview),
     }
 }
 
-export const getEditionOrFallback = (maybeEdition: string) =>
-    maybeEdition ? maybeEdition : 'daily-edition'
+export const buildEditionRootPath = (
+    maybeEdition: string,
+    asPreview: boolean,
+): Path => {
+    const edition = getEditionOrFallback(maybeEdition)
+    return {
+        key: `${edition}/`,
+        bucket: pickBucket(asPreview),
+    }
+}

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -4,7 +4,7 @@ import { Path } from '../s3'
 const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 
 export const getEditionOrFallback = (maybeEdition: string) =>
-    maybeEdition ? maybeEdition : 'daily-edition'
+    maybeEdition || 'daily-edition'
 
 export const buildIssueObjectPath = (
     issue: IssuePublicationIdentifier,

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,7 +1,7 @@
 import { IssuePublicationIdentifier } from '../common'
 import { Path } from '../s3'
 
-export const issueObjectPathBuilder = (
+export const buildIssueObjectPath = (
     issue: IssuePublicationIdentifier,
     asPreview: boolean,
 ): Path => {
@@ -12,5 +12,5 @@ export const issueObjectPathBuilder = (
     }
 }
 
-export const getEditionOrFallback = (editionType: string) =>
-    editionType ? editionType : 'daily-edition'
+export const getEditionOrFallback = (maybeEdition: string) =>
+    maybeEdition ? maybeEdition : 'daily-edition'

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -27,3 +27,10 @@ export const buildEditionRootPath = (
         bucket: pickBucket(asPreview),
     }
 }
+
+export const decodeVersionOrPreview = (
+    version: string,
+    isPreviewStage: boolean,
+): string => {
+    return decodeURIComponent(isPreviewStage ? 'preview' : version)
+}

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -618,12 +618,22 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chai@4":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.3.tgz#419477a3d5202bad19e14c787940a61dc9ea6407"
+  integrity sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
   integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
   dependencies:
     "@types/node" "*"
+
+"@types/cookiejar@*":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
+  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
 
 "@types/express-serve-static-core@*":
   version "4.16.7"
@@ -735,6 +745,14 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
+"@types/superagent@^3.8.3":
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.7.tgz#1f1ed44634d5459b3a672eb7235a8e7cfd97704c"
+  integrity sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"
@@ -901,6 +919,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -1190,6 +1213,31 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai-http@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.3.0.tgz#3c37c675c1f4fe685185a307e345de7599337c1a"
+  integrity sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==
+  dependencies:
+    "@types/chai" "4"
+    "@types/superagent" "^3.8.3"
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
+
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1198,6 +1246,11 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chownr@^1.1.1:
   version "1.1.2"
@@ -1270,7 +1323,7 @@ commander@~2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -1313,6 +1366,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -1395,7 +1453,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.6:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1418,6 +1476,13 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1738,7 +1803,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -1856,6 +1921,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -1864,6 +1938,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -1925,6 +2004,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -2184,6 +2268,11 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ipaddr.js@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
@@ -2302,6 +2391,13 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
+  dependencies:
+    ip-regex "^2.0.0"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -3098,7 +3194,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3134,7 +3230,7 @@ mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.40.0"
 
-mime@1.6.0, mime@^1.3.4:
+mime@1.6.0, mime@^1.3.4, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -3664,6 +3760,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -3811,6 +3912,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.5.1:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
+  integrity sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -3898,7 +4004,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -4433,6 +4539,22 @@ striptags@^3.1.1:
   resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
   integrity sha1-yMPn/db7S7OjKjt1LltePjgJPr0=
 
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4650,6 +4772,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
## Why are you doing this?

We want to be able to support multiple types of editions like (Daily Editions, American Edition, Australian Edition ...)
This PR makes edition type as a path param
and use this in downstream function calls
<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/qSmpzrIJ/128-backend-to-support-multiple-editions)

## Changes

* making edition type as path param
* adding contract tests that ensures if expected endpoints are registerd

## Screenshots
![Screenshot 2019-10-03 at 16 34 54](https://user-images.githubusercontent.com/10913420/66141555-c4093300-e5fb-11e9-9a40-24c277c38bda.png)

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->

- [x] unit tests added
- [ ] tested in Code
