### PR TITLE
Swipe on the issue from the issues menu to close the menu

### DIFF
--- a/projects/Mallard/src/navigation/helpers/base.tsx
+++ b/projects/Mallard/src/navigation/helpers/base.tsx
@@ -98,19 +98,16 @@ export interface IssueNavigationProps {
 interface NavigateToIssueProps {
     navigation: NavigationScreenProp<{}>
     navigationProps: IssueNavigationProps
-    shouldShowMoreIssuesBtn?: boolean
     setIssueId: (path: PathToIssue) => void
 }
 
 const navigateToIssue = ({
     navigation,
     navigationProps,
-    shouldShowMoreIssuesBtn = true,
     setIssueId,
 }: NavigateToIssueProps) => {
     navigation.navigate(routeNames.Issue, {
         ...navigationProps,
-        shouldShowMoreIssuesBtn,
     })
     if (navigationProps.path) {
         setIssueId(navigationProps.path)

--- a/projects/Mallard/src/navigation/navigators/underlay.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import {
     Animated,
+    Dimensions,
     StyleSheet,
     TouchableWithoutFeedback,
-    Dimensions,
     View,
 } from 'react-native'
 import {
@@ -15,21 +15,16 @@ import {
 } from 'react-navigation'
 import { ariaHidden } from 'src/helpers/a11y'
 import { supportsTransparentCards } from 'src/helpers/features'
-import { color } from 'src/theme/color'
-import {
-    NavigatorWrapper,
-    addStaticRouterWithPosition,
-} from '../helpers/transition'
-import {
-    screenInterpolator,
-    bottomLayerTransition,
-    topLayerTransition,
-} from './underlay/transition'
-import { addStaticRouter } from '../helpers/base'
 import { safeInterpolation } from 'src/helpers/math'
-import { Button } from 'src/components/button/button'
 import { Breakpoints } from 'src/theme/breakpoints'
+import { color } from 'src/theme/color'
+import { addStaticRouter } from '../helpers/base'
+import {
+    addStaticRouterWithPosition,
+    NavigatorWrapper,
+} from '../helpers/transition'
 import { sidebarWidth } from './underlay/positions'
+import { screenInterpolator, topLayerTransition } from './underlay/transition'
 
 const overlayStyles = StyleSheet.create({
     root: {

--- a/projects/Mallard/src/navigation/navigators/underlay/positions.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay/positions.tsx
@@ -1,0 +1,1 @@
+export const sidebarWidth = 360

--- a/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
@@ -4,12 +4,12 @@ import { minOpacity, minScale, radius } from 'src/navigation/helpers/transition'
 import { metrics } from 'src/theme/spacing'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { safeInterpolation } from 'src/helpers/math'
+import { sidebarWidth } from './positions'
 
-const sidebarWidth = 360
-
-const issueScreenToIssueList = (sceneProps: NavigationTransitionProps) => {
-    const { position, scene } = sceneProps
-    const sceneIndex = scene.index
+export const topLayerTransition = (
+    position: NavigationTransitionProps['position'],
+    sceneIndex: number,
+) => {
     const { height: windowHeight, width } = Dimensions.get('window')
     const isTablet = width >= Breakpoints.tabletVertical
     const isPhone = width >= Breakpoints.phone
@@ -58,9 +58,10 @@ const issueScreenToIssueList = (sceneProps: NavigationTransitionProps) => {
     }
 }
 
-const IssueListToIssueScreen = (sceneProps: NavigationTransitionProps) => {
-    const { position, scene } = sceneProps
-    const sceneIndex = scene.index
+export const bottomLayerTransition = (
+    position: NavigationTransitionProps['position'],
+    sceneIndex: number,
+) => {
     const { height: windowHeight, width } = Dimensions.get('window')
     const isTablet = width >= Breakpoints.tabletVertical
 
@@ -95,30 +96,21 @@ const IssueListToIssueScreen = (sceneProps: NavigationTransitionProps) => {
     const translateOffset = (windowHeight - windowHeight * minScale) * -0.5
     const finalTranslate = translateOffset + metrics.slideCardSpacing / 1.5
 
-    const translateY = position.interpolate({
+    const translate = position.interpolate({
         inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
         outputRange: safeInterpolation([0, finalTranslate]),
     })
 
-    const platformStyles = isTablet
-        ? {
-              transform: [{ translateX: width - sidebarWidth }, { scale }],
-              width: sidebarWidth,
-          }
-        : {
-              transform: [
-                  { translateY },
-                  {
-                      scale,
-                  },
-              ],
-          }
+    const transform = [
+        { scale },
+        isTablet ? { translateX: translate } : { translateY: translate },
+    ]
 
     return {
         zIndex: 0,
         elevation: 0,
         opacity,
-        ...platformStyles,
+        transform,
         borderRadius,
         overflow: 'hidden',
     }
@@ -126,9 +118,9 @@ const IssueListToIssueScreen = (sceneProps: NavigationTransitionProps) => {
 const screenInterpolator = (sceneProps: NavigationTransitionProps) => {
     const { scene } = sceneProps
     if (scene.route.routeName === '_') {
-        return issueScreenToIssueList(sceneProps)
+        return topLayerTransition(sceneProps.position, sceneProps.scene.index)
     }
-    return IssueListToIssueScreen(sceneProps)
+    return bottomLayerTransition(sceneProps.position, sceneProps.scene.index)
 }
 
 export { screenInterpolator }

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react'
 import {
     Animated,
+    Image,
     StyleProp,
     StyleSheet,
     View,
     ViewStyle,
-    Image,
 } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
@@ -25,15 +25,18 @@ import { Weather } from 'src/components/weather'
 import { supportsTransparentCards } from 'src/helpers/features'
 import { clearCache } from 'src/helpers/fetch/cache'
 import { useIssueDate } from 'src/helpers/issues'
-import { safeInterpolation } from 'src/helpers/math'
 import {
+    CONNECTION_FAILED_AUTO_RETRY,
     CONNECTION_FAILED_ERROR,
     CONNECTION_FAILED_SUB_ERROR,
     REFRESH_BUTTON_TEXT,
-    CONNECTION_FAILED_AUTO_RETRY,
 } from 'src/helpers/words'
 import { useIssueResponse } from 'src/hooks/use-issue'
-import { useMediaQuery, useDimensions } from 'src/hooks/use-screen'
+import {
+    issueSummaryToLatestPath,
+    useIssueSummary,
+} from 'src/hooks/use-issue-summary'
+import { useDimensions, useMediaQuery } from 'src/hooks/use-screen'
 import { useIsPreview } from 'src/hooks/use-settings'
 import { navigateToIssueList } from 'src/navigation/helpers/base'
 import { useNavigatorPosition } from 'src/navigation/helpers/transition'
@@ -43,10 +46,6 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
-import {
-    useIssueSummary,
-    issueSummaryToLatestPath,
-} from 'src/hooks/use-issue-summary'
 
 const styles = StyleSheet.create({
     weatherWide: {

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -84,7 +84,6 @@ const ScreenHeader = withNavigation(
         )
 
         const goToIssueList = () => {
-            navigation.setParams({ shouldShowMoreIssuesBtn: false })
             navigateToIssueList(navigation)
         }
 
@@ -95,29 +94,13 @@ const ScreenHeader = withNavigation(
                     goToIssueList()
                 }}
                 action={
-                    <Animated.View
-                        style={
-                            supportsTransparentCards() && {
-                                opacity: position.interpolate({
-                                    inputRange: safeInterpolation([0, 1]),
-                                    outputRange: safeInterpolation([1, 0]),
-                                }),
-                            }
-                        }
-                    >
-                        {!supportsTransparentCards() || // ignore for devices that obscure the button
-                        (navigation.getParam('shouldShowMoreIssuesBtn') ||
-                            navigation.getParam('shouldShowMoreIssuesBtn') ===
-                                undefined) ? (
-                            <Button
-                                icon={isTablet ? '' : ''}
-                                alt="More issues"
-                                onPress={() => {
-                                    goToIssueList()
-                                }}
-                            />
-                        ) : null}
-                    </Animated.View>
+                    <Button
+                        icon={isTablet ? '' : ''}
+                        alt="More issues"
+                        onPress={() => {
+                            goToIssueList()
+                        }}
+                    />
                 }
             >
                 <Animated.View


### PR DESCRIPTION
## Summary
Wow that's a mouthful. This makes the drawer (iPad and iPhone) 'swipeable' (it doesn't actually respond to swipes but it responds on touch down. Happy to add swipes later).

This PR also removes some of the button hiding code on the issue header because the logic for showing it is a bit of a mess and the reason I hid it in the first place was to not give the impression that area is tappable when it's not. Now it is!

<img width="697" alt="Screenshot 2019-10-23 at 15 01 21" src="https://user-images.githubusercontent.com/11539094/67400777-13f96b00-f5a6-11e9-8255-26c0af38f4ff.png">


[**Trello Card ->**](https://trello.com/c/ye9waNmn/917-fix-the-design-of-the-drawer-on-archive-so-users-can-swipe-it-up)

## Test Plan

- On iPhone+iPad, open the issue list, tap or swipe on the visible parts of the issue to bring back
- On iPhone+iPad, open the issue list, tap or swipe elsewhere and confirm rest of buttons respond
- On android, verify behaviour remains identical, verify there's not an invisible tap zone at the bottom of the issue list that takes you back