### PR TITLE
This ignores all the lint errors so far, so that new ones show up.

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -58,6 +58,8 @@ const styles = StyleSheet.create({
 
 const persistenceKey = 'dev-nav-key-232asdffgdfg1asdffgfdgfdga3413'
 
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const persistNavigationState = async (navState: any) => {
     try {
         await AsyncStorage.setItem(persistenceKey, JSON.stringify(navState))

--- a/projects/Mallard/src/authentication/AccessContext.tsx
+++ b/projects/Mallard/src/authentication/AccessContext.tsx
@@ -92,6 +92,8 @@ const AccessProvider = ({
             unsubIdentity()
             unsubCAS()
         }
+        // (ignored 15/10/19)
+        // eslint-disable-next-line
     }, [])
 
     const value = useMemo(

--- a/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
@@ -6,6 +6,8 @@ const createListener = (): EventEmitter & {
     addEventListener: EventEmitter['addListener']
     removeEventListener: EventEmitter['removeListener']
 } => {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     const ee: any = new EventEmitter()
     ee.addEventListener = ee.addListener
     ee.removeEventListener = ee.removeListener

--- a/projects/Mallard/src/authentication/lib/AccessController.ts
+++ b/projects/Mallard/src/authentication/lib/AccessController.ts
@@ -12,6 +12,8 @@ import {
 type UpdateHandler = (attempt: AnyAttempt<string>) => void
 
 type AuthMap<I extends {}> = {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     [K in keyof I]: I[K] extends Authorizer<any, any, any> ? I[K] : never
 }
 class AccessController<I extends {}> {

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -20,7 +20,8 @@ export type AsyncCache<T> = {
     set: (data: T) => Promise<void>
     reset: () => Promise<void>
 }
-
+// (ignored 15/10/19)
+// eslint-disable-next-line
 class Authorizer<T, A extends any[], C extends readonly AsyncCache<any>[]> {
     private subscribers: UpdateHandler<T>[] = []
     private attempt: AnyAttempt<T> = NotRun

--- a/projects/Mallard/src/authentication/lib/Result.ts
+++ b/projects/Mallard/src/authentication/lib/Result.ts
@@ -64,7 +64,11 @@ const fromResponse = async <T>(
         invalid = () => GENERIC_AUTH_ERROR,
     }: {
         error?: string
+        // (ignored 15/10/19)
+        // eslint-disable-next-line
         valid?: (json: any) => T
+        // (ignored 15/10/19)
+        // eslint-disable-next-line
         invalid?: (json: any) => string
     } = {},
 ): Promise<AuthResult<T>> => {

--- a/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
+++ b/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
@@ -49,6 +49,8 @@ const createSimpleAccessController = ({
         a: new Authorizer({
             name: 'a',
             userDataCache: cache,
+            // (ignored 15/10/19)
+            // eslint-disable-next-line
             authCaches: [] as AsyncCache<any>[],
             auth: invalidFromLiveCredentials
                 ? getInvalidUserData
@@ -90,6 +92,8 @@ describe('AccessController', () => {
             a: new Authorizer({
                 name: 'a',
                 userDataCache: cache,
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 authCaches: [] as AsyncCache<any>[],
                 auth: async () => {
                     throw new Error()
@@ -211,6 +215,8 @@ describe('AccessController', () => {
                 a: new Authorizer({
                     name: 'a',
                     userDataCache: cache,
+                    // (ignored 15/10/19)
+                    // eslint-disable-next-line
                     authCaches: [] as AsyncCache<any>[],
                     auth: async ([a]: [string]) => {
                         arg = a

--- a/projects/Mallard/src/authentication/services/identity.ts
+++ b/projects/Mallard/src/authentication/services/identity.ts
@@ -6,10 +6,13 @@ import { GENERIC_AUTH_ERROR } from 'src/helpers/words'
 interface ErrorReponse {
     errors: { message: string; description: string }[]
 }
-
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const hasErrorsArray = (json: any): json is ErrorReponse =>
     json && Array.isArray(json.errors)
 
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const getErrorString = (data: any) =>
     hasErrorsArray(data)
         ? data.errors.map(err => err.description).join(', ')

--- a/projects/Mallard/src/components/article/article-headline/index.tsx
+++ b/projects/Mallard/src/components/article/article-headline/index.tsx
@@ -18,6 +18,8 @@ import { TextWithIcon } from 'src/components/layout/text-with-icon'
 import { MINIMUM_BREAKPOINT } from 'src/theme/breakpoints'
 
 export type ArticleHeadlineProps = {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     children: any
     hasHighlight?: boolean
     textStyle?: StyleProp<TextStyle>

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -106,10 +106,13 @@ const ArticleWebViewAndroid = ({
 
     useEffect(() => {
         onTopPositionChange(false)
-    }, [])
+        // (ignored 15/10/19)
+    }, []) // eslint-disable-line
     return (
         <View style={androidStyles.wrapper}>
             <Animated.View
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 onLayout={(ev: any) => {
                     setHeight(ev.nativeEvent.layout.height)
                 }}

--- a/projects/Mallard/src/components/article/types/article/helpers.tsx
+++ b/projects/Mallard/src/components/article/types/article/helpers.tsx
@@ -7,6 +7,8 @@ const urlIsNotAnEmbed = (url: string) =>
         url.startsWith('https://www.youtube.com/embed')
     )
 
+// (ignored 15/10/19)
+// eslint-disable-next-line
 export const onShouldStartLoadWithRequest = (event: any) => {
     if (
         Platform.select({

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -25,6 +25,8 @@ const WebviewWithArticle = ({
     headerProps?: ArticleHeaderProps & { type: ArticleType }
     paddingTop?: number
     _ref?: (ref: { _component: WebView }) => void
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
 } & WebViewProps & { onScroll?: any }) => {
     const { isConnected } = useNetInfo()
     const [, { pillar }] = useArticle()

--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -97,9 +97,13 @@ const ItemTappable = withNavigation(
         return (
             <Animated.View
                 style={[style]}
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 ref={(view: any) => {
                     if (view) tappableRef.current = view._component as View
                 }}
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 onLayout={(ev: any) => {
                     setScreenPositionOfItem(article.key, ev.nativeEvent.layout)
                     tappableRef.current &&

--- a/projects/Mallard/src/components/layout/animators/fader.tsx
+++ b/projects/Mallard/src/components/layout/animators/fader.tsx
@@ -18,6 +18,8 @@ The build order goes up/down according to screen position
 */
 
 export interface PropTypes {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     children: any
 }
 

--- a/projects/Mallard/src/components/layout/text-boxes.tsx
+++ b/projects/Mallard/src/components/layout/text-boxes.tsx
@@ -26,12 +26,18 @@ const Item = () => {
 */
 
 type TextBoxes = RectangleType[]
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const useTextBoxes = (): [(ev: any) => void, TextBoxes] => {
     const [boxes, setBoxes] = useState<TextBoxes>([])
 
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     const onTextLayout = (ev: any) => {
         /* make the boxes a bit bigger vertically for aesthetics*/
         setBoxes(
+            // (ignored 15/10/19)
+            // eslint-disable-next-line
             ev.nativeEvent.lines.map((line: any) => ({
                 x: line.x,
                 y: line.y + 2,

--- a/projects/Mallard/src/components/layout/text-with-icon.tsx
+++ b/projects/Mallard/src/components/layout/text-with-icon.tsx
@@ -17,10 +17,14 @@ interface Icon {
 }
 
 type TextWithIconProps = {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     children: any
     unscaledFont: ReturnType<typeof getUnscaledFont>
     icon: Icon
     style: StyleProp<TextStyle>
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
 } & { onTextLayout?: any } & TextProps
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/components/layout/ui/errors/error-boundary.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-boundary.tsx
@@ -11,7 +11,8 @@ class ErrorBoundary extends Component<
         super(props)
         this.state = { hasError: false, message: undefined }
     }
-
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     static getDerivedStateFromError(error: any) {
         return { hasError: true, message: JSON.stringify(error) }
     }

--- a/projects/Mallard/src/components/login/login-overlay.tsx
+++ b/projects/Mallard/src/components/login/login-overlay.tsx
@@ -18,6 +18,8 @@ const overlayStyles = StyleSheet.create({
  * of the prop rather than the value at the time it was closed
  * over
  */
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const usePropToRef = <T extends any>(value: T) => {
     const ref = useRef(value)
     useEffect(() => {

--- a/projects/Mallard/src/components/slider/draw/background.tsx
+++ b/projects/Mallard/src/components/slider/draw/background.tsx
@@ -9,6 +9,8 @@ const Stop = ({
     ...props
 }: {
     fill: string
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     [key: string]: any
 }) => {
     return <Circle r={radius} cy={height} fill={fill} {...props} />

--- a/projects/Mallard/src/components/slider/draw/lozenge.tsx
+++ b/projects/Mallard/src/components/slider/draw/lozenge.tsx
@@ -110,6 +110,8 @@ const LozengeBigHeader = ({
             </Animated.Text>
             <Animated.View
                 {...ariaHidden}
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 onLayout={(ev: any) => {
                     setWidth(ev.nativeEvent.layout.width)
                 }}
@@ -213,6 +215,8 @@ const LozengeCircle = ({
 }: {
     fill: string
     children: string
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     style?: any
     position?: Animated.AnimatedInterpolation
 }) => {

--- a/projects/Mallard/src/components/styled-text.tsx
+++ b/projects/Mallard/src/components/styled-text.tsx
@@ -92,6 +92,8 @@ export type HeadlineTextProps = {
     children: React.ReactNode | React.ReactNode[]
     weight?: 'regular' | 'bold' | 'light' | 'titlepiece'
     style?: StyleProp<TextStyle>
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
 } & TextProps & { onTextLayout?: any }
 
 export const getHeadlineTextStyle = (

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -19,6 +19,8 @@ import {
 import { cacheClearCache } from './storage'
 import { Forecast, AccuWeatherLocation, WeatherForecast } from '../common'
 
+// (ignored 15/10/19)
+// eslint-disable-next-line
 export type ValidatorFn<T> = (response: any | T) => boolean
 
 const fetchFromApiSlow = async <T>(

--- a/projects/Mallard/src/helpers/fetch/cache.ts
+++ b/projects/Mallard/src/helpers/fetch/cache.ts
@@ -1,9 +1,21 @@
 const cacheStore: {
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     api: { [path: string]: any }
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     issue: { [path: string]: any }
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     ipAddress: { [path: string]: string }
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     weatherLocation: { [path: string]: any }
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     weatherForecasts: { [path: string]: any }
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     weatherForecastSummary: { [path: string]: any }
 } = {
     api: {},

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -42,7 +42,8 @@ export const renderIssueDate = (dateString: Issue['date']): IssueDate => {
 export const useIssueDate = (issue?: Issue): IssueDate =>
     useMemo(
         () => (issue ? renderIssueDate(issue.date) : { date: '', weekday: '' }),
-        [issue && issue.key, issue],
+        // (ignored 15/10/19)
+        [issue && issue.key, issue], // eslint-disable-line
     )
 
 const dateToFolderConvert = (date: Date): string => {

--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -72,6 +72,8 @@ const pushNotifcationRegistration = () => {
                 })
             }
         },
+        // (ignored 15/10/19)
+        // eslint-disable-next-line
         onNotification: async (notification: any) => {
             const key =
                 Platform.OS === 'ios' ? notification.data.key : notification.key

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -15,6 +15,8 @@ import { IdentityAuthData } from 'src/authentication/authorizers/IdentityAuthori
  * `Settings` only works on iOS but we only ever had a legacy app on iOS
  * and not Android.
  */
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const createSettingsCacheIOS = <T = any>(key: string) => ({
     set: async (value: T) => {
         Settings.set({ [key]: value })

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -14,6 +14,8 @@ and gives us syntax colors
 */
 const passthrough = (
     literals: TemplateStringsArray,
+    // (ignored 15/10/19)
+    // eslint-disable-next-line
     ...placeholders: any[]
 ): string =>
     literals.reduce((acc, literal, i) => {

--- a/projects/Mallard/src/hooks/article/dev-tools.tsx
+++ b/projects/Mallard/src/hooks/article/dev-tools.tsx
@@ -5,6 +5,8 @@ import { StyleSheet, View } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { Button, ButtonAppearance } from 'src/components/button/button'
 
+// (ignored 15/10/19)
+// eslint-disable-next-line
 const getFirstLast = <T extends any>(arr: T[]): T[] => [
     arr[0],
     arr.slice(-1)[0],

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -68,12 +68,13 @@ export const useImagePath = (image?: Image) => {
             selectImagePath(apiUrl, localIssueId, publishedIssueId, image).then(
                 setPaths,
             )
-        }
+        } // (ignored 15/10/19)
+        // eslint-disable-next-line
     }, [
         apiUrl,
         image,
-        issueId ? issueId.publishedIssueId : undefined, // Why isn't this just issueId?
-        issueId ? issueId.localIssueId : undefined,
+        issueId ? issueId.publishedIssueId : undefined, // eslint-disable-line
+        issueId ? issueId.localIssueId : undefined, // eslint-disable-line
     ])
     if (image === undefined) return undefined
     return paths
@@ -89,6 +90,7 @@ export const useScaledImage = (largePath: string, width: number) => {
         if (!isRemote) {
             compressImagePath(largePath, width).then(setUri)
         }
-    }, [largePath, width])
+        // (ignored 15/10/19)
+    }, [largePath, width]) //eslint-disable-line
     return uri
 }

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -166,6 +166,8 @@ const ArticleSlider = ({
                 <ViewPagerAndroid
                     style={styles.androidPager}
                     initialPage={startingPoint}
+                    // (ignored 15/10/19)
+                    // eslint-disable-next-line
                     onPageSelected={(ev: any) => {
                         setCurrent(ev.nativeEvent.position)
                     }}
@@ -205,6 +207,8 @@ const ArticleSlider = ({
                 showsHorizontalScrollIndicator={false}
                 showsVerticalScrollIndicator={false}
                 scrollEventThrottle={1}
+                // (ignored 15/10/19)
+                // eslint-disable-next-line
                 onScroll={(ev: any) => {
                     setCurrent(
                         Math.floor(ev.nativeEvent.contentOffset.x / width),

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -172,6 +172,8 @@ const IssueFronts = ({
                     <View style={{ height: container.height / 3 }} />
                 </>
             )}
+            // (ignored 15/10/19)
+            // eslint-disable-next-line
             getItemLayout={(_: any, index: number) => ({
                 length: card.height,
                 offset: card.height * index,

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -1,5 +1,4 @@
 import { FrontCardAppearance } from './collection/card-layouts'
-import { getImageUse } from './collection/thumbnails'
 export * from './collection/card-layouts'
 export * from './collection/layout-model'
 export * from './collection/layouts'


### PR DESCRIPTION
Please fix these if you see them. Being marked as ignore does not mean
you should. There's just thirty of them.

The linter on Mallard had become unusable for warnings as we had so many of them. This marks them all as ignore. 