### PR TITLE
fix: Cover Card Images

### DIFF
--- a/projects/Mallard/src/components/front/items/items.tsx
+++ b/projects/Mallard/src/components/front/items/items.tsx
@@ -103,7 +103,7 @@ const SplashImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
                     style={[splashImageStyles.image]}
                     image={cardImage}
                     setAspectRatio
-                    use="thumb"
+                    use="full-size"
                 />
             </View>
             <HeadlineCardText style={[splashImageStyles.hidden]}>


### PR DESCRIPTION
## Summary
Thumbnail cover card images cease to exist. Therefore moving this back to `full-size` until we can determine the cause of the problem.

![Screen Shot 2019-12-04 at 14 22 08](https://user-images.githubusercontent.com/935975/70150176-7b283600-16a1-11ea-8fa7-15cebdebbcdc.png)

[**Trello Card ->**](https://trello.com/c/LMWH01yG/1041-cover-cards-and-image-on-national-dont-render-build-594)