### PR TITLE
chore: Listener cleanup on Issue Summary

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -92,7 +92,7 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
             grabIssueAndSetLatest()
         }
 
-        NetInfo.addEventListener(({ isConnected }) => {
+        const unsubNet = NetInfo.addEventListener(({ isConnected }) => {
             // try and get a fresh summary until we made it to online
             if (!hasConnected.current) {
                 hasConnected.current = isConnected
@@ -101,15 +101,19 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
             }
         })
 
-        AppState.addEventListener(
-            'change',
-            async (appState: AppStateStatus) => {
-                // when we foreground have another go at fetching again
-                if (appState === 'active') {
-                    grabIssueAndSetLatest()
-                }
-            },
-        )
+        const appStateChangeListener = async (appState: AppStateStatus) => {
+            // when we foreground have another go at fetching again
+            if (appState === 'active') {
+                grabIssueAndSetLatest()
+            }
+        }
+
+        AppState.addEventListener('change', appStateChangeListener)
+
+        return () => {
+            unsubNet()
+            AppState.removeEventListener('change', appStateChangeListener)
+        }
     }, [issueId, maxAvailableEditions])
 
     return (


### PR DESCRIPTION
## Summary

As suggested in a previous PR, this will help reduce memory leaks and improve performance.
@jeanlauliac 

[**Trello Card ->**](https://trello.com/c/dtdqVf3K/1060-move-listeners-outside-of-useeffect-on-issue-summary)