### PR TITLE
disable auto hyphens in pullquotes

### DIFF
--- a/projects/Mallard/src/components/article/html/components/pull-quote.ts
+++ b/projects/Mallard/src/components/article/html/components/pull-quote.ts
@@ -39,9 +39,9 @@ const quoteStyles = ({ colors }: CssProps) => css`
         margin-bottom: calc(22px + 0.25em);
         margin-top: 0.25em;
         font-size: 1.1em;
-        -webkit-hyphens: auto;
-        -moz-hyphens: auto;
-        hyphens: auto;
+        -webkit-hyphens: manual;
+        -moz-hyphens: manual;
+        hyphens: manual;
         z-index: 10000;
     }
 


### PR DESCRIPTION
## Summary

Let's just disable automatic hyphens as the web browser is too aggressively generating them for the small-width use case (see screenshots). I propose we do that, audit how it goes, and if really there are need for hyphens occasionally, manually add these using the [unicode Soft Hyphen](https://en.wikipedia.org/wiki/Soft_hyphen). We could implement some simple rules based on RegExps that automatically add these for specific cases, either backend-side or client-side.

https://trello.com/c/Qs8jHkO1/693-pullquote-design-fixes#comment-5e05cebfad96b57468354560

## Test Plan

See below the version with hyphen versus without. I think we can arguably say the one without is cleaner and more legible.

![Screenshot 2019-12-30 at 16 05 40](https://user-images.githubusercontent.com/1733570/71590092-29978d80-2b1f-11ea-8aac-05bf12e3398c.png)
![Screenshot 2019-12-30 at 16 05 22](https://user-images.githubusercontent.com/1733570/71590093-29978d80-2b1f-11ea-9e38-ad2e48ca7afe.png)
