### PR TITLE
Rahb/tweak dls

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -1,5 +1,40 @@
-import { matchSummmaryToKey } from '../files'
+import {
+    matchSummmaryToKey,
+    downloadAndUnzipIssue,
+    DLStatus,
+    updateListeners,
+} from '../files'
 import { issueSummaries } from '../../../../common/src/__tests__/fixtures/IssueSummary'
+
+function createRunner(id: string) {
+    let resolve = () => {}
+    let reject = () => {}
+
+    return {
+        runner: () =>
+            new Promise<void>((res, rej) => {
+                resolve = res
+                reject = rej
+            }),
+        update: (status: DLStatus) => {
+            updateListeners(id, status)
+            if (status.type === 'success') {
+                resolve()
+            } else if (status.type === 'failure') {
+                reject()
+            }
+        },
+    }
+}
+
+const createIssueSummary = (localId: string) => ({
+    key: 'de/1-1-1',
+    name: 'any',
+    date: '1-1-1',
+    localId,
+    publishedId: '1/1',
+    assets: { data: '' },
+})
 
 describe('helpers/files', () => {
     describe('matchSummmaryToKey', () => {
@@ -13,6 +48,138 @@ describe('helpers/files', () => {
             const key = 'daily-edition/2019-09-20'
             const isValidIssueSummary = matchSummmaryToKey(issueSummaries, key)
             expect(isValidIssueSummary).toEqual(null)
+        })
+    })
+
+    describe('downloadAndUnzipIssue', () => {
+        it('should resolve the outer promise when the inner promise resolves', async () => {
+            const localId = '1'
+
+            const p = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            await expect(p).resolves.toBeUndefined()
+        })
+
+        it('should not set any statuses without the runner updating them', async () => {
+            let status: DLStatus | null = null
+
+            function updateStatus1(next: DLStatus) {
+                status = next
+            }
+
+            const localId = '1'
+
+            const p = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                updateStatus1,
+                () => Promise.resolve(),
+            )
+
+            expect(status).toBe(null)
+            await p
+        })
+
+        it('should fetch existing promises from a cache if they are unresolved when trying to download the same issue', async () => {
+            const localId = '1'
+
+            const p1 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            const p2 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            //
+            expect(p1).toBe(p2)
+
+            await Promise.all([p1, p2])
+        })
+
+        it('should create new downloads when previous ones have finished', async () => {
+            const localId = '1'
+
+            const p1 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            const p2 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            await Promise.all([p1, p2])
+
+            const p3 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                () => {},
+                () => Promise.resolve(),
+            )
+
+            expect(p3).not.toBe(p2)
+
+            await p3
+        })
+
+        it('should still register update handlers to the current download', async () => {
+            let status1: DLStatus | null = null
+            let status2: DLStatus | null = null
+
+            function updateStatus1(next: DLStatus) {
+                status1 = next
+            }
+
+            function updateStatus2(next: DLStatus) {
+                status2 = next
+            }
+
+            const localId = '1'
+
+            const runner = createRunner(localId)
+
+            const p1 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                updateStatus1,
+                runner.runner,
+            )
+
+            const p2 = downloadAndUnzipIssue(
+                createIssueSummary(localId),
+                'phone',
+                updateStatus2,
+                runner.runner, // this should not be called again so we can pass the same one here
+            )
+
+            // The runner passes the statuses through to all the handler, despite
+            // one using the cached promise from before
+            runner.update({ type: 'download', data: 50 })
+
+            expect(status1).toMatchObject({ type: 'download', data: 50 })
+            expect(status2).toMatchObject({ type: 'download', data: 50 })
+
+            runner.update({ type: 'success' })
+
+            // these should both now be resolved when the inner runner promise resolves
+            await Promise.all([p1, p2])
         })
     })
 })

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -52,7 +52,6 @@ export const getJson = <T extends any>(path: string): Promise<T> =>
 export const downloadNamedIssueArchive = async (
     localIssueId: Issue['localId'],
     assetPath: string,
-    filename: string,
 ) => {
     const apiUrl = await getSetting('apiUrl')
     const zipUrl = `${apiUrl}${assetPath}`
@@ -65,10 +64,6 @@ export const downloadNamedIssueArchive = async (
         promise: returnable.then(async res => {
             await prepFileSystem()
             await ensureDirExists(FSPaths.issueRoot(localIssueId))
-            await RNFetchBlob.fs.mv(
-                res.path(),
-                FSPaths.zip(localIssueId, filename),
-            )
             return res
         }),
         cancel: returnable.cancel,
@@ -76,11 +71,7 @@ export const downloadNamedIssueArchive = async (
     }
 }
 
-export const unzipNamedIssueArchive = (
-    localIssueId: Issue['localId'],
-    filename: string,
-) => {
-    const zipFilePath = FSPaths.zip(localIssueId, filename)
+export const unzipNamedIssueArchive = (zipFilePath: string) => {
     const outputPath = FSPaths.issuesDir
 
     return unzip(zipFilePath, outputPath).then(() => {
@@ -117,48 +108,47 @@ export type DLStatus =
     | { type: 'success' }
     | { type: 'failure' }
 
-export const downloadAndUnzipIssue = async (
+const deleteIssue = (issue: string): Promise<void> =>
+    RNFetchBlob.fs
+        .unlink(`${FSPaths.contentPrefixDir}/${issue}`)
+        .catch(e => errorService.captureException(e))
+
+// Cache of current downloads
+const dlCache: { [key: string]: Promise<void> } = {}
+
+// This caches downloads so that if there is one already running you
+// will get a reference to that rather promise than triggering a new one
+export const downloadAndUnzipIssue = (
     issue: IssueSummary,
     imageSize: ImageSize,
     onProgress: (status: DLStatus) => void = () => {},
 ) => {
     const { assets, localId } = issue
-    if (!assets) {
-        return null
-    }
+    const currentDownload = dlCache[localId]
+    if (currentDownload) return currentDownload
 
-    const issueDataDownload = await downloadNamedIssueArchive(
-        localId,
-        assets.data,
-        'data',
-    ) // just the issue json
+    const createDownloadPromise = async () => {
+        try {
+            if (!assets) {
+                return
+            }
 
-    issueDataDownload.progress((received, total) => {
-        if (total >= received) {
-            // the progress of the first 10% is driven by the issue
-            const num = (received / total) * 10
-            onProgress({
-                type: 'download',
-                data: num,
-            })
-        }
-    })
-
-    return issueDataDownload.promise
-        .then(async () => {
-            // might not need to await this but it's pretty quick
-            await unzipNamedIssueArchive(localId, 'data')
-
-            const imgDL = await downloadNamedIssueArchive(
+            const issueDataDownload = await downloadNamedIssueArchive(
                 localId,
-                assets[imageSize] as string,
-                imageSize,
-            ) // just the images
+                assets.data,
+            ) // just the issue json
+
+            const dataRes = await issueDataDownload.promise
+
+            const imgDL = await downloadNamedIssueArchive(localId, assets[
+                imageSize
+            ] as string) // just the images
 
             imgDL.progress((received, total) => {
                 if (total >= received) {
-                    // the progress of the last 90% is driven by the images
-                    const num = 10 + (received / total) * 90
+                    // the progress is only driven by the image download which will always
+                    // take the longest amount of time
+                    const num = (received / total) * 100
                     onProgress({
                         type: 'download',
                         data: num,
@@ -166,31 +156,45 @@ export const downloadAndUnzipIssue = async (
                 }
             })
 
-            return imgDL.promise.then(() => {
-                onProgress({
-                    type: 'unzip',
-                    data: 'start',
-                })
-                return unzipNamedIssueArchive(localId, imageSize)
-                    .then(() => {
-                        onProgress({ type: 'success' }) // null is unstarted or end
-                    })
-                    .catch(error => {
-                        onProgress({ type: 'failure', data: error })
-                        console.log('Unzip error: ', error)
-                    })
+            const imgRes = await imgDL.promise
+
+            onProgress({
+                type: 'unzip',
+                data: 'start',
             })
-        })
-        .catch(error => {
+
+            try {
+                /**
+                 * because `isIssueOnDevice` checks for the issue folder's existence
+                 * leave unzipping to be the last thing to do so that, if there is an issue
+                 * with the image downloads we don't assume the issue is on the device
+                 * and then block things like re-downloading if the images stopped downloading
+                 */
+                await unzipNamedIssueArchive(dataRes.path())
+
+                /**
+                 * The last thing we do is unzip the directory that will confirm if the issue exists
+                 */
+                await unzipNamedIssueArchive(imgRes.path())
+            } catch (error) {
+                onProgress({ type: 'failure', data: error })
+                console.log('Unzip error: ', error)
+            }
+
+            onProgress({ type: 'success' }) // null is unstarted or end
+        } catch (error) {
             onProgress({ type: 'failure', data: error })
             console.log('Download error: ', error)
-        })
-}
+        } finally {
+            // Very important!!
+            delete dlCache[localId]
+        }
+    }
 
-const deleteIssue = (issue: string): Promise<void> =>
-    RNFetchBlob.fs
-        .unlink(`${FSPaths.contentPrefixDir}/${issue}`)
-        .catch(e => errorService.captureException(e))
+    const downloadPromise = createDownloadPromise()
+    dlCache[localId] = downloadPromise
+    return downloadPromise
+}
 
 export const clearOldIssues = async (): Promise<void> => {
     const files = await RNFetchBlob.fs.ls(FSPaths.contentPrefixDir)

--- a/projects/Mallard/src/paths/__tests__/index.spec.ts
+++ b/projects/Mallard/src/paths/__tests__/index.spec.ts
@@ -34,11 +34,6 @@ describe('paths', () => {
             )
         })
 
-        it('should give a correct issue zip location based on a local issue id', () => {
-            expect(FSPaths.issueZip('daily-edition/2019-10-10')).toEqual(
-                'path/to/base/directory/issues/daily-edition/2019-10-10/data.zip',
-            )
-        })
         it('should give a correct issue location based on a local issue id', () => {
             expect(FSPaths.issue('daily-edition/2019-10-10')).toEqual(
                 'path/to/base/directory/issues/daily-edition/2019-10-10/issue',

--- a/projects/Mallard/src/paths/index.ts
+++ b/projects/Mallard/src/paths/index.ts
@@ -50,7 +50,6 @@ export const FSPaths = {
     ) => imagePath(issueRoot(localIssueId), size, image, use),
     zip: (localIssueId: string, filename: string) =>
         `${issueRoot(localIssueId)}/${filename}.zip`,
-    issueZip: (localIssueId: string) => `${issueRoot(localIssueId)}/data.zip`,
     issue: (localIssueId: string) => `${issueRoot(localIssueId)}/issue`,
     front: (localIssueId: string, frontId: string) =>
         `${issueRoot(localIssueId)}/front/${frontId}`,

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -23,8 +23,6 @@ import { isValid } from 'src/authentication/lib/Attempt'
 import DeviceInfo from 'react-native-device-info'
 import { getPushTracking, clearPushTracking } from 'src/helpers/push-tracking'
 import { getFileList } from 'src/helpers/files'
-import RNFetchBlob from 'rn-fetch-blob'
-import { londonTime } from 'src/helpers/date'
 import { deleteIssueFiles } from 'src/helpers/files'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -23,6 +23,9 @@ import { isValid } from 'src/authentication/lib/Attempt'
 import DeviceInfo from 'react-native-device-info'
 import { getPushTracking, clearPushTracking } from 'src/helpers/push-tracking'
 import { getFileList } from 'src/helpers/files'
+import RNFetchBlob from 'rn-fetch-blob'
+import { londonTime } from 'src/helpers/date'
+import { deleteIssueFiles } from 'src/helpers/files'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -88,6 +91,30 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                     }}
                 >
                     Re-start onboarding
+                </Button>
+                <Button
+                    onPress={() => {
+                        // go back to the main to simulate a fresh app
+                        Alert.alert(
+                            'Delete all issue files',
+                            'You sure?',
+                            [
+                                {
+                                    text: 'Delete issue files',
+                                    onPress: () => {
+                                        deleteIssueFiles()
+                                    },
+                                },
+                                {
+                                    style: 'cancel',
+                                    text: `No don't do it`,
+                                },
+                            ],
+                            { cancelable: false },
+                        )
+                    }}
+                >
+                    Delete issue files
                 </Button>
                 <Button
                     onPress={() => {


### PR DESCRIPTION
## Summary

This allows users to open and close the issue picker and have download statuses still appear in the UI. Additionally, this means you can't download the same issue twice at the same time.

Finally, this refactors issues to create the `/issue` directory as the very last thing in the download function so that `isIssueOnDevice` returns true only if everything has gone well 👍 . Otherwise, the issue won't be marked as ticked (say if a download doesn't complete), and the user can attempt to re-download it.

This is the most pragmatic solution to this card: https://trello.com/c/GOM3pPqL/972-automatically-pick-up-incomplete-downloads-and-complete-them-when-we-have-an-internet-connection

Trying to re-download bad downloads automatically could be somewhat prone to error (we may keep downloading something that a user keeps trying to remove). Not impossible, but hopefully this solves this card for the time being. As well as a few other edge cases around `isIssueOnDevice` related logic.

Oh and a dev button to delete all issues.