### PR TITLE
adjust Front spacing

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -42,7 +42,7 @@ const FRONT_TITLE_FONT = getFont('titlepiece', 1.25)
 const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
 
 export const ISSUE_ROW_HEADER_HEIGHT = ISSUE_TITLE_FONT.lineHeight * 2.6
-export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.9
+export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.65
 
 const styles = StyleSheet.create({
     frontsSelector: {
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
     },
     frontTitle: {
         height: '100%',
-        paddingTop: ISSUE_FRONT_ROW_HEIGHT * 0.15,
+        paddingTop: ISSUE_FRONT_ROW_HEIGHT * 0.1,
         paddingHorizontal: metrics.horizontal,
     },
     frontTitleText: {


### PR DESCRIPTION
## Summary

This adjust the space so that we have 44px-high rows for Fronts on iPhone. We still want to have a relative size to as to depend on font size (it's like using padding and letting the row get the size of the font, except we need the total size upfront for the flatlist's `getItemLayout`)

https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts

## Test Plan

Check it out, verified the rows are indeed 44px (there are 88px in the screenshot, consistent with a device pixel density of 2).


<img width="200" src="https://user-images.githubusercontent.com/1733570/70537877-16655380-1b59-11ea-9a6f-5d2d3e1debd9.png" />