### PR TITLE
feat: Artificial delay to splash screen

### DIFF
--- a/projects/Mallard/ios/Mallard/LaunchScreen.xib
+++ b/projects/Mallard/ios/Mallard/LaunchScreen.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad12_9rounded" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -131,7 +131,7 @@ const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
 
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {
-        SplashScreen.hide()
+        setTimeout(() => SplashScreen.hide(), 1000)
     }
 
     async componentDidCatch(e: Error) {


### PR DESCRIPTION
## Why are you doing this?

Feeling was the splash screen is disappearing too fast. This adds an artificial delay.

Also there was a little check mark about launch screen that needed a tick

## Screenshots

Example to see
![splash](https://user-images.githubusercontent.com/935975/66668537-6012ea00-ec4d-11e9-86ee-96fd985aa774.gif)

FYI @blongden73 - Would require your review before merging. If you want to play, just change the millisecond number and run in production mode in Xcode.