### PR TITLE
Hide solutions for crosswords with dateSolutionAvailable in future

### DIFF
--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -56,9 +56,6 @@ type CrosswordArticleOverrides = Pick<
 > &
     Pick<CrosswordArticle, 'crossword'>
 
-const shouldHaveSolution = (type: CrosswordType) =>
-    ![CrosswordType.EVERYMAN, CrosswordType.PRIZE].includes(type)
-
 const removeSolutionsFromEntries = (entries: Crossword['entries']) =>
     entries.map(omit(['solution']))
 
@@ -66,7 +63,11 @@ export const patchCrossword = (
     crossword: Crossword,
     type: CrosswordType,
 ): Crossword => {
-    const solutionAvailable = shouldHaveSolution(crossword.type)
+    const timeNow = new Date().getTime()
+    const solutionAvailable =
+        !crossword.dateSolutionAvailable ||
+        crossword.dateSolutionAvailable.dateTime < timeNow
+
     return {
         ...crossword,
         // the original type was a number from the CAPI thrift definition here

--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -63,6 +63,9 @@ export const patchCrossword = (
     crossword: Crossword,
     type: CrosswordType,
 ): Crossword => {
+    // for crosswords with a dateSolutionAvailable in the future, hide solutions
+    // this will be permanent even after the date has passed unless the edition is republished
+    // editions might be pressed before a crosssord is due to be published so + 1 day
     const oneDay = 24 * 60 * 60 * 1000
     const thisTimeTomorrow = new Date().getTime() + oneDay
     const solutionAvailable =

--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -63,10 +63,11 @@ export const patchCrossword = (
     crossword: Crossword,
     type: CrosswordType,
 ): Crossword => {
-    const timeNow = new Date().getTime()
+    const oneDay = 24 * 60 * 60 * 1000
+    const thisTimeTomorrow = new Date().getTime() + oneDay
     const solutionAvailable =
         !crossword.dateSolutionAvailable ||
-        crossword.dateSolutionAvailable.dateTime < timeNow
+        crossword.dateSolutionAvailable.dateTime < thisTimeTomorrow
 
     return {
         ...crossword,


### PR DESCRIPTION
## Summary
Crosswords have a dateSolutionAvailable field which has been passed through the crossword backend but wasn't actually being used. This rectifies that situation so that prize and everyman crosswords don't reveal their solutions until a week after they have been published. This is important because you get a prize for completing these crosswords early.

## Trello card
https://trello.com/c/v3IM9DtK/930-crossword-shouldnt-reveal-the-answers-for-prize-crosswords

## Test Plan
Look at an edition published on saturday or sunday in the last week - the prize (sat) and everyman (sunday) crosswords shouldn't have the reveal all button visible. It should reappear once 7 days has passed.


## UPDATE
This turns out to be hard - the only way to do it properly would be to expose a function within https://github.com/guardian/react-crossword that can be used to dynamically show/hide solutions. This PR contains a lazier option, which is to just remove solutions permanently for crosswords with a dateSolutionAvailable in the future