### PR TITLE
use-issue-summary: switch to Apollo

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -29,7 +29,6 @@ import { Modal, ModalRenderer } from './components/modal'
 import { NetInfoAutoToast } from './components/toast/net-info-auto-toast'
 import { nestProviders } from './helpers/provider'
 import { pushNotifcationRegistration } from './helpers/push-notifications'
-import { IssueSummaryProvider } from './hooks/use-issue-summary'
 import { NetInfoProvider } from './hooks/use-net-info'
 import { ToastProvider } from './hooks/use-toast'
 import { DeprecateVersionModal } from './screens/deprecate-screen'
@@ -125,7 +124,6 @@ const isReactNavPersistenceError = (e: Error) =>
 const WithProviders = nestProviders(
     Modal,
     ToastProvider,
-    IssueSummaryProvider,
     NavPositionProvider,
     ImageSizeProvider,
 )

--- a/projects/Mallard/src/apollo.ts
+++ b/projects/Mallard/src/apollo.ts
@@ -7,6 +7,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { SETTINGS_RESOLVERS } from './helpers/settings/resolvers'
 import { resolveWeather } from './helpers/weather'
 import { resolveLocationPermissionStatus } from './helpers/location-permission'
+import { initIssueSummary } from './hooks/use-issue-summary'
 
 /**
  * Resolvers is what Apollo uses to get the value of field that has never been
@@ -51,9 +52,13 @@ const link = {
     },
 }
 
-export const createApolloClient = () =>
-    new ApolloClient({
+export const createApolloClient = () => {
+    const client = new ApolloClient({
         cache: new InMemoryCache(),
         link,
         resolvers: RESOLVERS,
     })
+
+    initIssueSummary(client)
+    return client
+}


### PR DESCRIPTION
## Summary

I propose we move forward with unifying around Apollo for storing state. This changeset would switch `useIssueSummary` to Apollo to store the issue summary data, so that we leverage the query mechanism, which allows for a fine-grained selection of fields a component depends on, instead of having whole React Context containing blobs of state.

The high-level product logic is unchanged.

## Test Plan

Open app, notice it loads correctly the edition, open the Editions list, change the number of editions (ex. 14 days), notice it correctly updates. 
