### PR TITLE
Read correct bucket for index creation

### DIFF
--- a/projects/archiver/src/tasks/indexer/helpers/get-issues.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-issues.ts
@@ -4,8 +4,9 @@ import { getBucket, listNestedPrefixes } from '../../../utils/s3'
 /* Crawl S3 for a list of all of the issues that are available */
 export const getIssuesBy = async (
     edition: Edition,
+    bucket: string,
 ): Promise<IssueIdentifier[]> => {
-    const Bucket = getBucket('proof')
+    const Bucket = getBucket(bucket)
     const prefixes = await listNestedPrefixes(Bucket, edition)
 
     return prefixes.map(issueDate => ({

--- a/projects/archiver/src/tasks/indexer/helpers/summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/summary.ts
@@ -41,8 +41,9 @@ export const getOtherRecentIssues = (
 export const getOtherIssuesSummariesForEdition = async (
     currentlyPublishing: IssuePublicationIdentifier,
     edition: Edition,
+    bucket: string,
 ): Promise<IssueSummary[]> => {
-    const allEditionIssues = await getIssuesByEdition(edition)
+    const allEditionIssues = await getIssuesByEdition(edition, bucket)
 
     console.log(
         `allEditionIssues for ${edition}`,

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -37,6 +37,7 @@ const handlerCurry: (
         const otherIssuesSummariesForEdition = await getOtherIssuesSummariesForEdition(
             issuePublication,
             edition,
+            bucket,
         )
 
         console.log(


### PR DESCRIPTION
## Summary

Bugfix: Previous release did not read the data to construct the index from the correct bucket.

## Test Plan

See contents of issues file in editions-store-prod bucket.