### PR TITLE
fix: Download Today's Issue

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/issues.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/issues.spec.ts
@@ -1,5 +1,5 @@
 import MockDate from 'mockdate'
-import { todayAsFolder, lastSevenDays } from '../issues'
+import { todayAsFolder, lastSevenDays, todayAsKey } from '../issues'
 
 describe('helpers/issues', () => {
     describe('todayAsFolder', () => {
@@ -21,6 +21,13 @@ describe('helpers/issues', () => {
                 '2019-08-16',
                 '2019-08-15',
             ])
+        })
+    })
+
+    describe('todayAsKey', () => {
+        it('should return a key in the correct format for "todays" date', () => {
+            MockDate.set('2019-08-21')
+            expect(todayAsKey()).toEqual('daily-edition/2019-08-21')
         })
     })
 })

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -4,7 +4,7 @@ import { Issue } from 'src/common'
 import { getIssueSummary } from 'src/hooks/use-issue-summary'
 import { FSPaths } from 'src/paths'
 import { ImageSize, IssueSummary } from '../../../common/src'
-import { lastSevenDays, todayAsFolder } from './issues'
+import { lastSevenDays, todayAsKey } from './issues'
 import { imageForScreenSize } from './screen'
 import { getSetting } from './settings'
 import { defaultSettings } from './settings/defaults'
@@ -205,7 +205,7 @@ export const matchSummmaryToKey = (
 }
 
 export const downloadTodaysIssue = async () => {
-    const todaysKey = todayAsFolder()
+    const todaysKey = todayAsKey()
     try {
         const issueSummaries = await getIssueSummary()
 

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -1,5 +1,6 @@
 import { Issue } from 'src/common'
 import { useMemo } from 'react'
+import { defaultSettings } from 'src/helpers/settings/defaults'
 
 const months = [
     'Jan',
@@ -53,6 +54,9 @@ const dateToFolderConvert = (date: Date): string => {
 }
 
 export const todayAsFolder = (): string => dateToFolderConvert(new Date())
+
+export const todayAsKey = (): string =>
+    `${defaultSettings.contentPrefix}/${todayAsFolder()}`
 
 export const lastSevenDays = (): string[] => {
     return Array.from({ length: 7 }, (_, i) => {


### PR DESCRIPTION
## Why are you doing this?

Yesterday the chance to `matchSummmaryToKey` meant that when downloading "todays" issue, we were not able to match the key as this was a date - not a date prefixed.

There is a test to cover this change.