### PR TITLE
Play landscape videos

### DIFF
--- a/projects/Mallard/src/hooks/use-screen.ts
+++ b/projects/Mallard/src/hooks/use-screen.ts
@@ -28,7 +28,6 @@ const useDimensions = (): ScaledSize => {
                 Math.min(ev.window.width, ev.window.height) >=
                 Breakpoints.tabletVertical
             ) {
-                debugger
                 setDimensions(ev.window)
             }
         }

--- a/projects/Mallard/src/hooks/use-screen.ts
+++ b/projects/Mallard/src/hooks/use-screen.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { currentInsets } from '@delightfulstudio/react-native-safe-area-insets'
 import { getStatusBarHeight } from 'react-native-status-bar-height'
 import { Dimensions, ScaledSize } from 'react-native'
+import { Breakpoints } from 'src/theme/breakpoints'
 
 const useDimensions = (): ScaledSize => {
     const [dimensions, setDimensions] = useState(Dimensions.get('window'))
@@ -11,7 +12,25 @@ const useDimensions = (): ScaledSize => {
                 Parameters<typeof Dimensions.addEventListener>[1]
             >[0],
         ) => {
-            setDimensions(ev.window)
+            /*
+            this fixes this issue:
+            https://trello.com/c/iEtMz9TH/867-video-stretched-on-ios-and-android-crash-on-orientation-change
+
+            this means we will never relayout on smaller screens. For now this is ok
+            because our screen size assumptions are a 1:1 match with iphone/ipad and
+            a good enough™ match on android
+
+            a more elegant fix would be to detect when a full screen video/photo
+            is playing, basically anything that enables rotation when
+            things below it should not rotate, and not relayout then.
+            */
+            if (
+                Math.min(ev.window.width, ev.window.height) >=
+                Breakpoints.tabletVertical
+            ) {
+                debugger
+                setDimensions(ev.window)
+            }
         }
         Dimensions.addEventListener('change', listener)
         return () => {


### PR DESCRIPTION
            this fixes this issue:
            https://trello.com/c/iEtMz9TH/867-video-stretched-on-ios-and-android-crash-on-orientation-change

            this means we will never relayout on smaller screens. For now this is ok
            because our screen size assumptions are a 1:1 match with iphone/ipad and
            a good enough™ match on android

            a more elegant fix would be to detect when a full screen video/photo
            is playing, basically anything that enables rotation when
            things below it should not rotate, and not relayout then.


i've literally dumped this as a comment cuz it's not ideal AT ALL but itll do