### PR TITLE
google/fb authentication method upgrade

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -117,7 +117,7 @@ PODS:
     - React
   - RNIap (3.3.9):
     - React
-  - RNInAppBrowser (3.0.1):
+  - RNInAppBrowser (3.3.3):
     - React
   - RNKeychain (3.1.3):
     - React
@@ -335,7 +335,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
-  RNInAppBrowser: 24abaaff1fe1d8bea2492537ca32e455b14ef030
+  RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -68,7 +68,7 @@
         "react-native-iap": "^3.3.9",
         "react-native-image-resizer": "^1.0.1",
         "react-native-in-app-utils": "^6.0.2",
-        "react-native-inappbrowser-reborn": "^3.0.1",
+        "react-native-inappbrowser-reborn": "^3.3.3",
         "react-native-keychain": "^3.1.3",
         "react-native-permissions": "^2.0.3",
         "react-native-progress-circle": "^2.0.1",

--- a/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
@@ -1,6 +1,6 @@
 import { authWithDeepRedirect } from '../deep-link-auth'
 import { EventEmitter } from 'events'
-import { BrowserResult } from 'react-native-inappbrowser-reborn'
+import { RedirectResult } from 'react-native-inappbrowser-reborn'
 
 const createListener = (): EventEmitter & {
     addEventListener: EventEmitter['addListener']
@@ -15,22 +15,24 @@ const createListener = (): EventEmitter & {
 const createInAppBrowser = ({
     available = true,
     resultType,
+    url,
 }: {
     available?: boolean
-    resultType?: 'cancel' | 'dismiss'
+    resultType?: 'cancel' | 'dismiss' | 'success'
+    url?: string
 } = {}) => ({
-    open: () =>
-        new Promise<BrowserResult>(
-            res => resultType && res({ type: resultType }),
+    openAuth: () =>
+        new Promise<RedirectResult>(
+            res => resultType && res({ type: resultType, url } as any),
         ),
-    close: jest.fn(() => {}),
+    closeAuth: jest.fn(() => {}),
     isAvailable: () => Promise.resolve(available),
 })
 
 describe('deep-link-auth', () => {
     describe('authWithDeepRedirect', () => {
         describe('external link', () => {
-            it('waits for a deep link with a token before resolving', async () => {
+            it.only('waits for a deep link with a token before resolving', async () => {
                 const linking = Object.assign(createListener(), {
                     openURL: () => {},
                 })
@@ -39,6 +41,7 @@ describe('deep-link-auth', () => {
 
                 const promise = authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,

--- a/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
+++ b/projects/Mallard/src/authentication/__tests__/deep-link-auth.spec.ts
@@ -32,11 +32,45 @@ const createInAppBrowser = ({
 describe('deep-link-auth', () => {
     describe('authWithDeepRedirect', () => {
         describe('external link', () => {
-            it.only('waits for a deep link with a token before resolving', async () => {
+            it('waits for a deep link with a token before resolving', async () => {
                 const linking = Object.assign(createListener(), {
-                    openURL: () => {},
+                    openURL: () => {
+                        // Only emit the url once we actually opened the
+                        // original. Must be asynchronous for consistency with
+                        // real behavior.
+                        setImmediate(() => {
+                            linking.emit('url', { url: 'myurl' })
+                        })
+                    },
                 })
                 const appState = createListener()
+                const validator = jest.fn(async () => 'token')
+
+                const val = await authWithDeepRedirect(
+                    'https://authurl.com/auth',
+                    'myurl',
+                    validator,
+                    linking,
+                    appState,
+                    createInAppBrowser({ available: false }),
+                )
+
+                expect(val).toBe('token')
+                expect(validator).toBeCalledWith('myurl')
+            })
+
+            it('will throw if the app is foregrounded without a deep link', async () => {
+                const appState = createListener()
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {
+                        setImmediate(() => {
+                            appState.emit('change', 'active')
+                            // This should not be able to save us,
+                            // the error should already be fired.
+                            linking.emit('url', { url: 'myurl' })
+                        })
+                    },
+                })
                 const validator = jest.fn(async () => 'token')
 
                 const promise = authWithDeepRedirect(
@@ -48,66 +82,29 @@ describe('deep-link-auth', () => {
                     createInAppBrowser({ available: false }),
                 )
 
-                linking.emit('url', { url: 'myurl' })
-
-                const val = await promise
-
-                expect(val).toBe('token')
-                expect(validator).toBeCalledWith('myurl')
-            })
-
-            it('will throw if the app is foregrounded without a deep link', async () => {
-                const linking = Object.assign(createListener(), {
-                    openURL: () => {},
-                })
-                const appState = createListener()
-                const validator = jest.fn(async () => 'token')
-
-                const promise = authWithDeepRedirect(
-                    'https://authurl.com/auth',
-                    validator,
-                    linking,
-                    appState,
-                    createInAppBrowser({ available: false }),
-                )
-
-                // wait the in app browser check
-                await Promise.resolve()
-
-                let error
-
-                // there's probably a better way to do this with jest!
-                try {
-                    appState.emit('change', 'active')
-                    // this should not be able to save us, the error should already be fired
-                    linking.emit('url', { url: 'myurl' })
-                    await promise
-                } catch (e) {
-                    error = e
-                }
-
-                expect(error).toBe('Sign-in cancelled')
+                await expect(promise).rejects.toBe('Sign-in cancelled')
             })
 
             it('ignores the app being backgrounded and continues to wait for a deep link with a token before resolving', async () => {
-                const linking = Object.assign(createListener(), {
-                    openURL: () => {},
-                })
                 const appState = createListener()
+                const linking = Object.assign(createListener(), {
+                    openURL: () => {
+                        setImmediate(() => {
+                            appState.emit('change', 'inactive')
+                            linking.emit('url', { url: 'myurl' })
+                        })
+                    },
+                })
                 const validator = jest.fn(async () => 'token')
 
-                const promise = authWithDeepRedirect(
+                const val = await authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,
                     createInAppBrowser({ available: false }),
                 )
-
-                appState.emit('change', 'inactive')
-                linking.emit('url', { url: 'myurl' })
-
-                const val = await promise
 
                 expect(val).toBe('token')
                 expect(validator).toBeCalledWith('myurl')
@@ -115,7 +112,11 @@ describe('deep-link-auth', () => {
 
             it('will throw if the validator throws', async () => {
                 const linking = Object.assign(createListener(), {
-                    openURL: () => {},
+                    openURL: () => {
+                        setImmediate(() => {
+                            linking.emit('url', { url: 'myurl' })
+                        })
+                    },
                 })
                 const appState = createListener()
                 const validator = jest.fn(async () => {
@@ -124,124 +125,80 @@ describe('deep-link-auth', () => {
 
                 const promise = authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,
                     createInAppBrowser({ available: false }),
                 )
 
-                // wait the in app browser check
-                await Promise.resolve()
-
-                let error
-
-                try {
-                    linking.emit('url', { url: 'myurl' })
-                    await promise
-                } catch (e) {
-                    error = e
-                }
-
-                expect(error).toBe('hi')
+                await expect(promise).rejects.toBe('hi')
             })
         })
 
         describe('in app browser', () => {
             it('waits for a deep link with a token before resolving, and then closes browser', async () => {
                 const linking = Object.assign(createListener(), {
-                    openURL: () => {},
+                    openURL: () => {
+                        throw new Error('should not be called')
+                    },
                 })
                 const appState = createListener()
                 const validator = jest.fn(async () => 'token')
-                const browser = createInAppBrowser({ available: true })
+                const browser = createInAppBrowser({
+                    available: true,
+                    resultType: 'success',
+                    url: 'myurl',
+                })
 
-                const promise = authWithDeepRedirect(
+                const val = await authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,
                     browser,
                 )
 
-                linking.emit('url', { url: 'myurl' })
-
-                const val = await promise
-
                 expect(val).toBe('token')
                 expect(validator).toBeCalledWith('myurl')
-                expect(browser.close).toBeCalled()
-            })
-
-            it('will not throw if the app is foregrounded without a deep link but will wait for link emit', async () => {
-                const linking = Object.assign(createListener(), {
-                    openURL: () => {},
-                })
-                const appState = createListener()
-                const validator = jest.fn(async () => 'token')
-
-                const promise = authWithDeepRedirect(
-                    'https://authurl.com/auth',
-                    validator,
-                    linking,
-                    appState,
-                    createInAppBrowser({ available: true }),
-                )
-
-                // wait the in app browser check
-                await Promise.resolve()
-
-                let error
-
-                try {
-                    // fire this first, which would ordinarly trigger an error without an
-                    // in app browser
-                    appState.emit('change', 'active')
-                    linking.emit('url', { url: 'myurl' })
-                    await promise
-                } catch (e) {
-                    error = e
-                }
-
-                expect(error).toBeUndefined()
+                expect(browser.closeAuth).toBeCalled()
             })
 
             it('will throw if the validator throws, and will close the in app browser', async () => {
                 const linking = Object.assign(createListener(), {
-                    openURL: () => {},
+                    openURL: () => {
+                        throw new Error('should not be called')
+                    },
                 })
                 const appState = createListener()
                 const validator = jest.fn(async () => {
                     throw 'hi'
                 })
-                const browser = createInAppBrowser({ available: true })
+                const browser = createInAppBrowser({
+                    available: true,
+                    resultType: 'success',
+                    url: 'myurl',
+                })
 
                 const promise = authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,
                     browser,
                 )
 
-                // wait the in app browser check
-                await Promise.resolve()
-
-                let error
-
-                try {
-                    linking.emit('url', { url: 'myurl' })
-                    await promise
-                } catch (e) {
-                    error = e
-                }
-
-                expect(error).toBe('hi')
-                expect(browser.close).toBeCalled()
+                await expect(promise).rejects.toBe('hi')
+                expect(browser.closeAuth).toBeCalled()
             })
 
             it('will throw if the in app browser is closed', async () => {
                 const linking = Object.assign(createListener(), {
-                    openURL: () => {},
+                    openURL: () => {
+                        throw new Error('should not be called')
+                    },
                 })
                 const appState = createListener()
                 const validator = jest.fn(async () => 'token')
@@ -252,58 +209,15 @@ describe('deep-link-auth', () => {
 
                 const promise = authWithDeepRedirect(
                     'https://authurl.com/auth',
+                    'myurl',
                     validator,
                     linking,
                     appState,
                     browser,
                 )
 
-                // wait the in app browser check
-                await Promise.resolve()
-
-                let error
-
-                try {
-                    await promise
-                } catch (e) {
-                    error = e
-                }
-
-                expect(error).toBe('Sign-in cancelled')
-                expect(browser.close).toBeCalled()
-            })
-
-            it('will still auth if the browser is closed before the link handler is called', async () => {
-                const linking = Object.assign(createListener(), {
-                    openURL: () => {},
-                })
-                const appState = createListener()
-                const validator = jest.fn(async () => 'token')
-                const browser = createInAppBrowser({
-                    available: true,
-                    resultType: 'dismiss',
-                })
-
-                const promise = authWithDeepRedirect(
-                    'https://authurl.com/auth',
-                    validator,
-                    linking,
-                    appState,
-                    browser,
-                )
-
-                // wait the in app browser check
-                await Promise.resolve()
-
-                // wait the for the browser to close
-                await Promise.resolve()
-
-                linking.emit('url', { url: 'myurl' })
-
-                const val = await promise
-
-                expect(val).toBe('token')
-                expect(validator).toBeCalledWith('myurl')
+                await expect(promise).rejects.toBe('Sign-in cancelled')
+                expect(browser.closeAuth).toBeCalled()
             })
         })
     })

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -92,7 +92,6 @@ const authWithDeepRedirect = async (
             unlisteners.push(unlistenAppState)
             // open in the browser if in app browsers are not supported
             linkingImpl.openURL(authUrl)
-            console.warn('hello')
         }
 
         if (!(await inAppBrowserImpl.isAvailable())) {

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -46,8 +46,6 @@ const authWithDeepRedirect = async (
         const unlisteners: (() => void)[] = []
 
         const onFinish = async (url?: string) => {
-            console.warn('finish: ' + url)
-
             inAppBrowserImpl.close()
 
             let unlistener
@@ -67,8 +65,6 @@ const authWithDeepRedirect = async (
         }
 
         const runExternalBrowserDeepLink = () => {
-            console.warn('external')
-
             const unlistenLink = addListener(
                 linkingImpl,
                 'url',
@@ -98,53 +94,23 @@ const authWithDeepRedirect = async (
             linkingImpl.openURL(authUrl)
         }
 
-        if (await inAppBrowserImpl.isAvailable()) {
-            let result
-            try {
-                result = await inAppBrowserImpl.openAuth(authUrl, deepLink, {
-                    // iOS Properties
-                    dismissButtonStyle: 'cancel',
-                    // Android Properties
-                    showTitle: false,
-                    enableUrlBarHiding: true,
-                    enableDefaultShare: true,
-                })
-            } catch {
-                runExternalBrowserDeepLink()
-                return
-            }
-            if (result.type === 'success') {
-                onFinish((result as RedirectResult).url)
-            } else {
-                onFinish()
-            }
-
-            // switch (result.type) {
-            //     case 'cancel': {
-            //         /**
-            //          * this was a user cancel so reject the promise
-            //          */
-            //         onFinish()
-            //         break
-            //     }
-            //     case 'dismiss': {
-            //         /**
-            //          * the assumption here is that a dismiss event happens when a deep link
-            //          * happens or some other non-user cirucmstance.
-            //          *
-            //          * On iOS, if this was a deep link then the link handler above should already have fired
-            //          * and resolved / rejected this promise (making the rest of thie code a noop).
-            //          * However, this isn't the case on Android. Also if it _wan't_ a deep link then
-            //          * we should clean up.
-            //          *
-            //          * Hence a second for other handlers to fire before rejecting the promise
-            //          */
-            //         setTimeout(() => onFinish(), 1000)
-            //         break
-            //     }
-            // }
-        } else {
+        if (!(await inAppBrowserImpl.isAvailable())) {
             runExternalBrowserDeepLink()
+            return
+        }
+
+        const result = await inAppBrowserImpl.openAuth(authUrl, deepLink, {
+            // iOS Properties
+            dismissButtonStyle: 'cancel',
+            // Android Properties
+            showTitle: false,
+            enableUrlBarHiding: true,
+            enableDefaultShare: true,
+        })
+        if (result.type === 'success') {
+            onFinish((result as RedirectResult).url)
+        } else {
+            onFinish()
         }
     })
 }

--- a/projects/Mallard/src/authentication/deep-link-auth.ts
+++ b/projects/Mallard/src/authentication/deep-link-auth.ts
@@ -23,7 +23,7 @@ type ILinking = Emitter<{ url: string }> & {
 
 type IInAppBrowser = Pick<
     typeof InAppBrowser,
-    'openAuth' | 'closeAuth' | 'close' | 'open' | 'isAvailable'
+    'openAuth' | 'closeAuth' | 'isAvailable'
 >
 
 /**
@@ -46,7 +46,7 @@ const authWithDeepRedirect = async (
         const unlisteners: (() => void)[] = []
 
         const onFinish = async (url?: string) => {
-            inAppBrowserImpl.close()
+            inAppBrowserImpl.closeAuth()
 
             let unlistener
             while ((unlistener = unlisteners.pop())) {
@@ -92,6 +92,7 @@ const authWithDeepRedirect = async (
             unlisteners.push(unlistenAppState)
             // open in the browser if in app browsers are not supported
             linkingImpl.openURL(authUrl)
+            console.warn('hello')
         }
 
         if (!(await inAppBrowserImpl.isAvailable())) {

--- a/projects/Mallard/src/authentication/services/facebook.ts
+++ b/projects/Mallard/src/authentication/services/facebook.ts
@@ -30,19 +30,23 @@ const getFacebookOAuthURL = (validatorString: string) =>
 const facebookAuthWithDeepRedirect = (
     validatorString: string,
 ): Promise<string> =>
-    authWithDeepRedirect(getFacebookOAuthURL(validatorString), async url => {
-        invariant(url.startsWith(facebookRedirectURI), 'Sign-in cancelled')
+    authWithDeepRedirect(
+        getFacebookOAuthURL(validatorString),
+        facebookRedirectURI,
+        async url => {
+            invariant(url.startsWith(facebookRedirectURI), 'Sign-in cancelled')
 
-        const params = qs.parse(url.split('#')[1])
+            const params = qs.parse(url.split('#')[1])
 
-        invariant(
-            params.state === validatorString,
-            'Sign-in session expired, please try again',
-        )
+            invariant(
+                params.state === validatorString,
+                'Sign-in session expired, please try again',
+            )
 
-        invariant(params.access_token, 'Something went wrong')
+            invariant(params.access_token, 'Something went wrong')
 
-        return params.access_token as string
-    })
+            return params.access_token as string
+        },
+    )
 
 export { facebookAuthWithDeepRedirect }

--- a/projects/Mallard/src/authentication/services/google.ts
+++ b/projects/Mallard/src/authentication/services/google.ts
@@ -70,7 +70,7 @@ const getGoogleTokenFromCode = (code: string) =>
  */
 const googleAuthWithDeepRedirect = (validatorString: string): Promise<string> =>
     getGoogleOAuthURL(validatorString).then(authUrl =>
-        authWithDeepRedirect(authUrl, async url => {
+        authWithDeepRedirect(authUrl, googleRedirectURI, async url => {
             invariant(url.startsWith(googleRedirectURI), 'Sign-in cancelled')
 
             const params = qs.parse(url.split('?')[1])

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6428,10 +6428,10 @@ react-native-in-app-utils@^6.0.2:
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.2.tgz#b44498c7cce772fe1cebb00af082ff7bf4000a55"
   integrity sha512-hAQFhzl/qN1PwZJVAcE1+LR0baQrcDGzjGRIIgkSJuytjYo3iO9L4qxKqewsLlMwKRfxr2BfORWlPTp6djmJJA==
 
-react-native-inappbrowser-reborn@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.0.1.tgz#85f973fd821b9f67359681147d004ef9cf690b4d"
-  integrity sha512-W1aYWm9/bR6bOWWDJFo6c8w1ivnOC8Z+juUDTAXjH+COaDR5opXHHx8+KL0HZZW6CeyGcnbU/l7l1R2TO7GXBQ==
+react-native-inappbrowser-reborn@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-inappbrowser-reborn/-/react-native-inappbrowser-reborn-3.3.3.tgz#1225260aacf6777e3b4b01ab54c4b121b0bae6fd"
+  integrity sha512-OxWvuWm989n8MZYErhG5AnMkuNcRpvE4/GWBem5SbMra84rbmdmhQdgNjBrFtaqcs4rJd519LXpa8IbJugnABw==
   dependencies:
     invariant "^2.2.4"
     opencollective-postinstall "^2.0.2"


### PR DESCRIPTION
## Summary

https://trello.com/c/Ps7UwuW8/1006-google-sign-in-abitrarily-fails-with-error-message-sign-in-cancelled

The library we use already provides an `openAuth` function that includes the system that waits concurrently for the deep link and the "dismiss" event at the same time, so let's get rid of our custom logic. More importantly, it seems to successfully fix the bug seen in the Trello card by waiting for a foregrounding event before moving on (instead of our 1000ms timeout, which is indeed more fragile).

## Test Plan

Automated jest test.

Also, both on Android and iOS, try to log in both using Google, and Facebook. For all cases, try cancelling, or try logging-in successfully. Furthermore, disable the `inAppBrowserImpl.isAvailable()` call and verify that the external-based log-in works as well.
