### PR TITLE
Fix update on rotate for slider

### DIFF
--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -90,28 +90,26 @@ const SliderSectionBar = ({
     isFirst,
 }: SliderBarProps) => {
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
-    const [sliderPos] = useState(() =>
-        sliderPosition
-            .interpolate({
-                inputRange: [
-                    section.startIndex,
-                    section.startIndex + section.items - 1,
-                ],
-                outputRange: [
-                    section.startIndex,
-                    section.startIndex + section.items - 1,
-                ],
-                extrapolateLeft: 'clamp',
-                extrapolateRight: 'clamp',
-            })
-            .interpolate({
-                inputRange: [
-                    section.startIndex,
-                    section.startIndex + section.items - 1,
-                ],
-                outputRange: [0, 1],
-            }),
-    )
+    const sliderPos = sliderPosition
+        .interpolate({
+            inputRange: [
+                section.startIndex,
+                section.startIndex + section.items - 1,
+            ],
+            outputRange: [
+                section.startIndex,
+                section.startIndex + section.items - 1,
+            ],
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+        })
+        .interpolate({
+            inputRange: [
+                section.startIndex,
+                section.startIndex + section.items - 1,
+            ],
+            outputRange: [0, 1],
+        })
 
     const xValue = sliderPosition.interpolate({
         inputRange: [


### PR DESCRIPTION
The slide was holding an interpolation in state that had previously been
divided by the width. Not that width has been updated, the animated
value here needs an update but wasn't getting it. If we want perf
improvements we can think about `useMemo`.