### PR TITLE
gallery.tsx: add missing 'key' in rendered collection

### DIFF
--- a/projects/Mallard/src/components/article/types/gallery.tsx
+++ b/projects/Mallard/src/components/article/types/gallery.tsx
@@ -172,7 +172,7 @@ const Gallery = ({ gallery }: { gallery: GalleryArticle }) => {
             <View style={[styles.background]}>
                 {gallery.elements.map((element, index) => {
                     if (element.id === 'image' && publishedId) {
-                        return <GalleryItem element={element} />
+                        return <GalleryItem key={index} element={element} />
                     }
                     return <Text key={index}>{element.id}</Text>
                 })}


### PR DESCRIPTION
## Why are you doing this?

This was triggering a warning (and is indeed broken) if no `key` is provided. This fixes that, though using `index` we don't provide proper reconciliation. I think it's fine though as I expect this list of elements not to be changing dynamically.

## Changes

* add `key` in render function of `Gallery`

## Screenshots

No warning shows up on the page where I was getting it initially:

<img width="355" alt="Screenshot 2019-10-09 at 16 02 41" src="https://user-images.githubusercontent.com/1733570/66493631-49825c80-eaae-11e9-8350-014240e18b18.png">
