### PR TITLE
Don't call subscribers synchronously

### DIFF
--- a/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
@@ -101,7 +101,7 @@ describe('use-net-info', () => {
         })
 
         describe('#subscribe', () => {
-            it('forwards messages that are fired from the handlers it has registered with', () => {
+            it('forwards messages that are fired from the handlers it has registered with', async () => {
                 const nisc = new NetInfoStateContainer()
                 const sub = jest.fn()
                 nisc.subscribe(sub)

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -93,15 +93,16 @@ export class NetInfoStateContainer {
     }
 
     subscribe(fn: (state: NetInfoState) => void) {
-        let shouldSubscribe = true
+        let isSubscribed = true
+        this.subscribers.push(fn)
         this.fetch().then(state => {
-            if (shouldSubscribe) {
+            if (isSubscribed) {
                 fn(state)
-                this.subscribers.push(fn)
             }
         })
+
         return () => {
-            shouldSubscribe = false
+            isSubscribed = false
             this.subscribers = this.subscribers.filter(sub => sub !== fn)
         }
     }

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -94,13 +94,12 @@ export class NetInfoStateContainer {
 
     subscribe(fn: (state: NetInfoState) => void) {
         let shouldSubscribe = true
-        this.fetch()
-            .then(fn)
-            .finally(() => {
-                if (shouldSubscribe) {
-                    this.subscribers.push(fn)
-                }
-            })
+        this.fetch().then(state => {
+            if (shouldSubscribe) {
+                fn(state)
+                this.subscribers.push(fn)
+            }
+        })
         return () => {
             shouldSubscribe = false
             this.subscribers = this.subscribers.filter(sub => sub !== fn)

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -93,8 +93,11 @@ export class NetInfoStateContainer {
     }
 
     subscribe(fn: (state: NetInfoState) => void) {
-        this.subscribers.push(fn)
-        fn(this.state)
+        this.fetch()
+            .then(fn)
+            .finally(() => {
+                this.subscribers.push(fn)
+            })
         return () => {
             this.subscribers = this.subscribers.filter(sub => sub !== fn)
         }

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -93,12 +93,16 @@ export class NetInfoStateContainer {
     }
 
     subscribe(fn: (state: NetInfoState) => void) {
+        let shouldSubscribe = true
         this.fetch()
             .then(fn)
             .finally(() => {
-                this.subscribers.push(fn)
+                if (shouldSubscribe) {
+                    this.subscribers.push(fn)
+                }
             })
         return () => {
+            shouldSubscribe = false
             this.subscribers = this.subscribers.filter(sub => sub !== fn)
         }
     }


### PR DESCRIPTION
Keep async things async https://blog.izs.me/2013/08/designing-apis-for-asynchrony (also stops an extra render re-render)
