### PR TITLE
fix: Android Sentry

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
@@ -36,7 +36,6 @@ public class MainApplication extends Application implements ReactApplication {
             packages.add(new ReleaseStreamPackage());
 
             // packages.add(new MainReactPackage(),
-            packages.add(new RNSentryPackage());
             // packages.add(new RNDeviceInfo());
             // packages.add(new NetInfoPackage());
             // packages.add(new RNSentryPackage());


### PR DESCRIPTION
## Summary
In order to install Sentry, it goes through a "Wizard" which requires some "linking" which is not necessarily required in our version of React Native.

Removing this line fixes the build