### PR TITLE
easy: remove extra padding in weather

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
         width: 45,
         paddingTop: 2,
         paddingLeft: 4,
-        paddingRight: 8,
     },
     forecastItemWide: {
         width: 90,


### PR DESCRIPTION
## Summary

It causes time to be cut off if it's too long, for example "10pm" would get cut off. It doesn't change overall width because width is set separately.

## Test Plan

Check it renders correct as ususal.
