### PR TITLE
hide NetInfo button by default

### DIFF
--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -24,6 +24,8 @@ import { getPushTracking, clearPushTracking } from 'src/helpers/push-tracking'
 import { getFileList } from 'src/helpers/files'
 import { deleteIssueFiles } from 'src/helpers/files'
 import { DEV_getLegacyIAPReceipt } from 'src/authentication/services/iap'
+import { Switch } from 'react-native-gesture-handler'
+import { useNetInfo } from 'src/hooks/use-net-info'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -46,6 +48,12 @@ const ButtonList = ({ children }: { children: ReactNode }) => {
 }
 
 const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
+    const {
+        showDevButton: showNetInfoButton,
+        setShowDevButton: setShowNetInfoButton,
+    } = useNetInfo()
+    const onToggleNetInfoButton = () => setShowNetInfoButton(!showNetInfoButton)
+
     const { attempt, signOutCAS } = useContext(AccessContext)
     const { showToast } = useToast()
 
@@ -194,6 +202,17 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                             Clipboard.setString(FSPaths.issuesDir)
                             Alert.alert(FSPaths.issuesDir)
                         },
+                    },
+                    {
+                        key: 'Display NetInfo Button',
+                        title: 'Display NetInfo Button',
+                        onPress: onToggleNetInfoButton,
+                        proxy: (
+                            <Switch
+                                value={showNetInfoButton}
+                                onValueChange={onToggleNetInfoButton}
+                            />
+                        ),
                     },
                     {
                         key: 'Files in Issues',


### PR DESCRIPTION
## Summary

The NetInfo button used to virtually disable the connection can be useful sometimes but the rest of the time it's taking up space and overlaps some items such as toasts. Let's hide it by default and allow to enable it in the Dev menu?

## Test Plan

Checked toggling on and off the button.
