### PR TITLE
give more spacing to issue+fronts titles on tablet

### DIFF
--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -37,7 +37,7 @@ export const metrics = {
     },
     gridRowSplit: {
         narrow: (width: number) => width * 0.65,
-        wide: 240,
+        wide: 260,
     },
     slideCardSpacing:
         Platform.OS === 'ios'


### PR DESCRIPTION
## Summary

Addressing the spacing issue seen for the special "election" fronts: https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts#comment-5dea356e0062293443790ea4

## Test Plan

Check it now looks good on iPad. cc @pradasa @PriscillaAlcalde

<img width="725" alt="Screenshot 2019-12-06 at 14 46 13" src="https://user-images.githubusercontent.com/1733570/70332134-d80a2480-1838-11ea-98d0-b73a19f7441d.png">
