### PR TITLE
bring back header on crosswords

### DIFF
--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -5,7 +5,6 @@ import { color } from 'src/theme/color'
 import { ErrorBoundary } from '../layout/ui/errors/error-boundary'
 import { Article, HeaderControlProps } from './types/article'
 import { Crossword } from './types/crossword'
-import { View, Text } from 'react-native'
 
 /*
 This is the article view! For all of the articles.

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -5,6 +5,7 @@ import { color } from 'src/theme/color'
 import { ErrorBoundary } from '../layout/ui/errors/error-boundary'
 import { Article, HeaderControlProps } from './types/article'
 import { Crossword } from './types/crossword'
+import { View, Text } from 'react-native'
 
 /*
 This is the article view! For all of the articles.

--- a/projects/Mallard/src/components/article/types/crossword.tsx
+++ b/projects/Mallard/src/components/article/types/crossword.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { CrosswordArticle } from 'src/common'
 import { getBundleUri } from 'src/helpers/webview'
@@ -11,19 +11,26 @@ const Crossword = ({
 }: {
     crosswordArticle: CrosswordArticle
 }) => (
-    <WebView
-        key={crosswordArticle.key}
-        originWhitelist={['*']}
-        source={{ uri: getBundleUri('crosswords') }}
-        injectedJavaScript={`
+    <View
+        style={{
+            ...StyleSheet.absoluteFillObject,
+            bottom: 150,
+        }}
+    >
+        <WebView
+            key={crosswordArticle.key}
+            originWhitelist={['*']}
+            source={{ uri: getBundleUri('crosswords') }}
+            injectedJavaScript={`
                 window.loadCrosswordData("${
                     crosswordArticle.key
                 }", ${JSON.stringify(crosswordArticle.crossword)}); true;
             `}
-        allowFileAccess={true}
-        javaScriptEnabled={true}
-        style={styles.flex}
-    />
+            allowFileAccess={true}
+            javaScriptEnabled={true}
+            style={styles.flex}
+        />
+    </View>
 )
 
 export { Crossword }

--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -18,6 +18,7 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { ArticleScreenBody } from './article/body'
 import { ArticleSlider } from './article/slider'
+import { BasicArticleHeader } from './article/header'
 
 export interface ArticleTransitionProps {
     startAtHeightFromFrontsItem: number
@@ -112,14 +113,17 @@ const ArticleScreenWithProps = ({
                 removeClippedSubviews
             >
                 {prefersFullScreen ? (
-                    <ArticleScreenBody
-                        path={path}
-                        width={width}
-                        pillar={pillar}
-                        onShouldShowHeaderChange={() => {}}
-                        shouldShowHeader={true}
-                        topPadding={0}
-                    />
+                    <>
+                        <BasicArticleHeader />
+                        <ArticleScreenBody
+                            path={path}
+                            width={width}
+                            pillar={pillar}
+                            onShouldShowHeaderChange={() => {}}
+                            shouldShowHeader={true}
+                            topPadding={0}
+                        />
+                    </>
                 ) : (
                     <ArticleSlider
                         path={path}

--- a/projects/Mallard/src/screens/article/header.tsx
+++ b/projects/Mallard/src/screens/article/header.tsx
@@ -1,0 +1,24 @@
+import { Button, ButtonAppearance } from 'src/components/button/button'
+import { withNavigation } from 'react-navigation'
+import { NavigationInjectedProps } from 'react-navigation'
+import React from 'react'
+import { Header } from 'src/components/layout/header/header'
+
+export const BasicArticleHeader = withNavigation(
+    ({ navigation }: NavigationInjectedProps) => (
+        <Header
+            white
+            leftAction={
+                <Button
+                    appearance={ButtonAppearance.skeleton}
+                    icon={'\uE00A'}
+                    alt="Back"
+                    onPress={() => navigation.goBack(null)}
+                ></Button>
+            }
+            layout={'center'}
+        >
+            {null}
+        </Header>
+    ),
+)

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Animated, Platform, StyleSheet, View, Easing } from 'react-native'
-import { Header } from 'src/components/layout/header/header'
 import ViewPagerAndroid from '@react-native-community/viewpager'
 import { CAPIArticle, Collection, Front, Issue } from 'src/common'
 import { MaxWidthWrap } from 'src/components/article/wrap/max-width'
@@ -24,6 +23,7 @@ import {
 import { Button, ButtonAppearance } from 'src/components/button/button'
 import { withNavigation } from 'react-navigation'
 import { NavigationInjectedProps } from 'react-navigation'
+import { BasicArticleHeader } from './header'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -106,56 +106,37 @@ const SliderBar = ({ position, total, title, color }: SliderBarProps) => {
     )
 }
 
-const AndroidHeader = withNavigation(
-    ({
-        isShown,
-        navigation,
-        isAtTop,
-        ...sliderProps
-    }: { isShown: boolean; isAtTop: boolean } & SliderBarProps &
-        NavigationInjectedProps) => {
-        const [top] = useState(new Animated.Value(0))
-        useEffect(() => {
-            if (isShown) {
-                Animated.timing(top, {
-                    toValue: 0,
-                    easing: Easing.out(Easing.ease),
-                    duration: 200,
-                }).start()
-            } else {
-                Animated.timing(top, {
-                    toValue: -ANDROID_HEADER_HEIGHT,
-                    easing: Easing.out(Easing.ease),
-                    duration: 200,
-                }).start()
-            }
-        }, [isShown, top])
+const AndroidHeader = ({
+    isShown,
+    isAtTop,
+    ...sliderProps
+}: { isShown: boolean; isAtTop: boolean } & SliderBarProps) => {
+    const [top] = useState(new Animated.Value(0))
+    useEffect(() => {
+        if (isShown) {
+            Animated.timing(top, {
+                toValue: 0,
+                easing: Easing.out(Easing.ease),
+                duration: 200,
+            }).start()
+        } else {
+            Animated.timing(top, {
+                toValue: -ANDROID_HEADER_HEIGHT,
+                easing: Easing.out(Easing.ease),
+                duration: 200,
+            }).start()
+        }
+    }, [isShown, top])
 
-        return (
-            <Animated.View style={[styles.androidHeader, { top }]}>
-                <Header
-                    white
-                    leftAction={
-                        <Button
-                            appearance={ButtonAppearance.skeleton}
-                            icon={'\uE00A'}
-                            alt="Back"
-                            onPress={() => navigation.goBack(null)}
-                        ></Button>
-                    }
-                    layout={'center'}
-                >
-                    {null}
-                </Header>
-                <View
-                    style={[styles.slider, isAtTop ? styles.sliderAtTop : null]}
-                >
-                    <SliderBar {...sliderProps} />
-                </View>
-            </Animated.View>
-        )
-    },
-)
+    return (
+        <Animated.View style={[styles.androidHeader, { top }]}>
+            <BasicArticleHeader />
+            <View style={[styles.slider, isAtTop ? styles.sliderAtTop : null]}>
+                <SliderBar {...sliderProps} />
+            </View>
+        </Animated.View>
+    )
+}
 
 /**
  * We keep track of which articles are scrolled or not so that when we swipe

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -20,9 +20,6 @@ import {
     ArticleNavigator,
     getArticleDataFromNavigator,
 } from '../article-screen'
-import { Button, ButtonAppearance } from 'src/components/button/button'
-import { withNavigation } from 'react-navigation'
-import { NavigationInjectedProps } from 'react-navigation'
 import { BasicArticleHeader } from './header'
 
 export interface PathToArticle {


### PR DESCRIPTION
## Summary

I broke this when implementing the auto-hide (#810). This adds the header when in full-screen for the basic card.

This is quick fix, but I think we need to reconsider how this is designed long-term.

Additionally, I had to add an arbitrary padding at the bottom, otherwise the view overflows the screen and it's impossible to read the last definitions of the crosswords. I'm not sure what's the root cause. It needs more investigation but I think we need a quickfix for now so that we can ship the next release.

## Test Plan

Both iOs and Android, open a crosswords, verify there is a back button. Verify other articles are unnaffected.

<img width="300" alt="Screenshot 2019-11-13 at 17 27 39" src="https://user-images.githubusercontent.com/1733570/68789418-56f6ad80-063d-11ea-82b3-be3629134a72.png">

