### PR TITLE
Rahb/hide xword solutions

### DIFF
--- a/projects/backend/utils/__tests__/crossword.spec.ts
+++ b/projects/backend/utils/__tests__/crossword.spec.ts
@@ -1,0 +1,48 @@
+import { CrosswordType, CrosswordEntry } from '../../../common/src'
+import { patchCrossword } from '../crossword'
+
+const createCrossword = (type: CrosswordType = CrosswordType.QUICK) => ({
+    name: '',
+    type,
+    number: 1,
+    date: {
+        dateTime: 1,
+        iso8601: '',
+    },
+    dimensions: {
+        cols: 1,
+        rows: 1,
+    },
+    entries: [
+        {
+            id: '1',
+            number: 1,
+            solution: 'help',
+        },
+    ],
+    solutionAvailable: true,
+    hasNumbers: false,
+    randomCluesOrdering: false,
+})
+
+const hasNoSolution = (entry: CrosswordEntry) => !entry.solution
+const hasSolution = (entry: CrosswordEntry) => !!entry.solution
+const id = <A>(a: A) => a
+
+describe('getCrosswordArticleOverrides', () => {
+    it('removes the solutions from everyman and prize', () => {
+        const types = Object.values(CrosswordType)
+
+        for (const type of types) {
+            const cw = createCrossword(type)
+            const out = patchCrossword(cw, cw.type)
+            if ([CrosswordType.EVERYMAN, CrosswordType.PRIZE].includes(type)) {
+                expect(out.entries.map(hasNoSolution).every(id)).toBe(true)
+                expect(out.solutionAvailable).toBe(false)
+            } else {
+                expect(out.entries.map(hasSolution).every(id)).toBe(true)
+                expect(out.solutionAvailable).toBe(true)
+            }
+        }
+    })
+})


### PR DESCRIPTION
## Summary

This lets the server handle whether or not a crossword has solutions. Currently the `everyman` and `prize` will never show solutions. Not only that but the solutions will never make it to the device (as this check is done on the server).

## Test Plan
- Point local env to the development server
- View a weekend edition prize crossword
- Confirm absence of "Reveal all" and "Check all" buttons