### PR TITLE
fix: Download Edition

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -265,7 +265,10 @@ export const downloadAndUnzipIssue = async (
     )
 
     if (downloadBlocked !== DownloadBlockedStatus.NotBlocked) {
-        pushTracking('downloadBlocked', DownloadBlockedStatus[downloadBlocked])
+        await pushTracking(
+            'downloadBlocked',
+            DownloadBlockedStatus[downloadBlocked],
+        )
         return
     }
 

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -13,7 +13,10 @@ import { londonTime } from './date'
 import { pushTracking } from 'src/helpers/push-tracking'
 import { localIssueListStore } from 'src/hooks/use-issue-on-device'
 import { fetch } from '@react-native-community/netinfo'
-import { getDownloadBlockedStatus } from 'src/hooks/use-net-info'
+import {
+    getDownloadBlockedStatus,
+    DownloadBlockedStatus,
+} from 'src/hooks/use-net-info'
 
 interface BasicFile {
     filename: string
@@ -260,9 +263,12 @@ export const downloadAndUnzipIssue = async (
     const downloadBlocked = getDownloadBlockedStatus(
         ...(await Promise.all([fetch(), getSetting('wifiOnlyDownloads')])),
     )
-    if (downloadBlocked) {
+
+    if (downloadBlocked !== DownloadBlockedStatus.NotBlocked) {
+        pushTracking('downloadBlocked', DownloadBlockedStatus[downloadBlocked])
         return
     }
+
     const { localId } = issue
     const promise = maybeListenToExistingDownload(issue, onProgress)
     if (promise) return promise


### PR DESCRIPTION
## Summary
Editions are being blocked when downloading as we always return something from `getDownloadBlockedStatus`.

This PR checks for the appropriate status returned and adds some additional tracking if its blocked.

_Please note:_ If someone chooses to download only over wifi, they will not download overnight or when the first open the app
