### PR TITLE
fix: Path Traversal Vulnerability

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -117,11 +117,11 @@ PODS:
     - React
   - RNSVG (9.6.2):
     - React
-  - RNZipArchive (5.0.0):
+  - RNZipArchive (4.1.2):
     - React
-    - RNZipArchive/Core (= 5.0.0)
+    - RNZipArchive/Core (= 4.1.2)
     - SSZipArchive (= 2.2.2)
-  - RNZipArchive/Core (5.0.0):
+  - RNZipArchive/Core (4.1.2):
     - React
     - SSZipArchive (= 2.2.2)
   - Sentry (4.1.3):
@@ -310,7 +310,7 @@ SPEC CHECKSUMS:
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   RNSVG: ff9b094e39dd4a437ebe17d1c7ceed286e75f426
-  RNZipArchive: be636657a6630e9771d4a3223dc8fd0bd0137b55
+  RNZipArchive: 2179f7a0755905d68a3b0f2d9332796cca1e7aa4
   Sentry: 4e8a17b61ddd116f89536cc81d567fdee1ebca96
   SentryReactNative: 07237139c00366ea2e75ae3e5c566e7a71c27a90
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
@@ -318,4 +318,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c499c44aed47275a8e1f036511ecda7d7450e47a
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.5

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -70,7 +70,7 @@
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.6.2",
         "react-native-webview": "^6.9.0",
-        "react-native-zip-archive": "^5.0.0",
+        "react-native-zip-archive": "4.1.2",
         "react-navigation": "3.11.1",
         "react-navigation-fluid-transitions": "^0.3.2",
         "rn-fetch-blob": "0.10.16",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -5564,10 +5564,10 @@ react-native-webview@^6.9.0:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"
 
-react-native-zip-archive@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-5.0.0.tgz#7833e48b895f3da1f6c99b6f504f124ee243667f"
-  integrity sha512-4AoBKb09lKESRaKcwhBG4+DLAhEHlw4H7AKUZC5zFHjtsaewNfwAMRgP3y+K2mjKN+Ihr/O7NFJFVEDrtarygg==
+react-native-zip-archive@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-4.1.2.tgz#61bef40d507583171083537fc50fa790e4a14693"
+  integrity sha512-WBwcUf0YHNEMuf+ab3jfHO7+h29eDrQMFoV9YakEzLDY4fyQEmcr1XttO5wevR+Zu19TZFZW34JIVgFPxw+m6A==
 
 react-native@0.60.4:
   version "0.60.4"


### PR DESCRIPTION
## Why are you doing this?

We are getting warnings in Google Play console about a Path Traversal Vulnerability. This is caused by `react-native-zip-archive`. 

There is an open issue around this at the moment, and as a result, is not resolved in the latest version. However, there is a suggestion to downgrade to remove the error. https://github.com/mockingbot/react-native-zip-archive/issues/170

This is what this PR does.

[**Trello Card ->**](https://trello.com/c/MXoqBEpK/844-security-warning-on-android-playstore)