### PR TITLE
add hook cleanups to avoid warnings

### DIFF
--- a/projects/Mallard/src/hooks/use-aspect-ratio.ts
+++ b/projects/Mallard/src/hooks/use-aspect-ratio.ts
@@ -11,15 +11,17 @@ const useAspectRatio = (path?: string) => {
     const [ratio, setRatio] = useState(isLandscape ? 2 : 1.5)
 
     useEffect(() => {
+        let localSetRatio = setRatio
         if (path) {
             Image.getSize(
                 path,
                 (w, h) => {
-                    setRatio(w / h)
+                    localSetRatio(w / h)
                 },
                 () => {},
             )
         }
+        return () => void (localSetRatio = () => {})
     }, [path])
 
     return ratio

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -68,6 +68,7 @@ export const useImagePath = (image?: Image, use: ImageUse = 'full-size') => {
     const apiUrl = useApiUrl() || ''
 
     useEffect(() => {
+        let localSetPath = setPath
         if (issueId && image) {
             const { localIssueId, publishedIssueId } = issueId
             selectImagePath(
@@ -76,8 +77,9 @@ export const useImagePath = (image?: Image, use: ImageUse = 'full-size') => {
                 publishedIssueId,
                 image,
                 use,
-            ).then(setPath)
+            ).then(newPath => localSetPath(newPath))
         }
+        return () => void (localSetPath = () => {})
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         apiUrl,

--- a/projects/Mallard/src/hooks/use-screen.ts
+++ b/projects/Mallard/src/hooks/use-screen.ts
@@ -53,9 +53,10 @@ const useInsets = () => {
         right: 0,
     })
     useEffect(() => {
+        let localSetInsets = setInsets
         const updateInsets = () => {
             currentInsets().then(insets => {
-                setInsets({
+                localSetInsets({
                     ...insets,
                     top: insets.top ? insets.top : getStatusBarHeight(true),
                 })
@@ -67,6 +68,7 @@ const useInsets = () => {
                 updateInsets()
             })
         })
+        return () => void (localSetInsets = () => {})
     }, [])
     return insets
 }


### PR DESCRIPTION
## Summary

When components are dismounted, we should discard setters. It causes tons of React warning and that's problematic because we don't see and/or ignore new warnings as a result.

On the other hand it's sad to see that lots of these happen on startup, which mean there are several re-renders on start, probably not necessary. But that's another, separate issue.

## Test Plan

Load the app, navigate to a specific Front, navigate to another Edition, open article. Notice there is no more warnings showing up related to "setting state on unmounted component".