### PR TITLE
replace useImagePath with synchronous alternative in article rendering

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -266,7 +266,7 @@ export interface Issue extends IssueSummary, WithKey {
     fronts: Front['key'][]
 }
 
-export type IssueOrigin = 'fs' | 'api'
+export type IssueOrigin = 'filesystem' | 'api'
 
 export interface IssueWithFronts extends IssueSummary, WithKey {
     fronts: Front[]

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -266,8 +266,11 @@ export interface Issue extends IssueSummary, WithKey {
     fronts: Front['key'][]
 }
 
+export type IssueOrigin = 'fs' | 'api'
+
 export interface IssueWithFronts extends IssueSummary, WithKey {
     fronts: Front[]
+    origin: IssueOrigin
 }
 
 export interface Collection extends WithKey {

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -14,7 +14,7 @@ import { Line } from './components/line'
 import { Pullquote } from './components/pull-quote'
 import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { GetImagePath } from 'src/hooks/use-image-paths'
 import { Image as TImage } from '../../../../../Apps/common/src'
 import { getPillarColors } from 'src/helpers/transform'
 
@@ -22,10 +22,11 @@ interface ArticleContentProps {
     showMedia: boolean
     publishedId: Issue['publishedId'] | null
     imageSize: ImageSize
+    getImagePath: GetImagePath
 }
 
-const PictureArticleContent = (image: TImage) => {
-    const path = useImagePath(image)
+const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
+    const path = getImagePath(image)
     return Image({
         imageElement: {
             src: image,
@@ -38,7 +39,7 @@ const PictureArticleContent = (image: TImage) => {
 
 const renderArticleContent = (
     elements: BlockElement[],
-    { showMedia, publishedId }: ArticleContentProps,
+    { showMedia, publishedId, getImagePath }: ArticleContentProps,
 ) => {
     return elements
         .map(el => {
@@ -55,7 +56,7 @@ const renderArticleContent = (
                 case 'media-atom':
                     return showMedia ? renderMediaAtom(el) : ''
                 case 'image': {
-                    const path = useImagePath(el.src)
+                    const path = getImagePath(el.src)
                     return publishedId
                         ? Image({
                               imageElement: el,
@@ -88,6 +89,7 @@ export const renderArticle = (
         imageSize,
         type,
         theme,
+        getImagePath,
     }: {
         pillar: ArticlePillar
         topPadding: number
@@ -110,9 +112,10 @@ export const renderArticle = (
                 bylineHtml: article.bylineHtml,
                 showMedia,
                 canBeShared,
+                getImagePath,
             })
             if (article.image && publishedId) {
-                content = PictureArticleContent(article.image)
+                content = PictureArticleContent(article.image, getImagePath)
             }
             break
         case 'gallery':
@@ -125,11 +128,13 @@ export const renderArticle = (
                 image: article.image,
                 showMedia,
                 canBeShared,
+                getImagePath,
             })
             content = renderArticleContent(elements, {
                 showMedia,
                 publishedId,
                 imageSize,
+                getImagePath,
             })
             break
         default:
@@ -139,11 +144,13 @@ export const renderArticle = (
                 publishedId,
                 showMedia,
                 canBeShared,
+                getImagePath,
             })
             content = renderArticleContent(elements, {
                 showMedia,
                 publishedId,
                 imageSize,
+                getImagePath,
             })
             break
     }

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1,6 +1,6 @@
 import { ArticleType, Image as ImageT, Issue } from 'src/common'
 import { css, html, px } from 'src/helpers/webview'
-import { useImagePath } from 'src/hooks/use-image-paths'
+import { GetImagePath } from 'src/hooks/use-image-paths'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
@@ -504,8 +504,16 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
 `
 
-const Image = ({ image, className }: { image: ImageT; className?: string }) => {
-    const path = useImagePath(image)
+const Image = ({
+    image,
+    className,
+    getImagePath,
+}: {
+    image: ImageT
+    className?: string
+    getImagePath: GetImagePath
+}) => {
+    const path = getImagePath(image)
     return html`
         <img class="${className}" src="${path}" />
     `
@@ -516,13 +524,15 @@ const MainMediaImage = ({
     className,
     children,
     preserveRatio,
+    getImagePath,
 }: {
     image: CreditedImage
     className?: string
     children?: string
     preserveRatio?: boolean
+    getImagePath: GetImagePath
 }) => {
-    const path = useImagePath(image)
+    const path = getImagePath(image)
 
     return html`
         <div
@@ -561,12 +571,14 @@ const hasLargeByline = (type: ArticleType) =>
 const Header = ({
     publishedId,
     type,
+    getImagePath,
     ...headerProps
 }: {
     showMedia: boolean
     publishedId: Issue['publishedId'] | null
     type: ArticleType
     canBeShared: boolean
+    getImagePath: GetImagePath
 } & ArticleHeaderProps) => {
     const immersive = isImmersive(type)
     const largeByline = hasLargeByline(type)
@@ -596,6 +608,7 @@ const Header = ({
             MainMediaImage({
                 image: headerProps.image,
                 className: 'header-image header-image--immersive',
+                getImagePath,
             })}
         <div class="header-container-line-wrap">
             ${Line({ zIndex: 10 })}
@@ -615,6 +628,7 @@ const Header = ({
                                       sportScore: headerProps.sportScore,
                                   })
                                 : undefined,
+                            getImagePath,
                         })}
                     ${headerProps.mainMedia &&
                         (headerProps.showMedia
@@ -648,6 +662,7 @@ const Header = ({
                                               <div>
                                                   ${Image({
                                                       image: cutout,
+                                                      getImagePath,
                                                   })}
                                               </div>
                                           `}

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from '../layout/ui/errors/error-boundary'
 import { Article, HeaderControlProps } from './types/article'
 import { Crossword } from './types/crossword'
 import { PathToArticle } from 'src/paths'
+import { IssueOrigin } from '../../../../Apps/common/src'
 
 /*
 This is the article view! For all of the articles.
@@ -15,10 +16,12 @@ it gets everything it needs from its route
 const ArticleController = ({
     article,
     path,
+    origin,
     ...headerControlProps
 }: {
     article: CAPIArticle
     path: PathToArticle
+    origin: IssueOrigin
 } & HeaderControlProps) => {
     if (article.type === 'crossword') {
         return <Crossword crosswordArticle={article} />
@@ -33,7 +36,12 @@ const ArticleController = ({
                 />
             }
         >
-            <Article article={article} path={path} {...headerControlProps} />
+            <Article
+                article={article}
+                path={path}
+                origin={origin}
+                {...headerControlProps}
+            />
         </ErrorBoundary>
     )
 }

--- a/projects/Mallard/src/components/article/index.tsx
+++ b/projects/Mallard/src/components/article/index.tsx
@@ -5,6 +5,7 @@ import { color } from 'src/theme/color'
 import { ErrorBoundary } from '../layout/ui/errors/error-boundary'
 import { Article, HeaderControlProps } from './types/article'
 import { Crossword } from './types/crossword'
+import { PathToArticle } from 'src/paths'
 
 /*
 This is the article view! For all of the articles.
@@ -13,9 +14,11 @@ it gets everything it needs from its route
 
 const ArticleController = ({
     article,
+    path,
     ...headerControlProps
 }: {
     article: CAPIArticle
+    path: PathToArticle
 } & HeaderControlProps) => {
     if (article.type === 'crossword') {
         return <Crossword crosswordArticle={article} />
@@ -30,7 +33,7 @@ const ArticleController = ({
                 />
             }
         >
-            <Article article={article} {...headerControlProps} />
+            <Article article={article} path={path} {...headerControlProps} />
         </ErrorBoundary>
     )
 }

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/common'
 import DeviceInfo from 'react-native-device-info'
 import { PathToArticle } from 'src/paths'
+import { IssueOrigin } from '../../../../../Apps/common/src'
 
 const styles = StyleSheet.create({
     block: {
@@ -104,9 +105,11 @@ const Article = ({
     shouldShowHeader,
     topPadding,
     onIsAtTopChange,
+    origin,
 }: {
     article: ArticleT | PictureArticle | GalleryArticle
     path: PathToArticle
+    origin: IssueOrigin
 } & HeaderControlProps) => {
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
@@ -135,6 +138,7 @@ const Article = ({
                     ref.current = r
                 }}
                 topPadding={topPadding}
+                origin={origin}
                 onMessage={event => {
                     const parsed = parsePing(event.nativeEvent.data)
                     if (parsed.type === 'share') {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -13,6 +13,7 @@ import {
     GalleryArticle,
 } from 'src/common'
 import DeviceInfo from 'react-native-device-info'
+import { PathToArticle } from 'src/paths'
 
 const styles = StyleSheet.create({
     block: {
@@ -98,12 +99,14 @@ const useUpdateWebviewVariable = (
 
 const Article = ({
     article,
+    path,
     onShouldShowHeaderChange,
     shouldShowHeader,
     topPadding,
     onIsAtTopChange,
 }: {
     article: ArticleT | PictureArticle | GalleryArticle
+    path: PathToArticle
 } & HeaderControlProps) => {
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
@@ -123,6 +126,7 @@ const Article = ({
             <WebviewWithArticle
                 type={type}
                 article={article}
+                path={path}
                 theme={theme}
                 scrollEnabled={true}
                 useWebKit={false}

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -52,10 +52,11 @@ const WebviewWithArticle = ({
     const getImagePath = (image?: Image, use: ImageUse = 'full-size') => {
         if (image == null) return undefined
 
-        if (origin === 'fs') {
+        if (origin === 'filesystem') {
             const fs = FSPaths.image(localIssueId, imageSize, image, use)
             return Platform.OS === 'android' ? 'file:///' + fs : fs
         }
+        if (origin !== 'api') throw new Error('unrecognized "origin"')
 
         const issueId = publishedIssueId
         const imagePath = APIPaths.image(issueId, imageSize, image, use)

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -13,9 +13,11 @@ import {
 import { renderArticle } from '../../html/article'
 import { ArticleTheme } from '../article'
 import { onShouldStartLoadWithRequest } from './helpers'
+import { PathToArticle } from 'src/paths'
 
 const WebviewWithArticle = ({
     article,
+    path,
     type,
     _ref,
     theme,
@@ -23,6 +25,7 @@ const WebviewWithArticle = ({
     ...webViewProps
 }: {
     article: Article | PictureArticle | GalleryArticle
+    path: PathToArticle
     type: ArticleType
     theme: ArticleTheme
     _ref?: (ref: WebView) => void
@@ -32,8 +35,11 @@ const WebviewWithArticle = ({
     // the network connection changes, see the comments around
     // `fetchImmediate` where it is defined
     const [{ isConnected }] = useState(fetchImmediate())
+
+    // FIXME: pass this as article data instead so it's never out-of-sync?
     const [, { pillar }] = useArticle()
-    const { issueId } = useIssueSummary()
+
+    const { localIssueId, publishedIssueId } = path
     const imageSize = useImageSize()
 
     const html = renderArticle(article.elements, {
@@ -44,7 +50,7 @@ const WebviewWithArticle = ({
         theme,
         showWebHeader: true,
         showMedia: isConnected,
-        publishedId: (issueId && issueId.publishedIssueId) || null,
+        publishedId: publishedIssueId || null,
         topPadding,
     })
 

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -56,7 +56,7 @@ const fetchIssueWithFrontsFromFS = async (
     )
     return {
         ...issue,
-        origin: 'fs',
+        origin: 'filesystem',
         fronts,
     }
 }

--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -42,6 +42,7 @@ const fetchIssueWithFrontsFromAPI = async (
     )
     return {
         ...issue,
+        origin: 'api',
         fronts,
     }
 }
@@ -55,6 +56,7 @@ const fetchIssueWithFrontsFromFS = async (
     )
     return {
         ...issue,
+        origin: 'fs',
         fronts,
     }
 }

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -8,6 +8,8 @@ import { useIssueSummary } from './use-issue-summary'
 import { Platform } from 'react-native'
 import { useApiUrl } from './use-settings'
 
+export type GetImagePath = (image?: Image, use?: ImageUse) => string | undefined
+
 const getFsPath = (
     localIssueId: Issue['localId'],
     image: Image,

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -50,7 +50,7 @@ export const getArticleResponse = ({
         )
 
         if (articleContent) {
-            return chain.end(articleContent)
+            return chain.end({ ...articleContent, origin: issue.origin })
         }
         throw ERR_404_REMOTE
     })

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -86,6 +86,7 @@ const ArticleScreenBody = React.memo<
                                     path={path}
                                     article={article.article}
                                     onIsAtTopChange={handleIsAtTopChange}
+                                    origin={article.origin}
                                 />
                             </WithArticle>
                         </>

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -83,6 +83,7 @@ const ArticleScreenBody = React.memo<
                             >
                                 <ArticleController
                                     {...headerControlProps}
+                                    path={path}
                                     article={article.article}
                                     onIsAtTopChange={handleIsAtTopChange}
                                 />


### PR DESCRIPTION
## Summary

This changeset remove calls to `useImagePath` from within article HTML rendering code. This is erroneous because it uses `useIssueSummary` in turn, which grab the current issue ID, but not necessarily the ID of the issue the article is in. That in turn was causing images to "disappear". This is replaced by a synchronous `getImagePath` function that assumes either all images are local (FS), or all images are remote (API).

To do this we pass down additional information: the issue ID (instead of using `useIssueSummary`, which can be wrong as said), and the "origin" (whether get the images from API or FS).

Supersedes #936.

Addresses https://trello.com/c/RmhNdT2c/1022-offline-reading-images-disappear-when-you-offline-back-to-online-or-u-swap-out-of-the-app-and-come-back-in-offline-mode

## Test Plan

* Open an issue locally downloaded, open article, verify images are showing up correctly.
* Open an issue NOT downloaded, open article, verify images are showing up.
