### PR TITLE
only switch issue on foreground event

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -49,8 +49,8 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
         getIssueSummary(isConnected)
             .then((issueSummary: IssueSummary[]) => {
                 setIssueSummary(issueSummary)
-                setIssueId(issueSummaryToLatestPath(issueSummary))
                 setError('')
+                return issueSummary
             })
             .catch(e => {
                 setError(e.message)
@@ -71,7 +71,10 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
             if (appState === 'active') {
                 const { isConnected } = await NetInfo.fetch()
                 if (isConnected) {
-                    grabIssueSummary(isConnected)
+                    const issueSummary = await grabIssueSummary(isConnected)
+                    if (issueSummary != null) {
+                        setIssueId(issueSummaryToLatestPath(issueSummary))
+                    }
                 } else {
                     // now we've foregrounded again, wait for a new issue list
                     // seen as we couldn't get one now


### PR DESCRIPTION
## Summary

Mitigates https://trello.com/c/RmhNdT2c/1022-offline-reading-images-disappear-when-you-offline-back-to-online
We should probably never force-change the current issue when the app is being actively used.

It still doesn't completely clears things out, because for example someone might foreground the app while an article is open. In that case, this will still cause the photos to disappear. This is kind of a separate bug: why would images disappear just because the current issue changes in the background? An article's an article, no matter the issue. Sounds like a bug in the data layer.

## Test Plan

My going online while the app is in the foreground, this doesn't cause the issue to change anymore. By going foreground after going back online, on the other hand, still causes the last issue to be navigated to.
