### PR TITLE
fix weather layout

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     },
     forecastItemNarrow: {
         height: 64,
-        width: 50,
+        width: 40,
         paddingTop: 2,
         paddingLeft: 4,
         paddingRight: 8,
@@ -63,11 +63,13 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         marginTop: metrics.vertical * 0.5,
         marginRight: metrics.horizontal,
+        flexShrink: 1,
     },
     locationName: {
         ...getFont('sans', 0.5),
         color: '#000000',
         marginTop: 15,
+        flexShrink: 1,
     },
     locationPinIcon: {
         fontFamily: 'GuardianIcons-Regular',
@@ -194,7 +196,9 @@ const WeatherWithForecast = ({
                 })}
                 <View style={styles.locationNameContainer}>
                     <Text style={styles.locationPinIcon}>{'\uE01B'}</Text>
-                    <Text style={styles.locationName}>{locationName}</Text>
+                    <Text style={styles.locationName} numberOfLines={2}>
+                        {locationName}
+                    </Text>
                 </View>
             </View>
         )


### PR DESCRIPTION
## Summary

Accommodate for longer town names. @jimhunty  noticed it was broken since my previous changes. This fixes that.

## Test Plan

I tried with a long name, see screenshot, which now shows correctly without overflowing over the weather icons or onto the left. I also added the ellipsis if it's too long. I checked the rendering is unaffected for usual names such as "London".

<img width="540" alt="Screenshot 2019-11-07 at 14 38 46" src="https://user-images.githubusercontent.com/1733570/68398489-b865da80-016c-11ea-9f3c-7ace9c6f4a92.png">

