### PR TITLE
fix: Set the tick in the issue screen when we have images

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -54,15 +54,21 @@ const IssueButton = ({ issue }: { issue: IssueSummary }) => {
     const { showToast } = useToast()
 
     useEffect(() => {
-        // we probably need a better check for this
-        // e.g. do we have issue json and images?
-        RNFetchBlob.fs
-            .exists(FSPaths.issue(issue.key))
-            .then(exists =>
-                setExists(
-                    exists ? ExistsStatus.doesExist : ExistsStatus.doesNotExist,
-                ),
-            )
+        RNFetchBlob.fs.exists(FSPaths.issue(issue.key)).then(exists => {
+            if (exists) {
+                RNFetchBlob.fs
+                    .exists(FSPaths.mediaRoot(issue.key))
+                    .then(exists => {
+                        setExists(
+                            exists
+                                ? ExistsStatus.doesExist
+                                : ExistsStatus.doesNotExist,
+                        )
+                    })
+            } else {
+                setExists(ExistsStatus.doesNotExist)
+            }
+        })
     }, [issue.key])
 
     const onDownloadIssue = async () => {


### PR DESCRIPTION
## Summary

Previously we showed the tick in the issue list when the folder was there. This first occurs when the text is downloaded and unzipped. There is now another check for when the media file exists in that folder. That only exists after images have downloaded and been unzipped.

[**Trello Card ->**](https://trello.com/c/K33qHBL8/927-download-of-an-edition-the-icon-should-only-change-once-both-content-and-images-have-been-downloaded-completly)