### PR TITLE
Bring video caption style inline with images.

### DIFF
--- a/projects/Mallard/src/components/article/html/render.ts
+++ b/projects/Mallard/src/components/article/html/render.ts
@@ -26,6 +26,8 @@ import { Pullquote, quoteStyles } from './pull-quote'
 import { lineStyles, Line } from './line'
 import { useImageSize } from 'src/hooks/use-image-size'
 import { ratingStyles } from './rating'
+import { Arrow } from './arrow'
+import { Direction } from 'src/helpers/sizes'
 
 export const EMBED_DOMAIN = 'https://embed.theguardian.com'
 
@@ -126,14 +128,16 @@ export const makeCss = ({ colors, wrapLayout }: CssProps) => css`
 
 const renderMediaAtom = (mediaAtomElement: MediaAtomElement) => {
     return html`
-        <figure style="overflow: hidden;">
+        <figure class="image" style="overflow: hidden;">
             <iframe
                 scrolling="no"
                 src="${EMBED_DOMAIN}/embed/atom/media/${mediaAtomElement.atomId}"
                 style="width: 100%; display: block;"
                 frameborder="0"
             ></iframe>
-            <figcaption>${mediaAtomElement.title}</figcaption>
+            <figcaption>
+                ${Arrow({ direction: Direction.top })} ${mediaAtomElement.title}
+            </figcaption>
         </figure>
     `
 }


### PR DESCRIPTION
Before:

<img width="356" alt="Screenshot 2019-10-04 at 15 33 48" src="https://user-images.githubusercontent.com/8861681/66216003-933d0280-e6bc-11e9-934f-dc69e26bc478.png">

After: 

<img width="356" alt="Screenshot 2019-10-04 at 15 33 30" src="https://user-images.githubusercontent.com/8861681/66216017-97692000-e6bc-11e9-8257-4d527e154e9b.png">
