### PR TITLE
Remove dependency on env variable

### DIFF
--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -1,9 +1,10 @@
 import RNIAP, { Purchase } from 'react-native-iap'
 import { Platform } from 'react-native'
-import { ITUNES_CONNECT_SHARED_SECRET, USE_SANDBOX_IAP } from 'src/constants'
+import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants'
 import { ReceiptValidationResponse } from 'react-native-iap/apple'
 import { NativeModules } from 'react-native'
 import { InvalidResult, AuthResult, ValidResult } from '../lib/Result'
+import { isInBeta } from 'src/helpers/release-stream'
 const { InAppUtils } = NativeModules
 
 export interface ReceiptIOS {
@@ -31,7 +32,7 @@ const fetchDecodeReceipt = (receipt: string) =>
             'receipt-data': receipt,
             password: ITUNES_CONNECT_SHARED_SECRET,
         },
-        USE_SANDBOX_IAP,
+        isInBeta() || __DEV__,
     )
 
 const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -6,7 +6,6 @@ const {
     MEMBERS_DATA_API_URL,
     ID_ACCESS_TOKEN,
     ITUNES_CONNECT_SHARED_SECRET,
-    USE_SANDBOX_IAP: ENV_USE_SANDBOX_IAP,
     ANDROID_RELEASE_STREAM,
 } = Config
 
@@ -26,11 +25,6 @@ const GOOGLE_CLIENT_ID =
 const LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY = 'printSubscriberID'
 const LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY = 'printSubscriberPostcode'
 
-// this allows us to ensure some prod build use the sanboxed IAP endpoints
-// e.g. the beta builds for testflight
-// we should never be using sandbox for __DEV__ builds, hence the `||`
-const USE_SANDBOX_IAP = ENV_USE_SANDBOX_IAP || __DEV__ ? true : false
-
 export {
     CAS_ENDPOINT_URL,
     ID_API_URL,
@@ -42,6 +36,5 @@ export {
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
     ITUNES_CONNECT_SHARED_SECRET,
-    USE_SANDBOX_IAP,
     ANDROID_RELEASE_STREAM,
 }


### PR DESCRIPTION
## Why are you doing this?

This is redundant and broke the first release. This isn't required to fix the next build (simply removing the env variable from our TC deploy will fix this).
