### PR TITLE
Fix crossword types

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -271,7 +271,7 @@ export const getArticles = async (
         return fromPairs(firstArray.concat(lastArray))
     }
     console.log('Making CAPI query', endpoint)
-    console.log('Debug link:', endpoint.replace('thrift', 'json'))
+    console.log('Debug link:', endpoint.replace(/thrift/g, 'json'))
     const resp = await attempt(fetch(endpoint))
     if (hasFailed(resp)) throw new Error('Could not connect to CAPI.')
     const buffer = await resp.arrayBuffer()

--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -1,17 +1,20 @@
 import { capitalizeFirstLetter, addCommas } from './format'
 import { CCrossword } from '../capi/articles'
-import { CAPIArticle, Crossword, CrosswordArticle } from '../common'
+import {
+    CAPIArticle,
+    Crossword,
+    CrosswordArticle,
+    CrosswordType,
+} from '../common'
 import { getImageFromURL } from '../image'
 
-const crosswordTypes = ['quick', 'cryptic', 'speedy', 'everyman'] as const
-
-export type CrosswordType = typeof crosswordTypes[number] | null
+const enumKeyToKebabCase = (key: string) => key.toLowerCase().replace(/_/g, '-')
 
 const getCrosswordType = (path: string): CrosswordType => {
-    for (const key of crosswordTypes) {
-        if (path.includes(key)) return key
+    for (const [key, type] of Object.entries(CrosswordType)) {
+        if (path.includes(enumKeyToKebabCase(key))) return type
     }
-    return null
+    return CrosswordType.QUICK // default to something sensible as this is largely used for rendering
 }
 
 const getCrosswordName = (type: CrosswordType): string =>
@@ -45,6 +48,9 @@ export const getCrosswordArticleOverrides = (
         headline: getCrosswordName(type),
         kicker: getCrosswordKicker(article.crossword),
         trailImage: getCrosswordImage(type),
-        crossword: article.crossword,
+        crossword: {
+            ...article.crossword,
+            type,
+        },
     }
 }


### PR DESCRIPTION
## Why are you doing this?

CAPI appears to return a string for the crossword type - you can see this when using teleporter on a crossword. However, we fetch the CAPI data as a thrift format. Internally, Thrift enums are represented as numbers and only thanks to [this line](https://github.com/guardian/content-api/blob/801ae0b3bc0554cee18d4e56f1e88757628e5799/porter/src/main/scala/com.gu.contentapi.porter/model/codecs.scala#L79) in CAPI do they get converted to strings. We don't have a codec for doing this in the TS / Thrift infra that we use so we, confusingly, receive the number.

The fix was easier than the find here ...
