### PR TITLE
Only allow dismiss at the top of the card

### DIFF
--- a/projects/Mallard/src/components/layout/slide-card/header.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/header.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
     Animated,
     StyleSheet,
     View,
     TouchableWithoutFeedback,
+    PanResponder,
 } from 'react-native'
 import { Chevron } from '../../chevron'
 import { metrics } from 'src/theme/spacing'
@@ -38,8 +39,37 @@ const Header = ({
     scrollY: Animated.Value
     onDismiss: () => void
 }) => {
+    const panResponder = useMemo(
+        () =>
+            PanResponder.create({
+                onMoveShouldSetPanResponder: () => true,
+                onStartShouldSetPanResponder: () => true,
+                onPanResponderMove: Animated.event([
+                    null,
+                    {
+                        dy: scrollY,
+                    },
+                ]),
+                onPanResponderEnd: (ev, gestureState) => {
+                    if (gestureState.dy > 50) {
+                        onDismiss()
+                        scrollY.stopAnimation()
+                        return
+                    }
+                    Animated.timing(scrollY, {
+                        useNativeDriver: true,
+                        toValue: 0,
+                        duration: 200,
+                    }).start()
+                },
+            }),
+        [onDismiss, scrollY],
+    )
     return (
-        <View style={[styles.headerContainer]}>
+        <Animated.View
+            {...panResponder.panHandlers}
+            style={[styles.headerContainer]}
+        >
             <TouchableWithoutFeedback
                 onPress={onDismiss}
                 accessibilityHint="Go back"
@@ -66,7 +96,7 @@ const Header = ({
                     <Chevron color={color.text} />
                 </Animated.View>
             </TouchableWithoutFeedback>
-        </View>
+        </Animated.View>
     )
 }
 

--- a/projects/Mallard/src/components/layout/slide-card/index.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/index.tsx
@@ -32,7 +32,6 @@ export const SlideCard = ({
     getPosition: () => Animated.Value
 }) => {
     const [scrollY] = useState(() => new Animated.Value(0))
-    const blocked = useRef(false)
 
     useEffect(() => {
         Animated.timing(getPosition(), {
@@ -45,51 +44,9 @@ export const SlideCard = ({
         }).start()
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-    const panResponder = PanResponder.create({
-        onStartShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponder: (ev, gestureState) => {
-            if (gestureState.moveY < 100) {
-                return true
-            }
-            if (gestureState.dy < 0) {
-                return false
-            }
-            if (gestureState.dy > 10) {
-                blocked.current = true
-                if (enabled && gestureState.vy > 1) {
-                    blocked.current = false
-                    onDismiss()
-                    scrollY.stopAnimation()
-                }
-            }
-            return enabled && blocked.current
-        },
-        onPanResponderTerminationRequest: () => false,
-        onShouldBlockNativeResponder: () => false,
-        onPanResponderMove: Animated.event([
-            null,
-            {
-                dy: scrollY,
-            },
-        ]),
-        onPanResponderEnd: (ev, gestureState) => {
-            blocked.current = false
-            if (gestureState.dy > 50) {
-                onDismiss()
-                scrollY.stopAnimation()
-                return
-            }
-            Animated.timing(scrollY, {
-                useNativeDriver: true,
-                toValue: 0,
-                duration: 200,
-            }).start()
-        },
-    })
-
     return (
         <Animated.View style={[styles.container]}>
-            <View {...panResponder.panHandlers} style={[{ flex: 1 }]}>
+            <View style={[{ flex: 1 }]}>
                 <Header
                     {...{
                         scrollY,


### PR DESCRIPTION
## Why are you doing this?

This is an intermediate fix for swiping down early on when viewing an article closing the article - even when not at the top.

This happens because the `UIWebView` version of the webview does not send scroll events until after the scroll has finished (https://stackoverflow.com/a/46542445/609907). This is fixed in the WebKit version of the webview. However, changing our webview at this late stage seems a bit dangerous so as an intermediate fix we've opted to only be able do dismiss from the top.

You can tell when we think a browser is at the top of an article by when the little grey line under the slide appears. When a user is at the top of the article it is invisible, when the user scrolls down, just as the inertia stops, the bar appears, which means our webview has reported a scroll position of > 10. In fact I don't the scroll position is reported any differently until the user releases the gesture.

This also has the nice side effect of fixing https://trello.com/c/R7I4OMHL/725-bug-using-the-app-and-swiping-through-articles-is-still-super-difficult-as-every-time-i-swipe-it-trys-to-swipe-the-article-down as there aren't now too gesture handlers competing.