### PR TITLE
Archiver: Stop issue tasks if there is no fronts in issue

### DIFF
--- a/projects/archiver/src/tasks/issue/index.ts
+++ b/projects/archiver/src/tasks/issue/index.ts
@@ -30,11 +30,18 @@ export const handler: Handler<IssueParams, IssueTaskOutput> = handleAndNotify(
             throw new Error('Failed to download issue.')
         }
         console.log(`Downloaded issue ${JSON.stringify(issuePublication)}`)
+
+        const { fronts } = issue
+
+        if (fronts.length == 0) {
+            throw new Error(`No fronts found on '${publishedId}' issue`)
+        }
+
         return {
             issuePublication,
             issue: { ...issue, fronts: [] },
-            fronts: issue.fronts,
-            remainingFronts: issue.fronts.length,
+            fronts,
+            remainingFronts: fronts.length,
             message: 'Fetched issue succesfully.',
         }
     },


### PR DESCRIPTION
## Why are you doing this?
We want to fail fast archiver step functions if issue have no fronts with relevant error message 

## Changes

* Add throw error

## Screenshots

- before

![Screenshot 2019-10-09 at 12 03 45](https://user-images.githubusercontent.com/10913420/66476195-e3391200-ea8c-11e9-814c-9cd2e2d6d193.png)

- after 

![Screenshot 2019-10-09 at 12 04 20](https://user-images.githubusercontent.com/10913420/66476236-fc41c300-ea8c-11e9-8a18-08fec20af37b.png)
