### PR TITLE
Allow CODE to read from PROD fronts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 The future Daily Edition app.
 
+## setup
+
+Run `make install`.
+You will need `frontend` and `cmsFronts` credentials loaded.
+
 ## App setup
+
 To run the client-side app, cd into `projects/Mallard` and check out it's [README](https://github.com/guardian/editions/tree/master/projects/Mallard).
-
-
 
 ![image](https://user-images.githubusercontent.com/11539094/56376453-d2a38f80-61ff-11e9-9c78-c2875b22b551.png)

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -18,6 +18,12 @@ export class EditionsStack extends cdk.Stack {
             description: 'Stack',
         })
 
+        const frontsStageParameter = new cdk.CfnParameter(this, 'frontsStage', {
+            type: 'String',
+            description: 'Which stage of fronts to read from',
+            default: 'prod',
+        })
+
         const stageParameter = new cdk.CfnParameter(this, 'stage', {
             type: 'String',
             description: 'Stage',
@@ -160,6 +166,7 @@ export class EditionsStack extends cdk.Stack {
                     ),
                     handler: 'index.handler',
                     environment: {
+                        frontsStage: frontsStageParameter.valueAsString,
                         CAPI_KEY: capiKeyParameter.valueAsString,
                         arn: frontsRoleARN.valueAsString,
                         stage: stageParameter.valueAsString,

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -16,7 +16,7 @@ export interface Path {
     key: string
     bucket: 'published' | 'preview'
 }
-const stage = process.env.stage || 'code'
+const stage = process.env.frontsStage || 'code'
 
 const getBucket = (bucketType: Path['bucket']) =>
     `${bucketType}-editions-${stage.toLowerCase()}`


### PR DESCRIPTION
## Why are you doing this?
This will allow the CODE stack to read from the PROD editions, which will allow more thorough testing. 

To switch, the frontsStage param will need to be changed to PROD and the frontsARN changed to the PROD one. (unless we add prod read to the code role)