### PR TITLE
making edition parameter type safe in archiver

### DIFF
--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -22,7 +22,9 @@ export const parseRecordInternal = (
         })
     }
 
-    const { edition, version, issueDate } = JSON.parse(objContent)
+    const { edition, version, issueDate } = JSON.parse(
+        objContent,
+    ) as IssuePublicationIdentifier
 
     if (
         edition === undefined ||

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -1,5 +1,7 @@
+import { Edition } from '../../common'
+
 const createEditionToDisplayNameMap = () => {
-    const map = new Map<string, string>()
+    const map = new Map<Edition, string>()
     map.set('daily-edition', 'Daily Edition')
     map.set('american-edition', 'American Edition')
     map.set('australian-edition', 'Australian Edition')
@@ -9,7 +11,7 @@ const createEditionToDisplayNameMap = () => {
 
 const editionToName = createEditionToDisplayNameMap()
 
-export const getEditionDisplayName = (edition: string): string => {
+export const getEditionDisplayName = (edition: Edition): string => {
     if (!editionToName.has(edition)) {
         throw new Error(`${edition} missing in editionToName mapping`)
     }

--- a/projects/archiver/src/services/pub-status-notifier.ts
+++ b/projects/archiver/src/services/pub-status-notifier.ts
@@ -1,13 +1,13 @@
 import { attempt } from '../../../backend/utils/try'
 import { TemporaryCredentials, SNS } from 'aws-sdk'
-import { IssuePublicationIdentifier } from '../../common'
+import { IssuePublicationIdentifier, Edition } from '../../common'
 import { Status } from '../services/status'
 import { Moment } from 'moment'
 
 export type ToolStatus = 'Processing' | 'Published' | 'Failed'
 
 export interface PublishEvent {
-    edition: string
+    edition: Edition
     issueDate: string
     version: string
     status: ToolStatus

--- a/projects/archiver/src/services/status.ts
+++ b/projects/archiver/src/services/status.ts
@@ -69,7 +69,8 @@ const getStatus = async (
         return { ...issuePublication, status: 'unknown', updated: new Date(0) }
     }
     const decodedStatus = JSON.parse(statusResponse)
-    const status = statuses.find(_ => _ === decodedStatus.status) || 'unknown'
+    const status: Status =
+        statuses.find(_ => _ === decodedStatus.status) || 'unknown'
     const updated = oc(response).LastModified() || new Date(0)
     console.log(
         `Status for ${JSON.stringify(

--- a/projects/archiver/src/services/task-handler.spec.ts
+++ b/projects/archiver/src/services/task-handler.spec.ts
@@ -1,6 +1,7 @@
 import { handleAndNotifyInternal } from './task-handler'
 import moment = require('moment')
 import { createPublishEvent, PublishEvent } from './pub-status-notifier'
+import { IssuePublicationIdentifier } from '../../common'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dontCare = {} as any
@@ -10,7 +11,7 @@ const input = {
         edition: 'daily-edition',
         version: '2019-10-02T11:31:58.974+01:00',
         issueDate: '2019-09-11',
-    },
+    } as IssuePublicationIdentifier,
 }
 
 const successHandler = async () => 'banana'

--- a/projects/archiver/src/tasks/indexer/helpers/get-issues.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-issues.ts
@@ -1,9 +1,9 @@
-import { IssueIdentifier } from '../../../../common'
+import { IssueIdentifier, Edition } from '../../../../common'
 import { Bucket, listNestedPrefixes } from '../../../utils/s3'
 
 /* Crawl S3 for a list of all of the issues that are available */
 export const getIssuesBy = async (
-    edition: string,
+    edition: Edition,
 ): Promise<IssueIdentifier[]> => {
     const prefixes = await listNestedPrefixes(Bucket, edition)
 

--- a/projects/archiver/src/tasks/indexer/helpers/summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/summary.ts
@@ -3,13 +3,14 @@ import {
     notNull,
     IssuePublicationIdentifier,
     IssueIdentifier,
+    Edition,
 } from '../../../../common'
 import { getIssuesBy as getIssuesByEdition, issueWindow } from './get-issues'
 import { getIssueSummary } from './get-issue-summary'
 import { getPublishedVersion } from './get-published-version'
 import { oc } from 'ts-optchain'
 
-const validate = (allEditionIssues: IssueIdentifier[], edition: string) => {
+const validate = (allEditionIssues: IssueIdentifier[], edition: Edition) => {
     const otherEditions = allEditionIssues.filter(
         issue => issue.edition != edition,
     )
@@ -39,7 +40,7 @@ export const getOtherRecentIssues = (
 // currently publishing will remove this issue from the index, it should be generated in the indextask
 export const getOtherIssuesSummariesForEdition = async (
     currentlyPublishing: IssuePublicationIdentifier,
-    edition: string,
+    edition: Edition,
 ): Promise<IssueSummary[]> => {
     const allEditionIssues = await getIssuesByEdition(edition)
 

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -5,12 +5,13 @@ import {
     createScheduleTime,
     shouldSchedule,
 } from './device-notifications-helpers'
+import { Edition } from '../../../../common'
 
 export interface IssueNotificationData {
     key: string
     name: string
     issueDate: string
-    edition: string
+    edition: Edition
 }
 
 export interface ScheduleDeviceNotificationAPIResponse {

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from 'express'
 import { groupBy } from 'ramda'
-import { IssueSummary, notNull, IssuePublicationIdentifier } from '../common'
+import {
+    IssueSummary,
+    notNull,
+    IssuePublicationIdentifier,
+    Edition,
+} from '../common'
 import { getIssue } from '../issue'
 import { isPreview as isPreviewStage } from '../preview'
 import { s3List } from '../s3'
@@ -49,7 +54,7 @@ export const getIssuesSummary = async (
      * to support /issues path
      * TODO to delete in the future
      */
-    const edition = getEditionOrFallback(maybeEdition)
+    const edition: Edition = getEditionOrFallback(maybeEdition)
     const editionPath = buildEditionPath(maybeEdition, isPreview)
     const issueKeys = await s3List(editionPath)
 

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -3,19 +3,32 @@ import {
     buildEditionRootPath,
     decodeVersionOrPreview,
     pickIssuePathSegments,
+    getEditionOrFallback,
 } from '../issue'
-import { IssuePublicationIdentifier } from '../../common'
+import { IssuePublicationIdentifier, Edition } from '../../common'
 import { Path } from '../../s3'
 
 const issueDate = '2019-09-11'
 const version = '2019-10-04T11:28:04.07Z'
-const edition = 'daily-edition'
+const dailyEdition: Edition = 'daily-edition'
+const usEdition: Edition = 'american-edition'
 
 const issue: IssuePublicationIdentifier = {
     issueDate,
     version,
-    edition,
+    edition: dailyEdition,
 }
+
+describe('getEditionOrFallback', () => {
+    it('should get edition provided', () => {
+        expect(getEditionOrFallback(usEdition)).toStrictEqual(usEdition)
+    })
+    it('should fallback to daily-edition', () => {
+        expect(getEditionOrFallback('banana')).toStrictEqual(dailyEdition)
+        expect(getEditionOrFallback('')).toStrictEqual(dailyEdition)
+        expect(getEditionOrFallback(undefined)).toStrictEqual(dailyEdition)
+    })
+})
 
 describe('buildIssueObjectPath', () => {
     it('should build preview path', () => {
@@ -41,39 +54,43 @@ describe('buildIssueObjectPath', () => {
 describe('buildEditionRootPath', () => {
     it('should get preview edition path for edition provided', () => {
         const isPreview = true
-        const actual = buildEditionRootPath('other-edition', isPreview)
+        const actual = buildEditionRootPath(usEdition, isPreview)
         const expected: Path = {
-            key: 'other-edition/',
+            key: `${usEdition}/`,
             bucket: 'preview',
         }
         expect(actual).toStrictEqual(expected)
     })
     it('should get published edition path for edition provided', () => {
         const isPreview = false
-        const actual = buildEditionRootPath('other-edition', isPreview)
+        const actual = buildEditionRootPath(usEdition, isPreview)
         const expected: Path = {
-            key: 'other-edition/',
+            key: `${usEdition}/`,
             bucket: 'published',
         }
         expect(actual).toStrictEqual(expected)
     })
     it('should get preview edition path with fallback to daily-edition', () => {
         const isPreview = true
-        const actual = buildEditionRootPath('', isPreview)
         const expected: Path = {
             key: 'daily-edition/',
             bucket: 'preview',
         }
-        expect(actual).toStrictEqual(expected)
+        expect(buildEditionRootPath('', isPreview)).toStrictEqual(expected)
+        expect(buildEditionRootPath(undefined, isPreview)).toStrictEqual(
+            expected,
+        )
     })
     it('should get published edition path with fallback to daily-edition', () => {
         const isPreview = false
-        const actual = buildEditionRootPath('', isPreview)
         const expected: Path = {
             key: 'daily-edition/',
             bucket: 'published',
         }
-        expect(actual).toStrictEqual(expected)
+        expect(buildEditionRootPath('', isPreview)).toStrictEqual(expected)
+        expect(buildEditionRootPath(undefined, isPreview)).toStrictEqual(
+            expected,
+        )
     })
 })
 

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,10 +1,15 @@
-import { IssuePublicationIdentifier } from '../common'
+import { IssuePublicationIdentifier, Edition, Editions } from '../common'
 import { Path } from '../s3'
 
 const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 
-export const getEditionOrFallback = (maybeEdition: string) =>
-    maybeEdition || 'daily-edition'
+export const getEditionOrFallback = (
+    maybeEdition: string | undefined,
+): Edition => {
+    return (
+        (Editions.find(t => t === maybeEdition) as Edition) || 'daily-edition'
+    )
+}
 
 export const buildIssueObjectPath = (
     issue: IssuePublicationIdentifier,
@@ -18,10 +23,10 @@ export const buildIssueObjectPath = (
 }
 
 export const buildEditionRootPath = (
-    maybeEdition: string,
+    maybeEdition: string | undefined,
     asPreview: boolean,
 ): Path => {
-    const edition = getEditionOrFallback(maybeEdition)
+    const edition: Edition = getEditionOrFallback(maybeEdition)
     return {
         key: `${edition}/`,
         bucket: pickBucket(asPreview),

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -201,8 +201,17 @@ export const sizeDescriptions: { [k in ImageSize]: number } = {
     tabletXL: 1140,
 }
 
+export const Editions = [
+    'daily-edition',
+    'american-edition',
+    'australian-edition',
+    'training-edition',
+] as const
+
+export type Edition = typeof Editions[number]
+
 export interface IssueIdentifier {
-    edition: string
+    edition: Edition
     issueDate: string
 }
 


### PR DESCRIPTION
## Why are you doing this?
We want to be able to publish multiple types of editions like:
- Daily Edition
- American Edition
- Australian Edition
- Training Edition

This PR makes Edition parameter type typeSafe

## Tests

- [x] tested in CODE
- [x] tested locally
