### PR TITLE
Pass id down for persistence

### DIFF
--- a/projects/Mallard/src/components/article/types/crossword.tsx
+++ b/projects/Mallard/src/components/article/types/crossword.tsx
@@ -16,9 +16,9 @@ const Crossword = ({
         originWhitelist={['*']}
         source={{ uri: getBundleUri('crosswords') }}
         injectedJavaScript={`
-                window.loadCrosswordData(${JSON.stringify(
-                    crosswordArticle.crossword,
-                )}); true;
+                window.loadCrosswordData("${
+                    crosswordArticle.key
+                }", ${JSON.stringify(crosswordArticle.crossword)}); true;
             `}
         allowFileAccess={true}
         javaScriptEnabled={true}

--- a/projects/editions-crossword-renderer-app/src/index.js
+++ b/projects/editions-crossword-renderer-app/src/index.js
@@ -4,10 +4,10 @@ import ReactDOM from 'react-dom'
 
 const wrapper = document.getElementById('crossword-container')
 
-window.loadCrosswordData = crosswordData => {
+window.loadCrosswordData = (id, crosswordData) => {
     wrapper
         ? ReactDOM.render(
-              <CrosswordView crosswordData={crosswordData} />,
+              <CrosswordView id={id} crosswordData={crosswordData} />,
               wrapper,
           )
         : false

--- a/projects/editions-crossword-renderer-app/src/js/components/CrosswordView.jsx
+++ b/projects/editions-crossword-renderer-app/src/js/components/CrosswordView.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import Crossword from '@guardian/react-crossword'
 
-const CrosswordView = ({ crosswordData }) => {
+const CrosswordView = ({ id, crosswordData }) => {
     return (
         <div id="crossword-view">
-            <Crossword data={crosswordData} />
+            <Crossword id={id} data={crosswordData} />
         </div>
     )
 }


### PR DESCRIPTION
## Why are you doing this?

Previously every single crossword was getting the same cache key (probably '') because we weren't passing an `id` into the crossword component. Doing that keeps persistence for different crosswords but ensures it only loads on the _right_ ones 👏 
