### PR TITLE
home-screen.tsx: do not scroll to index outside of bounds

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -217,22 +217,18 @@ const IssueListView = withNavigation(
         } & NavigationInjectedProps) => {
             const { localId, publishedId, fronts } = currentIssueDetails
 
-            // We want to scroll to the current issue, both initially and when
-            // it changes. If not found, just in case, we push it to the end so
-            // that it does not affect `getItemLayout`.
+            // We want to scroll to the current issue.
             let currentIssueIndex = issueList.findIndex(
                 issue =>
                     issue.localId === localId &&
                     issue.publishedId === publishedId,
             )
-            if (currentIssueIndex < 0)
-                currentIssueIndex = Number.MAX_SAFE_INTEGER
 
             // Scroll to the relevant item if the current issue index has
             // changed (likely because the selected issue has changed itself).
             const listRef = useRef<FlatList<IssueSummary>>()
             useEffect(() => {
-                if (listRef.current == null) {
+                if (listRef.current == null || currentIssueIndex < 0) {
                     return
                 }
 
@@ -271,7 +267,9 @@ const IssueListView = withNavigation(
                             (index === currentIssueIndex ? frontRowsHeight : 0),
                         offset:
                             index * ISSUE_ROW_HEIGHT +
-                            (index > currentIssueIndex ? frontRowsHeight : 0),
+                            (currentIssueIndex > 0 && index > currentIssueIndex
+                                ? frontRowsHeight
+                                : 0),
                         index,
                     }
                 },
@@ -301,7 +299,9 @@ const IssueListView = withNavigation(
                     ListFooterComponent={footer}
                     style={styles.issueList}
                     data={issueList}
-                    initialScrollIndex={currentIssueIndex}
+                    initialScrollIndex={
+                        currentIssueIndex > 0 ? currentIssueIndex : undefined
+                    }
                     renderItem={renderItem}
                     getItemLayout={getItemLayout}
                     ref={refFn}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -218,7 +218,7 @@ const IssueListView = withNavigation(
             const { localId, publishedId, fronts } = currentIssueDetails
 
             // We want to scroll to the current issue.
-            let currentIssueIndex = issueList.findIndex(
+            const currentIssueIndex = issueList.findIndex(
                 issue =>
                     issue.localId === localId &&
                     issue.publishedId === publishedId,


### PR DESCRIPTION
## Summary

Because it does indeed happen in practice, `scrollToIndex` would crash when provided with the large number. I removed this logic so that we just do nothing if we didn't find the list item matching the details we have.

I don't understand how that can actually happen yet, because we always fetch the issue matching both `localId` and `publishedId`, and actually I can't repro locally, but this at least this changeset avoids the crash which is the worst experience.

## Test Plan

Verified navigating to one issue to another works as expected.
