### PR TITLE
Account for sliders in FlatList

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -173,8 +173,8 @@ const IssueFronts = ({
                 </>
             )}
             getItemLayout={(_: any, index: number) => ({
-                length: card.height,
-                offset: card.height * index,
+                length: card.height + metrics.fronts.sliderRadius * 2,
+                offset: (card.height + metrics.fronts.sliderRadius * 2) * index,
                 index,
             })}
             keyExtractor={item => item}


### PR DESCRIPTION
## Why are you doing this?

_Some_ janky behaviour in the vertical scrolling was caused by not accounting for the height of the slider in the `getItemLayout` prop. This fixes that jank.