### PR TITLE
chore: Improve push notifications

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -109,7 +109,23 @@ const pushNotifcationRegistration = () => {
             if (key) {
                 try {
                     const screenSize = await imageForScreenSize()
+
+                    sendComponentEvent({
+                        componentType: ComponentType.appVideo,
+                        action: Action.view,
+                        value: screenSize,
+                        componentId: 'pushScreenSize',
+                    })
+
                     const issueSummaries = await getIssueSummary()
+
+                    sendComponentEvent({
+                        componentType: ComponentType.appVideo,
+                        action: Action.view,
+                        value: JSON.stringify(issueSummaries),
+                        componentId: 'pushIssueSummaries',
+                    })
+
                     // Check to see if we can find the image summary for the one that is pushed
                     const pushImageSummary = matchSummmaryToKey(
                         issueSummaries,
@@ -124,6 +140,13 @@ const pushNotifcationRegistration = () => {
                     })
 
                     await downloadAndUnzipIssue(pushImageSummary, screenSize)
+
+                    sendComponentEvent({
+                        componentType: ComponentType.appVideo,
+                        action: Action.view,
+                        value: 'completed',
+                        componentId: 'pushDownloadComplete',
+                    })
                     notificationTracking(notificationId, 'downloaded')
                     // required on iOS only (see fetchCompletionHandler docs: https://facebook.github.io/react-native/docs/pushnotificationios.html)
                     notification.finish(PushNotificationIOS.FetchResult.NoData)

--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -116,9 +116,6 @@ const pushNotifcationRegistration = () => {
                         key,
                     )
 
-                    // Not there? Fahgettaboudit
-                    if (!pushImageSummary) return null
-
                     sendComponentEvent({
                         componentType: ComponentType.appVideo,
                         action: Action.view,


### PR DESCRIPTION
## Summary

Improve may be a strong word here...

We are not sure why Push Notifications are not doing the whole job. This PR adds more tracking points so we can see what is going on.

Additionally, this removed the early return which may be blocking the download if for some reason the notification is being triggered twice.