### PR TITLE
chore: Record Download Failures

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -247,6 +247,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
         updateListeners(localId, { type: 'success' }) // null is unstarted or end
     } catch (error) {
         await pushTracking('downloadAndUnzipError', JSON.stringify(error))
+        errorService.captureException(error)
         updateListeners(localId, { type: 'failure', data: error })
         console.log('Download error: ', error)
     }


### PR DESCRIPTION
## Summary
Couldn't find push download failures in Sentry. This is because we catch the error. This ensures this is sent to Sentry

[**Trello Card ->**](https://trello.com)