### PR TITLE
fix: If error, end the background process on iOS

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -101,6 +101,7 @@ const pushNotifcationRegistration = () => {
                     console.log(
                         `Push notification unable to download: ${e.message}`,
                     )
+                    notification.finish(PushNotificationIOS.FetchResult.NoData)
                 }
 
                 // No matter what happens, always clear up old issues


### PR DESCRIPTION
## Why are you doing this?

Follow on from my previous PR.

If for any reason the download is unsuccessful and causes an error (e.g. not enough space) then this will now finish the background process on iOS rather than leave it open.
