### PR TITLE
Remove aws-sdk from lambda bundles

### DIFF
--- a/projects/archiver/package.json
+++ b/projects/archiver/package.json
@@ -19,7 +19,7 @@
         "typescript": "^3.5.3"
     },
     "scripts": {
-        "build": "ncc build main.ts -o dist -m",
+        "build": "ncc build main.ts -o dist -m -e aws-sdk",
         "start": "AWS_PROFILE='frontend' ts-node local.ts",
         "start:index": "AWS_DEFAULT_PROFILE='frontend' ts-node src/indexer/local.ts",
         "validate": "cd ../.. && script/make validate-archiver",

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "editions-backend",
-  "version": "0.0.1",
-  "main": "index.js",
-  "license": "MIT",
-  "engines": {
-    "node": "10.15"
-  },
-  "devDependencies": {
-    "@types/aws-serverless-express": "^3.3.1",
-    "@types/express": "^4.17.0",
-    "@zeit/ncc": "^0.20.4",
-    "chai": "^4.1.2",
-    "chai-http": "^4.0.0",
-    "dotenv": "^8.0.0",
-    "ts-jest": "^24.0.2",
-    "ts-node": "^8.3.0",
-    "ts-node-dev": "^1.0.0-pre.40",
-    "typescript": "^3.5.3"
-  },
-  "scripts": {
-    "build": "ncc build index.ts -o dist -m",
-    "start": "ts-node-dev --ignore-watch node_modules index.ts",
-    "preview": "publicationStage=preview yarn start",
-    "validate": "cd ../.. && script/make validate-backend",
-    "fix": "cd ../.. && script/make fix-backend",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch"
-  },
-  "dependencies": {
-    "@creditkarma/thrift-server-core": "^0.14.1",
-    "@guardian/capi-ts": "^0.1.3",
-    "@types/aws-lambda": "^8.10.31",
-    "@types/jest": "^24.0.17",
-    "@types/node-fetch": "^2.5.0",
-    "@types/ramda": "^0.26.19",
-    "@zeit/ncc": "^0.20.4",
-    "aws-sdk": "2.507.0",
-    "aws-serverless-express": "^3.3.6",
-    "encoding": "^0.1.12",
-    "express": "^4.17.1",
-    "express-list-endpoints": "^4.0.1",
-    "jest": "^24.8.0",
-    "moment": "^2.24.0",
-    "node-fetch": "^2.6.0",
-    "ramda": "^0.26.1",
-    "react-native-inappbrowser-reborn": "^3.0.1",
-    "striptags": "^3.1.1",
-    "ts-optchain": "^0.1.8",
-    "utility-types": "^3.7.0"
-  }
+    "name": "editions-backend",
+    "version": "0.0.1",
+    "main": "index.js",
+    "license": "MIT",
+    "engines": {
+        "node": "10.15"
+    },
+    "devDependencies": {
+        "@types/aws-serverless-express": "^3.3.1",
+        "@types/express": "^4.17.0",
+        "@zeit/ncc": "^0.20.4",
+        "chai": "^4.1.2",
+        "chai-http": "^4.0.0",
+        "dotenv": "^8.0.0",
+        "ts-jest": "^24.0.2",
+        "ts-node": "^8.3.0",
+        "ts-node-dev": "^1.0.0-pre.40",
+        "typescript": "^3.5.3"
+    },
+    "scripts": {
+        "build": "ncc build index.ts -o dist -m -e aws-sdk",
+        "start": "ts-node-dev --ignore-watch node_modules index.ts",
+        "preview": "publicationStage=preview yarn start",
+        "validate": "cd ../.. && script/make validate-backend",
+        "fix": "cd ../.. && script/make fix-backend",
+        "test": "jest --coverage",
+        "test:watch": "jest --watch"
+    },
+    "dependencies": {
+        "@creditkarma/thrift-server-core": "^0.14.1",
+        "@guardian/capi-ts": "^0.1.3",
+        "@types/aws-lambda": "^8.10.31",
+        "@types/jest": "^24.0.17",
+        "@types/node-fetch": "^2.5.0",
+        "@types/ramda": "^0.26.19",
+        "@zeit/ncc": "^0.20.4",
+        "aws-sdk": "2.507.0",
+        "aws-serverless-express": "^3.3.6",
+        "encoding": "^0.1.12",
+        "express": "^4.17.1",
+        "express-list-endpoints": "^4.0.1",
+        "jest": "^24.8.0",
+        "moment": "^2.24.0",
+        "node-fetch": "^2.6.0",
+        "ramda": "^0.26.1",
+        "react-native-inappbrowser-reborn": "^3.0.1",
+        "striptags": "^3.1.1",
+        "ts-optchain": "^0.1.8",
+        "utility-types": "^3.7.0"
+    }
 }


### PR DESCRIPTION
I set up ncc wrong, and accidentally bundled the aws-sdk. This should massively cut our bundle size and thus riffraff costs.