### PR TITLE
use collectImagePath instead of useImagePath in articles

### DIFF
--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { ImageBackground, StyleSheet, View } from 'react-native'
 import { useArticle } from 'src/hooks/use-article'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { collectImagePath } from 'src/hooks/use-collected-image-paths'
 import { color } from 'src/theme/color'
 import { CreditedImage } from '../../common'
 import { Button } from '../button/button'
@@ -40,7 +40,7 @@ interface PropTypes {
 }
 
 const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
-    const path = useImagePath(image)
+    const path = collectImagePath(image)
     const defaultAspectRatio = useAspectRatio(path)
 
     const [showCredit, setShowCredit] = useState(false)

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -14,7 +14,7 @@ import { Line } from './components/line'
 import { Pullquote } from './components/pull-quote'
 import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { collectImagePath } from 'src/hooks/use-collected-image-paths'
 import { Image as TImage } from '../../../../../Apps/common/src'
 import { getPillarColors } from 'src/helpers/transform'
 
@@ -25,7 +25,7 @@ interface ArticleContentProps {
 }
 
 const PictureArticleContent = (image: TImage) => {
-    const path = useImagePath(image)
+    const path = collectImagePath(image)
     return Image({
         imageElement: {
             src: image,
@@ -55,7 +55,7 @@ const renderArticleContent = (
                 case 'media-atom':
                     return showMedia ? renderMediaAtom(el) : ''
                 case 'image': {
-                    const path = useImagePath(el.src)
+                    const path = collectImagePath(el.src)
                     return publishedId
                         ? Image({
                               imageElement: el,

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1,6 +1,6 @@
 import { ArticleType, Image as ImageT, Issue } from 'src/common'
 import { css, html, px } from 'src/helpers/webview'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { collectImagePath } from 'src/hooks/use-collected-image-paths'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
@@ -504,7 +504,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
 `
 
 const Image = ({ image, className }: { image: ImageT; className?: string }) => {
-    const path = useImagePath(image)
+    const path = collectImagePath(image)
     return html`
         <img class="${className}" src="${path}" />
     `
@@ -521,7 +521,7 @@ const MainMediaImage = ({
     children?: string
     preserveRatio?: boolean
 }) => {
-    const path = useImagePath(image)
+    const path = collectImagePath(image)
 
     return html`
         <div

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -5,6 +5,7 @@ import { color } from 'src/theme/color'
 import { ErrorBoundary } from '../layout/ui/errors/error-boundary'
 import { Article, HeaderControlProps } from './types/article'
 import { Crossword } from './types/crossword'
+import { PathToArticle } from 'src/paths'
 
 /*
 This is the article view! For all of the articles.
@@ -13,9 +14,11 @@ it gets everything it needs from its route
 
 const ArticleController = ({
     article,
+    path,
     ...headerControlProps
 }: {
     article: CAPIArticle
+    path: PathToArticle
 } & HeaderControlProps) => {
     if (article.type === 'crossword') {
         return <Crossword crosswordArticle={article} />
@@ -30,7 +33,7 @@ const ArticleController = ({
                 />
             }
         >
-            <Article article={article} {...headerControlProps} />
+            <Article article={article} path={path} {...headerControlProps} />
         </ErrorBoundary>
     )
 }

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -13,6 +13,7 @@ import {
     GalleryArticle,
 } from 'src/common'
 import DeviceInfo from 'react-native-device-info'
+import { PathToArticle } from 'src/paths'
 
 const styles = StyleSheet.create({
     block: {
@@ -98,12 +99,14 @@ const useUpdateWebviewVariable = (
 
 const Article = ({
     article,
+    path,
     onShouldShowHeaderChange,
     shouldShowHeader,
     topPadding,
     onIsAtTopChange,
 }: {
     article: ArticleT | PictureArticle | GalleryArticle
+    path: PathToArticle
 } & HeaderControlProps) => {
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
@@ -123,6 +126,7 @@ const Article = ({
             <WebviewWithArticle
                 type={type}
                 article={article}
+                path={path}
                 theme={theme}
                 scrollEnabled={true}
                 useWebKit={false}

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -1,10 +1,9 @@
 import { fetchImmediate } from 'src/hooks/use-net-info'
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import { WebView, WebViewProps } from 'react-native-webview'
 import { ArticleType } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
 import { useImageSize } from 'src/hooks/use-image-size'
-import { useIssueSummary } from 'src/hooks/use-issue-summary'
 import {
     Article,
     PictureArticle,
@@ -13,9 +12,16 @@ import {
 import { renderArticle } from '../../html/article'
 import { ArticleTheme } from '../article'
 import { onShouldStartLoadWithRequest } from './helpers'
+import { PathToArticle } from 'src/paths'
+import {
+    useCollectedImagePaths,
+    renderWithImagePaths,
+} from 'src/hooks/use-collected-image-paths'
+import { useApiUrl } from 'src/hooks/use-settings'
 
 const WebviewWithArticle = ({
     article,
+    path,
     type,
     _ref,
     theme,
@@ -23,6 +29,7 @@ const WebviewWithArticle = ({
     ...webViewProps
 }: {
     article: Article | PictureArticle | GalleryArticle
+    path: PathToArticle
     type: ArticleType
     theme: ArticleTheme
     _ref?: (ref: WebView) => void
@@ -32,21 +39,47 @@ const WebviewWithArticle = ({
     // the network connection changes, see the comments around
     // `fetchImmediate` where it is defined
     const [{ isConnected }] = useState(fetchImmediate())
+
+    // FIXME: pass this as article data instead so it's never out-of-sync
     const [, { pillar }] = useArticle()
-    const { issueId } = useIssueSummary()
+
+    const { localIssueId, publishedIssueId } = path
     const { imageSize } = useImageSize()
 
-    const html = renderArticle(article.elements, {
-        pillar,
-        article,
-        type,
-        imageSize,
-        theme,
-        showWebHeader: true,
-        showMedia: isConnected,
-        publishedId: (issueId && issueId.publishedIssueId) || null,
-        topPadding,
-    })
+    const renderThisArticle = useCallback(
+        () =>
+            renderArticle(article.elements, {
+                pillar,
+                article,
+                type,
+                imageSize,
+                theme,
+                showWebHeader: true,
+                showMedia: isConnected,
+                publishedId: publishedIssueId || null,
+                topPadding,
+            }),
+        [
+            article,
+            pillar,
+            type,
+            imageSize,
+            theme,
+            isConnected,
+            publishedIssueId,
+            topPadding,
+        ],
+    )
+
+    const apiUrl = useApiUrl()
+    const imagePaths = useCollectedImagePaths(
+        apiUrl,
+        localIssueId,
+        publishedIssueId,
+        renderThisArticle,
+    )
+    const html = renderWithImagePaths(renderThisArticle, imagePaths)
+    if (html == null) return null
 
     return (
         <WebView

--- a/projects/Mallard/src/hooks/use-collected-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-collected-image-paths.ts
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+import { Image, ImageUse } from '../../../Apps/common/src'
+import { selectImagePath } from './use-image-paths'
+
+type ImageData = { key: string; image: Image; use: ImageUse }
+type ImagePaths = Map<string, string>
+
+type ImagePathsState =
+    | { type: 'none' }
+    | { type: 'collect'; images: ImageData[] }
+    | { type: 'resolve'; paths: ImagePaths }
+
+const NO_STATE: ImagePathsState = { type: 'none' }
+let IMAGE_PATHS_STATE: ImagePathsState = NO_STATE
+
+/**
+ * Similar to `useImagePath` but for use from the code that builds the HTML.
+ */
+export const collectImagePath = (
+    image?: Image,
+    use: ImageUse = 'full-size',
+): string | undefined => {
+    if (image == null) return undefined
+    if (IMAGE_PATHS_STATE.type === 'none')
+        throw new Error(
+            '`getImagePath` calls must be wrapped in ' +
+                '`useCollectedImagePaths` or `renderWithImagePaths`',
+        )
+
+    const key = JSON.stringify([image, use])
+    if (IMAGE_PATHS_STATE.type === 'collect') {
+        IMAGE_PATHS_STATE.images.push({ key, image, use })
+        return undefined
+    }
+
+    return IMAGE_PATHS_STATE.paths.get(key)
+}
+
+/**
+ * Collect the list of all the images used by the `renderer`, then fetch the
+ * relevant image file paths, and eventually return these. Return `null` while
+ * we're still resolving the file paths. `renderer` should have no side effect,
+ * much like a React render function.
+ */
+export const useCollectedImagePaths = <R>(
+    apiUrl: string | null,
+    localIssueId: string,
+    publishedIssueId: string,
+    renderer: () => R,
+): ImagePaths | undefined => {
+    const [imagePaths, setImagePaths] = useState<ImagePaths | undefined>(
+        undefined,
+    )
+    useEffect(() => {
+        if (apiUrl == null) return
+        let localSetPaths = setImagePaths
+        const images: ImageData[] = []
+
+        try {
+            IMAGE_PATHS_STATE = { type: 'collect', images }
+            renderer()
+        } finally {
+            IMAGE_PATHS_STATE = NO_STATE
+        }
+
+        const getImagePath = async (imageData: ImageData) => {
+            const path = await selectImagePath(
+                apiUrl,
+                localIssueId,
+                publishedIssueId,
+                imageData.image,
+                imageData.use,
+            )
+            return [imageData.key, path]
+        }
+        ;(async () => {
+            const paths = await Promise.all(images.map(getImagePath))
+            // `Promise.all` isn't fully correctly typed, we have to use `any`
+            localSetPaths(new Map(paths as any))
+        })()
+
+        return () => void (localSetPaths = () => {})
+    }, [apiUrl, localIssueId, publishedIssueId, renderer])
+
+    return imagePaths
+}
+
+/**
+ * Run `renderer` with inner calls to `collectImagePath` resolving to the
+ * correct image paths. If `imagePaths` is `null` (ex. still loading), then
+ * we don't try to render anything yet.
+ */
+export const renderWithImagePaths = <R>(
+    renderer: () => R,
+    imagePaths: ImagePaths | undefined,
+) => {
+    if (imagePaths == null) return null
+    try {
+        IMAGE_PATHS_STATE = { type: 'resolve', paths: imagePaths }
+        return renderer()
+    } finally {
+        IMAGE_PATHS_STATE = NO_STATE
+    }
+}

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -83,6 +83,7 @@ const ArticleScreenBody = React.memo<
                             >
                                 <ArticleController
                                     {...headerControlProps}
+                                    path={path}
                                     article={article.article}
                                     onIsAtTopChange={handleIsAtTopChange}
                                 />


### PR DESCRIPTION
## Summary

There are 2 problems with how images are resolved with `useImagePath` IMO:

1. it uses `useIssueSummary` to get the "current ID", but this is wrong because we might be displaying an article from another issue, while we did update to a newer issue in the background. We do want to support that use case, so that we switch to the new issue during the night but leaving the article being read untouched for example.
2. it uses React hooks all across the article HTML rendering code. That means for each separate image showing up in an article, we might re-render **the entire article's HTML** at different point in time when the path for each image resolves in turn. Which arguably is a little broken IMO, we should just fetch all the image paths, and everything else in fact, and build the HTML only once, and render it. Technically, using hooks based on data is also an anti-pattern in React, because if the `article` prop change, React would indeed crash saying hook calls changed (doesn't happen in practice in that case).

The first idea I've got to resolve this situation is to pre-process all the images beforehand, but that requires custom code to traverse the article data. The other idea, which this PR implements, is to just run the normal rendering code and just gather all the images we need from the calls to `useImagePath`, which I rename `collectImagePath` (since it's not a React hook anymore).

This is the most robust solution, however this results in more code than I wish it had, and there isn't really a way to compress that more. This solution solves both problems above. I could make a shorter solution that only solves (1) but I wouldn't be very happy to leave problem (2) around.

Alternatively we can use the first idea, which is to crawl the article data to fetch images beforehand manually, rather than this "collect" mechanism. It creates some code duplication, but maybe one would prefer this.

https://trello.com/c/RmhNdT2c/1022-offline-reading-images-disappear-when-you-offline-back-to-online-or-u-swap-out-of-the-app-and-come-back-in-offline-mode

## Test Plan

Slide from article to article, notice all works as expected. Change code in `useIssueSummary` so that it switch to the most recent issue on foregrounding, reload the code, open an article, background then foreground the app again. Notice that images are not lost anymore (see original bug in Trello card).