### PR TITLE
Ensure header buttons on 'manage editions' screen display correctly given their context

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -25,7 +25,8 @@ export const GENERIC_ERROR = `Sorry! This didn't work`
 export const GENERIC_AUTH_ERROR = `Something went wrong`
 export const GENERIC_FATAL_ERROR = `Sorry! We broke the app. Can you email us at ${FEEDBACK_EMAIL} and tell us what happened?`
 export const NOT_CONNECTED = 'You are not connected to the internet'
-export const WIFI_ONLY_DOWNLOAD = `You must be connected to wifi to download, you can change this under 'Manage editions'`
+export const MANAGE_EDITIONS_TITLE = 'Manage Editions'
+export const WIFI_ONLY_DOWNLOAD = `You must be connected to wifi to download, you can change this under '${MANAGE_EDITIONS_TITLE}'`
 
 export const DIAGNOSTICS_TITLE = 'Found a bug?'
 export const DIAGNOSTICS_REQUEST = `Would you like us to include diagnostic information to help answer your query?${

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -38,7 +38,10 @@ import { createUnderlayNavigator } from './navigators/underlay'
 import { routeNames } from './routes'
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
-import { ManageEditionsScreen } from 'src/screens/settings/manage-editions-screen'
+import {
+    ManageEditionsScreen,
+    ManageEditionScreenFromIssuePicker,
+} from 'src/screens/settings/manage-editions-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 
 const navOptionsWithGraunHeader = {
@@ -82,7 +85,7 @@ const AppStack = createModalNavigator(
     ),
     {
         [routeNames.ManageEditions]: createHeaderStackNavigator({
-            [routeNames.ManageEditions]: ManageEditionsScreen,
+            [routeNames.ManageEditions]: ManageEditionScreenFromIssuePicker,
         }),
         [routeNames.Settings]: createHeaderStackNavigator(
             {

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -12,6 +12,7 @@ import {
 import { WithAppAppearance } from 'src/theme/appearance'
 import { getIssueSummary } from 'src/hooks/use-issue-summary'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
+import { MANAGE_EDITIONS_TITLE } from 'src/helpers/words'
 
 const buttonStyles = StyleSheet.create({
     background: {
@@ -184,8 +185,16 @@ const ManageEditionsScreen = () => {
     )
 }
 
+const ManageEditionScreenFromIssuePicker = () => <ManageEditionsScreen />
+
 ManageEditionsScreen.navigationOptions = {
-    title: 'Manage Editions',
+    title: MANAGE_EDITIONS_TITLE,
 }
 
-export { ManageEditionsScreen }
+ManageEditionScreenFromIssuePicker.navigationOptions = {
+    title: MANAGE_EDITIONS_TITLE,
+    showHeaderLeft: false,
+    showHeaderRight: true,
+}
+
+export { ManageEditionsScreen, ManageEditionScreenFromIssuePicker }


### PR DESCRIPTION
## Summary

If the 'manage editions' screen is shown from the settings menu, the back arrow on the left hand side of the header should show.

<img width="546" alt="Screenshot 2019-12-16 at 16 13 48" src="https://user-images.githubusercontent.com/8861681/70923283-8ecb8900-201f-11ea-8498-1f6b2d959070.png">

If the 'manage editions' screen is shown from the issue picker menu, the close icon on the right hand side of the header should show.

<img width="547" alt="Screenshot 2019-12-16 at 16 11 01" src="https://user-images.githubusercontent.com/8861681/70923342-a6a30d00-201f-11ea-8a1e-0b8622b6ce4f.png">
