### PR TITLE
Fix case of title on 'Manage Editions' page.

### DIFF
--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -185,7 +185,7 @@ const ManageEditionsScreen = () => {
 }
 
 ManageEditionsScreen.navigationOptions = {
-    title: 'Manage editions',
+    title: 'Manage Editions',
 }
 
 export { ManageEditionsScreen }


### PR DESCRIPTION
<img width="375" alt="Screenshot 2019-12-16 at 15 37 17" src="https://user-images.githubusercontent.com/8861681/70920218-1adab200-201a-11ea-9393-475e93be7a0a.png">
