### PR TITLE
default-info-text-webview.tsx: fix margin for header and bullet list

### DIFF
--- a/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
+++ b/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
@@ -27,12 +27,15 @@ const styles: string = css`
         font-family: 'GuardianTextEgyptian-Reg';
         padding: ${metrics.vertical}px ${metrics.horizontal}px;
     }
-    .app p {
+    .app p, .app h2 {
         margin-bottom: ${metrics.vertical * 2}px;
     }
     .app a {
         color: ${color.primary};
         text-decoration-color: ${color.line};
+    }
+    .app ul {
+        margin-left: ${metrics.horizontal}px;
     }
 `
 


### PR DESCRIPTION
## Why are you doing this?

Display wasn't very good, this adds some padding after the title, and at the left of bullet points (see screenshot)

[**Trello Card ->**](https://trello.com/c/bota9ToR/432-settings-menu-terms-conditions-faq)

## Screenshots

<img width="351" alt="Screenshot 2019-10-11 at 12 57 08" src="https://user-images.githubusercontent.com/1733570/66649747-d8b28000-ec26-11e9-8867-c90ca4f28f8a.png">

