### PR TITLE
ErrorService: refactor to remove dep on setting callback mechanism

### DIFF
--- a/projects/Mallard/index.js
+++ b/projects/Mallard/index.js
@@ -1,17 +1,12 @@
 import { AppRegistry, YellowBox, Text } from 'react-native'
 import { name as appName } from './app.json'
 import App from './src/App'
-import { errorService } from 'src/services/errors'
 
 // In lieu of a wrapper component (i.e. <UnscaledText />), this quickly opts us out of scaled text globally.
-Text.defaultProps = Text.defaultProps || {};
-Text.defaultProps.allowFontScaling = false;
+Text.defaultProps = Text.defaultProps || {}
+Text.defaultProps.allowFontScaling = false
 
 // Supress Could Not Find Image warnings as a result of our approach to find the image locally
 YellowBox.ignoreWarnings(['Could not find image'])
-
-if (!__DEV__) {
-    errorService.init()
-}
 
 AppRegistry.registerComponent(appName, () => App)

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -36,6 +36,7 @@ import { IdentityAuthData } from './authentication/authorizers/IdentityAuthorize
 import { IssueSummaryProvider } from './hooks/use-issue-summary'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { createApolloClient } from './apollo'
+import { errorService } from './services/errors'
 
 const clearAndDownloadIssue = async () => {
     await prepFileSystem()
@@ -44,6 +45,16 @@ const clearAndDownloadIssue = async () => {
     if (weOk) {
         downloadTodaysIssue()
     }
+}
+
+/**
+ * Only one global Apollo client. As such, any update done from any component
+ * will cause dependent views to refresh and keep up-to-date.
+ */
+const apolloClient = createApolloClient()
+
+if (!__DEV__) {
+    errorService.init(apolloClient)
 }
 
 // useScreens is not a hook
@@ -131,12 +142,6 @@ const WithProviders = nestProviders(
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
     setUserId(isValid(attempt) ? attempt.data.userDetails.id : null)
-
-/**
- * Only one global Apollo client. As such, any update done from any component
- * will cause dependent views to refresh and keep up-to-date.
- */
-const apolloClient = createApolloClient()
 
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -107,13 +107,6 @@ export const getVersionInfo = () => {
     return versionInfo as { version: string; commitId: string }
 }
 
-/*
-getters & setters
-*/
-let callbacks: ((
-    setting: keyof Settings,
-    value: UnsanitizedSetting,
-) => void)[] = []
 export const getSetting = (setting: keyof Settings) =>
     AsyncStorage.getItem('@Setting_' + setting).then(item => {
         if (!item) {
@@ -122,25 +115,10 @@ export const getSetting = (setting: keyof Settings) =>
         return unsanitize(item)
     })
 
-export const onSettingChanged = (
-    callback: (setting: keyof Settings, value: UnsanitizedSetting) => void,
-) => {
-    callbacks.push(callback)
-    return () => {
-        callbacks = callbacks.filter(item => item !== callback)
-    }
-}
-
 export const storeSetting = (
     setting: keyof Settings,
     value: UnsanitizedSetting,
-) => {
-    AsyncStorage.setItem('@Setting_' + setting, sanitize(value), () => {
-        for (const cb of callbacks) {
-            cb(setting, value)
-        }
-    })
-}
+) => AsyncStorage.setItem('@Setting_' + setting, sanitize(value))
 
 export type GdprSwitch = keyof GdprSwitchSettings
 

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -119,7 +119,7 @@ describe('errorService', () => {
 
         setMockedConsent(true)
         errorService.captureException(new Error())
-        expect(Sentry.captureException).toHaveBeenCalledTimes(2)
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1)
     })
 
     it('should stop firing errors if consent is revoked in the app', async () => {

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -1,310 +1,151 @@
 import { ErrorService } from '../errors'
-import { getMockPromise } from 'src/test-helpers/test-helpers'
-import { GdprSwitchSettings } from 'src/helpers/settings'
+import gql from 'graphql-tag'
+import Observable from 'zen-observable'
 
-type Sub = (key: keyof GdprSwitchSettings, value: boolean) => void
-
-const createEmitter = () => {
-    let cb: Sub = () => {}
-
-    return {
-        emit: (key: keyof GdprSwitchSettings, value: boolean) => {
-            cb(key, value)
-        },
-        sub: (fn: Sub) => {
-            cb = fn
-            return () => {
-                cb = () => {}
-            }
-        },
-    }
-}
-
-const createSentry = () => ({
+jest.mock('src/helpers/release-stream', () => ({
+    isInBeta: () => false,
+}))
+jest.mock('react-native-sentry', () => ({
     config: jest.fn(() => ({
         install: jest.fn(() => Promise.resolve()),
     })),
     captureException: jest.fn(() => {}),
     setTagsContext: jest.fn(() => {}),
-})
-
-jest.mock('src/helpers/release-stream', () => ({
-    isInBeta: () => false,
 }))
+const QUERY = gql('{ gdprAllowPerformance @client }')
 
-describe('errors', () => {
-    describe('ErrorService', () => {
-        it('should not do anything with calling `init`', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+describe('errorService', () => {
+    let errorService: ErrorService
+    let Sentry: any
+    let apolloClient: any
+    let setMockedConsent: (value: boolean) => void
+    let consentFetchPromise: Promise<void>
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
+    beforeEach(() => {
+        jest.resetModules()
+
+        errorService = require('../errors').errorService
+        Sentry = require('react-native-sentry')
+
+        let hasConsent = false
+        const observers: any = []
+
+        const notify = () => {
+            observers.forEach((observer: any) =>
+                observer.next({
+                    data: { gdprAllowPerformance: hasConsent },
+                }),
             )
+        }
+
+        setMockedConsent = (value: boolean) => {
+            hasConsent = value
+            notify()
+        }
+
+        const watchQuery = (opts: any) => {
+            expect(opts.query).toEqual(QUERY)
+            return new Observable(observer => {
+                observers.push(observer)
+                consentFetchPromise = Promise.resolve().then(notify)
+            })
+        }
+        apolloClient = { watchQuery }
+    })
 
-            await Promise.resolve()
+    it('should not do anything before calling `init`', async () => {
+        await Promise.resolve()
+        errorService.captureException(new Error())
 
-            errorService.captureException(new Error())
+        expect(Sentry.config).not.toHaveBeenCalled()
+        expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
 
-            expect(sentry.config).not.toHaveBeenCalled()
-            expect(sentry.captureException).not.toHaveBeenCalled()
-        })
+    it('should default to not having consent', () => {
+        errorService.init(apolloClient)
 
-        it('should default to not having consent', () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+        errorService.captureException(new Error())
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
+        expect(Sentry.config).not.toHaveBeenCalled()
+        expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
 
-            errorService.init()
+    it('should install the if consent is set to true', async () => {
+        setMockedConsent(true)
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            errorService.captureException(new Error())
+        expect(Sentry.config).toHaveBeenCalledTimes(1)
+    })
 
-            expect(sentry.config).not.toHaveBeenCalled()
-            expect(sentry.captureException).not.toHaveBeenCalled()
-        })
+    it('should not install without consent', async () => {
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-        it('should install the if consent is set to true', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+        expect(Sentry.config).not.toHaveBeenCalled()
+    })
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
+    it('should install only after consent is set to true', async () => {
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            errorService.init()
+        setMockedConsent(true)
+        expect(Sentry.config).toHaveBeenCalledTimes(1)
+    })
 
-            await Promise.resolve()
+    it('should not fire errors without consent', async () => {
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            expect(sentry.config).toHaveBeenCalledTimes(1)
-        })
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
 
-        it('should not install without consent', async () => {
-            const getSetting = getMockPromise(false)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+    it('should fire errors with consent', async () => {
+        setMockedConsent(true)
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+    })
 
-            errorService.init()
+    it('should start firing errors if consent is granted in the app', async () => {
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            await Promise.resolve()
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).not.toHaveBeenCalled()
 
-            expect(sentry.config).not.toHaveBeenCalled()
-        })
+        setMockedConsent(true)
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).toHaveBeenCalledTimes(2)
+    })
 
-        it('should install only after consent is set to true', async () => {
-            const getSetting = getMockPromise(false)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+    it('should stop firing errors if consent is revoked in the app', async () => {
+        setMockedConsent(true)
+        errorService.init(apolloClient)
+        await consentFetchPromise
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1)
 
-            errorService.init()
+        setMockedConsent(false)
+        errorService.captureException(new Error())
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+    })
 
-            await Promise.resolve()
+    it('should queue errors that happen while waiting to determine whether we have consent and send them if we do', async () => {
+        setMockedConsent(true)
+        errorService.init(apolloClient)
 
-            settingsUpdateEmitter.emit('gdprAllowPerformance', true)
+        errorService.captureException(new Error())
+        errorService.captureException(new Error())
 
-            expect(sentry.config).toHaveBeenCalledTimes(1)
-        })
+        expect(Sentry.captureException).not.toHaveBeenCalled()
 
-        it('should only listen for the relevant key', async () => {
-            const getSetting = getMockPromise(false)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
+        await consentFetchPromise
 
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            settingsUpdateEmitter.emit('gdprAllowFunctionality', true)
-
-            expect(sentry.config).not.toHaveBeenCalled()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).not.toHaveBeenCalled()
-        })
-
-        it('should not fire errors without consent', async () => {
-            const getSetting = getMockPromise(false)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).not.toHaveBeenCalled()
-        })
-
-        it('should fire errors with consent', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(1)
-        })
-
-        it('should start firing errors if consent is granted in the app', async () => {
-            const getSetting = getMockPromise(false)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).not.toHaveBeenCalled()
-
-            settingsUpdateEmitter.emit('gdprAllowPerformance', true)
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(1)
-        })
-
-        it('should stop firing errors if consent is revoked in the app', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(1)
-
-            settingsUpdateEmitter.emit('gdprAllowPerformance', false)
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(1)
-        })
-
-        it('should queue errors that happen while waiting to determine whether we have consent and send them if we do', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            errorService.captureException(new Error())
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).not.toHaveBeenCalled()
-
-            await Promise.resolve()
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(2)
-        })
-
-        it('should stop listening for events after calling destroy', async () => {
-            const getSetting = getMockPromise(true)
-            const settingsUpdateEmitter = createEmitter()
-            const sentry = createSentry()
-
-            const errorService = new ErrorService(
-                'gdprAllowPerformance',
-                getSetting,
-                settingsUpdateEmitter.sub,
-                sentry,
-            )
-
-            errorService.init()
-
-            await Promise.resolve()
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(1)
-
-            errorService.destroy()
-
-            settingsUpdateEmitter.emit('gdprAllowPerformance', false)
-
-            errorService.captureException(new Error())
-
-            expect(sentry.captureException).toHaveBeenCalledTimes(2)
-        })
+        expect(Sentry.captureException).toHaveBeenCalledTimes(2)
     })
 })

--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -7,7 +7,7 @@ import { GdprSwitchSetting } from 'src/helpers/settings'
 
 const { SENTRY_DSN_URL } = Config
 
-type QueryData = { gdprAllowPerformance: boolean }
+type QueryData = { gdprAllowPerformance: GdprSwitchSetting }
 const QUERY = gql('{ gdprAllowPerformance @client }')
 
 export interface ErrorService {
@@ -40,7 +40,7 @@ class ErrorServiceImpl implements ErrorService {
         })
     }
 
-    private handleConsentUpdate(hasConsent: boolean) {
+    private handleConsentUpdate(hasConsent: GdprSwitchSetting) {
         this.hasConsent = hasConsent
         if (hasConsent === false || hasConsent === null) return
 

--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -1,129 +1,70 @@
-import {
-    onSettingChanged,
-    getSetting,
-    GdprSwitchSettings,
-} from 'src/helpers/settings'
 import Sentry from 'react-native-sentry'
 import Config from 'react-native-config'
 import { isInBeta } from 'src/helpers/release-stream'
+import ApolloClient from 'apollo-client'
+import gql from 'graphql-tag'
 
 const { SENTRY_DSN_URL } = Config
 
-const DEFAULT_SETTING_KEY = 'gdprAllowPerformance' as const
+type QueryData = { gdprAllowPerformance: boolean }
+const QUERY = gql('{ gdprAllowPerformance @client }')
 
-interface SentryImpl {
-    config: (
-        dsn: string,
-        options?: object,
-    ) => {
-        install: () => Promise<void>
-    }
-    captureException: (err: Error) => void
-    setTagsContext: (tags: object) => void
+export interface ErrorService {
+    init(apolloClient: ApolloClient<object>): void
+    captureException(err: Error): void
 }
 
-enum InitState {
-    unitialized,
-    initializing,
-    initialized,
-}
-
-class ErrorService {
-    private settingKey: keyof GdprSwitchSettings
+class ErrorServiceImpl implements ErrorService {
     private hasConsent: boolean
     private hasConfigured: boolean
-    private initState: InitState
-    private initQueue: Error[]
-    private getSettingImpl: typeof getSetting
-    private onSettingChangedImpl: typeof onSettingChanged
-    private sentryImpl: SentryImpl
-    private deregisterSettingListener: () => void
+    private pendingQueue: Error[]
 
-    constructor(
-        settingKey: keyof GdprSwitchSettings = DEFAULT_SETTING_KEY,
-        getSettingImpl = getSetting,
-        onSettingChangedImpl = onSettingChanged,
-        sentryImpl: SentryImpl = Sentry,
-    ) {
-        this.settingKey = settingKey
+    constructor() {
         this.hasConsent = false
-        this.initState = InitState.unitialized
         this.hasConfigured = false
-        this.initQueue = []
-        this.getSettingImpl = getSettingImpl
-        this.onSettingChangedImpl = onSettingChangedImpl
-        this.sentryImpl = sentryImpl
-        this.deregisterSettingListener = () => {}
+        this.pendingQueue = []
     }
 
-    public async init() {
-        this.initState = InitState.initializing
-        this.addSettingListener()
-        this.handleConsentUpdate(!!(await this.getSettingImpl(this.settingKey)))
-        this.initState = InitState.initialized
-        this.processInitQueue()
-        return this
+    public init(apolloClient: ApolloClient<object>) {
+        const obs = apolloClient.watchQuery<QueryData>({ query: QUERY })
+        obs.subscribe({
+            next: query => {
+                if (query.loading) return
+                this.handleConsentUpdate(query.data.gdprAllowPerformance)
+            },
+            error: error => {
+                this.captureException(error)
+            },
+        })
     }
 
     private handleConsentUpdate(hasConsent: boolean) {
         this.hasConsent = hasConsent
-        if (this.hasConsent && !this.hasConfigured) {
-            this.sentryImpl.config(SENTRY_DSN_URL).install()
-            this.sentryImpl.setTagsContext({
+        if (!hasConsent) return
+
+        if (!this.hasConfigured) {
+            Sentry.config(SENTRY_DSN_URL).install()
+            Sentry.setTagsContext({
                 environment: __DEV__ ? 'DEV' : isInBeta() ? 'BETA' : 'RELEASE',
                 react: true,
             })
             this.hasConfigured = true
         }
-    }
 
-    private addSettingListener() {
-        this.deregisterSettingListener = this.onSettingChangedImpl(
-            (key, value) => {
-                if (key === this.settingKey) {
-                    this.handleConsentUpdate(!!value)
-                }
-            },
-        )
-    }
-
-    private processInitQueue() {
-        if (this.hasConsent) {
-            // if we do have consent send all the errors to sentry
-            while (this.initQueue.length) {
-                const err = this.initQueue.pop()
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.sentryImpl.captureException(err!)
-            }
-        } else {
-            // if we don't have consent then ignore all errors
-            this.initQueue = []
+        while (this.pendingQueue.length > 0) {
+            const err = this.pendingQueue.pop()
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            Sentry.captureException(err!)
         }
     }
 
     public captureException(err: Error) {
-        switch (this.initState) {
-            case InitState.initialized: {
-                if (this.hasConsent) {
-                    this.sentryImpl.captureException(err)
-                }
-                break
-            }
-            case InitState.initializing: {
-                this.initQueue.push(err)
-                break
-            }
-            default: {
-                break
-            }
+        if (this.hasConsent) {
+            Sentry.captureException(err)
+        } else {
+            this.pendingQueue.push(err)
         }
-    }
-
-    public destroy() {
-        this.deregisterSettingListener()
     }
 }
 
-const singletonErrorService = new ErrorService()
-
-export { singletonErrorService as errorService, ErrorService }
+export const errorService: ErrorService = new ErrorServiceImpl()


### PR DESCRIPTION
## Summary

We want settings to be accessed only through Apollo, so that we have a unified model. This changes `ErrorService` to do so.

I also altered the code so that it still keep tracks of errors into an array if consent is off and log them if consent switches to on. I think in practice that's a very unlikely scenario to happen, but on the other hand it simplifies the code quite a lot to do that, because we don't have to make a special case about the "initialisation" phase. I'm happy to discuss this though.

Additionally, as part of this change, this changes the classes and the automated tests to be simpler with a lot less boilerplate code (check out the deleted line count). Mocking modules instead of doing dependency-injection (DI) is quite common in Jest, if not idiomatic, and leads to cleaner logic code (something I've experienced on larger codebases as well).

It means we are testing the code exactly as it is written to run in prod instead of relying on extra interfaces, etc. I'm happy to discuss that strategy, but I hope this PR is a good example of how easy mocking makes this. One could argue the typing isn't proper in the test code itself, but then keep in mind that if something changes, the test would likely break anyway.

## Test Plan

`yarn jest`

I also tested running the app with the error service enabled, check that it was loading and logging as expected.

