### PR TITLE
chore: Fix Manage Editions Button

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -56,12 +56,10 @@ const MiscSettingsList = React.memo(
             {
                 key: 'manageEditions',
                 title: 'Manage editions',
-                data: {
-                    onPress: () =>
-                        props.navigation.navigate(
-                            routeNames.ManageEditionsSettings,
-                        ),
-                },
+                onPress: () =>
+                    props.navigation.navigate(
+                        routeNames.ManageEditionsSettings,
+                    ),
                 proxy: <RightChevron />,
             },
         ]


### PR DESCRIPTION
## Summary
Button was un-clickable - now clickable.

[**Trello Card ->**](https://trello.com/c/cYykXAgz/1065-edition-management-the-manage-edition-button-on-settings-is-unclickable)

## Test Plan
Click on the Manage Editions button in Settings