### PR TITLE
front/items: display rating stars on top of image items

### DIFF
--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, View, Text } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { useArticle } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
 import { ImageResource } from '../image-resource'

--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet, View, Text } from 'react-native'
 import { useArticle } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
 import { ImageResource } from '../image-resource'
@@ -19,15 +19,13 @@ import { TextBlock } from './helpers/text-block'
 import { SmallItem } from './small-items'
 import { Standfirst } from './helpers/standfirst'
 import { useIsOpinionCard, useIsSportCard } from './helpers/types'
+import { Stars } from 'src/components/stars/stars'
+import { TrailImage, ItemSizes } from 'src/common'
 
 /*
 Normal img on top + text
 */
 const imageStyles = StyleSheet.create({
-    image: {
-        width: '100%',
-        flex: 0,
-    },
     textBlock: {
         paddingTop: metrics.vertical / 2,
     },
@@ -54,15 +52,17 @@ const ImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
     }
     return (
         <ItemTappable {...tappableProps} {...{ article }}>
-            {'trailImage' in article && article.trailImage ? (
-                <ImageResource
-                    style={[
-                        imageStyles.image,
-                        { height: getImageHeight(size) },
-                    ]}
+            {article.trailImage && (
+                <TrailImageView
                     image={article.trailImage}
+                    itemSizes={size}
+                    starRating={
+                        article.type === 'article'
+                            ? article.starRating
+                            : undefined
+                    }
                 />
-            ) : null}
+            )}
             {isSportCard && isFullWidthItem(size) ? (
                 <SportItemBackground
                     style={{
@@ -220,4 +220,49 @@ const SplitImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
         </ItemTappable>
     )
 }
+
+const trailImageViewStyles = StyleSheet.create({
+    frame: {
+        width: '100%',
+        flex: 0,
+    },
+    image: {
+        width: '100%',
+        height: '100%',
+    },
+    rating: {
+        position: 'absolute',
+        backgroundColor: 'white',
+        left: 0,
+        bottom: 0,
+    },
+})
+
+/**
+ * If there is a rating for the article (ex. a theater piece rating) then we
+ * display it in the bottom-left corner of the image (by using absolute
+ * positioning).
+ */
+const TrailImageView = ({
+    image,
+    itemSizes,
+    starRating,
+}: {
+    image: TrailImage
+    itemSizes: ItemSizes
+    starRating?: number
+}) => {
+    const height = getImageHeight(itemSizes)
+    const frameStyle = [trailImageViewStyles.frame, { height }]
+    if (starRating == null) {
+        return <ImageResource style={frameStyle} image={image} />
+    }
+    return (
+        <View style={frameStyle}>
+            <ImageResource style={trailImageViewStyles.image} image={image} />
+            <Stars style={trailImageViewStyles.rating} rating={starRating} />
+        </View>
+    )
+}
+
 export { ImageItem, SplitImageItem, SmallItem, SidekickImageItem }

--- a/projects/Mallard/src/components/stars/stars.tsx
+++ b/projects/Mallard/src/components/stars/stars.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
 import { color } from 'src/theme/color'
@@ -28,12 +28,18 @@ export const getRatingAsText = (rating: number) =>
         return s
     })
 
-const Stars = ({ rating }: { rating: number }) => {
+const Stars = ({
+    style,
+    rating,
+}: {
+    style?: StyleProp<ViewStyle>
+    rating: number
+}) => {
     const ratingAsText = useMemo(() => getRatingAsText(rating), [rating])
     return (
         <View
             accessibilityLabel={`${rating.toString()} stars`}
-            style={styles.background}
+            style={[style, styles.background]}
         >
             <Text style={styles.text} accessible={false}>
                 {ratingAsText.join('')}


### PR DESCRIPTION
## Why are you doing this?

Stars [are missing on front page](https://trello.com/c/1FHZrJg0/649-reviews-show-stars-on-fronts-card). This is the first step towards having these show up, starting with the small image+text blocks.

A follow up diff will add support for star ratings on full-width image blocks, like the one showing up generally on the first page of the Culture front.

## Screenshots

Android, no ratings:

<img width="357" alt="Screenshot 2019-10-16 at 10 41 24" src="https://user-images.githubusercontent.com/1733570/66909292-66fe7b80-f004-11e9-8e85-1aa38cd20bb7.png">

Android, with ratings:

<img width="357" alt="Screenshot 2019-10-16 at 10 41 34" src="https://user-images.githubusercontent.com/1733570/66909307-6fef4d00-f004-11e9-83c6-9608dbb56c68.png">

iOS/iPad, no ratings:

<img width="610" alt="Screenshot 2019-10-16 at 11 00 46" src="https://user-images.githubusercontent.com/1733570/66909333-78e01e80-f004-11e9-8396-8d1a22aaf787.png">

iOS/iPad, with ratings:

<img width="610" alt="Screenshot 2019-10-16 at 11 00 54" src="https://user-images.githubusercontent.com/1733570/66909340-7f6e9600-f004-11e9-976d-32d27114cad0.png">

