### PR TITLE
fix: Image Resize Failure

### DIFF
--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -38,15 +38,19 @@ export const selectImagePath = async (
 }
 
 const compressImagePath = async (path: string, width: number) => {
-    const resized = await ImageResizer.createResizedImage(
-        path,
-        width,
-        99999,
-        'JPEG',
-        100,
-        0,
-    )
-    return resized.uri
+    try {
+        const resized = await ImageResizer.createResizedImage(
+            path,
+            width,
+            99999,
+            'JPEG',
+            100,
+            0,
+        )
+        return resized.uri
+    } catch {
+        return path
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
Image resizer appears to be occasionally failing according to Sentry errors. This wraps a `try/catch` and returns the larger path if there is a failure. 

Effort to reduce the noise in Sentry.

Image Resizer Docs: https://github.com/bamlab/react-native-image-resizer
Sentry Error: https://sentry.io/organizations/the-guardian/issues/1352200928/?project=1519156&query=is%3Aunresolved+dist%3A612&statsPeriod=14d
