### PR TITLE
dont add tablet.* to tablet.zip

### DIFF
--- a/projects/archiver/src/tasks/zip/helpers/zipper.ts
+++ b/projects/archiver/src/tasks/zip/helpers/zipper.ts
@@ -25,7 +25,7 @@ export const zip = async (
     const objects = await s3
         .listObjectsV2({
             Bucket,
-            Prefix: prefix,
+            Prefix: `${prefix}/`,
         })
         .promise()
     // TODO: deal with paginating S3 responses

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -21,7 +21,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
         console.log('data zip uploaded')
         await Promise.all(
             imageSizes.map(async size => {
-                await zip(`${name}/${size}`, mediaDir(publishedId, size), {
+                await zip(`${name}/${size}/`, mediaDir(publishedId, size), {
                     excludePrefixSegment: version,
                 })
                 console.log(` ${size} media zip uploaded`)

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -21,7 +21,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
         console.log('data zip uploaded')
         await Promise.all(
             imageSizes.map(async size => {
-                await zip(`${name}/${size}/`, mediaDir(publishedId, size), {
+                await zip(`${name}/${size}`, mediaDir(publishedId, size), {
                     excludePrefixSegment: version,
                 })
                 console.log(` ${size} media zip uploaded`)


### PR DESCRIPTION
we were fetching all the breakpoints with tablet.

this should significantly reduce tablet bundle size (well, yes)