### PR TITLE
Don't set default stage as riffraff blats over the selected with default

### DIFF
--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -21,7 +21,6 @@ export class EditionsStack extends cdk.Stack {
         const frontsStageParameter = new cdk.CfnParameter(this, 'frontsStage', {
             type: 'String',
             description: 'Which stage of fronts to read from',
-            default: 'prod',
         })
 
         const stageParameter = new cdk.CfnParameter(this, 'stage', {

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -21,6 +21,7 @@ export class EditionsStack extends cdk.Stack {
         const frontsStageParameter = new cdk.CfnParameter(this, 'frontsStage', {
             type: 'String',
             description: 'Which stage of fronts to read from',
+            allowedValues: ['prod', 'code'],
         })
 
         const stageParameter = new cdk.CfnParameter(this, 'stage', {
@@ -77,11 +78,7 @@ export class EditionsStack extends cdk.Stack {
             {
                 type: 'String',
                 description: 'Archive Bucket',
-                allowedValues: [
-                    'editions-store',
-                    'editions-store-prod',
-                    'editions-store-code',
-                ], //remove editions-store post merge
+                allowedValues: ['editions-store-prod', 'editions-store-code'],
             },
         )
 


### PR DESCRIPTION
This removes the default stage for fronts access, sets allowed values and removes the old editions store bucket from the list of outputs. 

This should fix riffraff continually overwriting prod on code.
