### PR TITLE
keep track of settings promises

### DIFF
--- a/projects/Mallard/src/helpers/settings/resolvers.ts
+++ b/projects/Mallard/src/helpers/settings/resolvers.ts
@@ -43,13 +43,20 @@ const ALL_NAMES = [
  */
 export const ALL_SETTINGS_FRAGMENT = makeFragment(ALL_NAMES)
 
+export const SettingValues: Map<string, Promise<unknown>> = new Map()
+
 /**
  * Build up a separate Apollo resolver function for each of all the known
  * settings.
  */
 const SETTINGS_RESOLVERS: { [name: string]: any } = {}
 for (const name of ALL_NAMES) {
-    SETTINGS_RESOLVERS[name] = getSetting.bind(undefined, name as any)
+    SETTINGS_RESOLVERS[name] = () => {
+        if (!SettingValues.has(name)) {
+            SettingValues.set(name, getSetting(name as any))
+        }
+        return SettingValues.get(name)
+    }
 }
 
 export { SETTINGS_RESOLVERS }

--- a/projects/Mallard/src/helpers/settings/setters.ts
+++ b/projects/Mallard/src/helpers/settings/setters.ts
@@ -5,6 +5,7 @@
  */
 import { Settings, storeSetting, GdprSwitchSetting } from 'src/helpers/settings'
 import ApolloClient from 'apollo-client'
+import { SettingValues } from './resolvers'
 
 const setSetting = (
     name: keyof Settings,
@@ -12,6 +13,7 @@ const setSetting = (
     value: any,
 ) => {
     storeSetting(name, value as any)
+    SettingValues.set(name, Promise.resolve(value))
     client.writeData({ data: { [name]: value } })
 }
 


### PR DESCRIPTION
## Summary

Apollo doesn't cache separate fields for any particular query, because it's designed around the idea you want all fields to be in-sync with each other, so fetched as a single batch. This can mean sometimes some settings are "fetched" twice. We can remediate this by caching promises.

## Test Plan

Make sure settings work correctly, ex. switch on/off weather, and GDPR consent flags.
