### PR TITLE
fix facebook handler scheme on Android

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="fb180444840287" />
+            <data android:scheme="fb528503751025697" />
         </intent-filter>
         <!-- Debug Google oAuth URI scheme -->
         <intent-filter>


### PR DESCRIPTION
## Summary

Facebook log-in was not working at all on Android because the deep link would not redirect to the app. This fixes the config to register for the actual scheme used by the Facebook log-in callback deeplink.

## Test Plan

Log-in with Facebook on Android. It works.
