### PR TITLE
Render main media atom in articles when available

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -92,6 +92,7 @@ export const renderArticle = (
                 headline: article.headline,
                 byline: article.byline,
                 bylineHtml: article.bylineHtml,
+                showMedia,
             })
             content =
                 article.image &&
@@ -114,6 +115,7 @@ export const renderArticle = (
                 byline: article.byline,
                 bylineHtml: article.bylineHtml,
                 image: article.image,
+                showMedia,
             })
             content = renderArticleContent(elements, {
                 showMedia,
@@ -122,7 +124,7 @@ export const renderArticle = (
             })
             break
         default:
-            header = Header({ ...article, type, publishedId })
+            header = Header({ ...article, type, publishedId, showMedia })
             content = renderArticleContent(elements, {
                 showMedia,
                 publishedId,

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -5,36 +5,16 @@ import {
     ArticleType,
     BlockElement,
     CAPIArticle,
-    Direction,
     ImageSize,
     Issue,
-    MediaAtomElement,
 } from '../../../common'
 import { ArticleTheme } from '../types/article'
-import { Arrow } from './components/arrow'
 import { Header, ArticleHeaderProps } from './components/header'
 import { Image } from './components/images'
 import { Line } from './components/line'
 import { Pullquote } from './components/pull-quote'
 import { makeCss } from './css'
-
-export const EMBED_DOMAIN = 'https://embed.theguardian.com'
-
-const renderMediaAtom = (mediaAtomElement: MediaAtomElement) => {
-    return html`
-        <figure class="image" style="overflow: hidden;">
-            <iframe
-                scrolling="no"
-                src="${EMBED_DOMAIN}/embed/atom/media/${mediaAtomElement.atomId}"
-                style="width: 100%; display: block;"
-                frameborder="0"
-            ></iframe>
-            <figcaption>
-                ${Arrow({ direction: Direction.top })} ${mediaAtomElement.title}
-            </figcaption>
-        </figure>
-    `
-}
+import { renderMediaAtom } from './components/media-atoms'
 
 interface ArticleContentProps {
     showMedia: boolean

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -521,6 +521,7 @@ const Header = ({
     type,
     ...headerProps
 }: {
+    showMedia: boolean
     publishedId: Issue['publishedId'] | null
     type: ArticleType
 } & ArticleHeaderProps) => {
@@ -554,7 +555,9 @@ const Header = ({
                                 : undefined,
                         })}
                     ${headerProps.mainMedia &&
-                        renderMediaAtom(headerProps.mainMedia)}
+                        (headerProps.showMedia
+                            ? renderMediaAtom(headerProps.mainMedia)
+                            : null)}
                     ${headerProps.kicker &&
                         html`
                             <span class="header-kicker"

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -5,12 +5,17 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { families } from 'src/theme/typography'
-import { CreditedImage, Article } from '../../../../../../common/src'
+import {
+    CreditedImage,
+    Article,
+    MediaAtomElement,
+} from '../../../../../../common/src'
 import { CssProps, themeColors } from '../helpers/css'
 import { breakSides } from '../helpers/layout'
 import { Quotes } from './icon/quotes'
 import { Line } from './line'
 import { Rating } from './rating'
+import { renderMediaAtom } from './media-atoms'
 
 export interface ArticleHeaderProps {
     headline: string
@@ -21,6 +26,7 @@ export interface ArticleHeaderProps {
     starRating?: Article['starRating']
     bylineImages?: { cutout?: ImageT }
     bylineHtml?: string
+    mainMedia?: MediaAtomElement
 }
 
 const outieKicker = (type: ArticleType) => css`
@@ -547,6 +553,8 @@ const Header = ({
                                 ? Rating(headerProps)
                                 : undefined,
                         })}
+                    ${headerProps.mainMedia &&
+                        renderMediaAtom(headerProps.mainMedia)}
                     ${headerProps.kicker &&
                         html`
                             <span class="header-kicker"

--- a/projects/Mallard/src/components/article/html/components/media-atoms.tsx
+++ b/projects/Mallard/src/components/article/html/components/media-atoms.tsx
@@ -1,0 +1,59 @@
+import { MediaAtomElement, Direction } from 'src/common'
+import { Arrow } from './arrow'
+import { css, html } from 'src/helpers/webview'
+
+/**
+ * 56.25% is the perfect 16:9 ratio that matches most videos (ex. YouTube).
+ *
+ * It'd be complex to have a ratio dynamically adjusted depending on the
+ * video without the server providing us this information, so we just have
+ * a default ratio of 16:9 that will almost always work great.
+ *
+ * We use a little trick here to set-up our height based on the width,
+ * [Aspect Ratio Boxes](https://css-tricks.com/aspect-ratio-boxes/). It relies
+ * on the fact that `padding-top` percentage is based off the real width of
+ * the element, not its height (surprisingly, perhaps). We then position the
+ * iframe in an `absolute` fashion.
+ */
+export const mediaAtomStyles = css`
+    .mediaWrapper {
+        width: 100%;
+        height: 0;
+        padding-top: 56.25%;
+        position: relative;
+        background: #eee;
+    }
+
+    .mediaIframe {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+`
+export const EMBED_DOMAIN = 'https://embed.theguardian.com'
+
+export const renderMediaAtom = (mediaAtomElement: MediaAtomElement) => {
+    return html`
+        <figure class="image" style="overflow: hidden;">
+            <div class="mediaWrapper">
+                <iframe
+                    scrolling="no"
+                    src="${EMBED_DOMAIN}/embed/atom/media/${mediaAtomElement.atomId}"
+                    class="mediaIframe"
+                    frameborder="0"
+                ></iframe>
+            </div>
+            ${mediaAtomElement.title
+                ? html`
+                      <figcaption>
+                          ${Arrow({ direction: Direction.top })}
+                          ${mediaAtomElement.title}
+                      </figcaption>
+                  `
+                : ''}
+        </figure>
+    `
+}

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -14,8 +14,7 @@ import { quoteStyles } from './components/pull-quote'
 import { ratingStyles } from './components/rating'
 import { CssProps, themeColors } from './helpers/css'
 import { Breakpoints } from 'src/theme/breakpoints'
-
-export const EMBED_DOMAIN = 'https://embed.theguardian.com'
+import { mediaAtomStyles } from './components/media-atoms'
 
 const makeFontsCss = () => css`
     /* text */
@@ -169,6 +168,7 @@ const makeCss = ({ colors, theme }: CssProps) => css`
     ${imageStyles({ colors, theme })}
     ${lineStyles({ colors, theme })}
     ${ratingStyles({ colors, theme })}
+    ${mediaAtomStyles}
 `
 
 export { makeCss }

--- a/projects/Mallard/src/components/article/types/article/helpers.tsx
+++ b/projects/Mallard/src/components/article/types/article/helpers.tsx
@@ -1,5 +1,5 @@
 import { Linking, Platform } from 'react-native'
-import { EMBED_DOMAIN } from '../../html/article'
+import { EMBED_DOMAIN } from '../../html/components/media-atoms'
 
 const urlIsNotAnEmbed = (url: string) =>
     !(


### PR DESCRIPTION
## Summary

We want to show [videos when available as the main header media of an article](https://trello.com/c/xzHCTsMr/590-video-as-main-media).

## Test Plan

1. Open the Wed 23 October edition, then open 1st Top Stories articles (*"MPs reject Boris Johnson's attempt [...]"*).
2. Observe: video shows up correctly.
3. Press and play the video, notice it plays correctly.
4. Navigate away, come back, observe it still works.
5. Close app, go in Aeroplane mode, open app.
6. Open the same article, notice that the video fails to load. (Maybe we need some design here? Should we not show the video? What if people reconnect when reading the article? etc.) **This could be changed and improved on later on, so I'd recommend we ship this as-is for now and discuss with relevant parties.**
7. Notice in-article videos are still showing correctly.
8. Repeat steps 1-7 on iOS (for ex. `yarn run-ios --simulator "iPhone 11"`).

<img width="356" alt="Screenshot 2019-10-23 at 16 19 28" src="https://user-images.githubusercontent.com/1733570/67409042-e61a2380-f5b1-11e9-982e-b71f87ba6135.png">

<img width="356" alt="Screenshot 2019-10-23 at 16 19 50" src="https://user-images.githubusercontent.com/1733570/67409041-e61a2380-f5b1-11e9-9ae9-c3c8372c04d6.png">


<img width="356" alt="Screenshot 2019-10-23 at 16 22 53" src="https://user-images.githubusercontent.com/1733570/67409039-e61a2380-f5b1-11e9-806f-ccd567fdbb6f.png">

<img width="418" alt="Screenshot 2019-10-23 at 16 34 25" src="https://user-images.githubusercontent.com/1733570/67409846-0ac2cb00-f5b3-11e9-91ce-8331274e81c8.png">

