### PR TITLE
fix: Get the editions when the max available editions changes

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -127,7 +127,16 @@ const IssueSummaryProvider = ({ children }: { children: React.ReactNode }) => {
             unsubNet()
             AppState.removeEventListener('change', appStateChangeListener)
         }
-    }, [issueId, maxAvailableEditions, issueSummary])
+    }, [issueId, issueSummary])
+
+    useEffect(() => {
+        ;(async () => {
+            if (maxAvailableEditions) {
+                const { isConnected } = await NetInfo.fetch()
+                grabIssueSummary(isConnected)
+            }
+        })()
+    }, [maxAvailableEditions])
 
     return (
         <IssueSummaryContext.Provider


### PR DESCRIPTION
## Summary
Since the new backend has gone live, in the new beta when you change the max available editions, that was not being reflected in the issue picker.

This now listens for changes in the max available editions and then goes to grab the issue summary forcing it to update.

## Test Plan

- Click on issue picker
- Choose 'Manage editions'
- Change number of 'Available Editions'
- Close 'Manage editions'
- See number reflected on the issue picker.