### PR TITLE
Add NSLocationAlwaysUsageDescription in iOS plist file

### DIFF
--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -123,5 +123,7 @@
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location-based weather</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Location-based weather</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

> TMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSLocationAlwaysUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. Learn more (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy).

We don't actually use "always on" location, but apparently it's required if we use the closely related "NSLocationWhenInUseUsageDescription".

## Test Plan

We'll know if that's all good only when submitting to App Store, I think.
