### PR TITLE
Check issues list has at least one element in it before uploading.

### DIFF
--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -80,6 +80,8 @@ const handlerCurry: (
                 }
 
                 console.log('Uploaded new issues file')
+            } else {
+                console.warn('New issues file is empty. Upload cancelled.')
             }
 
             return {

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -81,7 +81,7 @@ const handlerCurry: (
 
                 console.log('Uploaded new issues file')
             } else {
-                console.warn('New issues file is empty. Upload cancelled.')
+                console.error('New issues file is empty. Upload cancelled.')
             }
 
             return {

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -57,27 +57,30 @@ const handlerCurry: (
             const all = [thisIssueSummary, ...otherIssuesSummariesForEdition]
             const allSortedEditionsIssues = issueSummarySort(all)
 
-            await upload(
-                `${issuePublication.edition}/issues`,
-                allSortedEditionsIssues,
-                Bucket,
-                'application/json',
-                FIVE_SECONDS,
-            )
-
-            // Also upload the index into the root for older clients
-            // TODO: this can be removed once we are happy that the clients are consuming the namespaced index
-            if (issuePublication.edition === 'daily-edition') {
+            // make sure we don't upload an empty list of editions
+            if (allSortedEditionsIssues.length > 0) {
                 await upload(
-                    'issues',
+                    `${issuePublication.edition}/issues`,
                     allSortedEditionsIssues,
                     Bucket,
                     'application/json',
                     FIVE_SECONDS,
                 )
-            }
 
-            console.log('Uploaded new issues file')
+                // Also upload the index into the root for older clients
+                // TODO: this can be removed once we are happy that the clients are consuming the namespaced index
+                if (issuePublication.edition === 'daily-edition') {
+                    await upload(
+                        'issues',
+                        allSortedEditionsIssues,
+                        Bucket,
+                        'application/json',
+                        FIVE_SECONDS,
+                    )
+                }
+
+                console.log('Uploaded new issues file')
+            }
 
             return {
                 issuePublication,


### PR DESCRIPTION
## Summary
Following from an incident where we overwrote the issues list file with an empty file, this change adds a simple check around the issues file upload process to check that there is at least 1 element in the list of issues before uploading.

[**Trello Card ->**](https://trello.com/c/MvVMGXb3/1092-publishing-should-check-that-there-is-at-least-one-issue-in-the-issues-list-before-overwriting-stuff-in-s3)

This is actually a very small change, but github has decided to make it look a lot bigger than it is. The main bit is `if (allSortedEditionsIssues.length > 0)`

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
