### PR TITLE
Don't resize remote images.

### DIFF
--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -77,9 +77,15 @@ export const useImagePath = (image?: Image) => {
 }
 
 export const useScaledImage = (largePath: string, width: number) => {
-    const [uri, setUri] = useState<string | undefined>()
+    const isRemote = largePath.slice(0, 4) === 'http'
+
+    const [uri, setUri] = useState<string | undefined>(
+        isRemote ? largePath : undefined,
+    )
     useEffect(() => {
-        compressImagePath(largePath, width).then(setUri)
+        if (!isRemote) {
+            compressImagePath(largePath, width).then(setUri)
+        }
     }, [largePath, width])
     return uri
 }


### PR DESCRIPTION
## Why are you doing this?

Because the resizer does not support [http urls](https://github.com/bamlab/react-native-image-resizer/blob/master/android/src/main/java/fr/bamlab/rnimageresizer/ImageResizer.java) on android. So any attempt to show a remote image on android was causing an exception. This reverts remote images only to being shown at their native size.