### PR TITLE
cleanup eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,11 +20,12 @@ module.exports = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         'react/prop-types': 'off',
-        '@typescript-eslint/consistent-type-assertions': 'warn',
+        '@typescript-eslint/consistent-type-assertions': 'error',
         '@typescript-eslint/camelcase': 'off',
         'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'warn',
+        'react-hooks/exhaustive-deps': 'error',
         'react/display-name': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
     },
     overrides: [
         {

--- a/projects/Mallard/src/authentication/AccessContext.tsx
+++ b/projects/Mallard/src/authentication/AccessContext.tsx
@@ -109,6 +109,7 @@ const AccessProvider = ({
             unsubCAS()
             unsubIAP()
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const value = useMemo(

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -86,6 +86,7 @@ const useUpdateWebviewVariable = (
         if (value === valueInWebview.current) return
         valueInWebview.current = value
         webviewRef.current.injectJavaScript(`window.${name} = ${value};`)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
     return valueInWebview
 }

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -47,6 +47,7 @@ export const useIssueDate = (issue?: {
 }): IssueDate =>
     useMemo(
         () => (issue ? renderIssueDate(issue.date) : { date: '', weekday: '' }),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [issue && issue.key, issue],
     )
 

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -78,11 +78,14 @@ export const useImagePath = (image?: Image, use: ImageUse = 'full-size') => {
                 use,
             ).then(setPaths)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         apiUrl,
         image,
         use,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         issueId ? issueId.publishedIssueId : undefined, // Why isn't this just issueId?
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         issueId ? issueId.localIssueId : undefined,
     ])
     if (image === undefined) return undefined
@@ -99,6 +102,7 @@ export const useScaledImage = (largePath: string, width: number) => {
         if (!isRemote) {
             compressImagePath(largePath, width).then(setUri)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [largePath, width])
     return uri
 }

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -44,9 +44,11 @@ const ArticleScreenBody = React.memo<
         const handleIsAtTopChange = useCallback(
             (value: boolean) =>
                 onIsAtTopChange && onIsAtTopChange(value, path.article),
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             [onIsAtTopChange],
         )
         // First time it's mounted, we make sure to report we're at the top.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         useEffect(() => handleIsAtTopChange(true), [])
 
         return (

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -129,7 +129,7 @@ const AndroidHeader = withNavigation(
                     duration: 200,
                 }).start()
             }
-        }, [isShown])
+        }, [isShown, top])
 
         return (
             <Animated.View style={[styles.androidHeader, { top }]}>


### PR DESCRIPTION
## Summary

From experience and from observation of our project: 'warnings' are useless. They hang around and they pollute the output and rarely actioned upon. They don't get fixed before code is merged because they don't block CI. Let's get rid of lint warnings by either having them as errors, or disabling specific rules we don't need.

This changeset disable the rule about the type `any`, because we use it in many places and because I reckon it doesn't warrant an error. This is because it's already something explicit: by writing `any` in the code, the developer already knows they are circumventing the type system. (On the other hand, TypeScript already prevents implicit `any`s.)

This changeset also makes `react-hooks/exhaustive-deps` an error. I think it's an important one, because on the other hand it's an implicit mistake. If indeed the goal is to ignore one dependency in a hook then one can add a lint-ignore comment (which really should never happen and generally indicate poorly designed code).

## Test Plan

`make validate` at the root of the repo