### PR TITLE
Prevent 'no internet connection' message showing if the connection status is unknown to us.

### DIFF
--- a/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
+++ b/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
@@ -1,13 +1,14 @@
 import { useNetInfo } from 'src/hooks/use-net-info'
+import { NetInfoStateType } from '@react-native-community/netinfo'
 import { useEffect } from 'react'
 import { useToast } from 'src/hooks/use-toast'
 
 const NetInfoAutoToast = () => {
     const { showToast } = useToast()
-    const { isConnected } = useNetInfo()
+    const { isConnected, type } = useNetInfo()
     useEffect(() => {
         const time = setTimeout(() => {
-            if (!isConnected) {
+            if (!isConnected && type !== NetInfoStateType.unknown) {
                 showToast('No internet connection')
             }
         }, 100)


### PR DESCRIPTION
Fixes a bug we are currently seeing when opening an edition where this shows erroneously.