### PR TITLE
show location consent screen

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Text, StyleSheet, View, Alert } from 'react-native'
+import { Text, StyleSheet, View } from 'react-native'
 import { Forecast } from '../common'
 import { metrics } from 'src/theme/spacing'
 import { WeatherIcon } from './weather/weatherIcon'

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -11,6 +11,9 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 import { Button, ButtonAppearance } from './button/button'
+import { withNavigation } from 'react-navigation'
+import { routeNames } from 'src/navigation/routes'
+import { NavigationInjectedProps } from 'react-navigation'
 
 type QueryForecast = Pick<
     Forecast,
@@ -214,20 +217,12 @@ const WeatherIconView = ({
     )
 }
 
-const LocationName = ({
-    isLocationPrecise,
-    locationName,
-    isUsingProdDevtools,
-}: {
-    isLocationPrecise: boolean
-    locationName: string
-    isUsingProdDevtools: boolean
-}) => {
-    const onSetLocation = useCallback(() => {
-        Alert.alert('TODO: setting location')
-    }, [])
+const SetLocationButton = withNavigation(
+    ({ navigation }: NavigationInjectedProps) => {
+        const onSetLocation = useCallback(() => {
+            navigation.navigate(routeNames.WeatherGeolocationConsent)
+        }, [])
 
-    if (!isLocationPrecise && isUsingProdDevtools) {
         return (
             <Button
                 onPress={onSetLocation}
@@ -238,6 +233,20 @@ const LocationName = ({
                 Set Location
             </Button>
         )
+    },
+)
+
+const LocationName = ({
+    isLocationPrecise,
+    locationName,
+    isUsingProdDevtools,
+}: {
+    isLocationPrecise: boolean
+    locationName: string
+    isUsingProdDevtools: boolean
+}) => {
+    if (!isLocationPrecise && isUsingProdDevtools) {
+        return <SetLocationButton />
     }
     return (
         <>

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -39,6 +39,7 @@ import { routeNames } from './routes'
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 import { ManageEditionsScreen } from 'src/screens/settings/manage-editions-screen'
+import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -102,6 +103,9 @@ const AppStack = createModalNavigator(
                 },
             },
         ),
+        [routeNames.WeatherGeolocationConsent]: createHeaderStackNavigator({
+            [routeNames.WeatherGeolocationConsent]: WeatherGeolocationConsentScreen,
+        }),
     },
 )
 

--- a/projects/Mallard/src/navigation/routes.ts
+++ b/projects/Mallard/src/navigation/routes.ts
@@ -15,6 +15,7 @@ export const routeNames = {
     SubscriptionDetails: 'SubscriptionDetails',
     SignIn: 'SignIn',
     CasSignIn: 'CasSignIn',
+    WeatherGeolocationConsent: 'WeatherGeolocationConsent',
     onboarding: {
         OnboardingStart: 'OnboardingStart',
         OnboardingConsent: 'OnboardingConsent',

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { StyleSheet, View, Alert } from 'react-native'
+import { NavigationInjectedProps } from 'react-navigation'
+import { DefaultInfoTextWebview } from './settings/default-info-text-webview'
+import { useApolloClient } from '@apollo/react-hooks'
+import { metrics } from 'src/theme/spacing'
+import { html } from 'src/helpers/webview'
+import { setIsWeatherShown } from 'src/helpers/settings/setters'
+import { Button, ButtonAppearance } from 'src/components/button/button'
+
+const content = html`
+    <p>
+        This is a 3rd party service provided by AccuWeather. It works by taking
+        your location coordinates and bringing the weather to you.
+    </p>
+    <ul>
+        <li>
+            The Daily app only collects your geolocation and Accuweather uses it
+            for getting your weather forecast
+        </li>
+        <li>
+            Your geolocation is not used for advertising or any other purposes
+        </li>
+        <li>
+            Your geolocation is not linked to other identifiers such as your
+            name or email address
+        </li>
+        <li>
+            You can switch on/off your geolocation at any time on your app
+            settings
+        </li>
+        </ul>
+        <p>
+            For more information about how Accuweather uses your location,
+            please check their
+            <a href="https://www.accuweather.com/en/privacy"> privacy policy</a>
+        </p>
+    </ul>
+`
+
+const styles = StyleSheet.create({
+    button: {
+        marginTop: metrics.vertical,
+    },
+    buttons: {
+        marginHorizontal: metrics.horizontal,
+        marginBottom: metrics.vertical * 2,
+    },
+})
+
+const WeatherGeolocationConsentScreen = ({
+    navigation,
+}: NavigationInjectedProps) => {
+    const apolloClient = useApolloClient()
+    const onConsentPress = async () => {
+        Alert.alert('TODO: consent required!')
+    }
+    const onHidePress = () => {
+        setIsWeatherShown(apolloClient, false)
+        navigation.dismiss()
+    }
+
+    return (
+        <>
+            <DefaultInfoTextWebview html={content} />
+            <View style={styles.buttons}>
+                <Button
+                    appearance={ButtonAppearance.skeletonBlue}
+                    onPress={onConsentPress}
+                    style={styles.button}
+                >
+                    Ok, show me the weather
+                </Button>
+                <Button
+                    appearance={ButtonAppearance.skeletonBlue}
+                    onPress={onHidePress}
+                    style={styles.button}
+                >
+                    No thanks
+                </Button>
+            </View>
+        </>
+    )
+}
+
+WeatherGeolocationConsentScreen.navigationOptions = {
+    title: 'Location-based weather',
+    showHeaderLeft: false,
+    showHeaderRight: true,
+}
+
+export { WeatherGeolocationConsentScreen }


### PR DESCRIPTION
## Summary

Another steps towards real Location weather. Add the consent screen. For know consenting doesn't work but it's alright because this can only show in dev-only mode! I'm just breaking up my work in small PRs easier to review.

[**Trello Card ->**](https://trello.com/c/Ii5WqyrA/895-make-weather-in-app-use-geolocation-data-lat-long-rather-than-ip-address)

## Test Plan

1. Press "Set Location" on home page, observe new modal showing up:

<img width="300" alt="Screenshot 2019-11-12 at 13 52 59" src="https://user-images.githubusercontent.com/1733570/68677286-c1332380-0553-11ea-9438-d89d1a5925c0.png">
