### PR TITLE
enable sidebar on Android (>29), and make anim faster-feeling

### DIFF
--- a/projects/Mallard/src/navigation/navigators/sidebar.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar.tsx
@@ -5,6 +5,7 @@ import {
     StyleSheet,
     TouchableWithoutFeedback,
     View,
+    Platform,
 } from 'react-native'
 import {
     createStackNavigator,
@@ -25,6 +26,11 @@ import {
 } from '../helpers/transition'
 import { sidebarWidth } from './sidebar/positions'
 import { screenInterpolator, mainLayerTransition } from './sidebar/transition'
+
+const USE_SIDEBAR_ANIMATION =
+    supportsTransparentCards() ||
+    /* Android API Level 29; would need to test further on lower versions */
+    (Platform.OS === 'android' && Platform.Version >= 29)
 
 const overlayStyles = StyleSheet.create({
     root: {
@@ -122,12 +128,12 @@ export const createSidebarNavigator = (
     let animatedValue = new Animated.Value(0)
 
     const navigation: { [key: string]: NavigationContainer } = {
-        _: supportsTransparentCards()
+        _: USE_SIDEBAR_ANIMATION
             ? addViewsForMainLayer(mainRoute, () => animatedValue)
             : mainRoute,
     }
     for (const [key, value] of Object.entries(sidebarRoute)) {
-        navigation[key] = supportsTransparentCards()
+        navigation[key] = USE_SIDEBAR_ANIMATION
             ? addViewsForSidebarLayer(value, () => animatedValue)
             : value
     }
@@ -151,7 +157,7 @@ export const createSidebarNavigator = (
             gesturesEnabled: false,
         },
         headerMode: 'none',
-        ...(supportsTransparentCards()
+        ...(USE_SIDEBAR_ANIMATION
             ? {
                   mode: 'modal',
                   transparentCard: isTablet,


### PR DESCRIPTION
## Summary

We want to enable the sliding sidebar on android too. I'm wary of enabling below 29 for now until further testing. I propose we just do it on 29+ for now and lower this in a further PR once we test it. More explanations in code comments.

https://trello.com/c/tk2ri1qn/1110-nav-burger-open-and-close-animation-android

## Test Plan

Both on iOS + Android:

Open app, press hamburger, check editions show up with sidebar animation, navigate to an edition, notice closing sidebar animation.
