### PR TITLE
fix: Text size on IAP feedback message

### DIFF
--- a/projects/Mallard/src/components/missing-iap-modal-card.tsx
+++ b/projects/Mallard/src/components/missing-iap-modal-card.tsx
@@ -17,7 +17,7 @@ const MissingIAPModalCard = ({
         title={title}
         subtitle={subtitle}
         appearance={CardAppearance.blue}
-        size="medium"
+        size="small"
         onDismissThisCard={() => {
             close()
         }}


### PR DESCRIPTION
## Summary
Makes the title smaller

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-04 at 14 29 18](https://user-images.githubusercontent.com/935975/70151039-ec1c1d80-16a2-11ea-85db-7652e91a3938.png)

[**Trello Card ->**](https://trello.com/c/O1EogvDP/551-usability-feedback-message-if-existing-app-store-subscription-is-not-found)