### PR TITLE
Add manage editions to settings page.

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -193,7 +193,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - Sentry
     - SSZipArchive
@@ -348,4 +348,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 54889dd615f9e881ae29ac8db2b0b3dfd674d019
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -193,7 +193,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  trunk:
+  https://github.com/cocoapods/specs.git:
     - boost-for-react-native
     - Sentry
     - SSZipArchive
@@ -348,4 +348,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 54889dd615f9e881ae29ac8db2b0b3dfd674d019
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.7.5

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -40,7 +40,6 @@ import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 import { ManageEditionsScreen } from 'src/screens/settings/manage-editions-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
-import { ManageEditionsSettingsScreen } from 'src/screens/settings/manage-editions-settings'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -40,6 +40,7 @@ import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 import { ManageEditionsScreen } from 'src/screens/settings/manage-editions-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
+import { ManageEditionsSettingsScreen } from 'src/screens/settings/manage-editions-settings'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -90,6 +91,7 @@ const AppStack = createModalNavigator(
                 [routeNames.Endpoints]: ApiScreen,
                 [routeNames.GdprConsent]: GdprConsentScreen,
                 [routeNames.PrivacyPolicy]: PrivacyPolicyScreen,
+                [routeNames.ManageEditionsSettings]: ManageEditionsScreen,
                 [routeNames.TermsAndConditions]: TermsAndConditionsScreen,
                 [routeNames.Help]: HelpScreen,
                 [routeNames.Credits]: CreditsScreen,

--- a/projects/Mallard/src/navigation/routes.ts
+++ b/projects/Mallard/src/navigation/routes.ts
@@ -9,6 +9,7 @@ export const routeNames = {
     TermsAndConditions: 'TermsAndConditions',
     Help: 'Help',
     ManageEditions: 'ManageEditions',
+    ManageEditionsSettings: 'ManageEditionsSettings',
     Credits: 'Credits',
     FAQ: 'FAQ',
     AlreadySubscribed: 'AlreadySubscribed',

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,6 +1,10 @@
 import React, { useContext, useState } from 'react'
 import { Alert, StyleSheet, Text, Switch } from 'react-native'
-import { NavigationInjectedProps } from 'react-navigation'
+import {
+    NavigationInjectedProps,
+    NavigationRoute,
+    NavigationParams,
+} from 'react-navigation'
 import { RightChevron } from 'src/components/icons/RightChevron'
 import { ScrollContainer } from 'src/components/layout/ui/container'
 import { Heading } from 'src/components/layout/ui/row'
@@ -24,9 +28,17 @@ import {
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 import ApolloClient from 'apollo-client'
+import { NavigationScreenProp } from 'react-navigation'
 
 const MiscSettingsList = React.memo(
-    (props: { isWeatherShown: boolean; client: ApolloClient<object> }) => {
+    (props: {
+        isWeatherShown: boolean
+        client: ApolloClient<object>
+        navigation: NavigationScreenProp<
+            NavigationRoute<NavigationParams>,
+            NavigationParams
+        >
+    }) => {
         const onChange = () =>
             setIsWeatherShown(props.client, !props.isWeatherShown)
         const items = [
@@ -40,6 +52,17 @@ const MiscSettingsList = React.memo(
                         onValueChange={onChange}
                     />
                 ),
+            },
+            {
+                key: 'manageEditions',
+                title: 'Manage Editions',
+                data: {
+                    onPress: () =>
+                        props.navigation.navigate(
+                            routeNames.ManageEditionsSettings,
+                        ),
+                },
+                proxy: <RightChevron />,
             },
         ]
         return <List onPress={({ onPress }) => onPress()} data={items} />
@@ -170,6 +193,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                 <MiscSettingsList
                     client={client}
                     isWeatherShown={isWeatherShown}
+                    navigation={navigation}
                 />
                 <Heading>{``}</Heading>
                 <List


### PR DESCRIPTION
## Summary

Add 'manage editions' to the settings page - it makes sense for this page to allow users to configure everything rather than having to do something else for managing editions. 

Looks like this:

![Screenshot 2019-11-28 at 11 14 19](https://user-images.githubusercontent.com/3606555/69802029-85918e00-11d0-11ea-9b62-54451d2f5055.png)


https://trello.com/c/SIuLaurt/1025-manage-editions-show-it-on-settings-along-with-the-current-display-in-recent-editions

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
