### PR TITLE
support multiple editions in Invoker

### DIFF
--- a/projects/archiver/src/invoke/index.spec.ts
+++ b/projects/archiver/src/invoke/index.spec.ts
@@ -1,0 +1,76 @@
+import { internalHandler, Record, InvokerDependencies } from '.'
+import { GetS3ObjParams } from '../utils/s3'
+import {
+    withFailureMessage,
+    failure,
+    IssuePublicationIdentifier,
+} from '../../common'
+
+describe('state machine invoker', () => {
+    const obejctsContentsInput =
+        '{"id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}]}'
+
+    const recordsInput: Record[] = [
+        {
+            s3: {
+                bucket: {
+                    name: 'test-bucket',
+                },
+                object: {
+                    key: 'some/key/123.json',
+                },
+            },
+            eventTime: '2019-10-10',
+        },
+    ]
+
+    it('should handle (new records arrived) event when state machine invocation succeed', async () => {
+        const invokeStateMachineAllwaysSuccess = async (
+            issuePublication: IssuePublicationIdentifier,
+        ) => {
+            return issuePublication
+        }
+
+        const testDependencies: InvokerDependencies = {
+            stateMachineInvoke: invokeStateMachineAllwaysSuccess,
+            s3fetch: (params: GetS3ObjParams) => {
+                return Promise.resolve(obejctsContentsInput)
+            },
+        }
+
+        const actual = await internalHandler(recordsInput, testDependencies)
+
+        const issueExpected = {
+            edition: 'american-edition',
+            version: '2019-10-04T16:08:35.951Z',
+            issueDate: '2019-10-09',
+        }
+        const expecetd = [
+            `✅ Invocation of ${JSON.stringify(issueExpected)} succeeded.`,
+        ]
+
+        expect(actual).toStrictEqual(expecetd)
+    })
+
+    it('should thorw error when no state machine invocation were made', async () => {
+        const invokeStateMachineAllwaysFails = async (
+            issuePublication: IssuePublicationIdentifier,
+        ) => {
+            return withFailureMessage(
+                failure({ error: 'banana' }),
+                `⚠️ Invocation of ${JSON.stringify(issuePublication)} failed.`,
+            )
+        }
+
+        const testDependencies: InvokerDependencies = {
+            stateMachineInvoke: invokeStateMachineAllwaysFails,
+            s3fetch: (params: GetS3ObjParams) => {
+                return Promise.resolve(obejctsContentsInput)
+            },
+        }
+
+        await expect(
+            internalHandler(recordsInput, testDependencies),
+        ).rejects.toStrictEqual(new Error('No invocations were made.'))
+    })
+})

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -4,32 +4,104 @@ import { randomBytes } from 'crypto'
 import {
     Attempt,
     attempt,
-    failure,
     Failure,
     hasFailed,
     hasSucceeded,
     withFailureMessage,
-} from '../../../backend/utils/try'
-import { IssuePublicationIdentifier } from '../../common'
+    IssuePublicationIdentifier,
+} from '../../common'
 import { IssueParams } from '../tasks/issue'
-const stateMachineArnEnv = 'stateMachineARN'
-const stateMachineArn = process.env[stateMachineArnEnv]
-interface Record {
+import { fetchfromCMSFrontsS3, GetS3ObjParams } from '../utils/s3'
+import { parseRecord } from './parser'
+
+export interface Record {
     s3: { bucket: { name: string }; object: { key: string } }
     eventTime: string
 } //partial of https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 
-const parseRecord = (record: Record): Attempt<IssuePublicationIdentifier> => {
-    const key = decodeURIComponent(record.s3.object.key)
-    const [, issueDate, filename] = key.split('/')
-    if (filename === undefined || issueDate === undefined) {
-        return failure({
-            error: new Error(),
-            messages: [`⚠️ ${key} does not correspond to an issue`],
-        })
+const sf = new StepFunctions({
+    region: 'eu-west-1',
+})
+
+const getRuntimeInvokeStateMachineFunction = (stateMachineArn: string) => {
+    return async (
+        issuePublication: IssuePublicationIdentifier,
+    ): Promise<IssuePublicationIdentifier | Failure> => {
+        const invoke: IssueParams = {
+            issuePublication,
+        }
+        const run = await attempt(
+            sf
+                .startExecution({
+                    stateMachineArn,
+                    input: JSON.stringify(invoke),
+                    name: `issue ${invoke.issuePublication.issueDate} ${
+                        invoke.issuePublication.version
+                    } ${randomBytes(2).toString('hex')}`.replace(
+                        /\W/g,
+                        '-', // see character restrictions
+                        //https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html
+                    ),
+                })
+                .promise(),
+        )
+        if (hasFailed(run)) {
+            const msg = `⚠️ Invocation of ${JSON.stringify(
+                issuePublication,
+            )} failed.`
+            console.error(msg)
+            return withFailureMessage(run, msg)
+        }
+        console.log(
+            `Invocation of step function for ${JSON.stringify(
+                issuePublication,
+            )} succesful`,
+        )
+        return issuePublication
     }
-    const version = filename.replace('.json', '')
-    return { edition: 'daily-edition' as const, version, issueDate }
+}
+
+export interface InvokerDependencies {
+    stateMachineInvoke: (
+        issuePub: IssuePublicationIdentifier,
+    ) => Promise<IssuePublicationIdentifier | Failure>
+    s3fetch: (params: GetS3ObjParams) => Promise<string>
+}
+
+export const internalHandler = async (
+    Records: Record[],
+    dependencies: InvokerDependencies,
+) => {
+    const maybeIssuesPromises: Promise<
+        Attempt<IssuePublicationIdentifier>
+    >[] = Records.map(async r => {
+        return await parseRecord(r, dependencies.s3fetch)
+    })
+
+    const maybeIssues: Attempt<
+        IssuePublicationIdentifier
+    >[] = await Promise.all(maybeIssuesPromises)
+
+    const issues: IssuePublicationIdentifier[] = maybeIssues.filter(
+        hasSucceeded,
+    )
+
+    console.log('Found following issues:', JSON.stringify(issues))
+
+    const runs = await Promise.all(
+        issues.map(issuePublication =>
+            dependencies.stateMachineInvoke(issuePublication),
+        ),
+    )
+
+    const succesfulInvocations = runs
+        .filter(hasSucceeded)
+        .map(issue => `✅ Invocation of ${JSON.stringify(issue)} succeeded.`)
+    const failedInvocations = runs.filter(hasFailed)
+    console.error(JSON.stringify([...failedInvocations]))
+    if (succesfulInvocations.length < 1)
+        throw new Error('No invocations were made.')
+    return [...succesfulInvocations, ...failedInvocations]
 }
 
 export const handler: Handler<
@@ -38,70 +110,23 @@ export const handler: Handler<
     },
     (string | Failure)[]
 > = async ({ Records }) => {
-    console.log('Attempting to invoke.')
-    console.log(JSON.stringify(Records))
+    const stateMachineArnEnv = 'stateMachineARN'
+    const stateMachineArn = process.env[stateMachineArnEnv]
+
     if (stateMachineArn == null) {
         throw new Error('No State Machine ARN configured')
     }
-
-    const sf = new StepFunctions({
-        region: 'eu-west-1',
-    })
-
-    const maybeIssues = Records.map(parseRecord)
-    console.log(`Found following: ${JSON.stringify(maybeIssues)}`)
-
-    const issues = maybeIssues.filter(hasSucceeded)
-    const runs = await Promise.all(
-        issues.map(async issuePublication => {
-            const invoke: IssueParams = {
-                issuePublication,
-            }
-            const run = await attempt(
-                sf
-                    .startExecution({
-                        stateMachineArn,
-                        input: JSON.stringify(invoke),
-                        name: `issue ${invoke.issuePublication.issueDate} ${
-                            invoke.issuePublication.version
-                        } ${randomBytes(2).toString('hex')}`.replace(
-                            /\W/g,
-                            '-', // see character restrictions
-                            //https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html
-                        ),
-                    })
-                    .promise(),
-            )
-            if (hasFailed(run)) {
-                console.error(
-                    `⚠️ Invocation of ${JSON.stringify(
-                        issuePublication,
-                    )} failed.`,
-                )
-                return withFailureMessage(
-                    run,
-                    `⚠️ Invocation of ${JSON.stringify(
-                        issuePublication,
-                    )} failed.`,
-                )
-            }
-            console.log(
-                `Invoation of step function for ${JSON.stringify(
-                    issuePublication,
-                )} succesful`,
-            )
-            return issuePublication
-        }),
+    console.log(
+        `Attempting to invoke ${stateMachineArn} after receiving records:`,
+        Records,
     )
 
-    const invalidKeys = runs.filter(hasFailed)
+    const runtimeDependencies: InvokerDependencies = {
+        stateMachineInvoke: getRuntimeInvokeStateMachineFunction(
+            stateMachineArn,
+        ),
+        s3fetch: fetchfromCMSFrontsS3,
+    }
 
-    const succesfulInvocations = runs
-        .filter(hasSucceeded)
-        .map(issue => `✅ Invocation of ${JSON.stringify(issue)} succeeded.`)
-    const failedInvocations = runs.filter(hasFailed)
-    console.error(JSON.stringify([...failedInvocations, ...invalidKeys]))
-    if (succesfulInvocations.length < 1)
-        throw new Error('No invocations were made.')
-    return [...succesfulInvocations, ...failedInvocations, ...invalidKeys]
+    return internalHandler(Records, runtimeDependencies)
 }

--- a/projects/archiver/src/invoke/parser.spec.ts
+++ b/projects/archiver/src/invoke/parser.spec.ts
@@ -1,0 +1,50 @@
+import { parseRecordInternal } from './parser'
+import { hasFailed } from '../../common'
+
+describe('parseRecord', () => {
+    it('should parse correct json', async () => {
+        const obejctsContents =
+            '{"id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}]}'
+
+        const actual = parseRecordInternal(obejctsContents)
+
+        expect(actual).toStrictEqual({
+            edition: 'american-edition',
+            version: '2019-10-04T16:08:35.951Z',
+            issueDate: '2019-10-09',
+        })
+    })
+
+    it('should parse js smaller json with requiered fields', async () => {
+        const obejctsContents =
+            '{"edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z"}'
+
+        const actual = parseRecordInternal(obejctsContents)
+
+        expect(actual).toStrictEqual({
+            edition: 'american-edition',
+            version: '2019-10-04T16:08:35.951Z',
+            issueDate: '2019-10-09',
+        })
+    })
+
+    it('should fail if one of the requiered fields is missing', async () => {
+        const invalids = [
+            '{"issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z"}',
+            '{"issueDate":"2019-10-09","edition":"american-edition"}',
+            '{"version":"2019-10-04T16:08:35.951Z","edition":"american-edition"}',
+            '{"version":"2019-10-04T16:08:35.951Z"}',
+            '{"edition":"american-edition"}',
+            '{"issueDate":"2019-10-09"}',
+        ]
+
+        invalids.forEach(s => {
+            expect(hasFailed(parseRecordInternal(s))).toBe(true)
+        })
+    })
+
+    it('should fail if JSON was malformed', async () => {
+        const obejctsContents = '{"'
+        expect(hasFailed(parseRecordInternal(obejctsContents))).toBe(true)
+    })
+})

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -1,0 +1,57 @@
+import { Attempt, failure, IssuePublicationIdentifier } from '../../common'
+import { GetS3ObjParams } from '../utils/s3'
+import { Record } from '.'
+
+const isValidJSON = (s: string): boolean => {
+    try {
+        JSON.parse(s)
+    } catch (e) {
+        return false
+    }
+    return true
+}
+
+export const parseRecordInternal = (
+    objContent: string,
+    loc = '',
+): Attempt<IssuePublicationIdentifier> => {
+    if (!isValidJSON(objContent)) {
+        return failure({
+            error: new Error(),
+            messages: [`⚠️ JSON malformed in ${loc} file`],
+        })
+    }
+
+    const { edition, version, issueDate } = JSON.parse(objContent)
+
+    if (
+        edition === undefined ||
+        version === undefined ||
+        issueDate === undefined
+    ) {
+        return failure({
+            error: new Error(),
+            messages: [
+                `⚠️ ${loc} json file with issue details did not contained requiered fileds: (edition, version, issueDate)`,
+            ],
+        })
+    }
+    return { edition, version, issueDate }
+}
+
+export const parseRecord = async (
+    record: Record,
+    s3fetch: (params: GetS3ObjParams) => Promise<string>,
+): Promise<Attempt<IssuePublicationIdentifier>> => {
+    console.log('Starting to parse record')
+    const bucket = record.s3.bucket.name
+    const key = decodeURIComponent(record.s3.object.key)
+
+    const objContent = await s3fetch({ Bucket: bucket, Key: key })
+
+    const loc = `s3://${bucket}/${key}`
+
+    console.log(`got object content from ${loc} location:`, objContent)
+
+    return parseRecordInternal(objContent, loc)
+}

--- a/projects/archiver/src/tasks/front/index.ts
+++ b/projects/archiver/src/tasks/front/index.ts
@@ -27,7 +27,9 @@ export const handler: Handler<
         throw new Error(`Could not download front ${frontId}`)
     }
 
-    const images = unnest(getImagesFromFront(maybeFront))
+    console.log(`succesfully download front ${frontId}`, maybeFront)
+
+    const images: Image[] = unnest(getImagesFromFront(maybeFront))
 
     const frontUpload = await attempt(
         upload(
@@ -43,6 +45,9 @@ export const handler: Handler<
         throw new Error('Could not upload front')
     }
     const publishedFronts = [...issue.fronts, frontId]
+
+    console.log(`front uploaded`, publishedFronts)
+
     return {
         issuePublication,
         issue: { ...issue, fronts: publishedFronts },

--- a/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
@@ -64,10 +64,14 @@ export const getIssueSummary = async (
 
     const publishedId = getPublishedId(issuePublication)
 
+    const Prefix = `zips/${publishedId}/`
+
+    console.log(`getIssueSummary from location: s3://${Bucket}/${Prefix}`)
+
     const assetKeyList = await s3
         .listObjectsV2({
             Bucket,
-            Prefix: `zips/${publishedId}/`,
+            Prefix,
         })
         .promise()
 

--- a/projects/archiver/src/tasks/upload/index.ts
+++ b/projects/archiver/src/tasks/upload/index.ts
@@ -16,13 +16,17 @@ export const handler: Handler<
     UploadTaskOutput
 > = handleAndNotify('assembled', async ({ issuePublication, issue }) => {
     const { publishedId } = issue
+    const path = issuePath(publishedId)
     const issueUpload = await attempt(
-        upload(issuePath(publishedId), issue, 'application/json', ONE_WEEK),
+        upload(path, issue, 'application/json', ONE_WEEK),
     )
     if (hasFailed(issueUpload)) {
         console.error(JSON.stringify(issueUpload))
         throw new Error('Failed to upload issue file')
     }
+
+    console.log(`Issue file upload to ${path} succeeded`, issue)
+
     return {
         issuePublication,
         message: 'Issue uploaded succesfully',

--- a/projects/backend/common.ts
+++ b/projects/backend/common.ts
@@ -1,2 +1,3 @@
 export * from '../common/src/index'
 export * from '../common/src/helpers'
+export * from '../backend/utils/try'


### PR DESCRIPTION
## Why are you doing this?
We want to be able to publish multiple types of editions like:
- Daily Edition
- American Edition
- Australian Edition
- Training Edition

Now we support only Daily Edition
This PR enable that in archiver step functions tasks invoker

<!--
This sounds super accusatory BUT the idea is to help you work out the scope of the 
change outside of a typical trello card scope. You don't have to explain why 
you personally are doing this!

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card ->**](https://trello.com/c/qSmpzrIJ/128-backend-to-support-multiple-editions)

## Changes

* support multiple editions on invoker (invokes archiver step functions)

* Tag added to this lambda function

* unit tests for invoker

* more logs for assurance

## Tests

- [x] tested in CODE
- [x] tested locally

<!--
Please try to add visuals! 
This is super worthwhile for historical reasons as well
as to allow other contributors who aren't developers to collaborate
-->
