### PR TITLE
fix: Show images offline

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -62,7 +62,7 @@ const renderArticleContent = (
                         path: el.src.path,
                         source: el.src.source,
                     })
-                    return showMedia && publishedId
+                    return publishedId
                         ? Image({
                               imageElement: el,
                               path,


### PR DESCRIPTION
## Summary
A check was being added that when we were offline, we wouldn't show article images. This was in place when the inline images fix wasn't in place. Its now been fixed and this is now blocking showing of images.

This also ensures that videos stop being shown.