### PR TITLE
show Set Location button

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Text, StyleSheet, View } from 'react-native'
+import React, { useCallback } from 'react'
+import { Text, StyleSheet, View, Alert } from 'react-native'
 import { Forecast } from '../common'
 import { metrics } from 'src/theme/spacing'
 import { WeatherIcon } from './weather/weatherIcon'
@@ -8,29 +8,30 @@ import { color } from 'src/theme/color'
 import { getFont } from 'src/theme/typography'
 import { WithBreakpoints } from './layout/ui/sizing/with-breakpoints'
 import { Breakpoints } from 'src/theme/breakpoints'
-import { useQuery, QueryStatus } from 'src/hooks/apollo'
+import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
+import { Button, ButtonAppearance } from './button/button'
 
 type QueryForecast = Pick<
     Forecast,
     'DateTime' | 'Temperature' | 'WeatherIcon' | 'EpochDateTime'
 >
+type AvailableWeather = {
+    locationName: string
+    isLocationPrecise: boolean
+    forecasts: QueryForecast[]
+    available: true
+}
 type QueryData = {
-    weather:
-        | {
-              locationName: string
-              forecasts: QueryForecast[]
-              available: true
-          }
-        | {
-              available: false
-          }
+    weather: AvailableWeather | { available: false }
+    isUsingProdDevtools: boolean
 }
 
 const QUERY = gql`
     {
         weather @client {
             locationName
+            isLocationPrecise
             forecasts {
                 DateTime
                 Temperature {
@@ -42,6 +43,7 @@ const QUERY = gql`
             }
             available
         }
+        isUsingProdDevtools @client
     }
 `
 
@@ -117,6 +119,17 @@ const styles = StyleSheet.create({
         justifyContent: 'flex-start',
         flex: 0,
         width: 'auto',
+    },
+    setLocationButtonWrap: {
+        marginTop: metrics.vertical,
+    },
+    /**
+     * Exceptionnally, make the button smaller so as to fit in the limited
+     * space on smaller devices.
+     */
+    setLocationButton: {
+        paddingHorizontal: metrics.horizontal * 0.75,
+        height: metrics.buttonHeight * 0.75,
     },
 })
 
@@ -201,13 +214,49 @@ const WeatherIconView = ({
     )
 }
 
-const WeatherWithForecast = ({
+const LocationName = ({
+    isLocationPrecise,
     locationName,
-    forecasts,
+    isUsingProdDevtools,
 }: {
+    isLocationPrecise: boolean
     locationName: string
-    forecasts: QueryForecast[]
+    isUsingProdDevtools: boolean
 }) => {
+    const onSetLocation = useCallback(() => {
+        Alert.alert('TODO: setting location')
+    }, [])
+
+    if (!isLocationPrecise && isUsingProdDevtools) {
+        return (
+            <Button
+                onPress={onSetLocation}
+                appearance={ButtonAppearance.skeleton}
+                style={styles.setLocationButtonWrap}
+                buttonStyles={styles.setLocationButton}
+            >
+                Set Location
+            </Button>
+        )
+    }
+    return (
+        <>
+            <Text style={styles.locationPinIcon}>{'\uE01B'}</Text>
+            <Text style={styles.locationName} numberOfLines={2}>
+                {locationName}
+            </Text>
+        </>
+    )
+}
+
+const WeatherWithForecast = ({
+    weather,
+    isUsingProdDevtools,
+}: {
+    weather: AvailableWeather
+    isUsingProdDevtools: boolean
+}) => {
+    const { forecasts, locationName, isLocationPrecise } = weather
     if (forecasts && forecasts.length >= 9) {
         /*Get the hourly forecast in 2 hour intervals from the 12 hour forecast.*/
         const intervals = [8, 6, 4, 2, 0].map(idx => forecasts[idx])
@@ -222,10 +271,11 @@ const WeatherWithForecast = ({
                     )
                 })}
                 <View style={styles.locationNameContainer}>
-                    <Text style={styles.locationPinIcon}>{'\uE01B'}</Text>
-                    <Text style={styles.locationName} numberOfLines={2}>
-                        {locationName}
-                    </Text>
+                    <LocationName
+                        locationName={locationName}
+                        isLocationPrecise={isLocationPrecise}
+                        isUsingProdDevtools={isUsingProdDevtools}
+                    />
                 </View>
             </View>
         )
@@ -245,8 +295,8 @@ const WeatherWidget = React.memo(() => {
     if (!data.weather.available) return null
     return (
         <WeatherWithForecast
-            locationName={data.weather.locationName}
-            forecasts={data.weather.forecasts}
+            weather={data.weather}
+            isUsingProdDevtools={data.isUsingProdDevtools}
         />
     )
 })

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -24,6 +24,7 @@ Date.now = () => now
 const getExpectedWeather = () => ({
     __typename: 'Weather',
     locationName: 'London',
+    isLocationPrecise: false,
     lastUpdated: now,
     available: true,
     forecasts: [

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -40,6 +40,7 @@ export type Weather =
     | {
           __typename: 'Weather'
           locationName: string
+          isLocationPrecise: boolean
           forecasts: Forecast[]
           lastUpdated: number
           available: true
@@ -48,6 +49,7 @@ export type Weather =
           __typename: 'Weather'
           // Apollo forces us to have `null`s instead of missing fields
           locationName: null
+          isLocationPrecise: null
           forecasts: null
           lastUpdated: null
           available: false
@@ -56,6 +58,7 @@ export type Weather =
 const UNAVAILABLE_WEATHER: Weather = {
     __typename: 'Weather',
     locationName: null,
+    isLocationPrecise: null,
     forecasts: null,
     lastUpdated: null,
     available: false,
@@ -75,6 +78,7 @@ const getWeather = async (fallback?: Weather): Promise<Weather> => {
         return {
             __typename: 'Weather',
             locationName: loc.EnglishName,
+            isLocationPrecise: false,
             forecasts: forecasts.map(forecast => ({
                 ...forecast,
                 Temperature: {


### PR DESCRIPTION
## Summary

Add "Set Location" button according with design. For now behind the dev-only mode, because I still have to implement the consent screen, something I'll do in a separate PR to keep them nice and small.

[**Trello Card ->**](https://trello.com/c/Ii5WqyrA/895-make-weather-in-app-use-geolocation-data-lat-long-rather-than-ip-address)

## Test Plan

1. Open app, notice `Set Location` button.

