### PR TITLE
Don't handle taps with the swipe pan responder

### DIFF
--- a/projects/Mallard/src/components/layout/slide-card/header.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/header.tsx
@@ -42,7 +42,8 @@ const Header = ({
     const panResponder = useMemo(
         () =>
             PanResponder.create({
-                onMoveShouldSetPanResponder: () => true,
+                onMoveShouldSetPanResponder: (ev, gestureState) =>
+                    gestureState.dy !== 0, // ignore taps
                 onStartShouldSetPanResponder: () => true,
                 onPanResponderMove: Animated.event([
                     null,


### PR DESCRIPTION
## Why are you doing this?

This stops the pan responder from becoming the active one when the user taps. This allows the gesture to bubble up to the `TouchableWithoutFeedback` above that will then dismiss the card.
