### PR TITLE
ArticleSlider: switch to the community-scoped ViewPagerAndroid

### DIFF
--- a/projects/Mallard/ios/Podfile
+++ b/projects/Mallard/ios/Podfile
@@ -32,6 +32,8 @@ target 'Mallard' do
 #   https://github.com/luggit/react-native-config/issues/187
     pod 'react-native-in-app-utils', :path => '../node_modules/react-native-in-app-utils'
 
+    pod 'react-native-viewpager', :path => '../node_modules/@react-native-community/viewpager'
+
     post_install do |installer|
     installer.pods_project.targets.each do |target|
       if target.name == 'react-native-config'

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -69,6 +69,8 @@ PODS:
     - React
   - react-native-splash-screen (3.2.0):
     - React
+  - react-native-viewpager (2.0.1):
+    - React
   - react-native-webview (6.9.0):
     - React
   - React-RCTActionSheet (0.60.4):
@@ -151,6 +153,7 @@ DEPENDENCIES:
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - "react-native-safe-area-insets (from `../node_modules/@delightfulstudio/react-native-safe-area-insets`)"
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
+  - "react-native-viewpager (from `../node_modules/@react-native-community/viewpager`)"
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -218,6 +221,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@delightfulstudio/react-native-safe-area-insets"
   react-native-splash-screen:
     :path: "../node_modules/react-native-splash-screen"
+  react-native-viewpager:
+    :path: "../node_modules/@react-native-community/viewpager"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-RCTActionSheet:
@@ -288,6 +293,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 0da34082d2cec3100c9b5073bb217e35f1142bdd
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
+  react-native-viewpager: f41b42bba71407e916654d64e87ff2680edecc92
   react-native-webview: 2d8de2be422f0f8b9ba38db3f013f9ebfdb9b78f
   React-RCTActionSheet: 9f71d7ae3e8fb10e08d162cbf14c621349dbfab3
   React-RCTAnimation: 981d8c95b0e30918a9832ccac32af83562a27fae
@@ -316,6 +322,6 @@ SPEC CHECKSUMS:
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   yoga: c2c050f6ae6e222534760cc82f559b89214b67e2
 
-PODFILE CHECKSUM: c499c44aed47275a8e1f036511ecda7d7450e47a
+PODFILE CHECKSUM: 788719fce78dff3b2ae21dad8bb5cde3c56a97bb
 
 COCOAPODS: 1.7.5

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -40,6 +40,7 @@
         "@react-native-community/masked-view": "^0.1.1",
         "@react-native-community/netinfo": "^3.2.1",
         "@react-native-community/push-notification-ios": "^1.0.2",
+        "@react-native-community/viewpager": "^2.0.1",
         "chalk": "^2.4.2",
         "convert-svg-to-png": "^0.5.0",
         "deepmerge": "^4.0.0",

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -5,9 +5,9 @@ import {
     StyleProp,
     StyleSheet,
     View,
-    ViewPagerAndroid,
     ViewStyle,
 } from 'react-native'
+import ViewPagerAndroid from '@react-native-community/viewpager'
 import { Appearance, CAPIArticle, Collection, Front, Issue } from 'src/common'
 import { MaxWidthWrap } from 'src/components/article/wrap/max-width'
 import { AnimatedFlatListRef } from 'src/components/front/helpers/helpers'

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -943,6 +943,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/viewpager@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-2.0.1.tgz#892e2148c8bca4ff157280e4be81d88be3264efc"
+  integrity sha512-fTTpO6xdVrTAAWbC1B2TQbxOkzDtvE9YfovDPYpi+S9oWmT06Eh8pv1Umd/7R/ewuLy9i2fzBnAu5WY+Di8OwA==
+
 "@react-navigation/core@~3.4.1":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.4.2.tgz#bec563e94fde40fbab3730cdc97f22afbb2a1498"


### PR DESCRIPTION
## Why are you doing this?

React Native is giving warning that this component will be getting out of core and into the community group. This switches the ViewPager to the `@react-native-community/viewpager` one so that we don't have to think about it before next React Native upgrade.

## Changes

* `yarn add @react-native-community/viewpager`
* `react-native link @react-native-community/viewpager`, then I had to fix the Java file by hand.
* Change slider.tsx to use the new component.

## Screenshots

![viewpager](https://user-images.githubusercontent.com/1733570/66491251-4e451180-eaaa-11e9-8999-9014771b1f7c.gif)

