### PR TITLE
add fronts navigation

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -190,7 +190,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
     - Sentry
     - SSZipArchive
@@ -342,4 +342,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 54889dd615f9e881ae29ac8db2b0b3dfd674d019
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -115,7 +115,7 @@ PODS:
     - React
   - RNIap (3.3.9):
     - React
-  - RNInAppBrowser (3.3.3):
+  - RNInAppBrowser (3.0.1):
     - React
   - RNKeychain (3.1.3):
     - React
@@ -329,7 +329,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
-  RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
+  RNInAppBrowser: 24abaaff1fe1d8bea2492537ca32e455b14ef030
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -115,7 +115,7 @@ PODS:
     - React
   - RNIap (3.3.9):
     - React
-  - RNInAppBrowser (3.0.1):
+  - RNInAppBrowser (3.3.3):
     - React
   - RNKeychain (3.1.3):
     - React
@@ -190,7 +190,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - boost-for-react-native
     - Sentry
     - SSZipArchive
@@ -329,7 +329,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
-  RNInAppBrowser: 24abaaff1fe1d8bea2492537ca32e455b14ef030
+  RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
@@ -342,4 +342,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 54889dd615f9e881ae29ac8db2b0b3dfd674d019
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.7.5

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -28,7 +28,6 @@ import { fetch } from 'src/hooks/use-net-info'
 import { useToast } from 'src/hooks/use-toast'
 import { DOWNLOAD_ISSUE_MESSAGE_OFFLINE } from 'src/helpers/words'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
-import { HeadlineText } from '../styled-text'
 
 import { useIssueOnDevice, ExistsStatus } from 'src/hooks/use-issue-on-device'
 import { Front, IssueWithFronts } from '../../../../Apps/common/src'

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -12,7 +12,7 @@ import {
 } from 'src/components/issue/issue-title'
 import { IssueSummary } from 'src/common'
 import { renderIssueDate } from 'src/helpers/issues'
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet, View, Text } from 'react-native'
 import { Highlight } from 'src/components/highlight'
 import {
     DLStatus,
@@ -34,9 +34,13 @@ import { useIssueOnDevice, ExistsStatus } from 'src/hooks/use-issue-on-device'
 import { Front, IssueWithFronts } from '../../../../Apps/common/src'
 import { getColor } from 'src/helpers/transform'
 import { metrics } from 'src/theme/spacing'
+import { getFont } from 'src/theme/typography'
 
-export const ISSUE_ROW_HEADER_HEIGHT = 68
-export const ISSUE_FRONT_ROW_HEIGHT = 40
+const FRONT_TITLE_FONT = getFont('headline', 0.75, 'bold')
+const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
+
+export const ISSUE_ROW_HEADER_HEIGHT = ISSUE_TITLE_FONT.lineHeight * 2.6
+export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.7
 
 const styles = StyleSheet.create({
     frontsSelector: {
@@ -50,9 +54,17 @@ const styles = StyleSheet.create({
         height: ISSUE_FRONT_ROW_HEIGHT,
     },
     frontTitle: {
-        paddingVertical: metrics.vertical * 0.7,
+        height: '100%',
+        flexDirection: 'row',
+        alignContent: 'center',
+        alignItems: 'center',
         paddingHorizontal: metrics.horizontal,
     },
+    frontTitleText: {
+        flexShrink: 0,
+        ...FRONT_TITLE_FONT,
+    },
+
     frontSeparator: {
         height: 1,
         backgroundColor: color.line,
@@ -164,13 +176,15 @@ const IssueFrontRow = React.memo(
                 <View style={styles.frontTitleWrap}>
                     <Highlight onPress={onPress}>
                         <View style={styles.frontTitle}>
-                            <HeadlineText
-                                weight="bold"
-                                style={{ color: textColor }}
+                            <Text
+                                style={[
+                                    styles.frontTitleText,
+                                    { color: textColor },
+                                ]}
                                 numberOfLines={1}
                             >
                                 {front.displayName}
-                            </HeadlineText>
+                            </Text>
                         </View>
                     </Highlight>
                 </View>

--- a/projects/Mallard/src/components/issue/issue-title.tsx
+++ b/projects/Mallard/src/components/issue/issue-title.tsx
@@ -100,27 +100,28 @@ const appearances: {
     }),
 }
 
-const IssueTitle = ({
-    title,
-    subtitle,
-    appearance,
-    style,
-}: IssueTitleProps & { appearance: IssueTitleAppearance }) => (
-    <View style={style}>
-        <IssueTitleText style={[styles.text, appearances[appearance].title]}>
-            {title}
-        </IssueTitleText>
-        {!!subtitle && (
+const IssueTitle = React.memo(
+    ({
+        title,
+        subtitle,
+        appearance = IssueTitleAppearance.default,
+        style,
+    }: IssueTitleProps & { appearance?: IssueTitleAppearance }) => (
+        <View style={style}>
             <IssueTitleText
-                style={[styles.text, appearances[appearance].subtitle]}
+                style={[styles.text, appearances[appearance].title]}
             >
-                {subtitle}
+                {title}
             </IssueTitleText>
-        )}
-    </View>
+            {!!subtitle && (
+                <IssueTitleText
+                    style={[styles.text, appearances[appearance].subtitle]}
+                >
+                    {subtitle}
+                </IssueTitleText>
+            )}
+        </View>
+    ),
 )
-IssueTitle.defaultProps = {
-    appearance: IssueTitleAppearance.default,
-}
 
 export { IssueTitle, GridRowSplit }

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -11,8 +11,7 @@ import { getFont } from 'src/theme/typography'
 const styles = StyleSheet.create({
     background: {
         backgroundColor: color.primary,
-        padding: metrics.vertical,
-        paddingHorizontal: metrics.horizontal,
+        paddingVertical: metrics.vertical,
         justifyContent: 'flex-end',
         flexDirection: 'row',
     },
@@ -20,8 +19,7 @@ const styles = StyleSheet.create({
         backgroundColor: color.background,
         borderBottomColor: color.line,
         borderBottomWidth: StyleSheet.hairlineWidth,
-        padding: metrics.vertical,
-        paddingHorizontal: metrics.horizontal,
+        paddingVertical: metrics.vertical,
         justifyContent: 'flex-end',
         flexDirection: 'row',
     },
@@ -39,6 +37,7 @@ const styles = StyleSheet.create({
     headerTitle: {
         flexGrow: 1,
         flexShrink: 0,
+        paddingHorizontal: metrics.horizontal,
     },
 
     centerWrapper: {
@@ -53,8 +52,13 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         zIndex: 1,
     },
+    leftAction: {
+        zIndex: 2,
+        paddingLeft: metrics.horizontal,
+    },
     centerAction: {
         zIndex: 2,
+        paddingRight: metrics.horizontal,
     },
 })
 
@@ -92,7 +96,11 @@ const Header = ({
             <View style={[bg]}>
                 {layout === 'issue' ? (
                     <GridRowSplit
-                        proxy={leftAction}
+                        proxy={
+                            <View style={{ paddingLeft: metrics.horizontal }}>
+                                {leftAction}
+                            </View>
+                        }
                         style={[{ marginTop }, styles.height]}
                     >
                         <View style={[styles.headerSplit]}>
@@ -116,15 +124,15 @@ const Header = ({
                                     children
                                 )}
                             </View>
-                            {action}
+                            <View style={{ paddingRight: metrics.horizontal }}>
+                                {action}
+                            </View>
                         </View>
                     </GridRowSplit>
                 ) : (
                     <View style={{ marginTop, width: '100%' }}>
                         <View style={[styles.height, styles.centerWrapper]}>
-                            <View style={styles.centerAction}>
-                                {leftAction}
-                            </View>
+                            <View style={styles.leftAction}>{leftAction}</View>
                             <View style={styles.centerAction}>{action}</View>
                             <View style={styles.centerTitle}>{children}</View>
                         </View>

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -311,7 +311,7 @@ const IssueListView = withNavigation(
     ),
 )
 
-const IssueListViewWrapper = ({
+const IssueListViewWithDelay = ({
     issueList,
     currentIssueDetails,
 }: {
@@ -347,7 +347,7 @@ const IssueListViewWrapper = ({
 }
 
 const NO_ISSUES: IssueSummary[] = []
-const IssueListContainer = () => {
+const IssueListFetchContainer = () => {
     const { issueSummary, issueId } = useIssueSummary()
     const { localIssueId = '', publishedIssueId = '' } = issueId || {}
     const resp = useIssueResponse(
@@ -364,13 +364,13 @@ const IssueListContainer = () => {
     return resp({
         error: () => <></>,
         pending: () => (
-            <IssueListViewWrapper
+            <IssueListViewWithDelay
                 issueList={issueSummary || NO_ISSUES}
                 currentIssueDetails={null}
             />
         ),
         success: details => (
-            <IssueListViewWrapper
+            <IssueListViewWithDelay
                 issueList={issueSummary || NO_ISSUES}
                 currentIssueDetails={details}
             />
@@ -399,7 +399,7 @@ export const HomeScreen = ({
                 }}
             />
             {issueSummary ? (
-                <IssueListContainer />
+                <IssueListFetchContainer />
             ) : error ? (
                 <>
                     <FlexErrorMessage

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -16,7 +16,6 @@ export const color = {
     background: palette.neutral[100],
     text: palette.neutral[7],
     dimBackground: palette.neutral[93],
-    // only slightly darker than `dimBackground`
     dimmerBackground: palette.neutral[86],
     dimText: palette.neutral[20],
     darkBackground: palette.neutral[20],

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -17,7 +17,7 @@ export const color = {
     text: palette.neutral[7],
     dimBackground: palette.neutral[93],
     // only slightly darker than `dimBackground`
-    dimmerBackground: '#e3e3e3',
+    dimmerBackground: palette.neutral[86],
     dimText: palette.neutral[20],
     darkBackground: palette.neutral[20],
     photoBackground: palette.neutral[7],

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -16,6 +16,8 @@ export const color = {
     background: palette.neutral[100],
     text: palette.neutral[7],
     dimBackground: palette.neutral[93],
+    // only slightly darker than `dimBackground`
+    dimmerBackground: '#e3e3e3',
     dimText: palette.neutral[20],
     darkBackground: palette.neutral[20],
     photoBackground: palette.neutral[7],

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -36,8 +36,8 @@ export const metrics = {
         sliderRadius,
     },
     gridRowSplit: {
-        narrow: (width: number) => width * 0.7,
-        wide: 250,
+        narrow: (width: number) => width * 0.65,
+        wide: 240,
     },
     slideCardSpacing:
         Platform.OS === 'ios'

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -37,7 +37,7 @@ export const metrics = {
     },
     gridRowSplit: {
         narrow: (width: number) => width * 0.7,
-        wide: 200,
+        wide: 250,
     },
     slideCardSpacing:
         Platform.OS === 'ios'

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -36,7 +36,7 @@ export const metrics = {
         sliderRadius,
     },
     gridRowSplit: {
-        narrow: (width: number) => width * 0.6,
+        narrow: (width: number) => width * 0.7,
         wide: 200,
     },
     slideCardSpacing:


### PR DESCRIPTION
## Summary

Add the list of fronts below the current opened issue. When pressing a front, navigate to that front on the main page of the app.

I had to readjust a number of layout styles and structure to fit the design, so that fronts are properly aligned, so that press "highlights" show up correctly with a good padding.

A lot of the complexity also comes from the scrolling behavior: when pressing an Edition, we scroll the view to that edition+fronts, but this requires computing the right offsets and sizes for each cells ahead-of-time. Note that even without using `FlatList`, we'd have to do that to know the exact offset, but having the full correct `getItemLayout` implementation is good for when we'll have a long list of editions (ex. 30 days) in the future.

https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts

## Test Plan

1. Open the list of editions, verify everything looks correct.
2. Notice the list of fronts. Press one, say, "Journal". Verify it scrolls to the correct front.
3. Open the list of editions, press the previous day's edition. Notice it opens the list of fronts for it, and scrolls the view to it.
4. Press yet another day, verify same behavior. Press a front, verify is navigates to it correctly.
5. Press the original day edition. Verify it scrolls to it correctly in the editions list.
6. Press the current edition row again, verify it navigates back to the main page (articles).

<div>
<img width="200" alt="Screenshot 2019-12-02 at 16 17 32" src="https://user-images.githubusercontent.com/1733570/69977942-94a37380-1523-11ea-8ef5-237c57d5d4d3.png">
<img width="200" alt="Screenshot 2019-12-02 at 16 17 27" src="https://user-images.githubusercontent.com/1733570/69977943-94a37380-1523-11ea-9170-32839c2d9638.png">
<img width="300" alt="Screenshot 2019-12-02 at 16 17 26" src="https://user-images.githubusercontent.com/1733570/69977945-94a37380-1523-11ea-8060-bd914cb6c6e7.png">
</div>

