### PR TITLE
Rahb/fix invisible fronts and wrong images

### DIFF
--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -59,6 +59,7 @@ const ImageResource = ({
     const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
     return width && imagePath ? (
         <ScaledImageResource
+            key={imagePath} // an attempt to fix https://github.com/facebook/react-native/issues/9195
             width={width}
             imagePath={imagePath}
             style={styles}

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -172,7 +172,6 @@ const FrontWithResponse = React.memo(
                     showsVerticalScrollIndicator={false}
                     scrollEventThrottle={1}
                     horizontal={true}
-                    removeClippedSubviews={true}
                     style={styles.overflow}
                     decelerationRate="fast"
                     snapToInterval={card.width}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -7,7 +7,7 @@ import {
     ViewStyle,
     Image,
 } from 'react-native'
-import { ScrollView } from 'react-native-gesture-handler'
+import { FlatList } from 'react-native-gesture-handler'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
 import { Issue } from 'src/common'
 import { Button } from 'src/components/button/button'
@@ -142,29 +142,53 @@ const IssueFronts = ({
     ListHeaderComponent?: ReactElement
     style?: StyleProp<ViewStyle>
 }) => {
-    const { container } = useIssueScreenSize()
+    const { container, card } = useIssueScreenSize()
     const { width } = useDimensions()
+    console.log(issue)
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
-        <ScrollView style={style} key={width} removeClippedSubviews={true}>
-            {ListHeaderComponent}
-            {issue.fronts.map(key => (
+        <FlatList
+            showsHorizontalScrollIndicator={false}
+            ListHeaderComponent={ListHeaderComponent}
+            // These three props are responsible for the majority of
+            // performance improvements
+            initialNumToRender={2}
+            windowSize={2}
+            debug
+            maxToRenderPerBatch={2}
+            showsVerticalScrollIndicator={false}
+            scrollEventThrottle={1}
+            decelerationRate="fast"
+            ListFooterComponent={() => (
+                <>
+                    <View style={[styles.illustrationPosition]}>
+                        <Image
+                            style={styles.illustrationImage}
+                            resizeMode={'contain'}
+                            source={require('src/assets/images/privacy.png')}
+                        />
+                    </View>
+                    <View style={{ height: container.height / 3 }} />
+                </>
+            )}
+            getItemLayout={(_: any, index: number) => ({
+                length: card.height,
+                offset: card.height * index,
+                index,
+            })}
+            keyExtractor={item => item}
+            data={issue.fronts}
+            style={style}
+            key={width}
+            renderItem={({ item: key }) => (
                 <Front
                     localIssueId={issue.localId}
                     publishedIssueId={issue.publishedId}
                     front={key}
                     key={key}
                 />
-            ))}
-            <View style={[styles.illustrationPosition]}>
-                <Image
-                    style={styles.illustrationImage}
-                    resizeMode={'contain'}
-                    source={require('src/assets/images/privacy.png')}
-                />
-            </View>
-            <View style={{ height: container.height / 3 }} />
-        </ScrollView>
+            )}
+        />
     )
 }
 

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -153,7 +153,6 @@ const IssueFronts = ({
             // performance improvements
             initialNumToRender={2}
             windowSize={2}
-            debug
             maxToRenderPerBatch={2}
             showsVerticalScrollIndicator={false}
             scrollEventThrottle={1}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -144,7 +144,6 @@ const IssueFronts = ({
 }) => {
     const { container, card } = useIssueScreenSize()
     const { width } = useDimensions()
-    console.log(issue)
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
         <FlatList


### PR DESCRIPTION
## Why are you doing this?

Fixes fronts not loading when you go back to them. Instead of using `removeClippedSubviews` we use a `FlatList` to remove the views at the React layer rather than the native layer, which is more resilient but potentially uses a bit more memory than before. Hopefully we can further improve memory usage by shipping smaller images for certain cards in future.

This also fixes an issue where the wrong images were appearing in some cards (it was added to this PR as I thought it was a `FlatList` issue) - more info here: https://github.com/facebook/react-native/issues/9195
