### PR TITLE
fix: An article that appears in two fronts can break nav

### DIFF
--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -40,7 +40,9 @@ export const getArticleDataFromNavigator = (
     frontName: string
 } => {
     const startingPoint = navigator.findIndex(
-        ({ article }) => currentArticle.article === article,
+        ({ article, front }) =>
+            currentArticle.article === article &&
+            currentArticle.front === front,
     )
     if (startingPoint < 0)
         return {


### PR DESCRIPTION
## Summary
Fixes the bug that the same article appears twice in an edition and to show the one that was chosen.

[**Trello Card ->**](https://trello.com/c/rq5cLUOp/996-bug-an-article-that-appears-in-two-containers-can-cause-the-navigation-to-be-incorrect)

## Test Plan

As described in the ticket