### PR TITLE
tiny cleanup of navigate-to-front logic

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -198,15 +198,10 @@ const IssueFronts = ({
 
     useEffect(() => {
         if (trigger && frontWithCards) {
-            const frontToScrollTo = frontWithCards.find(obj => {
-                return obj.displayName === position.frontId
-            })
-
-            const index = frontToScrollTo
-                ? frontWithCards.findIndex(front => front === frontToScrollTo)
-                : 0
-
-            if (ref && ref.current && ref.current.scrollToIndex) {
+            const index = frontWithCards.findIndex(
+                front => front.key === position.frontId,
+            )
+            if (index >= 0 && ref && ref.current && ref.current.scrollToIndex) {
                 ref.current.scrollToIndex({ animated: false, index })
             }
             setTrigger(false)

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -198,10 +198,12 @@ const IssueFronts = ({
 
     useEffect(() => {
         if (trigger && frontWithCards) {
-            const index = frontWithCards.findIndex(
+            let index = frontWithCards.findIndex(
                 front => front.key === position.frontId,
             )
-            if (index >= 0 && ref && ref.current && ref.current.scrollToIndex) {
+            // Invalid index, navigate to the first one. Not sure this is right.
+            if (index < 0) index = 0
+            if (ref && ref.current && ref.current.scrollToIndex) {
                 ref.current.scrollToIndex({ animated: false, index })
             }
             setTrigger(false)


### PR DESCRIPTION
## Summary

I'm looking into the misalignment issues when navigating to a front (https://trello.com/c/VhXCFcQU/924-navigation-quick-access-to-fronts) and noticed the code is seemingly doing 2 `find` instead of 1 for no particular reason.

## Test Plan

Just checked the Fronts navigation from the Editions menu.
