### PR TITLE
avoid black screen for missing issue

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -39,6 +39,7 @@ import { colour } from '@guardian/pasteup/palette'
 
 import { useNetInfo, DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import { NOT_CONNECTED, WIFI_ONLY_DOWNLOAD } from 'src/helpers/words'
+import { UiBodyCopy } from '../styled-text'
 
 const FRONT_TITLE_FONT = getFont('titlepiece', 1.25)
 const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
@@ -314,13 +315,11 @@ const IssueRowHeader = React.memo(
 
 const IssueFrontsError = () => (
     <View style={styles.frontsSelector}>
-        <GridRowSplit>
-            <Text style={styles.errorMessage}>
-                We could not load the sections of this edition. If you{"'"}re
-                offline, try going online and downloading the edition.
-                Otherwise, close and open the app again.
-            </Text>
-        </GridRowSplit>
+        <UiBodyCopy style={styles.errorMessage}>
+            We could not load the sections of this edition. If you{"'"}re
+            offline, try going online and downloading the edition. Otherwise,
+            close and open the app&nbsp;again.
+        </UiBodyCopy>
     </View>
 )
 

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -254,7 +254,7 @@ const IssueFrontsError = () => (
     <View style={styles.frontsSelector}>
         <GridRowSplit>
             <Text style={styles.errorMessage}>
-                We could not load the sections of this edition. If you're
+                We could not load the sections of this edition. If you{"'"}re
                 offline, try going online and downloading the edition.
                 Otherwise, close and open the app again.
             </Text>

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -28,6 +28,7 @@ import { fetch } from 'src/hooks/use-net-info'
 import { useToast } from 'src/hooks/use-toast'
 import { DOWNLOAD_ISSUE_MESSAGE_OFFLINE } from 'src/helpers/words'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
+import { Loaded } from 'src/helpers/Loaded'
 
 import { useIssueOnDevice, ExistsStatus } from 'src/hooks/use-issue-on-device'
 import { Front, IssueWithFronts } from '../../../../Apps/common/src'
@@ -251,15 +252,15 @@ export const IssueRow = React.memo(
         onPressFront,
     }: {
         issue: IssueSummary
-        issueDetails: IssueWithFronts | null
+        issueDetails: Loaded<IssueWithFronts>
         onPress: () => void
         onPressFront: (key: string) => void
     }) => (
         <>
             <IssueRowHeader onPress={onPress} issue={issue} />
-            {issueDetails != null && (
+            {issueDetails != null && issueDetails.value != null && (
                 <IssueFrontsSelector
-                    fronts={issueDetails.fronts}
+                    fronts={issueDetails.value.fronts}
                     onPressFront={onPressFront}
                 />
             )}

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -48,6 +48,11 @@ const styles = StyleSheet.create({
         borderTopWidth: 1,
         borderTopColor: color.line,
     },
+    errorMessage: {
+        height: ISSUE_FRONT_ROW_HEIGHT,
+        paddingHorizontal: metrics.horizontal,
+        paddingTop: metrics.vertical,
+    },
 
     frontTitleWrap: {
         flex: 1,
@@ -252,7 +257,7 @@ export const IssueRow = React.memo(
         onPressFront,
     }: {
         issue: IssueSummary
-        issueDetails: Loaded<IssueWithFronts>
+        issueDetails: Loaded<IssueWithFronts> | null
         onPress: () => void
         onPressFront: (key: string) => void
     }) => (
@@ -263,6 +268,15 @@ export const IssueRow = React.memo(
                     fronts={issueDetails.value.fronts}
                     onPressFront={onPressFront}
                 />
+            )}
+            {issueDetails != null && issueDetails.error != null && (
+                <View style={styles.frontsSelector}>
+                    <GridRowSplit>
+                        <Text style={styles.errorMessage}>
+                            Failed to fetch the issue
+                        </Text>
+                    </GridRowSplit>
+                </View>
             )}
         </>
     ),

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -41,6 +41,7 @@ const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
 
 export const ISSUE_ROW_HEADER_HEIGHT = ISSUE_TITLE_FONT.lineHeight * 2.6
 export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.9
+export const ISSUE_FRONT_ERROR_HEIGHT = 120
 
 const styles = StyleSheet.create({
     frontsSelector: {
@@ -49,7 +50,7 @@ const styles = StyleSheet.create({
         borderTopColor: color.line,
     },
     errorMessage: {
-        height: ISSUE_FRONT_ROW_HEIGHT,
+        height: ISSUE_FRONT_ERROR_HEIGHT,
         paddingHorizontal: metrics.horizontal,
         paddingTop: metrics.vertical,
     },
@@ -249,6 +250,18 @@ const IssueRowHeader = React.memo(
     },
 )
 
+const IssueFrontsError = () => (
+    <View style={styles.frontsSelector}>
+        <GridRowSplit>
+            <Text style={styles.errorMessage}>
+                We could not load the sections of this edition. If you're
+                offline, try going online and downloading the edition.
+                Otherwise, close and open the app again.
+            </Text>
+        </GridRowSplit>
+    </View>
+)
+
 export const IssueRow = React.memo(
     ({
         issue,
@@ -270,13 +283,7 @@ export const IssueRow = React.memo(
                 />
             )}
             {issueDetails != null && issueDetails.error != null && (
-                <View style={styles.frontsSelector}>
-                    <GridRowSplit>
-                        <Text style={styles.errorMessage}>
-                            Failed to fetch the issue
-                        </Text>
-                    </GridRowSplit>
-                </View>
+                <IssueFrontsError />
             )}
         </>
     ),

--- a/projects/Mallard/src/components/styled-text.tsx
+++ b/projects/Mallard/src/components/styled-text.tsx
@@ -174,7 +174,7 @@ export const UiBodyCopy = ({
     weight = 'regular',
     ...props
 }: {
-    children: string
+    children: string | string[]
     weight?: 'regular' | 'bold'
     style?: StyleProp<TextStyle>
 } & TextProps) => {

--- a/projects/Mallard/src/helpers/Loaded.ts
+++ b/projects/Mallard/src/helpers/Loaded.ts
@@ -4,5 +4,5 @@ export type Loaded<Value> =
           error?: undefined
           isLoading?: undefined
       }
-    | { value?: undefined; error: Error; isLoading?: undefined }
+    | { value?: undefined; error: {}; isLoading?: undefined }
     | { isLoading: true; value?: undefined; error?: undefined }

--- a/projects/Mallard/src/helpers/Loaded.ts
+++ b/projects/Mallard/src/helpers/Loaded.ts
@@ -1,0 +1,8 @@
+export type Loaded<Value> =
+    | {
+          value: Value
+          error?: undefined
+          isLoading?: undefined
+      }
+    | { value?: undefined; error: Error; isLoading?: undefined }
+    | { isLoading: true; value?: undefined; error?: undefined }

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -19,6 +19,10 @@ export const getIssueResponse = (
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
 ) => {
+    return {
+        type: 'promise',
+        getValue: () => Promise.reject(new Error('hello')),
+    }
     //TODO: make this work with twin ids
     return fetchIssue(localIssueId, publishedIssueId)
 }

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -19,10 +19,6 @@ export const getIssueResponse = (
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
 ) => {
-    // return {
-    //     type: 'promise',
-    //     getValue: () => Promise.reject(new Error('hello')),
-    // }
     //TODO: make this work with twin ids
     return fetchIssue(localIssueId, publishedIssueId)
 }

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -19,10 +19,10 @@ export const getIssueResponse = (
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
 ) => {
-    return {
-        type: 'promise',
-        getValue: () => Promise.reject(new Error('hello')),
-    }
+    // return {
+    //     type: 'promise',
+    //     getValue: () => Promise.reject(new Error('hello')),
+    // }
     //TODO: make this work with twin ids
     return fetchIssue(localIssueId, publishedIssueId)
 }

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -349,15 +349,16 @@ const IssueListViewWithDelay = ({
     // fetch the details (ex. list of fronts). During this time,
     // `currentIssueDetails` will be `null`. So in the meantime, we'll
     // keep showing the previous fronts.
+    const { details } = shownIssue
     useEffect(() => {
         if (
             !currentIssue.isLoading &&
-            (currentIssue.value !== shownIssue.details.value ||
-                currentIssue.error !== shownIssue.details.error)
+            (currentIssue.value !== details.value ||
+                currentIssue.error !== details.error)
         ) {
             setShownIssue({ id: currentId, details: currentIssue })
         }
-    }, [currentId, currentIssue, shownIssue])
+    }, [currentId, currentIssue, details])
 
     return <IssueListView issueList={issueList} currentIssue={shownIssue} />
 }

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -12,6 +12,7 @@ import {
     IssueRow,
     ISSUE_ROW_HEADER_HEIGHT,
     ISSUE_FRONT_ROW_HEIGHT,
+    ISSUE_FRONT_ERROR_HEIGHT,
 } from 'src/components/issue/issue-row'
 import { GridRowSplit } from 'src/components/issue/issue-title'
 import { FlexCenter } from 'src/components/layout/flex-center'
@@ -207,6 +208,13 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
 
 const ISSUE_ROW_HEIGHT = ISSUE_ROW_HEADER_HEIGHT + 1
 
+const getFrontRowsHeight = (issue: Loaded<IssueWithFronts>) => {
+    if (issue.isLoading) return 0
+    if (issue.error) return ISSUE_FRONT_ERROR_HEIGHT + 1
+    const { fronts } = issue.value
+    return fronts.length * (ISSUE_FRONT_ROW_HEIGHT + 1)
+}
+
 const IssueListView = withNavigation(
     React.memo(
         ({
@@ -261,9 +269,7 @@ const IssueListView = withNavigation(
             )
 
             // Height of the fronts so we can provide this to `getItemLayout`.
-            const fronts =
-                !details.isLoading && details.value ? details.value.fronts : []
-            const frontRowsHeight = fronts.length * (ISSUE_FRONT_ROW_HEIGHT + 1)
+            const frontRowsHeight = getFrontRowsHeight(details)
 
             // Changing the current issue will affect the layout, so that's
             // indeed a dependency of the callback.

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -246,15 +246,17 @@ const IssueListView = withNavigation(
 
             // We pass down the issue details only for the selected issue.
             const renderItem = useCallback(
-                ({ item, index }) => (
-                    <IssueRowContainer
-                        issue={item}
-                        issueDetails={
-                            index === currentIssueIndex ? details : null
-                        }
-                        navigation={navigation}
-                    />
-                ),
+                ({ item, index }) => {
+                    return (
+                        <IssueRowContainer
+                            issue={item}
+                            issueDetails={
+                                index === currentIssueIndex ? details : null
+                            }
+                            navigation={navigation}
+                        />
+                    )
+                },
                 [currentIssueIndex, details, navigation],
             )
 
@@ -309,6 +311,7 @@ const IssueListView = withNavigation(
                         currentIssueIndex >= 0 ? currentIssueIndex : undefined
                     }
                     renderItem={renderItem}
+                    extraData={details}
                     getItemLayout={getItemLayout}
                     ref={refFn}
                 />


### PR DESCRIPTION
## Summary

If we have the list of issues but we couldn't fetch an issue's content, we'd show a black screen instead of the list of issues (https://trello.com/c/1ABS0oJg/1059-blank-editions-list-when-you-go-offline). This fixes this by having a more robust data structure being passed down the hierarchy, in particular accounting for loading and error state. In case of error we show a message specifically below the current issue instead showing an entire black screen.

## Test Plan

I added some code in `getIssueResponse` to return an error artificially, then verified that the issue-specific error message shows up correctly in the Issue list view:

<img width="200" alt="Screenshot 2019-12-10 at 11 40 30" src="https://user-images.githubusercontent.com/1733570/70527424-cdef6b00-1b43-11ea-8722-091a6fd493d5.png">


I also verified that when being completely offline we show a message and not a black screen either.