### PR TITLE
fix: Delete Issues

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -1,8 +1,10 @@
+import MockDate from 'mockdate'
 import {
     matchSummmaryToKey,
     downloadAndUnzipIssue,
     DLStatus,
     updateListeners,
+    issuesToDelete,
 } from '../files'
 import { issueSummaries } from '../../../../Apps/common/src/__tests__/fixtures/IssueSummary'
 
@@ -178,6 +180,30 @@ describe('helpers/files', () => {
 
             // these should both now be resolved when the inner runner promise resolves
             await Promise.all([p1, p2])
+        })
+    })
+
+    describe('issuesToDelete', () => {
+        MockDate.set('2019-08-21')
+        it('should return items outside of the 7 days that dont follow the issue naming, or the issue index', () => {
+            const files = [
+                'daily-edition/issues',
+                'some-random-file',
+                'daily-edition/2019-08-15',
+                'daily-edition/2019-08-14',
+            ]
+            expect(issuesToDelete(files)).toEqual([
+                'some-random-file',
+                'daily-edition/2019-08-14',
+            ])
+        })
+
+        it("should return an empty array if there isn't any to delete", () => {
+            const files = [
+                'daily-edition/2019-08-15',
+                'daily-edition/2019-08-16',
+            ]
+            expect(issuesToDelete(files)).toEqual([])
         })
     })
 })

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -120,7 +120,7 @@ export type DLStatus =
 
 const deleteIssue = (localId: string): Promise<void> => {
     const promise = RNFetchBlob.fs
-        .unlink(FSPaths.issue(localId))
+        .unlink(FSPaths.issueRoot(localId))
         .catch(e => errorService.captureException(e))
     promise.then(() => localIssueListStore.remove(localId))
     return promise
@@ -287,10 +287,8 @@ export const getLocalIssues = () =>
         .ls(FSPaths.contentPrefixDir)
         .then(files => files.map(withPathPrefix(defaultSettings.contentPrefix)))
 
-export const clearOldIssues = async (): Promise<void> => {
-    const files = await getLocalIssues()
-
-    const issuesToDelete = files.filter(
+export const issuesToDelete = (files: string[]) =>
+    files.filter(
         issue =>
             !lastSevenDays()
                 .map(withPathPrefix(defaultSettings.contentPrefix))
@@ -298,7 +296,12 @@ export const clearOldIssues = async (): Promise<void> => {
             issue !== `${defaultSettings.contentPrefix}/issues`,
     )
 
-    return Promise.all(issuesToDelete.map(issue => deleteIssue(issue)))
+export const clearOldIssues = async (): Promise<void> => {
+    const files = await getLocalIssues()
+
+    const iTD: string[] = issuesToDelete(files)
+
+    return Promise.all(iTD.map((issue: string) => deleteIssue(issue)))
         .then(() =>
             sendComponentEvent({
                 componentType: ComponentType.appVideo,

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -297,7 +297,6 @@ export const clearOldIssues = async (): Promise<void> => {
                 .includes(issue) &&
             issue !== `${defaultSettings.contentPrefix}/issues`,
     )
-    console.log(issuesToDelete)
 
     return Promise.all(issuesToDelete.map(issue => deleteIssue(issue)))
         .then(() =>

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -294,8 +294,10 @@ export const clearOldIssues = async (): Promise<void> => {
         issue =>
             !lastSevenDays()
                 .map(withPathPrefix(defaultSettings.contentPrefix))
-                .includes(issue) && issue !== 'issues',
+                .includes(issue) &&
+            issue !== `${defaultSettings.contentPrefix}/issues`,
     )
+    console.log(issuesToDelete)
 
     return Promise.all(issuesToDelete.map(issue => deleteIssue(issue)))
         .then(() =>


### PR DESCRIPTION
## Summary
A change a short while back affected how we delete issues. This has resulted in old issues not being deleted and these sentry errors:
https://sentry.io/organizations/the-guardian/issues/1351093667/?project=1519156&query=is%3Aunresolved

The fix? Make sure we have the correct path otherwise it errors and deletes nothing. This issues path is for a file we don't want to delete.