### PR TITLE
Set correct colour for share icon on obit headers.

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -340,6 +340,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
     .share-icon {
         padding-bottom: .1em;
+        color: ${colors.main};
     }
 
     .clearfix {
@@ -493,6 +494,12 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     ${'' /* this is needed to be more specific than an above style */}
     .header-container[data-type='${ArticleType.Obituary}'] .header-byline a {
         color: ${color.textOverDarkBackground};
+    }
+    .header-container[data-type='${ArticleType.Obituary}'] .share-icon {
+        color: ${color.textOverDarkBackground};
+    }
+    .header-container[data-type='${ArticleType.Obituary}'] .share-button {
+        border: 1px solid ${color.textOverDarkBackground};
     }
 `
 


### PR DESCRIPTION
<img width="370" alt="Screenshot 2019-12-06 at 11 22 57" src="https://user-images.githubusercontent.com/8861681/70320804-8c964d00-181d-11ea-85b2-c916ecb08303.png">

(Have checked it doesn't break other sharing icons)