### PR TITLE
Fix byline color on longreads.

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -449,27 +449,28 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
 
     /*longread*/
     ${outieHeader(ArticleType.Longread)}
-    .header-container[data-type='longread'] {
+    .header-container[data-type='${ArticleType.Longread}'] {
         color: ${color.textOverDarkBackground};
     }
-    .header-container[data-type='longread'] .header-bg {
+    .header-container[data-type='${ArticleType.Longread}'] .header-bg {
         background-color: ${color.palette.neutral[7]};
     }
-    .header-container[data-type='longread'] .header {
+    .header-container[data-type='${ArticleType.Longread}'] .header {
         background-color: ${color.palette.neutral[7]};
     }
-    .header-container[data-type='longread'] .header-kicker {
+    .header-container[data-type='${ArticleType.Longread}'] .header-kicker {
         background-color: ${colors.main};
         color: ${color.textOverDarkBackground};
         font-family: ${families.headline.bold};
     }
-    .header-container[data-type='longread'] .header-top h1 {
+    .header-container[data-type='${ArticleType.Longread}'] .header-top h1 {
         font-family: ${families.titlepiece.regular};
     }
-    .header-container[data-type='longread'] .header-byline {
+    .header-container[data-type='${ArticleType.Longread}'] .header-byline,
+    ${'' /* this is needed to be more specific than an above style */}
+    .header-container[data-type='${ArticleType.Longread}'] .header-byline a {
         color: ${color.textOverDarkBackground};
     }
-
 
     /*obit*/
     ${outieKicker(ArticleType.Obituary)}


### PR DESCRIPTION
Bylines should show as alternative text colour to background - not matching as before.

<img width="546" alt="Screenshot 2019-12-16 at 16 31 53" src="https://user-images.githubusercontent.com/8861681/70925017-73ae4880-2022-11ea-89db-57239761e5c8.png">
