### PR TITLE
use-issue-summary: always set issueId if missing

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -126,6 +126,7 @@ export const initIssueSummary = (client: ApolloClient<object>) => {
         const newLatest = issueSummaryToLatestPath(newIssueSummary)
         // only update to latest issue if there is indeed a new latest issue
         if (
+            (result && result.issueSummary.issueId == null) ||
             !previousLatest ||
             (previousLatest.localIssueId !== newLatest.localIssueId &&
                 previousLatest.publishedIssueId !== newLatest.publishedIssueId)


### PR DESCRIPTION
## Summary

I'm not really sure what conditions cause this bug yet, but at least one thing we should do is to set the `issueId` if none is set yet, which might mitigate the problem. Indeed the bug could happen when somehow we have an issue list, but `issueId` was not set. This could also be due to concurrency issues: ex. if the async fetching code runs twice in parallel, one might override the other with outdated data. So I think my next step is to refactor this code so that fetching (from API or local) is always sequential.

https://trello.com/c/g64so6QL/1099-sometimes-all-photos-are-blank-editions-list-shows-no-front-nothing-is-clickable


