### PR TITLE
Chore: Blocking push tracking

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -167,11 +167,11 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
     const { assets, localId } = issue
     try {
         if (!assets) {
-            pushTracking('noAssets', 'complete')
+            await pushTracking('noAssets', 'complete')
             return
         }
 
-        pushTracking(
+        await pushTracking(
             'attemptDataDownload',
             JSON.stringify({ localId, assets: assets.data }),
         )
@@ -183,9 +183,9 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 
         const dataRes = await issueDataDownload.promise
 
-        pushTracking('attemptDataDownload', 'completed')
+        await pushTracking('attemptDataDownload', 'completed')
 
-        pushTracking(
+        await pushTracking(
             'attemptMediaDownload',
             JSON.stringify({ localId, assets: assets[imageSize] }),
         )
@@ -208,7 +208,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 
         const imgRes = await imgDL.promise
 
-        pushTracking('attemptMediaDownload', 'completed')
+        await pushTracking('attemptMediaDownload', 'completed')
 
         updateListeners(localId, {
             type: 'unzip',
@@ -223,25 +223,25 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
              * and then block things like re-downloading if the images stopped downloading
              */
 
-            pushTracking('unzipData', 'start')
+            await pushTracking('unzipData', 'start')
             await unzipNamedIssueArchive(dataRes.path())
-            pushTracking('unzipData', 'end')
+            await pushTracking('unzipData', 'end')
             /**
              * The last thing we do is unzip the directory that will confirm if the issue exists
              */
-            pushTracking('unzipImages', 'start')
+            await pushTracking('unzipImages', 'start')
             await unzipNamedIssueArchive(imgRes.path())
-            pushTracking('unzipImages', 'end')
+            await pushTracking('unzipImages', 'end')
         } catch (error) {
             updateListeners(localId, { type: 'failure', data: error })
-            pushTracking('unzipError', JSON.stringify(error))
+            await pushTracking('unzipError', JSON.stringify(error))
             console.log('Unzip error: ', error)
         }
 
-        pushTracking('downloadAndUnzip', 'complete')
+        await pushTracking('downloadAndUnzip', 'complete')
         updateListeners(localId, { type: 'success' }) // null is unstarted or end
     } catch (error) {
-        pushTracking('downloadAndUnzipError', JSON.stringify(error))
+        await pushTracking('downloadAndUnzipError', JSON.stringify(error))
         updateListeners(localId, { type: 'failure', data: error })
         console.log('Download error: ', error)
     }
@@ -261,11 +261,11 @@ export const downloadAndUnzipIssue = (
 
     const createDownloadPromise = async () => {
         try {
-            pushTracking('attemptDownload', JSON.stringify(issue))
+            await pushTracking('attemptDownload', JSON.stringify(issue))
             await run(issue, imageSize)
             localIssueListStore.add(localId)
         } finally {
-            pushTracking('completeAndDeleteCache', 'completed')
+            await pushTracking('completeAndDeleteCache', 'completed')
             delete dlCache[localId]
         }
     }

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -261,7 +261,6 @@ export const downloadAndUnzipIssue = (
 
     const createDownloadPromise = async () => {
         try {
-            await pushTracking('attemptDownload', JSON.stringify(issue))
             await run(issue, imageSize)
             localIssueListStore.add(localId)
         } finally {

--- a/projects/Mallard/src/helpers/push-notifications.ts
+++ b/projects/Mallard/src/helpers/push-notifications.ts
@@ -95,17 +95,17 @@ const pushNotifcationRegistration = () => {
             // Do tracking as soon as possible
             notificationTracking(notificationId, 'received')
 
-            pushTracking('notification', JSON.stringify(notification))
+            await pushTracking('notification', JSON.stringify(notification))
 
             if (key) {
                 try {
                     const screenSize = await imageForScreenSize()
 
-                    pushTracking('pushScreenSize', screenSize)
+                    await pushTracking('pushScreenSize', screenSize)
 
                     const issueSummaries = await getIssueSummary()
 
-                    pushTracking(
+                    await pushTracking(
                         'pushIssueSummaries',
                         JSON.stringify(issueSummaries),
                     )
@@ -116,20 +116,18 @@ const pushNotifcationRegistration = () => {
                         key,
                     )
 
-                    pushTracking(
+                    await pushTracking(
                         'pushImageSummary',
                         JSON.stringify(pushImageSummary),
                     )
 
                     await downloadAndUnzipIssue(pushImageSummary, screenSize)
 
-                    pushTracking('pushDownloadComplete', 'completed')
+                    await pushTracking('pushDownloadComplete', 'completed')
 
                     notificationTracking(notificationId, 'downloaded')
                 } catch (e) {
-                    console.log(
-                        `Push notification unable to download: ${e.message}`,
-                    )
+                    await pushTracking('pushDownloadError', JSON.stringify(e))
                     errorService.captureException(e)
                 } finally {
                     // No matter what happens, always clear up old issues

--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -16,7 +16,7 @@ const getPushTracking = async (): Promise<string | null> =>
 const clearPushTracking = async (): Promise<void> =>
     AsyncStorage.removeItem(PUSH_TRACKING_KEY)
 
-const pushTracking = async (id: string, value: string) => {
+const pushTracking = async (id: string, value: string): Promise<void> => {
     try {
         if (__DEV__) {
             console.log(`Push Tracking: ${id} | ${value}`)


### PR DESCRIPTION
## Summary
After not receiving downloads on an iPad over the weekend, i attempted to recreate the issue.; However, using CODE environments, everything works perfectly....

The current internal tracking is non blocking at the moment. As a result we don't always get the full picture. This PR makes it blocking which should give us more of an idea when things stop.
