### PR TITLE
Rahb/better iap modals

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     },
 })
 
-const persistenceKey = 'dev-nav-key-232asdffgdfg1asdffgfdgfdga3413'
+const persistenceKey = 'dev-nav-key-232asfdffgdfg1asdffgfdgfdga3413'
 
 const persistNavigationState = async (navState: any) => {
     try {

--- a/projects/Mallard/src/authentication/AccessContext.tsx
+++ b/projects/Mallard/src/authentication/AccessContext.tsx
@@ -23,23 +23,32 @@ import { CASExpiry } from './services/cas'
 import { ReceiptIOS } from './services/iap'
 import * as NetInfo from '@react-native-community/netinfo'
 
+type AttemptResponse<T> = {
+    attempt: ResolvedAttempt<T>
+    accessAttempt: ResolvedAttempt<string>
+}
+
+const defaultAttemptResponse = Promise.resolve({
+    attempt: InvalidAttempt('offline'),
+    accessAttempt: InvalidAttempt('offline'),
+})
+
 const AccessContext = createContext({
     attempt: NotRun as AnyAttempt<string>,
     canAccess: false,
     authIdentity: (
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         params: AuthParams,
-    ): Promise<ResolvedAttempt<IdentityAuthData>> =>
-        Promise.resolve(InvalidAttempt('offline')),
+    ): Promise<AttemptResponse<IdentityAuthData>> => defaultAttemptResponse,
     authCAS: (
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         subscriberId: string,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         password: string,
-    ): Promise<ResolvedAttempt<CASExpiry>> =>
-        Promise.resolve(InvalidAttempt('offline')),
-    authIAP: (): Promise<ResolvedAttempt<ReceiptIOS>> =>
-        Promise.resolve(InvalidAttempt('offline')),
+    ): Promise<AttemptResponse<CASExpiry>> =>
+        Promise.resolve(defaultAttemptResponse),
+    authIAP: (): Promise<AttemptResponse<ReceiptIOS>> =>
+        Promise.resolve(defaultAttemptResponse),
     idenityData: null as IdentityAuthData | null,
     casData: null as CASExpiry | null,
     signOutIdentity: () => {},

--- a/projects/Mallard/src/authentication/lib/Attempt.ts
+++ b/projects/Mallard/src/authentication/lib/Attempt.ts
@@ -16,7 +16,14 @@ type InvalidAttempt = {
     time: number
 }
 
-export type ResolvedAttempt<T> = ValidAttempt<T> | InvalidAttempt
+type ErrorAttempt = {
+    type: 'error-attempt'
+    reason?: string
+    connectivity: Connectivity
+    time: number
+}
+
+export type ResolvedAttempt<T> = ValidAttempt<T> | InvalidAttempt | ErrorAttempt
 
 export type AnyAttempt<T> = NotRun | ResolvedAttempt<T>
 
@@ -64,6 +71,17 @@ const ValidAttemptCons = <T>(
     time,
 })
 
+const ErrorAttemptCons = <T>(
+    connectivity: Connectivity,
+    reason?: string,
+    time = Date.now(),
+): ErrorAttempt => ({
+    type: 'error-attempt',
+    reason,
+    connectivity,
+    time,
+})
+
 const isNotRun = <T>(attempt: AnyAttempt<T>): attempt is NotRun =>
     attempt.type === 'not-run-attempt'
 
@@ -72,6 +90,9 @@ const hasRun = <T>(attempt: AnyAttempt<T>): attempt is ResolvedAttempt<T> =>
 
 const isValid = <T>(attempt: AnyAttempt<T>): attempt is ValidAttempt<T> =>
     attempt.type === 'valid-attempt'
+
+const isError = <T>(attempt: AnyAttempt<T>): attempt is ErrorAttempt =>
+    attempt.type === 'error-attempt'
 
 const isOnline = <T>(attempt: ResolvedAttempt<T>) =>
     attempt.connectivity === 'online'
@@ -105,7 +126,9 @@ export {
     NotRunRef as NotRun,
     ValidAttemptCons as ValidAttempt,
     InvalidAttemptCons as InvalidAttempt,
+    ErrorAttemptCons as ErrorAttempt,
     isValid,
+    isError,
     isOnline,
     hasRun,
     isNotRun,

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -99,12 +99,13 @@ class Authorizer<T, A extends any[], C extends readonly AsyncCache<any>[]> {
         )
 
         /**
-         * This may not correspond to the attempt stored in the authorizer
-         * as if we've already logged in `getAttempt` will return that attempt
-         * rather than this if it is an invalid attempt.
-         * However, it's useful here to return the actual attempt to login
-         * here for the UI, although this will likely never be run if we're
-         * already logged in anyway.
+         * This may not correspond to the attempt stored in `this.attempt`
+         * as, if we've already logged in, `getAttempt` this attempt will not
+         * overwrite that attempt.
+         * However, it's useful here to return the _actual_ attempt for the login
+         * here for the UI to display a message,.
+         *
+         * That said, this will likely never be run if we're already logged in anyway.
          */
         return {
             attempt,

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -179,7 +179,7 @@ class Authorizer<T, A extends any[], C extends readonly AsyncCache<any>[]> {
                 : InvalidAttempt(
                       attempt.connectivity,
                       (!isValid(attempt) && attempt.reason) ||
-                          'Insufficient privileges',
+                          'Subscription not found',
                       attempt.time,
                   )
         } catch {

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -10,6 +10,7 @@ import {
     patchAttempt,
     isNotRun,
     hasRun,
+    ErrorAttempt,
 } from './Attempt'
 import { cataResult, AuthResult, ValidResult, InvalidResult } from './Result'
 
@@ -80,7 +81,7 @@ class Authorizer<T, A extends any[], C extends readonly AsyncCache<any>[]> {
                     this.clearCaches()
                     return InvalidAttempt(connectivity, reason)
                 },
-                error: reason => InvalidAttempt(connectivity, reason),
+                error: reason => ErrorAttempt(connectivity, reason),
             })
         } catch (e) {
             attempt = InvalidAttempt('online', 'Something went wrong')

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -3,7 +3,12 @@ import { Platform } from 'react-native'
 import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants'
 import { ReceiptValidationResponse } from 'react-native-iap/apple'
 import { NativeModules } from 'react-native'
-import { InvalidResult, AuthResult, ValidResult } from '../lib/Result'
+import {
+    InvalidResult,
+    AuthResult,
+    ValidResult,
+    ErrorResult,
+} from '../lib/Result'
 import { isInBeta } from 'src/helpers/release-stream'
 const { InAppUtils } = NativeModules
 
@@ -66,7 +71,7 @@ const tryRestoreActiveIOSSubscriptionReceipt = async (): Promise<
         const validReceipt = findValidReceipt(decodedReceipt)
         return validReceipt ? ValidResult(validReceipt) : InvalidResult()
     } catch {
-        return InvalidResult()
+        return ErrorResult('Verification error')
     }
 }
 

--- a/projects/Mallard/src/components/missing-iap-modal-card.tsx
+++ b/projects/Mallard/src/components/missing-iap-modal-card.tsx
@@ -3,15 +3,19 @@ import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { ModalButton } from './modal-button'
 
 const MissingIAPModalCard = ({
+    title,
+    subtitle,
     close,
     onTryAgain,
 }: {
+    title: string
+    subtitle: string
     close: () => void
     onTryAgain: () => void
 }) => (
     <OnboardingCard
-        title="Verification error"
-        subtitle="There was a problem whilst verifying your subscription"
+        title={title}
+        subtitle={subtitle}
         appearance={CardAppearance.blue}
         size="medium"
         onDismissThisCard={() => {

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext } from 'react'
-import { canViewEdition } from 'src/authentication/helpers'
 import { facebookAuthWithDeepRedirect } from 'src/authentication/services/facebook'
 import { googleAuthWithDeepRedirect } from 'src/authentication/services/google'
 import { NavigationScreenProp } from 'react-navigation'
@@ -65,12 +64,12 @@ const AuthSwitcherScreen = ({
                 allow: async () => {
                     setIsLoading(true)
                     try {
-                        const attempt = await authIdentity(
+                        const { attempt, accessAttempt } = await authIdentity(
                             await runGetIdentityAuthParams(),
                         )
                         if (isValid(attempt)) {
                             setIsLoading(false)
-                            if (!canViewEdition(attempt.data)) {
+                            if (!isValid(accessAttempt)) {
                                 open(close => (
                                     <SignInFailedModalCard
                                         email={

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -9,9 +9,9 @@ import { RightChevron } from 'src/components/icons/RightChevron'
 import { Platform, Text } from 'react-native'
 import { AccessContext, useAccess } from 'src/authentication/AccessContext'
 import { useModal } from 'src/components/modal'
-import { isValid } from 'src/authentication/lib/Attempt'
-import { isReceiptActive } from 'src/authentication/services/iap'
+import { isValid, isError } from 'src/authentication/lib/Attempt'
 import { MissingIAPModalCard } from 'src/components/missing-iap-modal-card'
+import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
 
 const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     const canAccess = useAccess()
@@ -71,15 +71,29 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                     title: 'Restore App Store subscription',
                                     data: {
                                         onPress: async () => {
-                                            const attempt = await authIAP()
-                                            if (
-                                                isValid(attempt) &&
-                                                isReceiptActive(attempt.data)
-                                            ) {
-                                                return
+                                            const {
+                                                accessAttempt,
+                                            } = await authIAP()
+                                            if (isValid(accessAttempt)) {
+                                                open(close => (
+                                                    <SubFoundModalCard
+                                                        close={close}
+                                                    />
+                                                ))
+                                            } else if (isError(accessAttempt)) {
+                                                open(close => (
+                                                    <MissingIAPModalCard
+                                                        title="Verification error"
+                                                        subtitle="There was a problem whilst verifying your subscription"
+                                                        close={close}
+                                                        onTryAgain={authIAP}
+                                                    />
+                                                ))
                                             } else {
                                                 open(close => (
                                                     <MissingIAPModalCard
+                                                        title="Subscription not found"
+                                                        subtitle="We were unable to find a subscription associated with your Apple ID"
                                                         close={close}
                                                         onTryAgain={authIAP}
                                                     />

--- a/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
+++ b/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
@@ -45,12 +45,15 @@ const CasSignInScreen = ({
             setShouldShowError(true)
             return
         }
-        const attempt = await authCAS(subscriberID.value, password.value)
-        if (isValid(attempt)) {
+        const { accessAttempt } = await authCAS(
+            subscriberID.value,
+            password.value,
+        )
+        if (isValid(accessAttempt)) {
             navigation.goBack()
             open(close => <SubFoundModalCard close={close} />)
         } else {
-            setErrorMessage(attempt.reason || 'Something went wrong')
+            setErrorMessage(accessAttempt.reason || 'Something went wrong')
         }
         setIsLoading(false)
     }


### PR DESCRIPTION
## Why are you doing this?

This allows us to show a clearer modal for IAP users that don't have a subscription to restore. This allows giving more information to the call site of the authentication request, hence some type / return type changes.

![Screen Shot 2019-10-18 at 11 33 04](https://user-images.githubusercontent.com/1652187/67087586-1ff6be80-f19b-11e9-91b1-fb9bdb38d9ab.png)
