### PR TITLE
Update podfile.lock following gestures upgrade.

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -249,7 +249,7 @@ PODS:
     - React
   - RNDeviceInfo (5.3.1):
     - React
-  - RNGestureHandler (1.3.0):
+  - RNGestureHandler (1.5.3):
     - React
   - RNIap (3.3.9):
     - React
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: b79e193409a90bf6b5170d421684f437ff4e2278
   RNCPushNotificationIOS: 0b8d06ff190d84627dd17501bfb96652375970e4
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
-  RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
+  RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e


### PR DESCRIPTION
## Summary
This should have been included in https://github.com/guardian/editions/pull/979
