### PR TITLE
adjust colors for Fronts in editions list

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -1,5 +1,4 @@
 import { html, makeHtml } from 'src/helpers/webview'
-import { getPillarColors } from 'src/hooks/use-article'
 import {
     ArticlePillar,
     ArticleType,
@@ -17,6 +16,7 @@ import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
 import { useImagePath } from 'src/hooks/use-image-paths'
 import { Image as TImage } from '../../../../../Apps/common/src'
+import { getPillarColors } from 'src/helpers/transform'
 
 interface ArticleContentProps {
     showMedia: boolean

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -202,25 +202,14 @@ const IssueButtonContainer = React.memo(
  * because their "main" counterpart isn't legible enough for text on a light
  * background.
  */
+const DARK_COLOURED_PILLARS = new Set(['culture', 'lifestyle'])
 const getCustomColor = (appr: Appearance): colour => {
-    switch (appr.type) {
-        case 'pillar': {
-            const colors = getPillarColors(appr.name)
-            switch (appr.name) {
-                case 'culture':
-                case 'lifestyle':
-                    return colors.dark
-                default:
-                    return colors.main
-            }
-        }
-        case 'custom': {
-            return appr.color
-        }
-        default: {
-            return getPillarColors('neutral').main
-        }
+    if (appr.type === 'pillar') {
+        const colors = getPillarColors(appr.name)
+        return DARK_COLOURED_PILLARS.has(appr.name) ? colors.dark : colors.main
     }
+    if (appr.type === 'custom') return appr.color
+    return getPillarColors('neutral').main
 }
 
 const IssueFrontRow = React.memo(

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -30,10 +30,11 @@ import { DOWNLOAD_ISSUE_MESSAGE_OFFLINE } from 'src/helpers/words'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
 
 import { useIssueOnDevice, ExistsStatus } from 'src/hooks/use-issue-on-device'
-import { Front, IssueWithFronts } from '../../../../Apps/common/src'
-import { getColor } from 'src/helpers/transform'
+import { Front, IssueWithFronts, Appearance } from '../../../../Apps/common/src'
+import { getPillarColors } from 'src/helpers/transform'
 import { metrics } from 'src/theme/spacing'
 import { getFont } from 'src/theme/typography'
+import { colour } from '@guardian/pasteup/palette'
 
 const FRONT_TITLE_FONT = getFont('titlepiece', 1.25)
 const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
@@ -165,9 +166,35 @@ const IssueButtonContainer = React.memo(
     ),
 )
 
+/**
+ * Custom palette for Front titles. We use the dark variants for some pillars
+ * because their "main" counterpart isn't legible enough for text on a light
+ * background.
+ */
+const getCustomColor = (appr: Appearance): colour => {
+    switch (appr.type) {
+        case 'pillar': {
+            const colors = getPillarColors(appr.name)
+            switch (appr.name) {
+                case 'culture':
+                case 'lifestyle':
+                    return colors.dark
+                default:
+                    return colors.main
+            }
+        }
+        case 'custom': {
+            return appr.color
+        }
+        default: {
+            return getPillarColors('neutral').main
+        }
+    }
+}
+
 const IssueFrontRow = React.memo(
     ({ front, onPress }: { front: Front; onPress: () => void }) => {
-        const textColor = getColor(front.appearance)
+        const textColor = getCustomColor(front.appearance)
         return (
             <GridRowSplit>
                 <View style={styles.frontTitleWrap}>

--- a/projects/Mallard/src/helpers/transform.ts
+++ b/projects/Mallard/src/helpers/transform.ts
@@ -4,7 +4,8 @@ import {
     Appearance,
     FrontCardAppearance,
 } from 'src/common'
-import { palette } from '@guardian/pasteup/palette'
+import { palette, PillarColours } from '@guardian/pasteup/palette'
+import { ArticlePillar } from '../../../Apps/common/src'
 
 export interface FlatCard {
     collection: Collection
@@ -13,24 +14,34 @@ export interface FlatCard {
 }
 
 const colorMap = {
-    news: palette.news.main,
-    opinion: palette.opinion.main,
-    sport: palette.sport.main,
-    culture: palette.culture.main,
-    lifestyle: palette.lifestyle.main,
-    neutral: palette.neutral[7],
+    news: palette.news,
+    opinion: palette.opinion,
+    sport: palette.sport,
+    culture: palette.culture,
+    lifestyle: palette.lifestyle,
+    neutral: {
+        dark: palette.neutral[7],
+        main: palette.neutral[7],
+        bright: palette.neutral[20],
+        pastel: palette.neutral[60],
+        faded: palette.neutral[97],
+    },
+}
+
+export const getPillarColors = (pillar: ArticlePillar): PillarColours => {
+    return colorMap[pillar]
 }
 
 export const getColor = (app: Appearance): string => {
     switch (app.type) {
         case 'pillar': {
-            return colorMap[app.name]
+            return getPillarColors(app.name).main
         }
         case 'custom': {
             return app.color
         }
         default: {
-            return colorMap.neutral
+            return colorMap.neutral.main
         }
     }
 }

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, useState } from 'react'
-import { color } from '../theme/color'
 import { ArticlePillar, ArticleType, Appearance, Collection } from '../common'
 import { PillarColours } from '@guardian/pasteup/palette'
 import { useIsUsingProdDevtools } from './use-settings'
 import { DevTools } from 'src/hooks/article/dev-tools'
+import { getPillarColors } from 'src/helpers/transform'
 
 /*
   Exports
@@ -51,17 +51,6 @@ export const WithArticle = (props: PropTypes) => {
     if (isUsingProdDevtools) return <ProvidersAndDevtools {...props} />
     return <Providers {...props} />
 }
-
-const neutrals: PillarColours = {
-    dark: color.palette.neutral[7],
-    main: color.palette.neutral[7],
-    bright: color.palette.neutral[20],
-    pastel: color.palette.neutral[60],
-    faded: color.palette.neutral[97],
-}
-
-export const getPillarColors = (pillar: ArticlePillar) =>
-    pillar === 'neutral' ? neutrals : color.palette[pillar]
 
 export const useArticle = (): [
     PillarColours,


### PR DESCRIPTION
## Summary

Design specifies a custom palette: https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts
This changeset codifies that. I also took this opportunity to merge some duplicate code that was going around for getting a pillar's colors.

## Test Plan

Open edition list, check it looks as expected:

<img width="300" alt="Screenshot 2019-12-09 at 12 20 26" src="https://user-images.githubusercontent.com/1733570/70435265-4ee42f00-1a7e-11ea-944c-17e819d23d9d.png">

