### PR TITLE
fix: Offline banner only when offline

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -136,14 +136,16 @@ const IssueButton = ({
                 return
             }
         }
-        if ((await fetch()).isConnected && !dlStatus) {
-            sendComponentEvent({
-                componentType: ComponentType.appButton,
-                action: Action.click,
-                value: 'issues_list_issue_clicked',
-            })
-            const imageSize = await imageForScreenSize()
-            downloadAndUnzipIssue(issue, imageSize, handleUpdate)
+        if ((await fetch()).isConnected) {
+            if (!dlStatus) {
+                sendComponentEvent({
+                    componentType: ComponentType.appButton,
+                    action: Action.click,
+                    value: 'issues_list_issue_clicked',
+                })
+                const imageSize = await imageForScreenSize()
+                downloadAndUnzipIssue(issue, imageSize, handleUpdate)
+            }
         } else {
             showToast(DOWNLOAD_ISSUE_MESSAGE_OFFLINE)
         }


### PR DESCRIPTION
## Summary
Offline banner mistakenly displays when clicking the download button again because its in progress. This PR separates both conditions.

[**Trello Card ->**](https://trello.com/c/3ltbJkXK/1056-yellow-you-are-offline-banner-keeps-appearing-even-when-online)