### PR TITLE
backend: expose webUrl for non-print articles

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -130,6 +130,8 @@ const parseArticleResult = async (
 
     if (elements == null) throw new Error(`Elements was undefined in ${path}!`)
 
+    const webUrl = !isFromPrint ? result.webUrl : undefined
+
     switch (result.type) {
         case ContentType.ARTICLE:
             const article: [number, CArticle] = [
@@ -150,6 +152,7 @@ const parseArticleResult = async (
                     starRating,
                     mainMedia: getMainMediaAtom(result.blocks),
                     isFromPrint,
+                    webUrl,
                 },
             ]
             return article
@@ -170,6 +173,7 @@ const parseArticleResult = async (
                     standfirst: trail || '',
                     elements,
                     isFromPrint,
+                    webUrl,
                 },
             ]
 
@@ -191,6 +195,7 @@ const parseArticleResult = async (
                     standfirst: trail || '',
                     elements,
                     isFromPrint,
+                    webUrl,
                 },
             ]
 
@@ -233,6 +238,7 @@ const parseArticleResult = async (
                     standfirst: trail || '',
                     crossword,
                     isFromPrint,
+                    webUrl,
                 },
             ]
 
@@ -264,6 +270,7 @@ const parseArticleResult = async (
                         },
                     ],
                     isFromPrint,
+                    webUrl,
                 },
             ]
     }

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -167,6 +167,7 @@ export interface Content extends WithKey {
     mediaType: MediaType
     sportScore?: string
     isFromPrint: boolean
+    webUrl?: string
 }
 export interface Article extends Content {
     type: 'article'


### PR DESCRIPTION
## Summary

Having the web URL allows sharing for a majority of articles. It might be sufficient to have sharing only for this general case and not work on the print-only article case for now.

## Test Plan

1. `yarn preview`
2. Open `http://localhost:3131/daily-edition/2019-10-14/preview/front/National`, check a few articles for having the correct `webUrl`
