### PR TITLE
Issues list: fix getItemLayout sizes and scrolling behavior

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -44,8 +44,12 @@ import { UiBodyCopy } from '../styled-text'
 const FRONT_TITLE_FONT = getFont('titlepiece', 1.25)
 const ISSUE_TITLE_FONT = getFont('titlepiece', 1.25)
 
-export const ISSUE_ROW_HEADER_HEIGHT = ISSUE_TITLE_FONT.lineHeight * 2.6
-export const ISSUE_FRONT_ROW_HEIGHT = FRONT_TITLE_FONT.lineHeight * 1.65
+export const ISSUE_ROW_HEADER_HEIGHT = Math.floor(
+    ISSUE_TITLE_FONT.lineHeight * 2.6,
+)
+export const ISSUE_FRONT_ROW_HEIGHT = Math.floor(
+    FRONT_TITLE_FONT.lineHeight * 1.65,
+)
 export const ISSUE_FRONT_ERROR_HEIGHT = 120
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -199,7 +199,7 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
     )
 }
 
-const ISSUE_ROW_HEIGHT = ISSUE_ROW_HEADER_HEIGHT + 1
+const ISSUE_ROW_HEIGHT = ISSUE_ROW_HEADER_HEIGHT + StyleSheet.hairlineWidth
 
 const getFrontRowsHeight = (issue: Loaded<IssueWithFronts>) => {
     if (issue.isLoading) return 0
@@ -234,16 +234,20 @@ const IssueListView = withNavigation(
             // Scroll to the relevant item if the current issue index has
             // changed (likely because the selected issue has changed itself).
             const listRef = useRef<FlatList<IssueSummary>>()
+            const prevCurrentIndexRef = useRef<number>(currentIssueIndex)
             useEffect(() => {
                 if (listRef.current == null || currentIssueIndex < 0) {
                     return
                 }
 
+                if (prevCurrentIndexRef.current === currentIssueIndex) return
+                prevCurrentIndexRef.current = currentIssueIndex
+
                 /* @types/react doesn't know about scroll functions */
                 ;(listRef.current as any).scrollToIndex({
                     index: currentIssueIndex,
                 })
-            }, [listRef, currentIssueIndex])
+            }, [currentIssueIndex])
 
             // We pass down the issue details only for the selected issue.
             const renderItem = useCallback(
@@ -268,7 +272,7 @@ const IssueListView = withNavigation(
                 (_, index) => {
                     return {
                         length:
-                            ISSUE_ROW_HEIGHT +
+                            ISSUE_ROW_HEADER_HEIGHT +
                             (index === currentIssueIndex ? frontRowsHeight : 0),
                         offset:
                             index * ISSUE_ROW_HEIGHT +


### PR DESCRIPTION
## Summary

1. account for hairline being 0.5px, not 1px (virtual pixels), by using `StyleSheet.hairlineWidth`.
2. do not trigger the `scrollToIndex` call on first render. This effectively fixes https://trello.com/c/srUOr8rq/1093-android-10-issue-list-bug.

## Test Plan

Open Android 10 emulator, enable 30 days for issue list, open an issue far in the list. Notice it scroll to the exact, pixel-perfect position. Close the edition list, then open it again. Notice it is scrolled to the exact, correct position again.
