### PR TITLE
feat: Clean push logs

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/push-tracking.spec.ts
@@ -1,0 +1,64 @@
+import MockDate from 'mockdate'
+import { findLastXDaysPushTracking } from '../push-tracking'
+
+const fixtures = [
+    {
+        time: '2020-01-04T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2020-01-03T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2020-01-02T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2020-01-01T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2019-12-31T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2019-12-30T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2019-12-29T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+    {
+        time: '2019-12-28T12:43:01Z',
+        id: 'unzipImages',
+        value: 'complete',
+    },
+]
+
+describe('helpers/push-tracking', () => {
+    describe('findLastXDaysPushTracking', () => {
+        beforeEach(() => MockDate.set('2020-01-04'))
+
+        it('should return only last 7 days of tracking by default', () => {
+            const lastSevenDays = findLastXDaysPushTracking(fixtures)
+            expect(lastSevenDays).toEqual(fixtures.slice(0, 7))
+        })
+        it('should return an empty array if there is no tracking available inside of the default 7 day period', () => {
+            const outsideOfScope = findLastXDaysPushTracking([fixtures[7]])
+            expect(outsideOfScope).toEqual([])
+        })
+        it('should return only 2 days worth of tracking if 2 days are selected', () => {
+            const lastTwoDays = findLastXDaysPushTracking(fixtures, 2)
+            expect(lastTwoDays).toEqual(fixtures.slice(0, 2))
+        })
+    })
+})

--- a/projects/Mallard/src/helpers/clear-download-issue.ts
+++ b/projects/Mallard/src/helpers/clear-download-issue.ts
@@ -1,10 +1,12 @@
 import { prepFileSystem, clearOldIssues, downloadTodaysIssue } from './files'
 import { fetchCacheClear } from './fetch'
 import ApolloClient from 'apollo-client'
+import { cleanPushTrackingByDays } from './push-tracking'
 
 const clearAndDownloadIssue = async (client: ApolloClient<object>) => {
     await prepFileSystem()
     await clearOldIssues()
+    await cleanPushTrackingByDays()
     const weOk = await fetchCacheClear()
     if (weOk) {
         return await downloadTodaysIssue(client)

--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-community/async-storage'
 import { londonTime } from 'src/helpers/date'
+import { lastNDays } from 'src/helpers/issues'
 import { errorService } from 'src/services/errors'
 
 const PUSH_TRACKING_KEY = '@push-tracking'
@@ -42,4 +43,33 @@ const pushTracking = async (id: string, value: string): Promise<void> => {
     }
 }
 
-export { pushTracking, getPushTracking, clearPushTracking }
+export const findLastXDaysPushTracking = (
+    pushTracking: Tracking[],
+    days = 7,
+) => {
+    const daysToKeep = lastNDays(days)
+    return pushTracking.filter(
+        (log: Tracking) =>
+            daysToKeep.some(day => log.time.includes(day)) && log,
+    )
+}
+
+// Only keep the last X days of push logs when run
+const cleanPushTrackingByDays = async () => {
+    const pushTracking = await getPushTracking()
+
+    if (!pushTracking) return
+
+    const logsToKeep = findLastXDaysPushTracking(JSON.parse(pushTracking))
+    return await AsyncStorage.setItem(
+        PUSH_TRACKING_KEY,
+        JSON.stringify(logsToKeep),
+    )
+}
+
+export {
+    pushTracking,
+    getPushTracking,
+    clearPushTracking,
+    cleanPushTrackingByDays,
+}


### PR DESCRIPTION
## Summary
We only really need a few days logs, anything beyond that is a bit pointless. I have limited this functionality to 7 days.

This runs with all the cleanup tasks

[**Trello Card ->**](https://trello.com/c/vZSzRPrJ/1112-add-functionality-to-clear-out-old-push-notification-older-than-7-days-from-users-device)

## Test Plan
1. Check your push logs before
2. Run this branch
3. Check the reduced push logs after.
