### PR TITLE
Stopgap: Mapping Obits to standard article template

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -49,7 +49,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isComment) return ArticleType.Opinion
                 else if (isReview) return ArticleType.Review
                 else if (isSeries) return ArticleType.Article
-                else if (isObituary) return ArticleType.Obituary
+                else if (isObituary) return ArticleType.Article
                 else return ArticleType.Article
 
             case 'sport':
@@ -61,7 +61,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
                 else if (isSeries) return ArticleType.Article
-                else if (isObituary) return ArticleType.Obituary
+                else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
                 else return ArticleType.Article
 
@@ -70,7 +70,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
                 else if (isSeries) return ArticleType.Article
-                else if (isObituary) return ArticleType.Obituary
+                else if (isObituary) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isLetter) return ArticleType.Letter
                 else if (isEditorial) return ArticleType.Article
@@ -88,7 +88,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
                 else if (isSeries) return ArticleType.Article
-                else if (isObituary) return ArticleType.Obituary
+                else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
                 else return ArticleType.Article
 
@@ -108,7 +108,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
                 else if (isSeries) return ArticleType.Article
-                else if (isObituary) return ArticleType.Obituary
+                else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
                 else return ArticleType.Article
 


### PR DESCRIPTION
This PR maps Obits to the standard article template, while we look for a better solution around scaling images. At the moment the issue of the Obit template leads to often inappropriate images. 

See Trello: https://trello.com/c/CxtGa0vu/1029-crop-positioning-for-immersive-templates

