### PR TITLE
nit: fix weather item width

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
     },
     forecastItemNarrow: {
         height: 64,
-        width: 40,
+        width: 45,
         paddingTop: 2,
         paddingLeft: 4,
         paddingRight: 8,


### PR DESCRIPTION
## Summary

Tiny fix for width, I set it too narrow last time and it caused "12pm" to be cut off.

## Test Plan

I replaced the time by "12pm", which is the largest possible text, to check it was showing properly:

<img width="300" alt="Screenshot 2019-11-11 at 10 35 58" src="https://user-images.githubusercontent.com/1733570/68580939-4d1f4f80-046f-11ea-845d-9bd6d031f7ef.png">
