### PR TITLE
feat: Reset the notification badge number

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -149,6 +149,12 @@ const pushNotifcationRegistration = () => {
             sound: false,
         },
     })
+
+    // Designed to reset the badge number - can be removed over time
+    PushNotification.getApplicationIconBadgeNumber(
+        number =>
+            number > 0 && PushNotification.setApplicationIconBadgeNumber(0),
+    )
 }
 
 export {


### PR DESCRIPTION
## Summary

Remove the badge number as raised by a number of customer complaints. 

My hope is setting to 0 will clear it as there is no clear method in the library. I believe @alfavata has a device that has this existing issue.