### PR TITLE
Editions page: adjust Fronts font and spacing

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -35,11 +35,11 @@ import { getColor } from 'src/helpers/transform'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
 
-const FRONT_TITLE_FONT = getFont('headline', 0.75, 'bold')
+const FRONT_TITLE_FONT = getFont('titlepiece', 1.25)
 const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
 
 export const ISSUE_ROW_HEADER_HEIGHT = ISSUE_TITLE_FONT.lineHeight * 2.6
-export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.7
+export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.9
 
 const styles = StyleSheet.create({
     frontsSelector: {
@@ -55,8 +55,7 @@ const styles = StyleSheet.create({
     frontTitle: {
         height: '100%',
         flexDirection: 'row',
-        alignContent: 'center',
-        alignItems: 'center',
+        paddingTop: ISSUE_FRONT_ROW_HEIGHT * 0.15,
         paddingHorizontal: metrics.horizontal,
     },
     frontTitleText: {

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -54,7 +54,6 @@ const styles = StyleSheet.create({
     },
     frontTitle: {
         height: '100%',
-        flexDirection: 'row',
         paddingTop: ISSUE_FRONT_ROW_HEIGHT * 0.15,
         paddingHorizontal: metrics.horizontal,
     },


### PR DESCRIPTION
## Summary

Fix font/spacing in accordance with what was discussed with design/UX, in particular Fronts list items need to be bigger (to be easier to press), font needs to be consistent with Fronts font in issue display, and titles shall not be centered as per design, so we just put a top padding. Top padding is set as percentage of item size so that we depend on the responsive font size itself.

 https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts

## Test Plan

check design:

<img width="959" alt="Screenshot 2019-12-06 at 16 17 18" src="https://user-images.githubusercontent.com/1733570/70339067-093d2180-1846-11ea-8af2-f3196bf1dead.png">
<img width="435" alt="Screenshot 2019-12-06 at 16 17 08" src="https://user-images.githubusercontent.com/1733570/70339072-09d5b800-1846-11ea-85e1-2c195cc0a646.png">
