### PR TITLE
Rahb/infinite swipe

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -78,7 +78,7 @@ const loadNavigationState = async () => {
     }
 }
 
-const rootNavigationProps = __DEV__ && {
+const rootNavigationProps = null && {
     persistNavigationState,
     loadNavigationState,
 }
@@ -101,6 +101,7 @@ const onNavigationStateChange = (
     prevState: NavigationState,
     currentState: NavigationState,
 ) => {
+    console.log(currentState)
     const prevScreen: ScreenTrackingMapping | null = getActiveRouteName(
         prevState,
     )

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,38 +1,34 @@
-import React, { useState, useRef, FunctionComponent, useMemo } from 'react'
-import { Animated, View, StyleSheet } from 'react-native'
-import { CollectionPage, PropTypes } from './collection-page'
-import { Slider, SliderSkeleton } from '../slider'
-import { Spinner } from '../spinner'
-import { FlexCenter } from '../layout/flex-center'
+import React, { FunctionComponent, useMemo, useRef, useState } from 'react'
+import { Animated, StyleSheet, View } from 'react-native'
 import {
-    Issue,
     ArticlePillar,
-    Front as FrontType,
     ArticleType,
+    Front as FrontType,
+    Issue,
     PageLayoutSizes,
 } from 'src/common'
-import { FlexErrorMessage } from '../layout/ui/errors/flex-error-message'
+import { safeInterpolation } from 'src/helpers/math'
 import {
     FlatCard,
-    getColor,
-    flattenFlatCardsToFront,
     flattenCollectionsToCards,
+    flattenFlatCardsToFront,
+    getColor,
 } from 'src/helpers/transform'
-import { Wrapper } from './helpers/wrapper'
-import {
-    getTranslateForPage,
-    AnimatedFlatListRef,
-    getNearestPage,
-} from './helpers/helpers'
 import { useFrontsResponse } from 'src/hooks/use-issue'
-import { ArticleNavigator } from '../../screens/article-screen'
+import { useIssueScreenSize } from 'src/screens/issue/use-size'
 import {
-    WithArticle,
     getAppearancePillar,
     getCollectionPillarOverride,
+    WithArticle,
 } from '../../hooks/use-article'
-import { useIssueScreenSize } from 'src/screens/issue/use-size'
-import { safeInterpolation } from 'src/helpers/math'
+import { ArticleNavigator } from '../../screens/article-screen'
+import { FlexCenter } from '../layout/flex-center'
+import { FlexErrorMessage } from '../layout/ui/errors/flex-error-message'
+import { Slider, SliderSkeleton } from '../slider'
+import { Spinner } from '../spinner'
+import { CollectionPage, PropTypes } from './collection-page'
+import { AnimatedFlatListRef, getTranslateForPage } from './helpers/helpers'
+import { Wrapper } from './helpers/wrapper'
 
 const CollectionPageInFront = ({
     index,
@@ -136,21 +132,6 @@ const FrontWithResponse = React.memo(
                         stops={stops}
                         title={frontData.displayName || 'News'}
                         fill={color}
-                        onReleaseScrub={screenX => {
-                            if (
-                                flatListRef.current &&
-                                flatListRef.current._component
-                            ) {
-                                flatListRef.current._component.scrollToOffset({
-                                    offset:
-                                        getNearestPage(
-                                            container.width,
-                                            screenX,
-                                            stops,
-                                        ) * container.width,
-                                })
-                            }
-                        }}
                         position={scrollX.interpolate({
                             inputRange: [
                                 0,

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo, useRef, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { Animated, StyleSheet, View } from 'react-native'
 import {
     ArticlePillar,
@@ -14,7 +14,6 @@ import {
     flattenFlatCardsToFront,
     getColor,
 } from 'src/helpers/transform'
-import { useFrontsResponse } from 'src/hooks/use-issue'
 import { useIssueScreenSize } from 'src/screens/issue/use-size'
 import {
     getAppearancePillar,
@@ -22,10 +21,7 @@ import {
     WithArticle,
 } from '../../hooks/use-article'
 import { ArticleNavigator } from '../../screens/article-screen'
-import { FlexCenter } from '../layout/flex-center'
-import { FlexErrorMessage } from '../layout/ui/errors/flex-error-message'
-import { Slider, SliderSkeleton } from '../slider'
-import { Spinner } from '../spinner'
+import { Slider } from '../slider'
 import { CollectionPage, PropTypes } from './collection-page'
 import { AnimatedFlatListRef, getTranslateForPage } from './helpers/helpers'
 import { Wrapper } from './helpers/wrapper'
@@ -84,7 +80,7 @@ const CollectionPageInFront = ({
 
 const styles = StyleSheet.create({ overflow: { overflow: 'hidden' } })
 
-const FrontWithResponse = React.memo(
+export const Front = React.memo(
     ({
         frontData,
         localIssueId,
@@ -216,35 +212,3 @@ const FrontWithResponse = React.memo(
         )
     },
 )
-
-export const Front: FunctionComponent<{
-    front: string
-    localIssueId: Issue['localId']
-    publishedIssueId: Issue['publishedId']
-}> = ({ front, localIssueId, publishedIssueId }) => {
-    const frontsResponse = useFrontsResponse(
-        localIssueId,
-        publishedIssueId,
-        front,
-    )
-
-    return frontsResponse({
-        pending: () => (
-            <Wrapper scrubber={<SliderSkeleton />}>
-                <FlexCenter>
-                    <Spinner />
-                </FlexCenter>
-            </Wrapper>
-        ),
-        error: err => (
-            <Wrapper scrubber={<SliderSkeleton />}>
-                <FlexErrorMessage debugMessage={err.message} />
-            </Wrapper>
-        ),
-        success: frontData => (
-            <FrontWithResponse
-                {...{ frontData, localIssueId, publishedIssueId }}
-            />
-        ),
-    })
-}

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -8,23 +8,18 @@ import {
     PageLayoutSizes,
 } from 'src/common'
 import { safeInterpolation } from 'src/helpers/math'
-import {
-    FlatCard,
-    flattenCollectionsToCards,
-    flattenFlatCardsToFront,
-    getColor,
-} from 'src/helpers/transform'
+import { FlatCard, getColor } from 'src/helpers/transform'
 import { useIssueScreenSize } from 'src/screens/issue/use-size'
 import {
     getAppearancePillar,
     getCollectionPillarOverride,
     WithArticle,
 } from '../../hooks/use-article'
-import { ArticleNavigator } from '../../screens/article-screen'
 import { Slider } from '../slider'
 import { CollectionPage, PropTypes } from './collection-page'
 import { AnimatedFlatListRef, getTranslateForPage } from './helpers/helpers'
 import { Wrapper } from './helpers/wrapper'
+import { ArticleNavigator } from 'src/screens/article-screen'
 
 const CollectionPageInFront = ({
     index,
@@ -82,41 +77,23 @@ const styles = StyleSheet.create({ overflow: { overflow: 'hidden' } })
 
 export const Front = React.memo(
     ({
+        articleNavigator,
         frontData,
         localIssueId,
         publishedIssueId,
+        cards,
     }: {
+        articleNavigator: ArticleNavigator
         localIssueId: Issue['localId']
         publishedIssueId: Issue['publishedId']
         frontData: FrontType
+        cards: FlatCard[]
     }) => {
         const color = getColor(frontData.appearance)
         const pillar = getAppearancePillar(frontData.appearance)
 
         const [scrollX] = useState(() => new Animated.Value(0))
         const flatListRef = useRef<AnimatedFlatListRef | undefined>()
-        const [cards, articleNavigator]: [
-            FlatCard[],
-            ArticleNavigator,
-        ] = useMemo(() => {
-            const flatCollections = flattenCollectionsToCards(
-                frontData.collections,
-            )
-            const navigator = {
-                articles: flattenFlatCardsToFront(flatCollections).map(
-                    ({ article, collection }) => ({
-                        collection: collection.key,
-                        front: frontData.key,
-                        article: article.key,
-                        localIssueId,
-                        publishedIssueId,
-                    }),
-                ),
-                appearance: frontData.appearance,
-                frontName: frontData.displayName || '',
-            }
-            return [flatCollections, navigator]
-        }, [localIssueId, publishedIssueId, frontData])
 
         const stops = cards.length
         const { card, container } = useIssueScreenSize()

--- a/projects/Mallard/src/components/slider/index.tsx
+++ b/projects/Mallard/src/components/slider/index.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react'
-
+import React from 'react'
+import { Animated, StyleSheet, View } from 'react-native'
+import { safeInterpolation } from 'src/helpers/math'
 import { color } from 'src/theme/color'
-import { Animated, View, PanResponder, StyleSheet } from 'react-native'
-import { Lozenge, MiniLozenge } from './draw/lozenge'
-import { Background } from './draw/background'
 import { metrics } from 'src/theme/spacing'
 import { WithLayoutRectangle } from '../layout/ui/sizing/with-layout-rectangle'
-import { safeInterpolation } from 'src/helpers/math'
+import { Background } from './draw/background'
+import { Lozenge, MiniLozenge } from './draw/lozenge'
 
 const stopRadius = 4
 
@@ -38,44 +37,14 @@ const Slider = ({
     stops = 0,
     title,
     position,
-    onScrub,
-    onReleaseScrub,
 }: {
     small?: boolean
     title: string
     fill: string
     stops: number
     position: Animated.AnimatedInterpolation
-    onScrub?: (to: number) => void
-    onReleaseScrub?: (to: number) => void
 }) => {
-    const [panResponder] = useState(
-        PanResponder.create({
-            onStartShouldSetPanResponder: () => true,
-            onMoveShouldSetPanResponder: () => true,
-            onPanResponderTerminationRequest: () => false,
-            onShouldBlockNativeResponder: () => true,
-            onPanResponderGrant: (ev, gestureState) => {
-                onScrub &&
-                    onScrub(gestureState.x0 - metrics.fronts.sliderRadius)
-            },
-            onPanResponderMove: (ev, gestureState) => {
-                onScrub &&
-                    onScrub(gestureState.moveX - metrics.fronts.sliderRadius)
-            },
-            onPanResponderEnd: (ev, gestureState) => {
-                onReleaseScrub &&
-                    onReleaseScrub(
-                        gestureState.x0 +
-                            gestureState.dx -
-                            metrics.fronts.sliderRadius,
-                    )
-            },
-        }),
-    )
-
     const isScrollable = stops > 1
-    const isScrubbable = onScrub && isScrollable
 
     const lozengePosition = (width: number) =>
         isScrollable
@@ -94,10 +63,7 @@ const Slider = ({
             minHeight={metrics.fronts.sliderRadius}
         >
             {({ width }) => (
-                <View
-                    {...(isScrubbable ? panResponder.panHandlers : {})}
-                    style={styles.root}
-                >
+                <View style={styles.root}>
                     {isScrollable ? (
                         <View style={styles.background}>
                             <Background

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -1,10 +1,7 @@
 import { Platform } from 'react-native'
 import { withCache } from './fetch/cache'
 import { getSetting } from './settings'
-import {
-    REQUEST_INVALID_RESPONSE_VALIDATION,
-    LOCAL_JSON_INVALID_RESPONSE_VALIDATION,
-} from './words'
+import { REQUEST_INVALID_RESPONSE_VALIDATION } from './words'
 import {
     CachedOrPromise,
     createCachedOrPromise,

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -18,134 +18,76 @@ import {
 } from './settings/defaults'
 import { cacheClearCache } from './storage'
 import { Forecast, AccuWeatherLocation, WeatherForecast } from '../common'
+import { FSPaths, APIPaths } from 'src/paths'
+import { Front, IssueWithFronts } from '../../../common/src'
 
 export type ValidatorFn<T> = (response: any | T) => boolean
 
-const fetchFromApiSlow = async <T>(
-    path: string,
-    {
-        validator = () => true,
-    }: {
-        validator?: ValidatorFn<T>
-    } = {},
-): Promise<T> => {
+const fetchIssueWithFrontsFromAPI = async (
+    id: string,
+): Promise<IssueWithFronts> => {
     const apiUrl = await getSetting('apiUrl')
-    const url = apiUrl + path
-    return fetch(url)
-        .then(res => {
-            if (res.status >= 500) {
-                throw new Error('Failed to fetch') // 500s don't return json
+    const issue: Issue = await fetch(`${apiUrl}${APIPaths.issue(id)}`).then(
+        res => {
+            if (res.status !== 200) {
+                throw new Error('Failed to fetch')
             }
             return res.json()
-        })
-        .then(data => {
-            if (data && validator(data)) {
-                return data
-            } else {
-                throw new Error(REQUEST_INVALID_RESPONSE_VALIDATION)
-            }
-        })
-        .catch(err => {
-            throw new Error(`${err.message} @ [${apiUrl + path}]`)
-        })
+        },
+    )
+    const fronts: Front[] = await Promise.all(
+        issue.fronts.map(frontId =>
+            fetch(`${apiUrl}${APIPaths.front(id, frontId)}`).then(res => {
+                if (res.status !== 200) {
+                    throw new Error('Failed to fetch')
+                }
+                return res.json()
+            }),
+        ),
+    )
+    return {
+        ...issue,
+        fronts,
+    }
 }
 
-const fetchFromFileSystemSlow = <T>(
-    path: string,
-    {
-        validator = () => true,
-    }: {
-        validator?: ValidatorFn<T>
-    } = {},
-): Promise<T> =>
-    getJson(path).then(data => {
-        if (data && validator(data)) {
-            return data
-        } else {
-            throw new Error(LOCAL_JSON_INVALID_RESPONSE_VALIDATION)
+const fetchIssueWithFrontsFromFS = (id: string): Promise<IssueWithFronts> =>
+    getJson<Issue>(FSPaths.issue(id)).then(async issue => {
+        const fronts = await Promise.all(
+            issue.fronts.map(frontId =>
+                getJson<Front>(FSPaths.front(id, frontId)),
+            ),
+        )
+        return {
+            ...issue,
+            fronts,
         }
     })
 
-/*
-Use these! They'll default to caching if possible.
-
-These fetchers assume a clean split between the app's
-api (sign in, issue list. maybe cachable maybe not)
-and the issue files (always cachable, identical
-across zip file & issue API)
-*/
-const fetchFromApi = <T>(
-    endpointPath: string,
-    {
-        validator,
-        cached = true,
-    }: {
-        validator?: ValidatorFn<T>
-        cached?: boolean
-    } = {},
-): CachedOrPromise<T> => {
-    const { retrieve, store, clear } = withCache<T>('api')
-    if (!cached) {
-        clear(endpointPath)
-        return createCachedOrPromise(
-            [
-                null,
-                () =>
-                    fetchFromApiSlow<T>(endpointPath, {
-                        validator,
-                    }),
-            ],
-            {
-                savePromiseResultToValue: () => {},
-            },
-        )
-    }
-    return createCachedOrPromise(
-        [
-            retrieve(endpointPath),
-            () =>
-                fetchFromApiSlow<T>(endpointPath, {
-                    validator,
-                }),
-        ],
-        {
-            savePromiseResultToValue: result => {
-                store(endpointPath, result)
-            },
-        },
-    )
-}
-
-const fetchFromIssue = <T>(
+const fetchIssue = (
     localIssueId: Issue['localId'],
-    fsPath: string,
-    endpointPath: string,
-    { validator }: { validator?: ValidatorFn<T> } = {},
-): CachedOrPromise<T> => {
+    publishedIssueId: Issue['publishedId'],
+): CachedOrPromise<IssueWithFronts> => {
     /*
     retrieve any cached value if we have any
     TODO: invalidate/background refresh these values
     */
-    const { retrieve, store } = withCache<T>('issue')
+    const { retrieve, store } = withCache<IssueWithFronts>('issue')
     return createCachedOrPromise(
         [
-            retrieve(endpointPath),
+            retrieve(localIssueId),
             async () => {
                 const issueOnDevice = await isIssueOnDevice(localIssueId)
                 if (issueOnDevice) {
-                    return fetchFromFileSystemSlow<T>(fsPath, {
-                        validator,
-                    })
+                    return fetchIssueWithFrontsFromFS(localIssueId)
                 } else {
-                    return fetchFromApiSlow<T>(endpointPath, {
-                        validator,
-                    })
+                    return fetchIssueWithFrontsFromAPI(publishedIssueId)
                 }
             },
         ],
         {
             savePromiseResultToValue: result => {
-                store(endpointPath, result)
+                store(localIssueId, result)
             },
         },
     )
@@ -309,8 +251,7 @@ const notificationTracking = (
 }
 
 export {
-    fetchFromIssue,
-    fetchFromApi,
+    fetchIssue,
     fetchWeatherForecastForLocation,
     fetchFromNotificationService,
     fetchAndStoreIpAddress,

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -48,18 +48,18 @@ const fetchIssueWithFrontsFromAPI = async (
     }
 }
 
-const fetchIssueWithFrontsFromFS = (id: string): Promise<IssueWithFronts> =>
-    getJson<Issue>(FSPaths.issue(id)).then(async issue => {
-        const fronts = await Promise.all(
-            issue.fronts.map(frontId =>
-                getJson<Front>(FSPaths.front(id, frontId)),
-            ),
-        )
-        return {
-            ...issue,
-            fronts,
-        }
-    })
+const fetchIssueWithFrontsFromFS = async (
+    id: string,
+): Promise<IssueWithFronts> => {
+    const issue = await getJson<Issue>(FSPaths.issue(id))
+    const fronts = await Promise.all(
+        issue.fronts.map(frontId => getJson<Front>(FSPaths.front(id, frontId))),
+    )
+    return {
+        ...issue,
+        fronts,
+    }
+}
 
 const fetchIssue = (
     localIssueId: Issue['localId'],

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -45,7 +45,7 @@ export const deleteIssueFiles = async (): Promise<void> => {
     await prepFileSystem()
 }
 
-export const getJson = (path: string) =>
+export const getJson = <T extends any>(path: string): Promise<T> =>
     RNFetchBlob.fs.readFile(path, 'utf8').then(d => JSON.parse(d))
 
 export const downloadNamedIssueArchive = async (

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -41,7 +41,10 @@ export const renderIssueDate = (dateString: Issue['date']): IssueDate => {
     }
 }
 
-export const useIssueDate = (issue?: Issue): IssueDate =>
+export const useIssueDate = (issue?: {
+    date: string
+    key: string
+}): IssueDate =>
     useMemo(
         () => (issue ? renderIssueDate(issue.date) : { date: '', weekday: '' }),
         [issue && issue.key, issue],

--- a/projects/Mallard/src/navigation/helpers/base.tsx
+++ b/projects/Mallard/src/navigation/helpers/base.tsx
@@ -63,11 +63,7 @@ const getArticleNavigationProps = (
 ) => {
     const path = navigation.getParam('path')
     const prefersFullScreen = navigation.getParam('prefersFullScreen', false)
-    const articleNavigator = navigation.getParam('articleNavigator', {
-        articles: [],
-        appearance: { type: 'pillar', name: 'neutral' },
-        frontName: '',
-    })
+    const articleNavigator = navigation.getParam('articleNavigator', [])
 
     if (
         !path ||

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -23,10 +23,38 @@ export interface ArticleTransitionProps {
     startAtHeightFromFrontsItem: number
 }
 
-export interface ArticleNavigator {
-    articles: PathToArticle[]
+export type ArticleSpec = PathToArticle & {
     appearance: Appearance
     frontName: string
+}
+
+export type ArticleNavigator = ArticleSpec[]
+
+export const getArticleDataFromNavigator = (
+    navigator: ArticleNavigator,
+    currentArticle: PathToArticle,
+): {
+    isInScroller: boolean
+    startingPoint: number
+    appearance: Appearance
+    frontName: string
+} => {
+    const startingPoint = navigator.findIndex(
+        ({ article }) => currentArticle.article === article,
+    )
+    if (startingPoint < 0)
+        return {
+            isInScroller: false,
+            startingPoint: 0,
+            appearance: { type: 'pillar', name: 'neutral' } as const,
+            frontName: '',
+        }
+    return {
+        startingPoint,
+        isInScroller: true,
+        appearance: navigator[startingPoint].appearance,
+        frontName: navigator[startingPoint].frontName,
+    }
 }
 
 const ArticleScreenLoginOverlay = ({
@@ -58,15 +86,12 @@ const ArticleScreenWithProps = ({
 }: Required<ArticleNavigationProps> & {
     navigation: NavigationScreenProp<{}, ArticleNavigationProps>
 }) => {
-    const pillar = getAppearancePillar(articleNavigator.appearance)
-    const firstUpdate = useRef(true)
+    const current = getArticleDataFromNavigator(articleNavigator, path)
+    // TODO use `getData` for this
+    const pillar = getAppearancePillar(current.appearance)
     const viewRef = useRef<View>()
     const { width } = useDimensions()
     useEffect(() => {
-        if (firstUpdate.current) {
-            firstUpdate.current = false
-            return
-        }
         if (viewRef.current) {
             viewRef.current.setNativeProps({ opacity: 0 })
             setTimeout(() => {

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Animated, Platform, StyleSheet, View, ViewProps } from 'react-native'
 import ViewPagerAndroid from '@react-native-community/viewpager'
-import { Appearance, CAPIArticle, Collection, Front, Issue } from 'src/common'
+import { CAPIArticle, Collection, Front, Issue } from 'src/common'
 import { MaxWidthWrap } from 'src/components/article/wrap/max-width'
 import { AnimatedFlatListRef } from 'src/components/front/helpers/helpers'
 import { Slider } from 'src/components/slider'

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -47,6 +47,7 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { useIsWeatherShown } from 'src/hooks/use-is-weather-shown'
+import { IssueWithFronts } from '../../../common/src'
 
 const styles = StyleSheet.create({
     weatherWide: {
@@ -79,7 +80,10 @@ const styles = StyleSheet.create({
 })
 
 const ScreenHeader = withNavigation(
-    ({ issue, navigation }: { issue?: Issue } & NavigationInjectedProps) => {
+    ({
+        issue,
+        navigation,
+    }: { issue?: IssueWithFronts } & NavigationInjectedProps) => {
         const position = useNavigatorPosition()
         const { date, weekday } = useIssueDate(issue)
         const isTablet = useMediaQuery(
@@ -128,7 +132,7 @@ const IssueFronts = ({
     ListHeaderComponent,
     style,
 }: {
-    issue: Issue
+    issue: IssueWithFronts
     ListHeaderComponent?: ReactElement
     style?: StyleProp<ViewStyle>
 }) => {
@@ -163,16 +167,16 @@ const IssueFronts = ({
                 offset: (card.height + metrics.fronts.sliderRadius * 2) * index,
                 index,
             })}
-            keyExtractor={item => item}
+            keyExtractor={item => item.key}
             data={issue.fronts}
             style={style}
             key={width}
-            renderItem={({ item: key }) => (
+            renderItem={({ item: front }) => (
                 <Front
                     localIssueId={issue.localId}
                     publishedIssueId={issue.publishedId}
-                    front={key}
-                    key={key}
+                    frontData={front}
+                    key={front.key}
                 />
             )}
         />

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -264,6 +264,10 @@ export interface Issue extends IssueSummary, WithKey {
     fronts: Front['key'][]
 }
 
+export interface IssueWithFronts extends IssueSummary, WithKey {
+    fronts: Front[]
+}
+
 export interface Collection extends WithKey {
     cards: Card[]
 }


### PR DESCRIPTION
## Summary

This card adds the ability to swipe all the way through an Issue (Edition in the proper parlance). Prior to this PR a front was unable to know about all the other fronts articles, additionally, the only way to get front data was through a hook. This has been refactored such that the issue fetching hook always fetches all front data too (making parallel network requests for the fronts and merging them into an edition) - this is reflected in the new type `IssueWithFronts`.

This PR also removes quite a lot of redundant code.

Worth noting that, at present, the slider on the top of an article now represents the whole edition, and will change colour / letter as you move to new fronts. I'm not sure whether this is the design and will confirm tomorrow, but I quite like it 🤷‍♂ 

## Screenshots

![ezgif-6-49130150387c](https://user-images.githubusercontent.com/1652187/67885083-dc0e9c80-fb3e-11e9-9473-2d9b7291445f.gif)
