### PR TITLE
Always show chevron for some devices

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -105,9 +105,10 @@ const ScreenHeader = withNavigation(
                             }
                         }
                     >
-                        {navigation.getParam('shouldShowMoreIssuesBtn') ||
-                        navigation.getParam('shouldShowMoreIssuesBtn') ===
-                            undefined ? (
+                        {!supportsTransparentCards() || // ignore for devices that obscure the button
+                        (navigation.getParam('shouldShowMoreIssuesBtn') ||
+                            navigation.getParam('shouldShowMoreIssuesBtn') ===
+                                undefined) ? (
                             <Button
                                 icon={isTablet ? '' : ''}
                                 alt="More issues"


### PR DESCRIPTION
## Why are you doing this?

The Chevron was occasionally disappearing on Android. This fix makes sure we don't hide the Chevron on devices that don't use the overlaid card at the bottom of the issue picker. This includes all Android devices.