### PR TITLE
weather: show real location

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -61,6 +61,8 @@ PODS:
   - React-jsinspector (0.60.4)
   - react-native-config (0.11.7):
     - React
+  - react-native-geolocation (2.0.2):
+    - React
   - react-native-image-resizer (1.0.1):
     - React
   - react-native-in-app-utils (6.0.2):
@@ -153,6 +155,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-config (from `../node_modules/react-native-config`)
+  - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - react-native-image-resizer (from `../node_modules/react-native-image-resizer`)
   - react-native-in-app-utils (from `../node_modules/react-native-in-app-utils`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
@@ -219,6 +222,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-geolocation:
+    :path: "../node_modules/@react-native-community/geolocation"
   react-native-image-resizer:
     :path: "../node_modules/react-native-image-resizer"
   react-native-in-app-utils:
@@ -299,6 +304,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 7549641e48bafae7bfee3f3ea19bf4901639c5de
   React-jsinspector: 73f24a02fa684ed6a2b828ba116874a2191ded88
   react-native-config: 55548054279d92e0e4566ea15a8b9b81028ec342
+  react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
   react-native-netinfo: 0da34082d2cec3100c9b5073bb217e35f1142bdd

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -38,6 +38,7 @@
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
         "@react-native-community/async-storage": "^1.5.0",
+        "@react-native-community/geolocation": "^2.0.2",
         "@react-native-community/masked-view": "^0.1.1",
         "@react-native-community/netinfo": "^3.2.1",
         "@react-native-community/push-notification-ios": "^1.0.2",

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -20,14 +20,13 @@ type QueryForecast = Pick<
     Forecast,
     'DateTime' | 'Temperature' | 'WeatherIcon' | 'EpochDateTime'
 >
-type AvailableWeather = {
+type Weather = {
     locationName: string
     isLocationPrecise: boolean
     forecasts: QueryForecast[]
-    available: true
 }
 type QueryData = {
-    weather: AvailableWeather | { available: false }
+    weather: Weather | null
     isUsingProdDevtools: boolean
     locationPermissionStatus: PermissionStatus
 }
@@ -46,7 +45,6 @@ const QUERY = gql`
                 WeatherIcon
                 EpochDateTime
             }
-            available
         }
         isUsingProdDevtools @client
         locationPermissionStatus @client
@@ -264,7 +262,7 @@ const WeatherWithForecast = ({
     weather,
     isUsingProdDevtools,
 }: {
-    weather: AvailableWeather
+    weather: Weather
     isUsingProdDevtools: boolean
 }) => {
     const { forecasts, locationName, isLocationPrecise } = weather
@@ -303,7 +301,7 @@ const WeatherWidget = React.memo(() => {
     if (query.loading) return null
 
     const { data } = query
-    if (!data.weather.available) return null
+    if (data.weather == null) return null
     return (
         <WeatherWithForecast
             weather={data.weather}

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -1,5 +1,3 @@
-import { PerformanceObserver } from 'perf_hooks'
-
 const CITIES_URL =
     'http://mobile-weather.guardianapis.com/locations/v1/cities/ipAddress?q=127.0.0.1&details=false'
 const FORECASTS_URL =
@@ -134,10 +132,13 @@ it('should fetch real location if available', async () => {
     check.mockResolvedValue(RESULTS.GRANTED)
 
     const client = { writeData: jest.fn() } as any
-    let res = await resolveWeather({}, {}, { client })
+    const res = await resolveWeather({}, {}, { client })
     expect(res).toEqual({
         ...getExpectedWeather(),
         isLocationPrecise: true,
         locationName: 'Kings Cross',
     })
 })
+
+// make it a valid ES6 module
+export {}

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -1,10 +1,12 @@
-import { resolveWeather, refreshWeather, UNAVAILABLE_WEATHER } from '../weather'
-import { AppState } from 'react-native'
+import { PerformanceObserver } from 'perf_hooks'
 
 const CITIES_URL =
     'http://mobile-weather.guardianapis.com/locations/v1/cities/ipAddress?q=127.0.0.1&details=false'
 const FORECASTS_URL =
     'http://mobile-weather.guardianapis.com/forecasts/v1/hourly/12hour/london.json?metric=true&language=en-gb'
+const GEOLOC_URL =
+    'http://mobile-weather.guardianapis.com/locations/v1/cities/geoposition/search?q=12,34&details=false'
+
 let forecasts = [{ DateTime: '0000' }]
 ;(global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
     if (url === 'https://api.ipify.org')
@@ -15,8 +17,38 @@ let forecasts = [{ DateTime: '0000' }]
                 Promise.resolve({ Key: 'london', EnglishName: 'London' }),
         }
     if (url === FORECASTS_URL) return { json: () => Promise.resolve(forecasts) }
-    throw new Error(`unknown: ${url}`)
+    if (url === GEOLOC_URL)
+        return {
+            json: () =>
+                Promise.resolve({
+                    Key: 'london',
+                    EnglishName: 'Kings Cross',
+                }),
+        }
+    console.error(`unknown url: ${url}`)
+    throw new Error(`unknown url`)
 })
+
+jest.mock('react-native-permissions', () => {
+    return {
+        RESULTS: { GRANTED: 1, DENIED: 2 },
+        PERMISSIONS: {
+            IOS: { LOCATION_WHEN_IN_USE: 1 },
+            ANDROID: { ACCESS_FINE_LOCATION: 1 },
+        },
+        check: jest.fn().mockResolvedValue(2),
+    }
+})
+
+jest.mock('@react-native-community/geolocation', () => ({
+    setRNConfiguration: () => {},
+    getCurrentPosition: (resolve: any) =>
+        Promise.resolve().then(() => {
+            resolve({
+                coords: { latitude: 12, longitude: 34 },
+            })
+        }),
+}))
 
 let now = 100000000
 Date.now = () => now
@@ -26,7 +58,6 @@ const getExpectedWeather = () => ({
     locationName: 'London',
     isLocationPrecise: false,
     lastUpdated: now,
-    available: true,
     forecasts: [
         {
             __typename: 'Forecast',
@@ -36,6 +67,17 @@ const getExpectedWeather = () => ({
             Temperature: { __typename: 'Temperature' },
         },
     ],
+})
+
+let resolveWeather: any, refreshWeather: any
+let AppState: any
+let check: any, RESULTS: any
+
+beforeEach(() => {
+    jest.resetModules()
+    ;({ resolveWeather, refreshWeather } = require('../weather'))
+    ;({ AppState } = require('react-native'))
+    ;({ check, RESULTS } = require('react-native-permissions'))
 })
 
 it('should resolve and update the weather', async () => {
@@ -76,7 +118,7 @@ it('should refresh the weather completely', async () => {
     expect(client.writeData).toHaveBeenCalledTimes(1)
     expect(client.writeData).toHaveBeenCalledWith({
         data: {
-            weather: UNAVAILABLE_WEATHER,
+            weather: null,
         },
     })
 
@@ -85,5 +127,17 @@ it('should refresh the weather completely', async () => {
     expect(client.writeData).toHaveBeenCalledTimes(2)
     expect(client.writeData).toHaveBeenCalledWith({
         data: { weather: getExpectedWeather() },
+    })
+})
+
+it('should fetch real location if available', async () => {
+    check.mockResolvedValue(RESULTS.GRANTED)
+
+    const client = { writeData: jest.fn() } as any
+    let res = await resolveWeather({}, {}, { client })
+    expect(res).toEqual({
+        ...getExpectedWeather(),
+        isLocationPrecise: true,
+        locationName: 'Kings Cross',
     })
 })

--- a/projects/Mallard/src/helpers/location-permission.ts
+++ b/projects/Mallard/src/helpers/location-permission.ts
@@ -13,16 +13,16 @@ const LOCATION_PERMISSION = Platform.select({
     android: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
 })
 
-const [resolveLocationPermissionStatus, requestLocationPermission] = (() => {
+const { resolveLocationPermissionStatus, requestLocationPermission } = (() => {
     let promise: Promise<PermissionStatus> | undefined
 
-    const resolvePermission = () => {
+    const resolveLocationPermissionStatus = () => {
         if (promise) return promise
         promise = check(LOCATION_PERMISSION)
         return promise
     }
 
-    const requestPermission = async (
+    const requestLocationPermission = async (
         apolloClient: ApolloClient<object>,
     ): Promise<PermissionStatus> => {
         promise = request(LOCATION_PERMISSION)
@@ -36,7 +36,7 @@ const [resolveLocationPermissionStatus, requestLocationPermission] = (() => {
         return result
     }
 
-    return [resolvePermission, requestPermission]
+    return { resolveLocationPermissionStatus, requestLocationPermission }
 })()
 
 export { resolveLocationPermissionStatus, requestLocationPermission }

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -944,6 +944,11 @@
     shell-quote "1.6.1"
     ws "^1.1.0"
 
+"@react-native-community/geolocation@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/geolocation/-/geolocation-2.0.2.tgz#ba8b40f560ead8d014740d1cdea970b33f19312e"
+  integrity sha512-tTNXRCgnhJBu79mulQwzabXRpDqfh/uaDqfHVpvF0nX4NTpolpy6mvTRiFg7eWFPGRArsnZz1EYp6rHfJWGgEA==
+
 "@react-native-community/masked-view@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.1.tgz#dbcfc5ec08efbb02d4142dd9426c8d7a396829d7"


### PR DESCRIPTION
## Summary

Finally! This is pretty much the last step for weather… show the actual location.

https://trello.com/c/Ii5WqyrA/895-make-weather-in-app-use-geolocation-data-lat-long-rather-than-ip-address

I also took this opportunity to remove the "available" field: if not available, we simply make the field `null`. That's easier to manage at Apollo level.

## Test Plan

1. Open app, see "Set Location" button
2. Press button, accept conditions
3. Accept location permission request
4. Notice the weather updates accordingly (ex. in the emulator it shows me location and weather in San Francisco)

I also tested various other combinations, like going to app-specific system settings, blocking or removing the permissions, going back to the app, noticing the "Set Location" button comes back as expected, etc.


