### PR TITLE
Rahb/auth fixes

### DIFF
--- a/projects/Mallard/src/authentication/services/google.ts
+++ b/projects/Mallard/src/authentication/services/google.ts
@@ -5,9 +5,20 @@ import invariant from 'invariant'
 
 const googleRedirectURI = `com.googleusercontent.apps.${GOOGLE_CLIENT_ID}:authorize`
 
+const DEFAULT_AUTHORIZATION_ENDPOINT =
+    'https://accounts.google.com/o/oauth2/v2/auth'
+
 const getGoogleOAuthURL = (validatorString: string) =>
     fetch('https://accounts.google.com/.well-known/openid-configuration')
-        .then(res => res.json())
+        .then(res => {
+            if (res.ok) return res.json()
+            throw new Error() // knock us into the `catch` below
+        })
+        /**
+         * The above is the right way to find the auth endpoint but, in case of an error,
+         * return auth endpoint for google OAuth that is correct at time of writing
+         */
+        .catch(() => DEFAULT_AUTHORIZATION_ENDPOINT)
         .then(
             json =>
                 `${json.authorization_endpoint}?${qs.stringify({

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -52,7 +52,7 @@ const AuthSwitcherScreen = ({
     const { open } = useModal()
 
     const handleAuthClick = async (
-        paramsPromise: Promise<AuthParams>,
+        runParamsPromise: () => Promise<AuthParams>,
         {
             requiresFunctionalConsent,
             signInName,
@@ -65,7 +65,9 @@ const AuthSwitcherScreen = ({
                 allow: async () => {
                     setIsLoading(true)
                     try {
-                        const attempt = await authIdentity(await paramsPromise)
+                        const attempt = await authIdentity(
+                            await runParamsPromise(),
+                        )
                         if (isValid(attempt)) {
                             setIsLoading(false)
                             if (!canViewEdition(attempt.data)) {
@@ -132,25 +134,29 @@ const AuthSwitcherScreen = ({
             }
             onFacebookPress={() =>
                 handleAuthClick(
-                    facebookAuthWithDeepRedirect(validatorString).then(
-                        token => ({
-                            'facebook-access-token': token,
-                        }),
-                    ),
+                    () =>
+                        facebookAuthWithDeepRedirect(validatorString).then(
+                            token => ({
+                                'facebook-access-token': token,
+                            }),
+                        ),
                     { requiresFunctionalConsent: true, signInName: 'Facebook' },
                 )
             }
             onGooglePress={() =>
                 handleAuthClick(
-                    googleAuthWithDeepRedirect(validatorString).then(token => ({
-                        'google-access-token': token,
-                    })),
+                    () =>
+                        googleAuthWithDeepRedirect(validatorString).then(
+                            token => ({
+                                'google-access-token': token,
+                            }),
+                        ),
                     { requiresFunctionalConsent: true, signInName: 'Google' },
                 )
             }
             onSubmit={() =>
                 handleAuthClick(
-                    Promise.resolve({
+                    async () => ({
                         email: email.value,
                         password: password.value,
                     }),

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -52,7 +52,7 @@ const AuthSwitcherScreen = ({
     const { open } = useModal()
 
     const handleAuthClick = async (
-        runParamsPromise: () => Promise<AuthParams>,
+        runGetIdentityAuthParams: () => Promise<AuthParams>,
         {
             requiresFunctionalConsent,
             signInName,
@@ -66,7 +66,7 @@ const AuthSwitcherScreen = ({
                     setIsLoading(true)
                     try {
                         const attempt = await authIdentity(
-                            await runParamsPromise(),
+                            await runGetIdentityAuthParams(),
                         )
                         if (isValid(attempt)) {
                             setIsLoading(false)


### PR DESCRIPTION
## Why are you doing this?

Trying to iron out some potential issues with the Google auth "blank screen" bug, which I basically think is the device running out of memory ... but I can't be sure.

- Fallback to sensible Google auth endpoint, currently we use the `.well-known` endpoint for getting this. I can't see how this would cause this issues but it seems like a good change to make.
- Turned the auth runners into thunks as they were being evaluated even if we didn't have consent to run them ... this is more likely to fix the blank screen issue ... but still unlikely IMHO.