### PR TITLE
weather: don't clear the weather when offline

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -16,11 +16,15 @@ type QueryForecast = Pick<
     'DateTime' | 'Temperature' | 'WeatherIcon' | 'EpochDateTime'
 >
 type QueryData = {
-    weather: {
-        locationName: string
-        forecasts: QueryForecast[]
-        available: boolean
-    }
+    weather:
+        | {
+              locationName: string
+              forecasts: QueryForecast[]
+              available: true
+          }
+        | {
+              available: false
+          }
 }
 
 const QUERY = gql`

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -24,11 +24,14 @@ Date.now = () => now
 const getExpectedWeather = () => ({
     __typename: 'Weather',
     locationName: 'London',
+    lastUpdated: now,
     available: true,
     forecasts: [
         {
             __typename: 'Forecast',
             DateTime: forecasts[0].DateTime,
+            PrecipitationIntensity: null,
+            PrecipitationType: null,
             Temperature: { __typename: 'Temperature' },
         },
     ],
@@ -52,7 +55,7 @@ it('should resolve and update the weather', async () => {
 
     expect(AppState.addEventListener).toHaveBeenCalledTimes(1)
     const cb = (AppState.addEventListener as any).mock.calls[0][1]
-    cb('active')
+    await cb('active')
 
     res = await resolveWeather({}, {}, { client })
     expect(res).toEqual(getExpectedWeather())

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -2,70 +2,100 @@ import { AccuWeatherLocation, Forecast } from 'src/common'
 import { AppState } from 'react-native'
 import ApolloClient from 'apollo-client'
 
+class CannotFetchError extends Error {}
+
 /**
- * Return `null` on network error, most notably is connection is down.
+ * Throw strongly typed error on network error, most notably
+ * is connection is down. Allows us to process this correctly downstream.
  */
-const tryFetch = async (url: string): Promise<Response | null> => {
+const tryFetch = async (url: string): Promise<Response> => {
     try {
         return await fetch(url)
     } catch (error) {
-        return null
+        throw new CannotFetchError(error.message)
     }
 }
 
-const getIpAddress = async (): Promise<string | null> => {
+const getIpAddress = async (): Promise<string> => {
     const resp = await tryFetch('https://api.ipify.org')
-    if (resp == null) return null
     return await resp.text()
 }
 
-const fetchFromWeatherApi = async <T>(path: string): Promise<T | null> => {
+const fetchFromWeatherApi = async <T>(path: string): Promise<T> => {
     const res = await tryFetch(`http://mobile-weather.guardianapis.com/${path}`)
-    if (res == null) return null
     if (res.status >= 500) {
-        throw new Error('Failed to fetch') // 500s don't return json
+        throw new CannotFetchError('Server returned 500') // 500s don't return json
     }
     return await res.json()
 }
 
 const getCurrentLocation = async () => {
     const ip = await getIpAddress()
-    if (ip == null) return null
     return await fetchFromWeatherApi<AccuWeatherLocation>(
         `locations/v1/cities/ipAddress?q=${ip}&details=false`,
     )
 }
 
+export type Weather =
+    | {
+          __typename: 'Weather'
+          locationName: string
+          forecasts: Forecast[]
+          lastUpdated: number
+          available: true
+      }
+    | {
+          __typename: 'Weather'
+          // Apollo forces us to have `null`s instead of missing fields
+          locationName: null
+          forecasts: null
+          lastUpdated: null
+          available: false
+      }
+
 const UNAVAILABLE_WEATHER: Weather = {
     __typename: 'Weather',
-    locationName: '',
-    forecasts: [],
+    locationName: null,
+    forecasts: null,
+    lastUpdated: null,
     available: false,
 }
 
 /**
  * We augment the return object with `__typename` fields to that Apollo can
- * "reconcile" the value when we update the cache later.
+ * "reconcile" the value when we update the cache later. If the wheater if
+ * unavailable we keep the previous data as a `fallback`.
  */
-const getWeather = async (): Promise<Weather> => {
-    const loc = await getCurrentLocation()
-    if (loc == null) return UNAVAILABLE_WEATHER
-    const forecasts = await fetchFromWeatherApi<Forecast[]>(
-        `forecasts/v1/hourly/12hour/${loc.Key}.json?metric=true&language=en-gb`,
-    )
-    if (forecasts == null) return UNAVAILABLE_WEATHER
-    return {
-        __typename: 'Weather',
-        locationName: loc.EnglishName,
-        forecasts: forecasts.map(forecast => ({
-            ...forecast,
-            Temperature: {
-                ...forecast.Temperature,
-                __typename: 'Temperature',
-            },
-            __typename: 'Forecast',
-        })),
-        available: true,
+const getWeather = async (fallback?: Weather): Promise<Weather> => {
+    try {
+        const loc = await getCurrentLocation()
+        const forecasts = await fetchFromWeatherApi<Forecast[]>(
+            `forecasts/v1/hourly/12hour/${loc.Key}.json?metric=true&language=en-gb`,
+        )
+        return {
+            __typename: 'Weather',
+            locationName: loc.EnglishName,
+            forecasts: forecasts.map(forecast => ({
+                ...forecast,
+                Temperature: {
+                    ...forecast.Temperature,
+                    __typename: 'Temperature',
+                },
+                // Sometimes the api doesn't provide these fields but Apollo
+                // needs `null`s rather than missing fields.
+                PrecipitationType: forecast.PrecipitationType || null,
+                PrecipitationIntensity: forecast.PrecipitationIntensity || null,
+                __typename: 'Forecast',
+            })),
+            lastUpdated: Date.now(),
+            available: true,
+        }
+    } catch (error) {
+        if (error instanceof CannotFetchError) {
+            if (fallback != null) return fallback
+            return UNAVAILABLE_WEATHER
+        }
+        throw error
     }
 }
 
@@ -74,14 +104,6 @@ const SECS_IN_A_MINUTE = 60
 const MINS_IN_AN_HOUR = 60
 const ONE_HOUR = MS_IN_A_SECOND * SECS_IN_A_MINUTE * MINS_IN_AN_HOUR
 
-export type Weather = {
-    __typename: 'Weather'
-    locationName: string
-    forecasts: Forecast[]
-    available: boolean
-}
-type WeatherUpdate = { value: Promise<Weather>; lastUpdated: number }
-
 /**
  * Resolve weather location information and forecasts. Refetch weather
  * after that if app is foregrounded and data is more than an hour old.
@@ -89,22 +111,18 @@ type WeatherUpdate = { value: Promise<Weather>; lastUpdated: number }
  */
 export const resolveWeather = (() => {
     // If `undefined`, weather has never been shown.
-    let weather: WeatherUpdate | undefined
-
-    const getUpdate = (): WeatherUpdate => {
-        return { value: getWeather(), lastUpdated: Date.now() }
-    }
+    let weather: Promise<Weather> | undefined
 
     // When going foreground, we get the fresh weather (and potentially new
     // location). Once that resolves we update the cache with the correct value,
     // which updates any view showing the weather.
-    const onAppGoesForeground = (client: ApolloClient<object>) => {
+    const onAppGoesForeground = async (client: ApolloClient<object>) => {
         if (weather == null) return
-        if (Date.now() < weather.lastUpdated + ONE_HOUR) return
-        weather = getUpdate()
-        weather.value.then(weather => {
-            client.writeData({ data: { weather } })
-        })
+        let value = await weather
+        if (value.available && Date.now() < value.lastUpdated + ONE_HOUR) return
+        weather = getWeather(value)
+        value = await weather
+        client.writeData({ data: { weather: value } })
     }
 
     // The first time this is called we setup a listener to update the weather
@@ -114,13 +132,13 @@ export const resolveWeather = (() => {
         _args: {},
         { client }: { client: ApolloClient<object> },
     ) => {
-        if (weather !== undefined) return weather.value
+        if (weather !== undefined) return weather
 
-        weather = getUpdate()
+        weather = getWeather()
         AppState.addEventListener('change', status => {
             if (status !== 'active') return
             onAppGoesForeground(client)
         })
-        return weather.value
+        return weather
     }
 })()

--- a/projects/common/src/index.ts
+++ b/projects/common/src/index.ts
@@ -70,6 +70,8 @@ export interface Forecast {
     PrecipitationProbability: number
     MobileLink: string
     Link: string
+    PrecipitationIntensity: unknown
+    PrecipitationType: unknown
 }
 
 interface AccuWeatherRegion {


### PR DESCRIPTION
## Summary

If we can't fetch the weather right now, but already have some weather showing up from some time ago, even stale, then don't fetch again. I removed the `WeatherUpdate` object, instead we just check the "lastUpdated" field on the weather object.

## Test Plan

On iOS:

1. Disconnect network, open app from fresh. Notice weather doesn't appear.
2. Background the app, enable network, then come back. Notice weather shows up.
3. Background, come back. Weather's not updated.
4. Wait 1 hour (you can change value in code to smth smaller), background, come back. Weather's gotten updated.


