### PR TITLE
prevent sliding onto crosswords

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -167,20 +167,24 @@ const IssueFronts = ({
                         ...front,
                         cards: flatCollections,
                     })
-                    const specs = flattenFlatCardsToFront(flatCollections).map(
-                        ({ article, collection }) => ({
+                    const specs = flattenFlatCardsToFront(flatCollections)
+                        // Exlude crosswords because we don't want to be able to
+                        // "slide" onto them.
+                        .filter(({ article }) => article.type !== 'crossword')
+                        .map(({ article, collection }) => ({
                             collection: collection.key,
                             front: front.key,
                             article: article.key,
                             localIssueId: issue.localId,
                             publishedIssueId: issue.publishedId,
-                        }),
-                    )
-                    acc.frontSpecs.push({
-                        appearance: front.appearance,
-                        frontName: front.displayName || '',
-                        articleSpecs: specs,
-                    })
+                        }))
+                    if (specs.length > 0) {
+                        acc.frontSpecs.push({
+                            appearance: front.appearance,
+                            frontName: front.displayName || '',
+                            articleSpecs: specs,
+                        })
+                    }
                     return acc
                 },
                 {


### PR DESCRIPTION
## Summary

Crosswords are "fullscreen" with no slider so we don't want to be able to slide onto them. This changeset removes them from the "articleNavigator" (a bit of an odd name for what is just the slide-able list of fronts) collection.

## Test Plan

1. Open close to thelast article of the slidable articles, ex. last article of Sports. Verify sliding left and right works. Verify it's not possible to slide beyond the last Sports article (or whichever last Front it right before Crosswords).
2. Verify opening the Crosswords works as expected.

