### PR TITLE
underlay transition: slide card fully out of the way

### DIFF
--- a/projects/Mallard/src/navigation/navigators/underlay.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay.tsx
@@ -142,6 +142,9 @@ const createUnderlayNavigator = (
         }
     }
 
+    const { width } = Dimensions.get('window')
+    const isTablet = width >= Breakpoints.tabletVertical
+
     return createStackNavigator(navigation, {
         initialRouteName: '_',
         defaultNavigationOptions: {
@@ -151,8 +154,8 @@ const createUnderlayNavigator = (
         ...(supportsTransparentCards()
             ? {
                   mode: 'modal',
-                  transparentCard: true,
-                  cardOverlayEnabled: true,
+                  transparentCard: isTablet,
+                  cardOverlayEnabled: isTablet,
                   transitionConfig,
               }
             : {}),

--- a/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/underlay/transition.tsx
@@ -6,12 +6,6 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { safeInterpolation } from 'src/helpers/math'
 import { sidebarWidth } from './positions'
 
-export const getIssueCardOverlayAmount = () => {
-    const { width, height } = Dimensions.get('window')
-    const isPhone = width >= Breakpoints.phone
-    return isPhone ? height / 5 : height / 5.6
-}
-
 export const topLayerTransition = (
     position: NavigationTransitionProps['position'],
     sceneIndex: number,
@@ -19,11 +13,9 @@ export const topLayerTransition = (
     const { width, height } = Dimensions.get('window')
     const isTablet = width >= Breakpoints.tabletVertical
 
-    const finalTranslate = height - getIssueCardOverlayAmount()
-
     const translateY = position.interpolate({
         inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
-        outputRange: safeInterpolation([0, finalTranslate]),
+        outputRange: safeInterpolation([0, height]),
     })
     const translateX = position.interpolate({
         inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
@@ -33,12 +25,6 @@ export const topLayerTransition = (
     const platformStyles = isTablet
         ? {
               transform: [{ translateX }],
-              shadowOffset: {
-                  width: 10,
-                  height: 10,
-              },
-              shadowOpacity: 1,
-              shadowRadius: 3.84,
               borderRadius: position.interpolate({
                   inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
                   outputRange: safeInterpolation([0, radius / 4]),
@@ -46,10 +32,6 @@ export const topLayerTransition = (
           }
         : {
               transform: [{ translateY }],
-              borderRadius: position.interpolate({
-                  inputRange: safeInterpolation([sceneIndex, sceneIndex + 1]),
-                  outputRange: safeInterpolation([0, radius]),
-              }),
           }
 
     return {

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -35,7 +35,6 @@ import { metrics } from 'src/theme/spacing'
 import { ApiState } from './settings/api-screen'
 import { useIsUsingProdDevtools } from 'src/hooks/use-settings'
 import { routeNames } from 'src/navigation/routes'
-import { getIssueCardOverlayAmount } from 'src/navigation/navigators/underlay/transition'
 import { useSetNavPosition } from 'src/hooks/use-nav-position'
 import { NavigationParams } from 'react-navigation'
 import { Separator } from 'src/components/layout/ui/row'
@@ -49,7 +48,7 @@ const styles = StyleSheet.create({
     issueListFooter: {
         padding: metrics.horizontal,
         paddingTop: metrics.vertical * 2,
-        paddingBottom: getIssueCardOverlayAmount() + metrics.vertical * 2,
+        paddingBottom: metrics.vertical * 8,
     },
     issueListFooterGrid: {
         marginBottom: metrics.vertical,


### PR DESCRIPTION
## Summary

After several discussions we decided the card entirely out of the way: https://trello.com/c/CL9ChL1y/1070-drawer-should-slide-down-fully-offscreen-for-recent-editions-screen-on-phones

This is to leave quite a bit more space to be able to see more Fronts at a glance instead of having to scroll.

## Test Plan

Verify both on iPad and iPhone that the transition is correct. Android is unaffected as it uses a pretty different transition mechanism.

<div>
<img width="200" alt="Screenshot 2019-12-12 at 12 50 59" src="https://user-images.githubusercontent.com/1733570/70713610-4d18a680-1cde-11ea-83d6-d6cbbbe25780.png">
<img width="300" alt="Screenshot 2019-12-12 at 12 50 57" src="https://user-images.githubusercontent.com/1733570/70713611-4d18a680-1cde-11ea-9173-a39f8a5d2815.png">
</div>