### PR TITLE
issues.ts: fix timezone usage

### DIFF
--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,6 +1,8 @@
 import moment from 'moment-timezone'
 
-const londonTime = (time?: moment.MomentInput) =>
-    moment(time).tz('Europe/London')
+const londonTime = (time?: string) => {
+    if (time != null) return moment.tz(time, 'Europe/London')
+    return moment.tz('Europe/London')
+}
 
 export { londonTime }

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -2,7 +2,6 @@ import { Issue } from 'src/common'
 import { useMemo } from 'react'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { londonTime } from './date'
-import moment from 'moment-timezone'
 
 const months = [
     'Jan',

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -2,6 +2,7 @@ import { Issue } from 'src/common'
 import { useMemo } from 'react'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { londonTime } from './date'
+import moment from 'moment-timezone'
 
 const months = [
     'Jan',


### PR DESCRIPTION
## Summary

Edition title was wrong. We were using `moment()` incorrectly by setting the timezone after parsing, which would convert the local midnight to the London. Instead, we need to parse the original date as **being** in London timezone, then `date()` and other functions on the object will correctly return a London-based interpretation.

https://trello.com/c/GQ1diW9N/767-name-of-editions-in-the-editions-picker-are-incorrectly-affected-by-the-users-time-zone

## Test Plan

1. On Android, go to Settings app, System, set timezone to something such as China/Shanghai.
2. Open Daily editions app
3. Observe title: it correctly shows today's date (in London)
4. Open list of editions: it correctly shows the edition titles.

<img width="354" alt="Screenshot 2019-10-21 at 14 23 29" src="https://user-images.githubusercontent.com/1733570/67209257-f47c0a00-f40e-11e9-91c0-2b00561edbcd.png">
<img width="354" alt="Screenshot 2019-10-21 at 14 21 41" src="https://user-images.githubusercontent.com/1733570/67209258-f47c0a00-f40e-11e9-9794-a40626a67fbf.png">


