### PR TITLE
issues.ts: remove abbreviation for Jan and Feb

### DIFF
--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -4,8 +4,8 @@ import { defaultSettings } from 'src/helpers/settings/defaults'
 import { londonTime } from './date'
 
 const months = [
-    'Jan',
-    'Feb',
+    'January',
+    'February',
     'March',
     'April',
     'May',
@@ -34,6 +34,7 @@ interface IssueDate {
 }
 
 export const renderIssueDate = (dateString: Issue['date']): IssueDate => {
+    console.warn(dateString)
     const date = londonTime(dateString)
     return {
         date: date.date() + ' ' + months[date.month()],

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -34,7 +34,6 @@ interface IssueDate {
 }
 
 export const renderIssueDate = (dateString: Issue['date']): IssueDate => {
-    console.warn(dateString)
     const date = londonTime(dateString)
     return {
         date: date.date() + ' ' + months[date.month()],


### PR DESCRIPTION
## Summary

All the other months are full-length, doesn't make sense for these to be abbreviated (or we should abbreviate September, for ex.)

## Test Plan

Trivial change, just content.