### PR TITLE
Ensure download promise waits for unzip

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -168,7 +168,7 @@ export const downloadAndUnzipIssue = async (
                     type: 'unzip',
                     data: 'start',
                 })
-                unzipNamedIssueArchive(localId, imageSize)
+                return unzipNamedIssueArchive(localId, imageSize)
                     .then(() => {
                         onProgress({ type: 'success' }) // null is unstarted or end
                     })


### PR DESCRIPTION
## Why are you doing this?

Given that when we run our background notifications on iOS, we await the download and then send a message to the OS that we've finished with our download, it seems like a good idea to chain the unzip part of the process into the download promise, so that the promise doesn't resolve until it's unzipped.

This may not matter in practice but currently iOS notifications are being received but the issues are not appearing on the device, so this seems like a worthwhile change.