### PR TITLE
use the correct pillar to render articles

### DIFF
--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -263,8 +263,6 @@ const ArticleSlider = ({
 
     const currentArticle = flattenedArticles[Math.floor(current)]
 
-    const pillar = getAppearancePillar(currentArticle.appearance)
-
     const sliderSections = articleNavigator.reduce(
         (sectionsWithStartIndex, frontSpec) => {
             const sections = sectionsWithStartIndex.sections.concat({
@@ -309,7 +307,9 @@ const ArticleSlider = ({
                                 <ArticleScreenBody
                                     width={width}
                                     path={item}
-                                    pillar={pillar}
+                                    pillar={getAppearancePillar(
+                                        item.appearance,
+                                    )}
                                     position={index}
                                     onShouldShowHeaderChange={
                                         onShouldShowHeaderChange
@@ -401,7 +401,7 @@ const ArticleSlider = ({
                     <ArticleScreenBody
                         width={width}
                         path={item}
-                        pillar={pillar}
+                        pillar={getAppearancePillar(item.appearance)}
                         position={index}
                         onShouldShowHeaderChange={onShouldShowHeaderChange}
                         shouldShowHeader={shouldShowHeader}


### PR DESCRIPTION
## Summary

Using the current article's pillar to render all article would cause articles to re-render when swiping from one pillar to the next, reinjecting fresh HTML, breaking scrolling, and displaying the article incorrectly all-in-all.

## Test Plan

Verified that swiping from a Culture to a Jounal article doesn't re-render the article.
