### PR TITLE
[rfc][infra] queries

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -37,6 +37,8 @@ import { IssueSummaryProvider } from './hooks/use-issue-summary'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { createApolloClient } from './apollo'
 import { errorService } from './services/errors'
+import { QueryEnvironment, QueryEnvironmentContext } from './helpers/queries'
+import { registerLiveWeather } from './helpers/weather'
 
 const clearAndDownloadIssue = async () => {
     await prepFileSystem()
@@ -133,11 +135,19 @@ const onNavigationStateChange = (
 const isReactNavPersistenceError = (e: Error) =>
     __DEV__ && e.message.includes('There is no route defined for')
 
+const queryEnv = new QueryEnvironment()
+registerLiveWeather(queryEnv)
+
 const WithProviders = nestProviders(
     Modal,
     ToastProvider,
     NetInfoProvider,
     IssueSummaryProvider,
+    ({ children }) => (
+        <QueryEnvironmentContext.Provider value={queryEnv}>
+            {children}
+        </QueryEnvironmentContext.Provider>
+    ),
 )
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>

--- a/projects/Mallard/src/apollo.ts
+++ b/projects/Mallard/src/apollo.ts
@@ -5,8 +5,6 @@
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { SETTINGS_RESOLVERS } from './helpers/settings/resolvers'
-import { resolveWeather } from './helpers/weather'
-import { resolveLocationPermissionStatus } from './helpers/location-permission'
 
 /**
  * Resolvers is what Apollo uses to get the value of field that has never been
@@ -25,8 +23,6 @@ import { resolveLocationPermissionStatus } from './helpers/location-permission'
 const RESOLVERS = {
     Query: {
         ...SETTINGS_RESOLVERS,
-        weather: resolveWeather,
-        locationPermissionStatus: resolveLocationPermissionStatus,
     },
 }
 

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -8,48 +8,12 @@ import { color } from 'src/theme/color'
 import { getFont } from 'src/theme/typography'
 import { WithBreakpoints } from './layout/ui/sizing/with-breakpoints'
 import { Breakpoints } from 'src/theme/breakpoints'
-import { useQuery } from 'src/hooks/apollo'
-import gql from 'graphql-tag'
 import { Button, ButtonAppearance } from './button/button'
 import { withNavigation } from 'react-navigation'
 import { routeNames } from 'src/navigation/routes'
 import { NavigationInjectedProps } from 'react-navigation'
-import { PermissionStatus } from 'react-native-permissions'
-
-type QueryForecast = Pick<
-    Forecast,
-    'DateTime' | 'Temperature' | 'WeatherIcon' | 'EpochDateTime'
->
-type Weather = {
-    locationName: string
-    isLocationPrecise: boolean
-    forecasts: QueryForecast[]
-}
-type QueryData = {
-    weather: Weather | null
-    isUsingProdDevtools: boolean
-    locationPermissionStatus: PermissionStatus
-}
-
-const QUERY = gql`
-    {
-        weather @client {
-            locationName
-            isLocationPrecise
-            forecasts {
-                DateTime
-                Temperature {
-                    Value
-                    Unit
-                }
-                WeatherIcon
-                EpochDateTime
-            }
-        }
-        isUsingProdDevtools @client
-        locationPermissionStatus @client
-    }
-`
+import { WEATHER_QUERY, Weather } from 'src/helpers/weather'
+import { useQuery } from 'src/helpers/queries'
 
 const narrowSpace = String.fromCharCode(8201)
 
@@ -149,14 +113,14 @@ const styles = StyleSheet.create({
 
 export interface WeatherForecast {
     locationName: string
-    forecasts: QueryForecast[]
+    forecasts: Forecast[]
 }
 
 const WeatherIconView = ({
     forecast,
     iconSize = 1,
 }: {
-    forecast: QueryForecast
+    forecast: Forecast
     iconSize?: number
 }) => {
     const info = (
@@ -294,12 +258,12 @@ const WeatherWithForecast = ({ weather }: { weather: Weather }) => {
 }
 
 const WeatherWidget = React.memo(() => {
-    const query = useQuery<QueryData>(QUERY)
+    const query = useQuery(WEATHER_QUERY, {})
     if (query.loading) return null
 
-    const { data } = query
-    if (data.weather == null) return null
-    return <WeatherWithForecast weather={data.weather} />
+    const { value } = query
+    if (value == null) return null
+    return <WeatherWithForecast weather={value} />
 })
 
 export { WeatherWidget }

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -46,6 +46,26 @@ it('resolves a query', async () => {
     expect(fn).toHaveBeenCalledTimes(1)
 })
 
+it('rejects a query', async () => {
+    const helloQuery = Query.create(
+        jest.fn().mockImplementation(async () => {
+            throw new Error('failed')
+        }),
+    )
+
+    expect(env.peek(helloQuery, null)).toEqual({ loading: true })
+
+    const [fn, join] = createJoinableFn()
+    const release = env.watch(helloQuery, {}, fn)
+
+    const result = await join()
+    expect(result).toEqual({ error: new Error('failed') })
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(1)
+
+    release()
+    expect(fn).toHaveBeenCalledTimes(1)
+})
+
 it('resolves and updates nested queries', async () => {
     let name = 'world'
     const nameQuery = Query.create(
@@ -79,4 +99,87 @@ it('resolves and updates nested queries', async () => {
 
     release()
     expect(fn).toHaveBeenCalledTimes(2)
+})
+
+it('clear cache of unwatched queries', async () => {
+    const helloQuery = Query.create(
+        jest.fn().mockImplementation(async () => {
+            return 'hello, world'
+        }),
+    )
+
+    const [fn, join] = createJoinableFn()
+    let release = env.watch(helloQuery, {}, fn)
+    await join()
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(1)
+    release()
+
+    release = env.watch(helloQuery, {}, fn)
+    await join()
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(2)
+    release()
+})
+
+it('caches queries in progress watched simutaneously', async () => {
+    const helloQuery = Query.create(
+        jest.fn().mockImplementation(async () => {
+            return 'hello, world'
+        }),
+    )
+
+    const [fn1, join1] = createJoinableFn()
+    const [fn2, join2] = createJoinableFn()
+    let release1 = env.watch(helloQuery, {}, fn1)
+    let release2 = env.watch(helloQuery, {}, fn2)
+
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(0)
+    await join1()
+    await join2()
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(1)
+
+    release1()
+    release2()
+})
+
+it('resolves a query with variables', async () => {
+    const helloQuery = Query.create(
+        jest.fn().mockImplementation(async ({ name }) => {
+            return 'hello, ' + name
+        }),
+    )
+
+    const [fn1, join1] = createJoinableFn()
+    const release1 = env.watch(helloQuery, { name: 'world' }, fn1)
+
+    let result = await join1()
+    expect(result).toEqual({ value: 'hello, world' })
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(1)
+    expect(fn1).toHaveBeenCalledTimes(1)
+
+    const [fn2, join2] = createJoinableFn()
+    const release2 = env.watch(helloQuery, { name: "y'all" }, fn2)
+
+    result = await join2()
+    expect(result).toEqual({ value: "hello, y'all" })
+    expect(helloQuery.resolver).toHaveBeenCalledTimes(2)
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+
+    release1()
+    release2()
+})
+
+it('resolves recursive queries', async () => {
+    const factorialQuery = Query.create(async (n: number, resolve) => {
+        if (n === 0) return 1
+        const result: number = await resolve(factorialQuery, n - 1)
+        return result * n
+    })
+
+    const [fn, join] = createJoinableFn()
+    const release = env.watch(factorialQuery, 4, fn)
+    const result = await join()
+    expect(result).toEqual({ value: 24 })
+
+    release()
 })

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -76,7 +76,7 @@ it('resolves and updates nested queries', async () => {
 
     const helloQuery = Query.create(
         jest.fn().mockImplementation(async (_vars, resolve) => {
-            const name = await resolve(nameQuery, null)
+            const name = await resolve(nameQuery, {})
             return 'hello, ' + name
         }),
     )

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -129,8 +129,8 @@ it('caches queries in progress watched simutaneously', async () => {
 
     const [fn1, join1] = createJoinableFn()
     const [fn2, join2] = createJoinableFn()
-    let release1 = env.watch(helloQuery, {}, fn1)
-    let release2 = env.watch(helloQuery, {}, fn2)
+    const release1 = env.watch(helloQuery, {}, fn1)
+    const release2 = env.watch(helloQuery, {}, fn2)
 
     expect(helloQuery.resolver).toHaveBeenCalledTimes(0)
     await join1()

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -33,7 +33,7 @@ it('resolves a query', async () => {
         }),
     )
 
-    expect(env.peek(helloQuery, null)).toEqual({ loading: true })
+    expect(env.peek(helloQuery, {})).toEqual({ loading: true })
 
     const [fn, join] = createJoinableFn()
     const release = env.watch(helloQuery, {}, fn)
@@ -53,7 +53,7 @@ it('rejects a query', async () => {
         }),
     )
 
-    expect(env.peek(helloQuery, null)).toEqual({ loading: true })
+    expect(env.peek(helloQuery, {})).toEqual({ loading: true })
 
     const [fn, join] = createJoinableFn()
     const release = env.watch(helloQuery, {}, fn)
@@ -81,7 +81,7 @@ it('resolves and updates nested queries', async () => {
         }),
     )
 
-    expect(env.peek(helloQuery, null)).toEqual({ loading: true })
+    expect(env.peek(helloQuery, {})).toEqual({ loading: true })
 
     const [fn, join] = createJoinableFn()
     const release = env.watch(helloQuery, {}, fn)
@@ -90,7 +90,7 @@ it('resolves and updates nested queries', async () => {
     expect(result).toEqual({ value: 'hello, world' })
 
     name = "y'all"
-    env.invalidate(nameQuery, null)
+    env.invalidate(nameQuery, {})
 
     result = await join()
     expect(result).toEqual({ value: "hello, y'all" })
@@ -170,14 +170,16 @@ it('resolves a query with variables', async () => {
 })
 
 it('resolves recursive queries', async () => {
-    const factorialQuery = Query.create(async (n: number, resolve) => {
-        if (n === 0) return 1
-        const result: number = await resolve(factorialQuery, n - 1)
-        return result * n
-    })
+    const factorialQuery = Query.create(
+        async ({ n }: { n: number }, resolve) => {
+            if (n === 0) return 1
+            const result: number = await resolve(factorialQuery, { n: n - 1 })
+            return result * n
+        },
+    )
 
     const [fn, join] = createJoinableFn()
-    const release = env.watch(factorialQuery, 4, fn)
+    const release = env.watch(factorialQuery, { n: 4 }, fn)
     const result = await join()
     expect(result).toEqual({ value: 24 })
 

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -5,16 +5,61 @@ beforeEach(() => {
     env = new QueryEnvironment()
 })
 
-it('resolve some value', () =>
-    new Promise(resolve => {
-        const HelloWorld = Query.create(async () => {
-            return 'hello, world'
-        })
+const createWaitableFn = <Value>(): [
+    (value: Value) => void,
+    Promise<Value>,
+] => {
+    let resolve: any
+    let resolved = false
+    const fn = jest.fn().mockImplementation(result => {
+        if (resolved) throw new Error('resolved twice')
+        resolved = true
+        resolve(result)
+    })
+    const promise = new Promise<Value>(r => {
+        resolve = r
+    })
+    return [fn, promise]
+}
 
-        expect(env.peek(HelloWorld, {})).toEqual({ loading: true })
-        const release = env.watch(HelloWorld, {}, result => {
-            expect(result).toEqual({ value: 'hello, world' })
-            release()
-            resolve()
-        })
-    }))
+it('resolves a query', async () => {
+    const HelloWorld = Query.create(async () => {
+        return 'hello, world'
+    })
+    const [fn, promise] = createWaitableFn()
+
+    expect(env.peek(HelloWorld, {})).toEqual({ loading: true })
+    const release = env.watch(HelloWorld, {}, fn)
+    const result = await promise
+
+    expect(result).toEqual({ value: 'hello, world' })
+    release()
+})
+
+// it('resolves nested queries', () =>
+//     new Promise(resolve => {
+//         let name = 'world'
+
+//         const GetName = Query.create(async () => {
+//             return name
+//         })
+
+//         const HelloWorld = Query.create(async (vars, resolve) => {
+//             const name = await resolve(GetName, {})
+//             return 'hello, ' + name
+//         })
+
+//         expect(env.peek(HelloWorld, {})).toEqual({ loading: true })
+//         const release = env.watch(HelloWorld, {}, result => {
+//             expect(result).toEqual({ value: 'hello, world' })
+//             const release2 = env.watch(HelloWorld, {}, result => {
+//                 expect(result).toEqual({ value: 'hello, there' })
+//                 release2()
+//                 resolve()
+//             })
+//             release()
+
+//             name = 'there'
+//             env.invalidate(GetName, {})
+//         })
+//     }))

--- a/projects/Mallard/src/helpers/__tests__/queries.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/queries.spec.ts
@@ -1,0 +1,20 @@
+import { Query, QueryEnvironment } from '../queries'
+
+let env: QueryEnvironment
+beforeEach(() => {
+    env = new QueryEnvironment()
+})
+
+it('resolve some value', () =>
+    new Promise(resolve => {
+        const HelloWorld = Query.create(async () => {
+            return 'hello, world'
+        })
+
+        expect(env.peek(HelloWorld, {})).toEqual({ loading: true })
+        const release = env.watch(HelloWorld, {}, result => {
+            expect(result).toEqual({ value: 'hello, world' })
+            release()
+            resolve()
+        })
+    }))

--- a/projects/Mallard/src/helpers/location-permission.ts
+++ b/projects/Mallard/src/helpers/location-permission.ts
@@ -5,38 +5,21 @@ import {
     PermissionStatus,
 } from 'react-native-permissions'
 import { Platform } from 'react-native'
-import { ApolloClient } from 'apollo-client'
-import { refreshWeather } from './weather'
+import { Query, QueryEnvironment } from './queries'
 
 const LOCATION_PERMISSION = Platform.select({
     ios: PERMISSIONS.IOS.LOCATION_WHEN_IN_USE,
     android: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
 })
 
-const { resolveLocationPermissionStatus, requestLocationPermission } = (() => {
-    let promise: Promise<PermissionStatus> | undefined
+export const PERMISSION_STATUS_QUERY = Query.create(async () => {
+    return await check(LOCATION_PERMISSION)
+})
 
-    const resolveLocationPermissionStatus = () => {
-        if (promise) return promise
-        promise = check(LOCATION_PERMISSION)
-        return promise
-    }
-
-    const requestLocationPermission = async (
-        apolloClient: ApolloClient<object>,
-    ): Promise<PermissionStatus> => {
-        promise = request(LOCATION_PERMISSION)
-        const result = await promise
-        apolloClient.writeData({
-            data: {
-                locationPermissionStatus: result,
-            },
-        })
-        refreshWeather(apolloClient)
-        return result
-    }
-
-    return { resolveLocationPermissionStatus, requestLocationPermission }
-})()
-
-export { resolveLocationPermissionStatus, requestLocationPermission }
+export const requestLocationPermission = async (
+    env: QueryEnvironment,
+): Promise<PermissionStatus> => {
+    const result = await request(LOCATION_PERMISSION)
+    env.invalidate(PERMISSION_STATUS_QUERY, undefined)
+    return result
+}

--- a/projects/Mallard/src/helpers/location-permission.ts
+++ b/projects/Mallard/src/helpers/location-permission.ts
@@ -12,7 +12,7 @@ const LOCATION_PERMISSION = Platform.select({
     android: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
 })
 
-export const PERMISSION_STATUS_QUERY = Query.create(async () => {
+export const LOCATION_PERMISSION_STATUS_QUERY = Query.create(async () => {
     return await check(LOCATION_PERMISSION)
 })
 
@@ -20,6 +20,6 @@ export const requestLocationPermission = async (
     env: QueryEnvironment,
 ): Promise<PermissionStatus> => {
     const result = await request(LOCATION_PERMISSION)
-    env.invalidate(PERMISSION_STATUS_QUERY, undefined)
+    env.invalidate(LOCATION_PERMISSION_STATUS_QUERY, {})
     return result
 }

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -1,30 +1,62 @@
 import { useEffect, useState, useContext, createContext } from 'react'
 
+/**
+ * Keeps track of the state of a specific query run with specific variables.
+ */
 type QueryNode = {
+    /* Identifies uniquely this node in the graph, built from the query ID and
+     * variables. */
     key: string
+    /* The query being run. */
     query: Query<unknown, unknown>
-    promise: Promise<unknown> | undefined
-    value: unknown
-    error: unknown
+    /* The variables used to run the query. */
     variables: unknown
+    /* If the query is running right now, this will be defined. Set to
+     * `undefined` once we got a result value (or an error). */
+    promise: Promise<unknown> | undefined
+    /* The value the query resolved to. `undefined` if we didn't
+     * get a result yet. */
+    value: unknown
+    /* Same as `value` but in case the query was rejected. */
+    error: unknown
+    /* Keeps track of the keys of other nodes this query run depend on. */
     deps: Set<string>
+    /* Reverse-linking of `deps` ("predecessors"). */
     preds: Set<string>
+    /* Functions that must be called when the value/error state changes. */
     listeners: (() => void)[]
 }
 
-type AllowedVariables = { [key: string]: number | string }
+/**
+ * Only plain JavaScript types are allowed in variables because it needs to
+ * be serializable with `JSON.stringify()`
+ */
+type AllowedVariableValues = number | string | boolean
+type AllowedVariables = {
+    [key: string]: AllowedVariableValues
+}
 
+/**
+ * Resolves a query which the currently running query depends on.
+ */
 export type LocalResolver = <Value, Variables>(
     query: Query<Value, Variables>,
     variables: Variables,
 ) => Promise<Value>
 
+/**
+ * Entry point for a query.
+ */
 export type QueryResolver<Value, Variables> = (
     variables: Variables,
     resolve: LocalResolver,
     prevValue: Value,
 ) => Promise<Value>
 
+/**
+ * Explicitly adding `undefined` fields makes refinement easier
+ * for consumer code.
+ */
 export type QueryResult<Value> =
     | { loading: true; value: undefined; error: undefined }
     | { loading: undefined; value: Value; error: undefined }
@@ -38,12 +70,24 @@ const formatResult = <Value>(node: QueryNode): QueryResult<Value> => {
 
 const EMPTY_STR_SET: Set<string> = new Set()
 
+class QueryAbortedError extends Error {
+    constructor() {
+        super(
+            'The current query has been aborted because one of its ' +
+                'dependencies got invalidated.',
+        )
+    }
+}
+
+/**
+ * Keeps track of query promises, results, errors and inter-dependencies.
+ */
 export class QueryEnvironment {
     private _graph = new Map<string, QueryNode>()
 
     /**
-     * Given the specific `query`, call `callback` everytime the value changes.
-     * If the query hasn't been resolved yet, this function will do so.
+     * Given the specific `query`, call `callback` every time its value changes.
+     * If the query hasn't been started yet, this function will do so.
      */
     watch<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
@@ -61,6 +105,11 @@ export class QueryEnvironment {
         }
     }
 
+    /**
+     * Look at the current value of a particular `query` without having any
+     * side effect. If the query has never been run and is not running, return
+     * as if it was loading, but do not trigger an actual run.
+     */
     peek<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
         variables: Variables,
@@ -71,6 +120,12 @@ export class QueryEnvironment {
         return formatResult(node)
     }
 
+    /**
+     * Mark a `query` with particular `variables` as now being stale and
+     * in need to be run again. If it never ran before, nothing happens.
+     * Otherwise it is run along all the queries depending on it, and listeners
+     * are notified of the new values.
+     */
     invalidate<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
         variables: Variables,
@@ -112,10 +167,51 @@ export class QueryEnvironment {
         return node
     }
 
+    private _resolve(
+        parentNode: QueryNode,
+        run: { promise: Promise<unknown> | undefined },
+        query: Query<unknown, unknown>,
+        variables: unknown,
+    ) {
+        if (run.promise !== parentNode.promise) throw new QueryAbortedError()
+
+        const subNode = this._getNode(query, variables)
+        parentNode.deps.add(subNode.key)
+        subNode.preds.add(parentNode.key)
+        if (subNode.promise !== undefined) return subNode.promise
+        if (subNode.value !== undefined) return Promise.resolve(subNode.value)
+        if (subNode.error !== undefined) return Promise.reject(subNode.error)
+        throw new Error('inconsistent graph')
+    }
+
+    private async _handleNodePromise(
+        node: QueryNode,
+        promise: Promise<unknown>,
+    ) {
+        let value, error
+        try {
+            value = await promise
+        } catch (err) {
+            error = err
+        }
+        // if the node has been refreshed again in between, we ignore results
+        if (node.promise !== promise) return
+        node.promise = undefined
+        node.value = value
+        node.error = error
+
+        for (const listener of node.listeners) {
+            listener()
+        }
+    }
+
     private _refresh(node: QueryNode, trail: Set<string>) {
         if (trail.has(node.key))
             throw new Error('circular dependency between queries')
 
+        // We first remove all our dependencies. This is because the new run
+        // of the resolver might well depend on a different set of
+        // queries/variables, so we're going to collect them from scratch.
         for (const depKey of node.deps) {
             const dep = this._graph.get(depKey)
             if (dep === undefined || !dep.preds.has(node.key))
@@ -124,57 +220,31 @@ export class QueryEnvironment {
         }
         node.deps.clear()
 
-        const resolve = (
-            query: Query<unknown, unknown>,
-            variables: unknown,
-        ) => {
-            const subNode = this._getNode(query, variables)
-            node.deps.add(subNode.key)
-            subNode.preds.add(node.key)
-            if (subNode.promise !== undefined) return subNode.promise
-            if (subNode.value !== undefined)
-                return Promise.resolve(subNode.value)
-            if (subNode.error !== undefined)
-                return Promise.reject(subNode.error)
-            throw new Error('inconsistent graph')
-        }
-
         const prevValue = node.value
+        let run = { promise: undefined as (Promise<unknown> | undefined) }
+        const resolve: any = this._resolve.bind(this, node, run)
+
+        // Use `Promise.resolve()` to ensure that `resolve` is only ever called
+        // when this function is done running (ie. asynchronously).
         const promise = Promise.resolve().then(() =>
-            node.query.resolver(
-                node.variables,
-                (resolve as unknown) as LocalResolver,
-                prevValue,
-            ),
+            node.query.resolver(node.variables, resolve, prevValue),
         )
+        run.promise = promise
         node.promise = promise
-        promise
-            .then(
-                value => {
-                    if (node.promise !== promise) return
-                    node.promise = undefined
-                    node.value = value
-                },
-                error => {
-                    if (node.promise !== promise) return
-                    node.promise = undefined
-                    node.error = error
-                },
-            )
-            .then(() => {
-                for (const listener of node.listeners) {
-                    listener()
-                }
+        this._handleNodePromise(node, promise).catch(error => {
+            // "Escape" the Promise to throw in the global context so that
+            // this triggers the global "unhandled errors" handler.
+            setImmediate(() => {
+                throw error
             })
-            .catch(error => {
-                setImmediate(() => {
-                    throw error
-                })
-            })
+        })
 
         const innerTrail = new Set(trail)
         innerTrail.add(node.key)
 
+        // Now that the promise is set-up, trigger a refresh of all the nodes
+        // that depends on the one being refreshed. They'll likely try to
+        // resolve it again, and thus await on our fresh promise.
         for (const predKey of node.preds) {
             const pred = this._graph.get(predKey)
             if (pred === undefined || !pred.deps.has(node.key))
@@ -183,6 +253,10 @@ export class QueryEnvironment {
         }
     }
 
+    /**
+     * When there is no more listeners or predecessors on a node, we can
+     * forget about it and drop the data.
+     */
     private _releaseNode(node: QueryNode): void {
         if (node.listeners.length > 0 || node.preds.size > 0) return
         for (const depKey of node.deps) {
@@ -198,20 +272,12 @@ export class QueryEnvironment {
 export class Query<Value, Variables> {
     private static _nextId = 1
 
-    private _resolver: QueryResolver<Value, Variables>
-    private _id: number
+    public readonly resolver: QueryResolver<Value, Variables>
+    public readonly id: number
 
     private constructor(resolver: QueryResolver<Value, Variables>) {
-        this._id = Query._nextId++
-        this._resolver = resolver
-    }
-
-    get id() {
-        return this._id
-    }
-
-    get resolver() {
-        return this._resolver
+        this.id = Query._nextId++
+        this.resolver = resolver
     }
 
     static create<Value, Variables>(
@@ -231,6 +297,11 @@ export const useQueryEnvironment = (): QueryEnvironment => {
     return env
 }
 
+/**
+ * From a React component, give the current status of a `query` and re-render
+ * when any changes happens. For example if the query is invalidated and the
+ * result is different.
+ */
 export const useQuery = <Value, Variables extends AllowedVariables>(
     query: Query<Value, Variables>,
     variables: Variables,
@@ -238,12 +309,11 @@ export const useQuery = <Value, Variables extends AllowedVariables>(
     const env = useQueryEnvironment()
     const [result, setResult] = useState(env.peek(query, variables))
     const serializedVars = JSON.stringify(variables)
-    useEffect(
-        () =>
-            env.watch(query, JSON.parse(serializedVars), newResult => {
-                setResult(newResult)
-            }),
+    useEffect(() => env.watch(query, JSON.parse(serializedVars), setResult), [
+        // We don't want to depend on an object by referential equality, but
+        // instead rely on the object as a value. The easiest way to do this is
+        // to serialize that value.
         [env, query, serializedVars],
-    )
+    ])
     return result
 }

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -15,7 +15,7 @@ type QueryNode = {
 type LocalResolver = <Value, Variables>(
     query: Query<Value, Variables>,
     variables: Variables,
-) => QueryResult<Value>
+) => Promise<Value>
 
 type QueryResolver<Value, Variables> = (
     variables: Variables,

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -12,6 +12,8 @@ type QueryNode = {
     listeners: (() => void)[]
 }
 
+type AllowedVariables = { [key: string]: number | string }
+
 export type LocalResolver = <Value, Variables>(
     query: Query<Value, Variables>,
     variables: Variables,
@@ -43,7 +45,7 @@ export class QueryEnvironment {
      * Given the specific `query`, call `callback` everytime the value changes.
      * If the query hasn't been resolved yet, this function will do so.
      */
-    watch<Value, Variables>(
+    watch<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
         variables: Variables,
         listener: (value: QueryResult<Value>) => unknown,
@@ -59,7 +61,7 @@ export class QueryEnvironment {
         }
     }
 
-    peek<Value, Variables>(
+    peek<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
         variables: Variables,
     ): QueryResult<Value> {
@@ -69,7 +71,7 @@ export class QueryEnvironment {
         return formatResult(node)
     }
 
-    invalidate<Value, Variables>(
+    invalidate<Value, Variables extends AllowedVariables>(
         query: Query<Value, Variables>,
         variables: Variables,
     ): void {
@@ -229,7 +231,7 @@ export const useQueryEnvironment = (): QueryEnvironment => {
     return env
 }
 
-export const useQuery = <Value, Variables>(
+export const useQuery = <Value, Variables extends AllowedVariables>(
     query: Query<Value, Variables>,
     variables: Variables,
 ): QueryResult<Value> => {

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -107,6 +107,7 @@ export class QueryEnvironment {
             preds: new Set(),
             listeners: [],
         }
+        this._graph.set(key, node)
         this._refresh(node)
         return node
     }

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -235,12 +235,13 @@ export const useQuery = <Value, Variables>(
 ): QueryResult<Value> => {
     const env = useQueryEnvironment()
     const [result, setResult] = useState(env.peek(query, variables))
+    const serializedVars = JSON.stringify(variables)
     useEffect(
         () =>
-            env.watch(query, variables, newResult => {
+            env.watch(query, JSON.parse(serializedVars), newResult => {
                 setResult(newResult)
             }),
-        [query, variables],
+        [env, query, serializedVars],
     )
     return result
 }

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react'
-import { watch } from 'fs'
+import { useEffect, useState, useContext, createContext } from 'react'
 
 type QueryNode = {
     key: string
@@ -8,58 +7,88 @@ type QueryNode = {
     value: unknown
     error: unknown
     variables: unknown
-    deps: string[]
-    preds: string[]
+    deps: Set<string>
+    preds: Set<string>
     listeners: (() => void)[]
 }
 
-type Resolver = <RValue, RVars>(
-    query: Query<RValue, RVars>,
-    variables: RVars,
-) => QueryResult<RValue>
+type LocalResolver = <Value, Variables>(
+    query: Query<Value, Variables>,
+    variables: Variables,
+) => QueryResult<Value>
+
 type QueryResolver<Value, Variables> = (
     variables: Variables,
-    resolve: Resolver,
+    resolve: LocalResolver,
 ) => Promise<Value>
+
+type Invalidate<Variables> = (
+    env: QueryEnvironment,
+    variables: Variables,
+) => void
 
 export type QueryResult<Value> =
     | { loading: true }
     | { value: Value }
-    | { error: Error }
+    | { error: unknown }
 
-const formatResult = <Value>(node: QueryNode) => {
-    return {
-        value: node.value,
-        error: node.error,
-        loading:
-            node.value == null && node.error == null && node.promise != null,
-    } as QueryResult<Value>
+const formatResult = <Value>(node: QueryNode): QueryResult<Value> => {
+    if (node.value) return { value: node.value as Value }
+    if (node.error) return { error: node.error }
+    return { loading: true }
 }
 
-export class Query<Value, Variables> {
-    private static _graph = new Map<string, QueryNode>()
-    private _resolver: QueryResolver<Value, Variables>
+export class QueryEnvironment {
+    private _graph = new Map<string, QueryNode>()
 
-    private _id: number
-    private static _nextId = 1
-
-    private constructor(resolver: QueryResolver<Value, Variables>) {
-        this._id = Query._nextId++
-        this._resolver = resolver
+    /**
+     * Given the specific `query`, call `callback` everytime the value changes.
+     * If the query hasn't been resolved yet, this function will do so.
+     */
+    watch<Value, Variables>(
+        query: Query<Value, Variables>,
+        variables: Variables,
+        listener: (value: QueryResult<Value>) => unknown,
+    ): () => void {
+        const node = this._getNode(query, variables)
+        const callback = () => {
+            listener(formatResult(node))
+        }
+        node.listeners.push(callback)
+        return () => {
+            node.listeners.splice(node.listeners.indexOf(callback), 1)
+            this._releaseNode(node)
+        }
     }
 
-    static create<Value, Variables>(resolver: QueryResolver<Value, Variables>) {
-        return new Query(resolver)
+    peek<Value, Variables>(
+        query: Query<Value, Variables>,
+        variables: Variables,
+    ): QueryResult<Value> {
+        const key = this._getKey(query, variables)
+        const node = this._graph.get(key)
+        if (node === undefined) return { loading: true }
+        return formatResult(node)
     }
 
-    private static _getKey<Value, Variables>(
+    invalidate<Value, Variables>(
+        query: Query<Value, Variables>,
+        variables: Variables,
+    ): void {
+        const key = this._getKey(query, variables)
+        const node = this._graph.get(key)
+        if (node === undefined) return
+        this._refresh(node)
+    }
+
+    private _getKey<Value, Variables>(
         query: Query<Value, Variables>,
         variables: Variables,
     ) {
-        return query._id + ':' + JSON.stringify(variables)
+        return query.id + ':' + JSON.stringify(variables)
     }
 
-    private static _getNode<Value, Variables>(
+    private _getNode<Value, Variables>(
         query: Query<Value, Variables>,
         variables: Variables,
     ): QueryNode {
@@ -67,95 +96,137 @@ export class Query<Value, Variables> {
         let node = this._graph.get(key)
         if (node !== undefined) return node
 
-        const qnode: QueryNode = {
+        node = {
             key,
             query,
             promise: undefined,
             value: undefined,
             error: undefined,
             variables,
-            deps: [],
-            preds: [],
+            deps: new Set(),
+            preds: new Set(),
             listeners: [],
         }
+        this._refresh(node)
+        return node
+    }
+
+    private _refresh(node: QueryNode) {
+        for (const depKey of node.deps) {
+            const dep = this._graph.get(depKey)
+            if (dep === undefined) throw new Error('inconsistent graph')
+            dep.preds.delete(node.key)
+        }
+        node.deps.clear()
+
         const resolve = (
             query: Query<unknown, unknown>,
             variables: unknown,
         ) => {
             const subNode = this._getNode(query, variables)
-            qnode.deps.push(subNode.key)
-            subNode.preds.push(qnode.key)
+            node.deps.add(subNode.key)
+            subNode.preds.add(node.key)
+            if (subNode.promise !== undefined) return subNode.promise
             if (subNode.value !== undefined)
                 return Promise.resolve(subNode.value)
             if (subNode.error !== undefined)
-                return Promise.resolve(subNode.error)
-            return subNode.promise
+                return Promise.reject(subNode.error)
+            throw new Error('inconsistent graph')
         }
 
-        const promise = query._resolver(
-            variables,
-            (resolve as unknown) as Resolver,
+        const promise = (node.query as Query<unknown, unknown>).resolver(
+            node.variables,
+            (resolve as unknown) as LocalResolver,
         )
-        qnode.promise = promise
-        promise.then(
-            value => {
-                qnode.promise = undefined
-                qnode.value = value
-            },
-            error => {
-                qnode.promise = undefined
-                qnode.error = error
-            },
-        )
-        return qnode
+        node.promise = promise
+        promise
+            .then(
+                value => {
+                    if (node.promise !== promise) return
+                    node.promise = undefined
+                    node.value = value
+                },
+                error => {
+                    if (node.promise !== promise) return
+                    node.promise = undefined
+                    node.error = error
+                },
+            )
+            .then(() => {
+                for (const listener of node.listeners) {
+                    listener()
+                }
+            })
+            .catch(error => {
+                setImmediate(() => {
+                    throw error
+                })
+            })
+
+        for (const predKey of node.preds) {
+            const pred = this._graph.get(predKey)
+            if (pred === undefined) throw new Error('inconsistent graph')
+            this._refresh(pred)
+        }
     }
 
-    private static _releaseNode(node: QueryNode): void {
-        if (node.listeners.length > 0 || node.preds.length > 0) return
+    private _releaseNode(node: QueryNode): void {
+        if (node.listeners.length > 0 || node.preds.size > 0) return
         for (const depKey of node.deps) {
             const dnode = this._graph.get(depKey)
             if (dnode === undefined) throw new Error('inconsistent state')
-            dnode.preds.splice(dnode.preds.indexOf(node.key))
+            dnode.preds.delete(node.key)
             this._releaseNode(dnode)
         }
         this._graph.delete(node.key)
     }
+}
 
-    /**
-     * Given the specific `query`, call `callback` everytime the value changes.
-     * If the query hasn't been resolved yet, this function will do so.
-     */
-    watch(
-        variables: Variables,
-        listener: (value: QueryResult<Value>) => unknown,
-    ): () => void {
-        const node = Query._getNode(this, variables)
-        const callback = () => {
-            listener(formatResult(node))
-        }
-        node.listeners.push(callback)
-        return () => {
-            node.listeners.splice(node.listeners.indexOf(callback), 1)
-            Query._releaseNode(node)
-        }
+export class Query<Value, Variables> {
+    private static _nextId = 1
+
+    private _resolver: QueryResolver<Value, Variables>
+    private _id: number
+
+    private constructor(resolver: QueryResolver<Value, Variables>) {
+        this._id = Query._nextId++
+        this._resolver = resolver
     }
 
-    peek(variables: Variables): QueryResult<Value> {
-        const key = Query._getKey(this, variables)
-        const node = Query._graph.get(key)
-        if (node === undefined) return { loading: true }
-        return formatResult(node)
+    get id() {
+        return this._id
     }
+
+    get resolver() {
+        return this._resolver
+    }
+
+    static create<Value, Variables>(
+        resolver: QueryResolver<Value, Variables>,
+    ): Query<Value, Variables> {
+        return new Query(resolver)
+    }
+}
+
+export const QueryEnvironmentContext = createContext<
+    QueryEnvironment | undefined
+>(undefined)
+
+export const useQueryEnvironment = (): QueryEnvironment => {
+    const env = useContext(QueryEnvironmentContext)
+    if (env === undefined) throw new Error('no query environment availalbe')
+    return env
 }
 
 export const useQuery = <Value, Variables>(
     query: Query<Value, Variables>,
     variables: Variables,
 ): QueryResult<Value> => {
-    const [result, setResult] = useState(query.peek(variables))
+    const env = useQueryEnvironment()
+    const [result, setResult] = useState(env.peek(query, variables))
     useEffect(
         () =>
-            query.watch(variables, newResult => {
+            env.watch(query, variables, newResult => {
                 setResult(newResult)
             }),
         [query, variables],

--- a/projects/Mallard/src/helpers/queries.ts
+++ b/projects/Mallard/src/helpers/queries.ts
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react'
+import { watch } from 'fs'
+
+type QueryNode = {
+    key: string
+    query: unknown
+    promise: Promise<unknown> | undefined
+    value: unknown
+    error: unknown
+    variables: unknown
+    deps: string[]
+    preds: string[]
+    listeners: (() => void)[]
+}
+
+type Resolver = <RValue, RVars>(
+    query: Query<RValue, RVars>,
+    variables: RVars,
+) => QueryResult<RValue>
+type QueryResolver<Value, Variables> = (
+    variables: Variables,
+    resolve: Resolver,
+) => Promise<Value>
+
+export type QueryResult<Value> =
+    | { loading: true }
+    | { value: Value }
+    | { error: Error }
+
+const formatResult = <Value>(node: QueryNode) => {
+    return {
+        value: node.value,
+        error: node.error,
+        loading:
+            node.value == null && node.error == null && node.promise != null,
+    } as QueryResult<Value>
+}
+
+export class Query<Value, Variables> {
+    private static _graph = new Map<string, QueryNode>()
+    private _resolver: QueryResolver<Value, Variables>
+
+    private _id: number
+    private static _nextId = 1
+
+    private constructor(resolver: QueryResolver<Value, Variables>) {
+        this._id = Query._nextId++
+        this._resolver = resolver
+    }
+
+    static create<Value, Variables>(resolver: QueryResolver<Value, Variables>) {
+        return new Query(resolver)
+    }
+
+    private static _getKey<Value, Variables>(
+        query: Query<Value, Variables>,
+        variables: Variables,
+    ) {
+        return query._id + ':' + JSON.stringify(variables)
+    }
+
+    private static _getNode<Value, Variables>(
+        query: Query<Value, Variables>,
+        variables: Variables,
+    ): QueryNode {
+        const key = this._getKey(query, variables)
+        let node = this._graph.get(key)
+        if (node !== undefined) return node
+
+        const qnode: QueryNode = {
+            key,
+            query,
+            promise: undefined,
+            value: undefined,
+            error: undefined,
+            variables,
+            deps: [],
+            preds: [],
+            listeners: [],
+        }
+        const resolve = (
+            query: Query<unknown, unknown>,
+            variables: unknown,
+        ) => {
+            const subNode = this._getNode(query, variables)
+            qnode.deps.push(subNode.key)
+            subNode.preds.push(qnode.key)
+            if (subNode.value !== undefined)
+                return Promise.resolve(subNode.value)
+            if (subNode.error !== undefined)
+                return Promise.resolve(subNode.error)
+            return subNode.promise
+        }
+
+        const promise = query._resolver(
+            variables,
+            (resolve as unknown) as Resolver,
+        )
+        qnode.promise = promise
+        promise.then(
+            value => {
+                qnode.promise = undefined
+                qnode.value = value
+            },
+            error => {
+                qnode.promise = undefined
+                qnode.error = error
+            },
+        )
+        return qnode
+    }
+
+    private static _releaseNode(node: QueryNode): void {
+        if (node.listeners.length > 0 || node.preds.length > 0) return
+        for (const depKey of node.deps) {
+            const dnode = this._graph.get(depKey)
+            if (dnode === undefined) throw new Error('inconsistent state')
+            dnode.preds.splice(dnode.preds.indexOf(node.key))
+            this._releaseNode(dnode)
+        }
+        this._graph.delete(node.key)
+    }
+
+    /**
+     * Given the specific `query`, call `callback` everytime the value changes.
+     * If the query hasn't been resolved yet, this function will do so.
+     */
+    watch(
+        variables: Variables,
+        listener: (value: QueryResult<Value>) => unknown,
+    ): () => void {
+        const node = Query._getNode(this, variables)
+        const callback = () => {
+            listener(formatResult(node))
+        }
+        node.listeners.push(callback)
+        return () => {
+            node.listeners.splice(node.listeners.indexOf(callback), 1)
+            Query._releaseNode(node)
+        }
+    }
+
+    peek(variables: Variables): QueryResult<Value> {
+        const key = Query._getKey(this, variables)
+        const node = Query._graph.get(key)
+        if (node === undefined) return { loading: true }
+        return formatResult(node)
+    }
+}
+
+export const useQuery = <Value, Variables>(
+    query: Query<Value, Variables>,
+    variables: Variables,
+): QueryResult<Value> => {
+    const [result, setResult] = useState(query.peek(variables))
+    useEffect(
+        () =>
+            query.watch(variables, newResult => {
+                setResult(newResult)
+            }),
+        [query, variables],
+    )
+    return result
+}

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -150,7 +150,6 @@ const ONE_HOUR = MS_IN_A_SECOND * SECS_IN_A_MINUTE * MINS_IN_AN_HOUR
  */
 export const WEATHER_QUERY = Query.create(
     async (_, resolve, prevValue: Weather | undefined) => {
-        console.warn('fetching weather')
         return await getWeather(resolve, prevValue)
     },
 )
@@ -158,9 +157,12 @@ export const WEATHER_QUERY = Query.create(
 export const registerLiveWeather = (env: QueryEnvironment) => {
     AppState.addEventListener('change', status => {
         if (status !== 'active') return
-        const result = env.peek(WEATHER_QUERY, undefined)
-        if (result.value == null) return
-        if (Date.now() < result.value.lastUpdated + ONE_HOUR) return
-        env.invalidate(WEATHER_QUERY, undefined)
+        const result = env.peek(WEATHER_QUERY, {})
+        if (
+            result.value != null &&
+            Date.now() < result.value.lastUpdated + ONE_HOUR
+        )
+            return
+        env.invalidate(WEATHER_QUERY, {})
     })
 }

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -1,10 +1,9 @@
 import { AccuWeatherLocation, Forecast } from 'src/common'
 import { AppState } from 'react-native'
-import ApolloClient from 'apollo-client'
 import Geolocation, {
     GeolocationResponse,
 } from '@react-native-community/geolocation'
-import { PERMISSION_STATUS_QUERY } from './location-permission'
+import { LOCATION_PERMISSION_STATUS_QUERY } from './location-permission'
 import { RESULTS } from 'react-native-permissions'
 import { Query, QueryEnvironment, LocalResolver } from './queries'
 
@@ -64,7 +63,7 @@ const getIpBasedLocation = async () => {
 }
 
 const getCurrentLocation = async (resolve: LocalResolver) => {
-    const permStatus = await resolve(PERMISSION_STATUS_QUERY, undefined)
+    const permStatus = await resolve(LOCATION_PERMISSION_STATUS_QUERY, {})
     if (permStatus !== RESULTS.GRANTED) {
         return await getIpBasedLocation()
     }
@@ -151,6 +150,7 @@ const ONE_HOUR = MS_IN_A_SECOND * SECS_IN_A_MINUTE * MINS_IN_AN_HOUR
  */
 export const WEATHER_QUERY = Query.create(
     async (_, resolve, prevValue: Weather | undefined) => {
+        console.warn('fetching weather')
         return await getWeather(resolve, prevValue)
     },
 )

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -10,6 +10,7 @@ import { Button, ButtonAppearance } from 'src/components/button/button'
 import { requestLocationPermission } from 'src/helpers/location-permission'
 import { RESULTS } from 'react-native-permissions'
 import { getGeolocation } from 'src/helpers/weather'
+import { useQueryEnvironment } from 'src/helpers/queries'
 
 const content = html`
     <h2>Location-based weather</h2>
@@ -66,8 +67,9 @@ const WeatherGeolocationConsentScreen = ({
     navigation,
 }: NavigationInjectedProps) => {
     const apolloClient = useApolloClient()
+    const env = useQueryEnvironment()
     const onConsentPress = async () => {
-        const result = await requestLocationPermission(apolloClient)
+        const result = await requestLocationPermission(env)
         if (result === RESULTS.BLOCKED) {
             Alert.alert(
                 'Location permission',


### PR DESCRIPTION
## Summary

Now that I've worked with Apollo a little bit more for local state, I could find a lot of shortcomings for handling local data while on the other hand we're not leveraging its remote data mechanism/GraphQL. Notably the way to invalidate is to write directly into the cache global values, which is error-prone. Additionally, Apollo doesn't cache values per-field promises, but instead per GraphQL query data, so we have to manually cache Promises. It's is not correctly typed. Finally, it doesn't allow a resolver to depend on another cleanly.

This changeset replaces Apollo with a little "query library" that I think is much better fitted, but it's proposal-stage for now. It is (1) strongly typed, (2) caches promises, (3) allows queries to depend on each other, (4) have a clean API for invalidating the cache (no direct writes). This would replace Apollo completely and all other usages of "cachedOrPromise" as well.

The API for this "query library" has 2 main functions:

* `watch`: to get the result + regular updates of some asynchronous function that might or might have not run yet. For example to fetch Issues Summary, a file's content, a specific issue, a setting, weather, etc. Can be anything.

* `invalidate`: to tell the system *"okay, this result isn't valid anymore, refetch!"*. For example if we know the filesystem changed, we invalidate the FS query. If we know a setting changed, we invalidate the setting query. The good thing is that this will also invalidate *any query that depends on the invalidated query*. So things are always consistent.

On top of this, we have `useQuery` which is just a light wrapper on top of `watch` for easy use from React components.

Finally, queries are cached in a "environment", so no globals anymore. In React world, this is being passed with a Context.

To see the impact this change has, check out the file `weather.ts`, which is greatly simplified compared to being Apollo-based.

This is also inspired from [react-query](https://github.com/tannerlinsley/react-query), but less complex API-wise and with two improvements: (1) no global string IDs, so much less risk of typos; (2) ability to have queries depend on each other and automatically refresh when something is invalidated.

## Test Plan

Tested the flow related to permisions/weather, but this needs a bit more discussion anyway.