### PR TITLE
Fix downloaded images on android

### DIFF
--- a/projects/Mallard/src/helpers/screen.ts
+++ b/projects/Mallard/src/helpers/screen.ts
@@ -1,18 +1,19 @@
 import { Dimensions } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
-import { sizeDescriptions, ImageSize } from '../../../common/src'
+import { sizeDescriptions, ImageSize, imageSizes } from '../../../common/src'
+import AsyncStorage from '@react-native-community/async-storage'
 
-const maxScreenSize = (): number => {
+export const maxScreenSize = (): number => {
     const { width, height } = Dimensions.get('window')
     return Math.max(width, height)
 }
 
-const minScreenSize = (): number => {
+export const minScreenSize = (): number => {
     const { width, height } = Dimensions.get('window')
     return Math.min(width, height)
 }
 
-const screenSizeToImageSize = (screenSize: number): number => {
+export const screenSizeToImageSize = (screenSize: number): number => {
     const allSizes = Object.values(sizeDescriptions)
     const minPossibleSize = Math.min(...allSizes)
     if (screenSize <= minPossibleSize) {
@@ -30,7 +31,9 @@ const screenSizeToImageSize = (screenSize: number): number => {
     return Math.min(...availableSizes)
 }
 
-const convertImageSizeToImageDescription = (screenSize: number): ImageSize => {
+export const convertImageSizeToImageDescription = (
+    screenSize: number,
+): ImageSize => {
     if (!screenSize) {
         return 'phone'
     }
@@ -40,16 +43,19 @@ const convertImageSizeToImageDescription = (screenSize: number): ImageSize => {
     return (imageSize as ImageSize) || 'phone'
 }
 
-const imageForScreenSize = async () => {
+const IMAGE_SIZE_KEY = '@image_size'
+
+export const imageForScreenSize = async (): Promise<ImageSize> => {
+    const persisted = await AsyncStorage.getItem(IMAGE_SIZE_KEY)
+    const persistedSize = imageSizes.find(_ => _ == persisted)
+    if (persistedSize != undefined) {
+        return persistedSize
+    }
     const isTablet = await DeviceInfo.isTablet()
     const screenSize = isTablet ? maxScreenSize() : minScreenSize()
-    return convertImageSizeToImageDescription(screenSizeToImageSize(screenSize))
-}
-
-export {
-    maxScreenSize,
-    minScreenSize,
-    screenSizeToImageSize,
-    convertImageSizeToImageDescription,
-    imageForScreenSize,
+    const size = convertImageSizeToImageDescription(
+        screenSizeToImageSize(screenSize),
+    )
+    await AsyncStorage.setItem(IMAGE_SIZE_KEY, size)
+    return size
 }

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -28,10 +28,8 @@ export const selectImagePath = async (
     )}`
 
     const fs = getFsPath(localIssueId, { source, path }, imageSize)
-    console.log(fs)
     const fsExists = await RNFetchBlob.fs.exists(fs)
     return fsExists ? fs : api
-    //should this be a file url
 }
 
 const compressImagePath = async (path: string, width: number) => {

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -13,7 +13,7 @@ const getFsPath = (
     size: ImageSize,
 ) => FSPaths.media(localIssueId, source, path, size)
 
-const selectImagePath = async (
+export const selectImagePath = async (
     apiUrl: string,
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
@@ -56,7 +56,7 @@ const compressImagePath = async (path: string, width: number) => {
  *
  *  */
 
-const useImagePath = (image?: Image) => {
+export const useImagePath = (image?: Image) => {
     const key = useIssueCompositeKey()
 
     const [paths, setPaths] = useState<string | undefined>()
@@ -78,12 +78,10 @@ const useImagePath = (image?: Image) => {
     return paths
 }
 
-const useScaledImage = (largePath: string, width: number) => {
-    const [path, setPath] = useState<string | undefined>()
+export const useScaledImage = (largePath: string, width: number) => {
+    const [uri, setUri] = useState<string | undefined>()
     useEffect(() => {
-        compressImagePath(largePath, width).then(setPath)
+        compressImagePath(largePath, width).then(setUri)
     }, [largePath, width])
-    return path
+    return uri
 }
-
-export { useImagePath, useScaledImage, selectImagePath }

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react'
+import ImageResizer from 'react-native-image-resizer'
 import RNFetchBlob from 'rn-fetch-blob'
 import { imageForScreenSize } from 'src/helpers/screen'
 import { APIPaths, FSPaths } from 'src/paths'
-import { Image, Issue } from '../../../common/src'
+import { Image, ImageSize, Issue } from '../../../common/src'
 import { useIssueCompositeKey } from './use-issue-id'
 import { useSettingsValue } from './use-settings'
-import ImageResizer from 'react-native-image-resizer'
+
+const getFsPath = (
+    localIssueId: Issue['localId'],
+    { source, path }: Image,
+    size: ImageSize,
+) => FSPaths.media(localIssueId, source, path, size)
 
 const selectImagePath = async (
     apiUrl: string,
@@ -20,9 +26,12 @@ const selectImagePath = async (
         source,
         path,
     )}`
-    const fs = FSPaths.media(localIssueId, source, path)
+
+    const fs = getFsPath(localIssueId, { source, path }, imageSize)
+    console.log(fs)
     const fsExists = await RNFetchBlob.fs.exists(fs)
     return fsExists ? fs : api
+    //should this be a file url
 }
 
 const compressImagePath = async (path: string, width: number) => {
@@ -34,7 +43,7 @@ const compressImagePath = async (path: string, width: number) => {
         100,
         0,
     )
-    return resized.path
+    return resized.uri
 }
 
 /**
@@ -62,7 +71,7 @@ const useImagePath = (image?: Image) => {
     }, [
         apiUrl,
         image,
-        key ? key.publishedIssueId : undefined,
+        key ? key.publishedIssueId : undefined, // Why isn't this just key?
         key ? key.localIssueId : undefined,
     ])
     if (image === undefined) return undefined

--- a/projects/Mallard/src/paths/index.ts
+++ b/projects/Mallard/src/paths/index.ts
@@ -6,6 +6,7 @@ import {
     Collection,
     Front,
     CAPIArticle,
+    ImageSize,
 } from 'src/common'
 import RNFetchBlob from 'rn-fetch-blob'
 
@@ -38,10 +39,12 @@ export const FSPaths = {
     issuesDir,
     issueRoot,
     mediaRoot,
-    media: (localIssueId: string, source: string, path: string) =>
-        `${mediaRoot(
-            localIssueId,
-        )}/${MEDIA_CACHE_DIRECTORY_NAME}/${source}/${path}`,
+    media: (
+        localIssueId: string,
+        source: string,
+        path: string,
+        size: ImageSize,
+    ) => `${mediaRoot(localIssueId)}/${size}/${source}/${path}`,
     zip: (localIssueId: string, filename: string) =>
         `${issueRoot(localIssueId)}/${filename}.zip`,
     issueZip: (localIssueId: string) => `${issueRoot(localIssueId)}/data.zip`,


### PR DESCRIPTION
The `<Image>` component on android needs a uri and not a path. 
With #637 we can just get a uri off the returned resize object instead of manually synthesizing one.

Also `fs.mv` only supports files on android and cannot move/rename directories. 
So this pr now uses the current breakpoint to fetch local images. 

This now persists the breakpoint in Asyncstorage. 
