### PR TITLE
use-issue-summary: update to latest issue only if there is a new one

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -76,14 +76,27 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
 
     useEffect(() => {
         const grabIssueAndSetLatest = async () => {
+            const previousLatest =
+                issueSummary && issueSummaryToLatestPath(issueSummary)
+
             const { isConnected } = await NetInfo.fetch()
-            const issueSummary = await grabIssueSummary(isConnected)
-            if (issueSummary != null) {
-                setIssueId(issueSummaryToLatestPath(issueSummary))
-            } else {
+            const newIssueSummary = await grabIssueSummary(isConnected)
+            if (newIssueSummary == null) {
                 // now we've foregrounded again, wait for a new issue list
                 // seen as we couldn't get one now
                 hasConnected.current = false
+                return
+            }
+
+            const newLatest = issueSummaryToLatestPath(newIssueSummary)
+            // only update to latest issue if there is indeed a new latest issue
+            if (
+                !previousLatest ||
+                (previousLatest.localIssueId !== newLatest.localIssueId &&
+                    previousLatest.publishedIssueId !==
+                        newLatest.publishedIssueId)
+            ) {
+                setIssueId(newLatest)
             }
         }
 
@@ -114,7 +127,7 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
             unsubNet()
             AppState.removeEventListener('change', appStateChangeListener)
         }
-    }, [issueId, maxAvailableEditions])
+    }, [issueId, maxAvailableEditions, issueSummary])
 
     return (
         <IssueSummaryContext.Provider


### PR DESCRIPTION
## Summary

If there isn't a new issue we can assume people already know about it whichever issue there currently are on.

Part of fixes on https://trello.com/c/KVRmctcK/1016-more-logical-issue-selection-for-accessing-editions

## Test Plan

1. Open app, open Editions list, open older edition, select Front, background the app.
2. Foreground the app. Notice it doesn't force-update edition.

(3. I didn't find a clear approach to test when there **is** a new edition. Shall we add a unit test? Looking for some opinions on this.)