### PR TITLE
chore: Additonal push download tracking to debug

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -126,17 +126,15 @@ const pushNotifcationRegistration = () => {
                     pushTracking('pushDownloadComplete', 'completed')
 
                     notificationTracking(notificationId, 'downloaded')
-
-                    // No matter what happens, always clear up old issues
-                    await clearOldIssues()
-                    // required on iOS only (see fetchCompletionHandler docs: https://facebook.github.io/react-native/docs/pushnotificationios.html)
-                    notification.finish(PushNotificationIOS.FetchResult.NoData)
                 } catch (e) {
                     console.log(
                         `Push notification unable to download: ${e.message}`,
                     )
                     errorService.captureException(e)
+                } finally {
+                    // No matter what happens, always clear up old issues
                     await clearOldIssues()
+                    // required on iOS only (see fetchCompletionHandler docs: https://facebook.github.io/react-native/docs/pushnotificationios.html)
                     notification.finish(PushNotificationIOS.FetchResult.NoData)
                 }
             }

--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -126,6 +126,9 @@ const pushNotifcationRegistration = () => {
                     pushTracking('pushDownloadComplete', 'completed')
 
                     notificationTracking(notificationId, 'downloaded')
+
+                    // No matter what happens, always clear up old issues
+                    await clearOldIssues()
                     // required on iOS only (see fetchCompletionHandler docs: https://facebook.github.io/react-native/docs/pushnotificationios.html)
                     notification.finish(PushNotificationIOS.FetchResult.NoData)
                 } catch (e) {
@@ -133,11 +136,9 @@ const pushNotifcationRegistration = () => {
                         `Push notification unable to download: ${e.message}`,
                     )
                     errorService.captureException(e)
+                    await clearOldIssues()
                     notification.finish(PushNotificationIOS.FetchResult.NoData)
                 }
-
-                // No matter what happens, always clear up old issues
-                clearOldIssues()
             }
         },
         senderID: defaultSettings.senderId,


### PR DESCRIPTION
## Summary
Increasingly inconsistent results. This PR tracks the whole chain of the download based on @RichieAHB latest changes.

I have also moved the clearing of old editions as part of the process in case there is read/write blocking.