### PR TITLE
Add grace period of three days for IAP receipts

### DIFF
--- a/projects/Mallard/src/authentication/authorizers/IAPAuthorizer.ts
+++ b/projects/Mallard/src/authentication/authorizers/IAPAuthorizer.ts
@@ -2,7 +2,7 @@ import { iapReceiptCache } from '../../helpers/storage'
 import { Authorizer } from '../lib/Authorizer'
 import {
     fetchActiveIOSSubscriptionReceipt,
-    isReceiptActive,
+    isReceiptValid,
     tryRestoreActiveIOSSubscriptionReceipt,
 } from '../services/iap'
 
@@ -12,5 +12,5 @@ export default new Authorizer({
     authCaches: [],
     auth: tryRestoreActiveIOSSubscriptionReceipt,
     authWithCachedCredentials: fetchActiveIOSSubscriptionReceipt,
-    checkUserHasAccess: isReceiptActive,
+    checkUserHasAccess: isReceiptValid,
 })

--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,0 +1,29 @@
+import moment from 'moment'
+import { receiptIOS } from 'src/authentication/__tests__/fixtures'
+import { isReceiptValid } from '../iap'
+
+describe('iap', () => {
+    describe('isReceiptValid', () => {
+        it('returns false for expiry dates that are more thanthree days older than now', () => {
+            const fourDaysAgo = moment()
+                .subtract(4, 'days')
+                .toDate()
+            const isValid = isReceiptValid(
+                receiptIOS({ expires_date: fourDaysAgo }),
+            )
+
+            expect(isValid).toBe(false)
+        })
+
+        it('returns true for expiry dates that are less than three days older than now', () => {
+            const twoDaysAgo = moment()
+                .subtract(2, 'days')
+                .toDate()
+            const isValid = isReceiptValid(
+                receiptIOS({ expires_date: twoDaysAgo }),
+            )
+
+            expect(isValid).toBe(true)
+        })
+    })
+})

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -12,6 +12,8 @@ import {
 import { isInBeta } from 'src/helpers/release-stream'
 const { InAppUtils } = NativeModules
 
+const THREE_DAYS = 1000 * 60 * 60 * 24 * 3
+
 export interface ReceiptIOS {
     expires_date: string
     expires_date_ms: string
@@ -47,14 +49,15 @@ const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {
         .transactionReceipt
 }
 
-const isReceiptActive = (receipt: ReceiptIOS) => {
+const isReceiptValid = (receipt: ReceiptIOS) => {
     const expirationInMilliseconds = Number(receipt.expires_date_ms)
+    const expirationWithGracePeriod = expirationInMilliseconds + THREE_DAYS
     const nowInMilliseconds = Date.now()
-    return expirationInMilliseconds > nowInMilliseconds
+    return expirationWithGracePeriod > nowInMilliseconds
 }
 
 const findValidReceipt = (receipt: ReceiptValidationResponse) =>
-    (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptActive) || null
+    (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid) || null
 
 /**
  * This will attempt to restore existing purchases
@@ -107,5 +110,5 @@ const fetchActiveIOSSubscriptionReceipt = async (): Promise<
 export {
     fetchActiveIOSSubscriptionReceipt,
     tryRestoreActiveIOSSubscriptionReceipt,
-    isReceiptActive,
+    isReceiptValid,
 }


### PR DESCRIPTION
## Summary

Adds a 3 day grace period for all IAP receipts, in a hope to avoid missing receipts and, from that, failed IAP sign-ins.

An attempted fix for the below two cards:

https://trello.com/c/ejl8Xr8Y/933-itunes-subs-becoming-unavailable-in-the-app-for-no-apparent-reason
https://trello.com/c/nxDT0KDw/1017-users-having-to-repeatedly-sign-back-into-subscription