### PR TITLE
fix analysis header style

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -414,7 +414,12 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
     .header-container[data-type='analysis'] h1 .header-top-byline {
         display: block;
+        font-family: ${families.headline.regular};
+        font-style: italic;
+    }
+    .header-container[data-type='analysis'] h1 .header-top-byline > a {
         font-family: ${families.titlepiece.regular};
+        font-style: normal;
     }
 
     /*gallery*/


### PR DESCRIPTION
## Summary

This fix assumes the author's name will always be wrapped in a `<a>` tag. I think it's fairly safe to assume so for now. It will still show up if it's not wrapped, just not with the exact correct styling, however I think it's better to support the base case than not support anything.

We can't control styling very precisely because the byline is in an HTML format, and this HTML comes from CAPI. Getting the author's name and "additional context" separate would require backend change, and maybe CAPI, which perhaps isn't necessary for the time being if this simple CSS fix proves to be enough.

https://trello.com/c/puPnKeDv/899-css-can-we-use-the-same-rules-for-bylines-on-non-standard-templates

## Test Plan

Compare before (left) and after (right). Notice the "Diplomatic Editor" in the byline has now the correct style.

<div>
<img width="200" alt="Screenshot 2020-01-06 at 15 41 10" src="https://user-images.githubusercontent.com/1733570/71828827-1181ba00-309b-11ea-8983-36624a46a49f.png">
<img width="200" alt="Screenshot 2020-01-06 at 15 40 27" src="https://user-images.githubusercontent.com/1733570/71828828-1181ba00-309b-11ea-8c03-448c24c867fb.png">

</div>
