### PR TITLE
Move weather hook to stop full re-render of issue

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -226,11 +226,26 @@ const pathsAreEqual = (a: PathToIssue, b: PathToIssue) =>
     a.localIssueId === b.localIssueId &&
     a.publishedIssueId === b.publishedIssueId
 
+const MaybeWeather = ({
+    style,
+    otherwise = null,
+}: {
+    style: StyleProp<ViewStyle>
+    otherwise?: React.ReactNode
+}) => {
+    const isWeatherShown = useIsWeatherShown()
+    return isWeatherShown ? (
+        <View style={style}>
+            <Weather />
+        </View>
+    ) : (
+        <>{otherwise}</>
+    )
+}
+
 const IssueScreenWithPath = React.memo(
     ({ path }: { path: PathToIssue }) => {
         const response = useIssueResponse(path)
-        const isWeatherShown = useIsWeatherShown()
-        if (isWeatherShown == null) return null
 
         return response({
             error: handleError,
@@ -262,21 +277,18 @@ const IssueScreenWithPath = React.memo(
                                             >
                                                 <IssueFronts
                                                     ListHeaderComponent={
-                                                        isWeatherShown ? (
-                                                            <View
-                                                                style={
-                                                                    styles.weatherWide
-                                                                }
-                                                            >
-                                                                <Weather />
-                                                            </View>
-                                                        ) : (
-                                                            <View
-                                                                style={
-                                                                    styles.weatherHidden
-                                                                }
-                                                            />
-                                                        )
+                                                        <MaybeWeather
+                                                            style={
+                                                                styles.weatherWide
+                                                            }
+                                                            otherwise={
+                                                                <View
+                                                                    style={
+                                                                        styles.weatherHidden
+                                                                    }
+                                                                />
+                                                            }
+                                                        />
                                                     }
                                                     issue={issue}
                                                 />
@@ -290,11 +302,9 @@ const IssueScreenWithPath = React.memo(
                                             flexDirection: 'row',
                                         }}
                                     >
-                                        {isWeatherShown ? (
-                                            <View style={styles.sideWeather}>
-                                                <Weather />
-                                            </View>
-                                        ) : null}
+                                        <MaybeWeather
+                                            style={styles.weatherWide}
+                                        />
 
                                         <WithLayoutRectangle>
                                             {metrics => (


### PR DESCRIPTION
## Summary

Small fix as I noticed that we were calling Ophan too many times when updating the weather. This is probably more to do with the fact that we're calling `sendPageViewEvent` in render when perhaps they should be added to either `useEffect(() => ..., [])` or even hooked into the navigation at some point rather than in re-renders @jimhunty ... not crucial but will probably need a fix for more accurate stats relatively soon.

I fixed it this was because it solved the immediate issue and the lack of a full re-render on the issue screen seemed worthwhile too.