### PR TITLE
Use string crossword type variable in patchCrossword.

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -399,7 +399,7 @@ export interface CapiDateTime {
 
 export interface Crossword {
     name: string
-    type: CrosswordType
+    type: CrosswordType //NOTE: this is a number as it comes from the capi thrift enum
     number: number
     date: CapiDateTime
     dimensions: CrosswordDimensions

--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -66,7 +66,7 @@ export const patchCrossword = (
     crossword: Crossword,
     type: CrosswordType,
 ): Crossword => {
-    const solutionAvailable = shouldHaveSolution(crossword.type)
+    const solutionAvailable = shouldHaveSolution(type)
     return {
         ...crossword,
         // the original type was a number from the CAPI thrift definition here


### PR DESCRIPTION
## Summary
Currently `shouldHaveSolution` doesn't return correctly as it tries to compare crossword.type which is a number with CrosswordType.EVERYMAN - which is a string. I've not quite got to the bottom of this but I think it's due to some weirdness with typescrip string enums.

It looks like whoever wrote this function initally was aware of the problem as they make the parameter `type` available - which is a string - to deal with this issue. This change gets us using that parameter.

[**Trello Card ->**](https://trello.com/c/v3IM9DtK/930-crossword-shouldnt-reveal-the-answers-for-prize-crosswords)

## Test Plan
Check that everyman (sunday) and prize (saturday) crosswords don't have the 'reveal all' button
