### PR TITLE
refresh weather on permission change

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -68,7 +68,7 @@ it('should resolve and update the weather', async () => {
 
 it('should refresh the weather completely', async () => {
     const client = { writeData: jest.fn() } as any
-    let res = await resolveWeather({}, {}, { client })
+    await resolveWeather({}, {}, { client })
 
     forecasts = [{ DateTime: '1234' }]
     const refreshPromise = refreshWeather(client)

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -1,4 +1,4 @@
-import { resolveWeather } from '../weather'
+import { resolveWeather, refreshWeather, UNAVAILABLE_WEATHER } from '../weather'
 import { AppState } from 'react-native'
 
 const CITIES_URL =
@@ -63,5 +63,27 @@ it('should resolve and update the weather', async () => {
 
     expect(client.writeData).toHaveBeenCalledWith({
         data: { weather: res },
+    })
+})
+
+it('should refresh the weather completely', async () => {
+    const client = { writeData: jest.fn() } as any
+    let res = await resolveWeather({}, {}, { client })
+
+    forecasts = [{ DateTime: '1234' }]
+    const refreshPromise = refreshWeather(client)
+
+    expect(client.writeData).toHaveBeenCalledTimes(1)
+    expect(client.writeData).toHaveBeenCalledWith({
+        data: {
+            weather: UNAVAILABLE_WEATHER,
+        },
+    })
+
+    await refreshPromise
+
+    expect(client.writeData).toHaveBeenCalledTimes(2)
+    expect(client.writeData).toHaveBeenCalledWith({
+        data: { weather: getExpectedWeather() },
     })
 })

--- a/projects/Mallard/src/helpers/location-permission.ts
+++ b/projects/Mallard/src/helpers/location-permission.ts
@@ -6,6 +6,7 @@ import {
 } from 'react-native-permissions'
 import { Platform } from 'react-native'
 import { ApolloClient } from 'apollo-client'
+import { refreshWeather } from './weather'
 
 const LOCATION_PERMISSION = Platform.select({
     ios: PERMISSIONS.IOS.LOCATION_WHEN_IN_USE,
@@ -31,6 +32,7 @@ const [resolveLocationPermissionStatus, requestLocationPermission] = (() => {
                 locationPermissionStatus: result,
             },
         })
+        refreshWeather(apolloClient)
         return result
     }
 

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -127,6 +127,8 @@ const { resolveWeather, refreshWeather } = (() => {
         if (weather == null) return
         const newWeather = (weather = getWeather(fallback))
         const value = await weather
+        // `weather` might have changed while we were awaiting, in which case
+        // we don't want to update the cache with stale data.
         if (weather == newWeather)
             client.writeData({ data: { weather: value } })
     }

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -55,7 +55,7 @@ export type Weather =
           available: false
       }
 
-const UNAVAILABLE_WEATHER: Weather = {
+export const UNAVAILABLE_WEATHER: Weather = {
     __typename: 'Weather',
     locationName: null,
     isLocationPrecise: null,
@@ -111,11 +111,25 @@ const ONE_HOUR = MS_IN_A_SECOND * SECS_IN_A_MINUTE * MINS_IN_AN_HOUR
 /**
  * Resolve weather location information and forecasts. Refetch weather
  * after that if app is foregrounded and data is more than an hour old.
- * (We can't use `setTimeout` because of https://github.com/facebook/react-native/issues/12981)
+ * (We can't use `setTimeout` because of
+ * https://github.com/facebook/react-native/issues/12981)
+ *
+ * `refreshWeather` forces an immediate refresh, can be from user request or
+ * when the location permission change and we can now fetch more
+ * precise weather.
  */
-export const resolveWeather = (() => {
+const { resolveWeather, refreshWeather } = (() => {
     // If `undefined`, weather has never been shown.
     let weather: Promise<Weather> | undefined
+
+    // We update the cache only if no other update happened in-between.
+    const update = async (client: ApolloClient<object>, fallback?: Weather) => {
+        if (weather == null) return
+        const newWeather = (weather = getWeather(fallback))
+        const value = await weather
+        if (weather == newWeather)
+            client.writeData({ data: { weather: value } })
+    }
 
     // When going foreground, we get the fresh weather (and potentially new
     // location). Once that resolves we update the cache with the correct value,
@@ -124,14 +138,12 @@ export const resolveWeather = (() => {
         if (weather == null) return
         let value = await weather
         if (value.available && Date.now() < value.lastUpdated + ONE_HOUR) return
-        weather = getWeather(value)
-        value = await weather
-        client.writeData({ data: { weather: value } })
+        update(client, value)
     }
 
     // The first time this is called we setup a listener to update the weather
     // from time to time.
-    return (
+    const resolveWeather = (
         _context: unknown,
         _args: {},
         { client }: { client: ApolloClient<object> },
@@ -145,4 +157,14 @@ export const resolveWeather = (() => {
         })
         return weather
     }
+
+    const refreshWeather = async (client: ApolloClient<object>) => {
+        if (weather == null) return
+        client.writeData({ data: { weather: UNAVAILABLE_WEATHER } })
+        await update(client)
+    }
+
+    return { resolveWeather, refreshWeather }
 })()
+
+export { resolveWeather, refreshWeather }

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -136,7 +136,7 @@ const { resolveWeather, refreshWeather } = (() => {
     // which updates any view showing the weather.
     const onAppGoesForeground = async (client: ApolloClient<object>) => {
         if (weather == null) return
-        let value = await weather
+        const value = await weather
         if (value.available && Date.now() < value.lastUpdated + ONE_HOUR) return
         update(client, value)
     }


### PR DESCRIPTION
## Summary

Refresh weather explicitly if permissions change.

## Test Plan

1. Open app, sign-in, enable dev mode
2. Press "Set Location" on weather
3. Accept, then allow permission
4. Observe: weather is cleared up and displays again with fresh data (it's still not using real location yet, I'll add this in the next and final PR)
