### PR TITLE
chore: Update unzip library

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -130,11 +130,11 @@ PODS:
     - Sentry (~> 4.4.0)
   - RNSVG (9.6.2):
     - React
-  - RNZipArchive (4.1.2):
+  - RNZipArchive (5.0.0):
     - React
-    - RNZipArchive/Core (= 4.1.2)
+    - RNZipArchive/Core (= 5.0.0)
     - SSZipArchive (= 2.2.2)
-  - RNZipArchive/Core (4.1.2):
+  - RNZipArchive/Core (5.0.0):
     - React
     - SSZipArchive (= 2.2.2)
   - Sentry (4.4.0):
@@ -341,7 +341,7 @@ SPEC CHECKSUMS:
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   RNSentry: 932ac1c8b2f581b1c8be5812f88ff556c99e7fb7
   RNSVG: ff9b094e39dd4a437ebe17d1c7ceed286e75f426
-  RNZipArchive: 2179f7a0755905d68a3b0f2d9332796cca1e7aa4
+  RNZipArchive: be636657a6630e9771d4a3223dc8fd0bd0137b55
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   yoga: c2c050f6ae6e222534760cc82f559b89214b67e2

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -79,7 +79,7 @@
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.6.2",
         "react-native-webview": "^6.9.0",
-        "react-native-zip-archive": "4.1.2",
+        "react-native-zip-archive": "5.0.0",
         "react-navigation": "3.11.1",
         "react-navigation-fluid-transitions": "^0.3.2",
         "rn-fetch-blob": "0.10.16",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6516,10 +6516,10 @@ react-native-webview@^6.9.0:
     escape-string-regexp "1.0.5"
     invariant "2.2.4"
 
-react-native-zip-archive@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-4.1.2.tgz#61bef40d507583171083537fc50fa790e4a14693"
-  integrity sha512-WBwcUf0YHNEMuf+ab3jfHO7+h29eDrQMFoV9YakEzLDY4fyQEmcr1XttO5wevR+Zu19TZFZW34JIVgFPxw+m6A==
+react-native-zip-archive@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-5.0.0.tgz#7833e48b895f3da1f6c99b6f504f124ee243667f"
+  integrity sha512-4AoBKb09lKESRaKcwhBG4+DLAhEHlw4H7AKUZC5zFHjtsaewNfwAMRgP3y+K2mjKN+Ihr/O7NFJFVEDrtarygg==
 
 react-native@0.60.4:
   version "0.60.4"


### PR DESCRIPTION
## Summary
When downloading large editions, it sometimes doesnt complete. This could be to do with the zip library, so giving it an update