### PR TITLE
fix: Attempted background download fix

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -61,6 +61,7 @@ export const downloadNamedIssueArchive = async (
     const returnable = RNFetchBlob.config({
         fileCache: true,
         overwrite: true,
+        IOSBackgroundTask: true,
     }).fetch('GET', zipUrl)
     return {
         promise: returnable.then(async res => {
@@ -356,6 +357,7 @@ export const fetchAndStoreIssueSummary = async () => {
     return RNFetchBlob.config({
         overwrite: true,
         path: FSPaths.contentPrefixDir + defaultSettings.issuesPath,
+        IOSBackgroundTask: true,
     })
         .fetch('GET', apiUrl + 'issues', {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
Since removing the background task from push summaries, we experienced issues with it not existing. I have added the background task across all download elements of the push download. Let's see what happens.