### PR TITLE
fix: Background Download

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -87,12 +87,10 @@ export const unzipNamedIssueArchive = (zipFilePath: string) => {
 export const isIssueOnDevice = async (
     localIssueId: Issue['localId'],
 ): Promise<boolean> =>
-    (
-        await Promise.all([
-            RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
-            RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
-        ])
-    ).every(_ => _)
+    (await Promise.all([
+        RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
+        RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
+    ])).every(_ => _)
 
 /*
 Cheeky size helper
@@ -192,10 +190,9 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
             JSON.stringify({ localId, assets: assets[imageSize] }),
         )
 
-        const imgDL = await downloadNamedIssueArchive(
-            localId,
-            assets[imageSize] as string,
-        ) // just the images
+        const imgDL = await downloadNamedIssueArchive(localId, assets[
+            imageSize
+        ] as string) // just the images
 
         imgDL.progress((received, total) => {
             if (total >= received) {

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -61,7 +61,6 @@ export const downloadNamedIssueArchive = async (
     const returnable = RNFetchBlob.config({
         fileCache: true,
         overwrite: true,
-        IOSBackgroundTask: true,
     }).fetch('GET', zipUrl)
     return {
         promise: returnable.then(async res => {
@@ -88,10 +87,12 @@ export const unzipNamedIssueArchive = (zipFilePath: string) => {
 export const isIssueOnDevice = async (
     localIssueId: Issue['localId'],
 ): Promise<boolean> =>
-    (await Promise.all([
-        RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
-        RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
-    ])).every(_ => _)
+    (
+        await Promise.all([
+            RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
+            RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
+        ])
+    ).every(_ => _)
 
 /*
 Cheeky size helper
@@ -191,9 +192,10 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
             JSON.stringify({ localId, assets: assets[imageSize] }),
         )
 
-        const imgDL = await downloadNamedIssueArchive(localId, assets[
-            imageSize
-        ] as string) // just the images
+        const imgDL = await downloadNamedIssueArchive(
+            localId,
+            assets[imageSize] as string,
+        ) // just the images
 
         imgDL.progress((received, total) => {
             if (total >= received) {


### PR DESCRIPTION
## Summary
Sometimes, particularly with large weekend editions, the download and unzip process doesnt complete. It seems to always fail at the large media download.

When doing the data and media download, we set a flag to create a iOS background task. We do the data before the media asynchronously. I _think_ the push is received, creating a background task. After multiple processes (which also include a seperate download that doesnt create a background task) we do a data download, this creates another background tasks this happens before the media.

My theory is that is completes, and there is a race condition where the completion kills the background tasks and sends the app back to sleep. If the media download starting is fast enough to create another background task it doesnt fall asleep.

Then we do unzipping after this, which sometimes completes, or part completes. This could be due to a race condition of the background task being cancelled and the app falling asleep again.

Therefore, as other tasks download in the background without the background flag, by removing this we hopefully only use the pus notification background task which gets completed with the finally block here: https://github.com/guardian/editions/blob/master/projects/Mallard/src/helpers/push-notifications.ts#L138

**_tldr;_ Background tasks starting and completed in the middle of the push download cause it the app to go to sleep. Therefore remove background tasks.**