### PR TITLE
Relative URLs fix

### DIFF
--- a/projects/Mallard/src/components/article/types/article/helpers.tsx
+++ b/projects/Mallard/src/components/article/types/article/helpers.tsx
@@ -1,5 +1,6 @@
 import { Linking, Platform } from 'react-native'
 import { EMBED_DOMAIN } from '../../html/components/media-atoms'
+import { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes'
 
 const urlIsNotAnEmbed = (url: string) =>
     !(
@@ -7,14 +8,17 @@ const urlIsNotAnEmbed = (url: string) =>
         url.startsWith('https://www.youtube.com/embed')
     )
 
-export const onShouldStartLoadWithRequest = (event: any) => {
+export const onShouldStartLoadWithRequest = (event: WebViewNavigation) => {
     if (
         Platform.select({
             ios: event.navigationType === 'click',
             android: urlIsNotAnEmbed(event.url), // android doesn't have 'click' types so check for our embed types
         })
     ) {
-        Linking.openURL(event.url)
+        // if a relative URL got clicked then, for now, ignore it
+        if (!event.url.startsWith('file://')) {
+            Linking.openURL(event.url)
+        }
         return false
     }
     return true

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -52,8 +52,14 @@ const WebviewWithArticle = ({
             scrollEnabled={true}
             source={{
                 html,
-                baseUrl:
-                    '' /* required as per https://stackoverflow.com/a/51931187/609907 */,
+                baseUrl: '',
+                /**
+                 * required as per https://stackoverflow.com/a/51931187/609907
+                 * note, this breaks relative URLs in the document, currently our
+                 * `onShouldStartLoadWithRequest` looks for events that start with
+                 * `file://` and ignores them (this will be true foe all relative
+                 *  paths - certainly on iOS)
+                 */
             }}
             ref={_ref}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}


### PR DESCRIPTION
## Summary

Currently relative urls are being transformed to file URLs.
This is plain wrong. We need to set the baseURL to empty for relative
paths to allow local images to work. This has the side effect of
breaking relative URLs. For now ignore them.