### PR TITLE
fix: Show a more readable version in the settings

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,12 +1,11 @@
 import AsyncStorage from '@react-native-community/async-storage'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { Alert, StyleSheet, Text } from 'react-native'
 import { NavigationInjectedProps } from 'react-navigation'
 import { RightChevron } from 'src/components/icons/RightChevron'
 import { ScrollContainer } from 'src/components/layout/ui/container'
 import { Heading } from 'src/components/layout/ui/row'
 import { List } from 'src/components/lists/list'
-import { getVersionInfo } from 'src/helpers/settings'
 import { useSettings, useSettingsValue } from 'src/hooks/use-settings'
 import { routeNames } from 'src/navigation/routes'
 import { WithAppAppearance } from 'src/theme/appearance'
@@ -19,6 +18,7 @@ import {
     useIdentity,
     useAccess,
 } from 'src/authentication/AccessContext'
+import DeviceInfo from 'react-native-device-info'
 
 const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const setSetting = useSettings()
@@ -32,6 +32,12 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
             color: color.ui.supportBlue,
             ...getFont('sans', 1),
         },
+    })
+
+    const [versionNumber, setVersionNumber] = useState('')
+
+    useEffect(() => {
+        DeviceInfo.getVersion().then(version => setVersionNumber(version))
     })
 
     const versionClickHandler = identityData
@@ -199,7 +205,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                             data: {
                                 onPress: versionClickHandler,
                             },
-                            proxy: <Text>{getVersionInfo().version}</Text>,
+                            proxy: <Text>{versionNumber}</Text>,
                         },
                     ]}
                 />


### PR DESCRIPTION
## Summary

As per the trello card.

There is a function that returns a version which was being used previously. This is being used in a number of places and is not consistent with this. However, this is used more for diagnostics including a commit hash. It seemed sensible to keep that as it was.

[**Trello Card ->**](https://trello.com/c/CT3FVgpV/912-android-ios-can-we-get-version-number-in-the-settings-to-match-the-version-number-in-the-google-play-store-apple-store)

## Test Plan

Go to settings screen and look at `Version` which appears under `Credits`

![Screen Shot 2019-10-28 at 11 24 45](https://user-images.githubusercontent.com/935975/67674863-90f55d80-f975-11e9-891a-7aeb4c1d666e.png)
![Screen Shot 2019-10-28 at 11 24 22](https://user-images.githubusercontent.com/935975/67674864-90f55d80-f975-11e9-8736-5b353b912f47.png)

