### PR TITLE
Feat/preview article buttons

### DIFF
--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -19,9 +19,8 @@ import { withNavigation } from 'react-navigation'
 import { NavigationInjectedProps } from 'react-navigation'
 import { BasicArticleHeader } from './header'
 import { useNavPosition } from 'src/hooks/use-nav-position'
-import { isPreview } from 'src/helpers/settings/defaults'
 import { Button } from 'src/components/button/button'
-import { getSetting } from 'src/helpers/settings'
+import { useIsPreview } from 'src/hooks/use-settings'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -121,13 +120,7 @@ const SliderSectionBar = ({
         extrapolate: 'clamp',
     })
 
-    const [previewMode, setPreviewMode] = useState(false)
-
-    useEffect(() => {
-        getSetting('apiUrl').then(apiUrl => {
-            setPreviewMode(isPreview(apiUrl))
-        })
-    }, [])
+    const isPreview = useIsPreview()
 
     return (
         <Animated.View
@@ -143,7 +136,7 @@ const SliderSectionBar = ({
                 { flexDirection: 'row' },
             ]}
         >
-            {previewMode && <Button>&larr;</Button>}
+            {isPreview && <Button>&larr;</Button>}
             <Slider
                 small={false}
                 title={section.title}
@@ -151,7 +144,7 @@ const SliderSectionBar = ({
                 stops={2}
                 position={sliderPos}
             />
-            {previewMode && <Button>&rarr;</Button>}
+            {isPreview && <Button>&rarr;</Button>}
         </Animated.View>
     )
 }

--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -19,6 +19,9 @@ import { withNavigation } from 'react-navigation'
 import { NavigationInjectedProps } from 'react-navigation'
 import { BasicArticleHeader } from './header'
 import { useNavPosition } from 'src/hooks/use-nav-position'
+import { isPreview } from 'src/helpers/settings/defaults'
+import { Button } from 'src/components/button/button'
+import { getSetting } from 'src/helpers/settings'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -118,6 +121,14 @@ const SliderSectionBar = ({
         extrapolate: 'clamp',
     })
 
+    const [previewMode, setPreviewMode] = useState(false)
+
+    useEffect(() => {
+        getSetting('apiUrl').then(apiUrl => {
+            setPreviewMode(isPreview(apiUrl))
+        })
+    }, [])
+
     return (
         <Animated.View
             style={[
@@ -129,8 +140,10 @@ const SliderSectionBar = ({
                         },
                     ],
                 },
+                { flexDirection: 'row' },
             ]}
         >
+            {previewMode && <Button>&larr;</Button>}
             <Slider
                 small={false}
                 title={section.title}
@@ -138,6 +151,7 @@ const SliderSectionBar = ({
                 stops={2}
                 position={sliderPos}
             />
+            {previewMode && <Button>&rarr;</Button>}
         </Animated.View>
     )
 }


### PR DESCRIPTION
## Summary
Buttons added next to slider in preview mode to help the production team from getting RSI

![previewmode](https://user-images.githubusercontent.com/935975/70463302-92f22680-1ab4-11ea-8876-2592145ba6f9.gif)

[**Trello Card ->**](https://trello.com/c/5eYjE6IL/1009-easy-nav-in-preview-mode)

## Test Plan
1. Go into the duck menu
2. Choose Prod Preview from the API list
3. Go back to the issue
4. Choose an article
5. Use yellow buttons  as shown in gif.