### PR TITLE
chore: Small refactor to downloads

### DIFF
--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -130,6 +130,7 @@ const pushNotifcationRegistration = () => {
                     console.log(
                         `Push notification unable to download: ${e.message}`,
                     )
+                    pushTracking('pushDownloadError', JSON.stringify(e))
                     errorService.captureException(e)
                 } finally {
                     // No matter what happens, always clear up old issues


### PR DESCRIPTION
## Summary

Evidence on last nights push is that a problem existed between the download of the image zip file and the unzipping of it. No error thrown either way.

Some images existed on an offline edition, with all the data, but only a few images showed.

So either it didn't download in full and it unzipped, or the Unzip was cut off too soon.

This was experienced on iOS12. iOS13 worked perfectly (which could be that it was a more modern device)

Anyway, this removes some unused code and calls the file preparation steps before we attempt a download to ensure its a synchronous process.