### PR TITLE
feat: Push Tracking Logging to Dev Centre

### DIFF
--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -37,14 +37,10 @@ const pushTracking = async (id: string, value: string) => {
             ? [...JSON.parse(storedTracking), tracking]
             : [tracking]
 
-        try {
-            await AsyncStorage.setItem(
-                PUSH_TRACKING_KEY,
-                JSON.stringify(saveTracking),
-            )
-        } catch (e) {
-            errorService.captureException(e)
-        }
+        await AsyncStorage.setItem(
+            PUSH_TRACKING_KEY,
+            JSON.stringify(saveTracking),
+        )
     } catch (e) {
         errorService.captureException(e)
     }

--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-community/async-storage'
+import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
+import { londonTime } from 'src/helpers/date'
+import { errorService } from 'src/services/errors'
+
+const PUSH_TRACKING_KEY = '@push-tracking'
+
+interface Tracking {
+    time: string
+    id: string
+    value: string
+}
+
+const getPushTracking = async (): Promise<string | null> =>
+    AsyncStorage.getItem(PUSH_TRACKING_KEY)
+
+const clearPushTracking = async (): Promise<void> =>
+    AsyncStorage.removeItem(PUSH_TRACKING_KEY)
+
+const pushTracking = async (id: string, value: string) => {
+    sendComponentEvent({
+        componentType: ComponentType.appVideo,
+        action: Action.view,
+        value,
+        componentId: id,
+    })
+
+    try {
+        const storedTracking = await AsyncStorage.getItem(PUSH_TRACKING_KEY)
+        const tracking: Tracking = {
+            time: londonTime().format(),
+            id,
+            value,
+        }
+
+        const saveTracking = storedTracking
+            ? [...JSON.parse(storedTracking), tracking]
+            : [tracking]
+
+        try {
+            await AsyncStorage.setItem(
+                PUSH_TRACKING_KEY,
+                JSON.stringify(saveTracking),
+            )
+        } catch (e) {
+            errorService.captureException(e)
+        }
+    } catch (e) {
+        errorService.captureException(e)
+    }
+}
+
+export { pushTracking, getPushTracking, clearPushTracking }

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -23,6 +23,7 @@ import { isValid } from 'src/authentication/lib/Attempt'
 import DeviceInfo from 'react-native-device-info'
 import RNFetchBlob from 'rn-fetch-blob'
 import { londonTime } from 'src/helpers/date'
+import { getPushTracking, clearPushTracking } from 'src/helpers/push-tracking'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -75,6 +76,8 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
 
     const [buildNumber, setBuildId] = useState('fetching...')
     const [files, setFiles] = useState('fetching...')
+    const [pushTrackingInfo, setPushTrackingInfo] = useState('fetching...')
+
     useEffect(() => {
         DeviceInfo.getBuildNumber().then(buildNumber => setBuildId(buildNumber))
     }, [])
@@ -82,6 +85,12 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     useEffect(() => {
         getFileList().then(fileList => {
             setFiles(JSON.stringify(fileList, null, 2))
+        })
+    }, [])
+
+    useEffect(() => {
+        getPushTracking().then(pushTracking => {
+            pushTracking && setPushTrackingInfo(pushTracking)
         })
     }, [])
 
@@ -210,6 +219,50 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         key: 'Files in Issues',
                         title: 'Files in Issues',
                         explainer: files,
+                        data: {
+                            onPress: () => {},
+                        },
+                    },
+                    {
+                        key: 'Clear Push Tracking',
+                        title: 'Clear Push Tracking',
+                        explainer:
+                            'Clears out tracking information relating to pushes',
+                        data: {
+                            onPress: () =>
+                                Alert.alert(
+                                    'Are you sure?',
+                                    'Are you sure you want to delete the push tracking infromation. Please note this will be unrecoverable',
+                                    [
+                                        {
+                                            text: 'Cancel',
+                                            onPress: () => null,
+                                        },
+                                        {
+                                            text: 'Delete',
+                                            onPress: () => {
+                                                clearPushTracking()
+                                                setPushTrackingInfo(
+                                                    'fetching...',
+                                                )
+                                            },
+                                            style: 'cancel',
+                                        },
+                                    ],
+                                ),
+                        },
+                    },
+                    {
+                        key: 'Push Tracking Information',
+                        title: 'Push Tracking Information',
+                        explainer:
+                            pushTrackingInfo !== 'fetching...'
+                                ? JSON.stringify(
+                                      JSON.parse(pushTrackingInfo),
+                                      null,
+                                      2,
+                                  )
+                                : pushTrackingInfo,
                         data: {
                             onPress: () => {},
                         },


### PR DESCRIPTION
## Summary

Adding a verbose logging strategy to get to the bottom of what is happening when push notifications are being received.

Additional "clear" button in case it all gets a bit much. Should only happen once a day so shouldnt get too long. 

This is meant to exist in the app on a temporary basis.

[**Trello Card ->**](https://trello.com/c/Edbegw8h/968-more-push-notification-tracking)

<img width="312" alt="Screen Shot 2019-11-01 at 12 41 51" src="https://user-images.githubusercontent.com/935975/68025551-011d1f80-fca5-11e9-9e49-8bd73f14f044.png">
