### PR TITLE
use-issue-summary: forward message of Error objecrs

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -85,6 +85,9 @@ const refetch = async (
         // from an error as it could contain technical details that are
         // irrelevant for end users; instead errors should be coded (ex. with
         // numeric error code, each of which has a corresponding UI message).
+        if (error instanceof Error) {
+            error = error.message
+        }
         return { ...prevIssueSummary, error }
     }
 


### PR DESCRIPTION
## Summary

Sometimes we get strings, but we can also get `Error` objects if thrown by the `fetch` function for example, in which case let's just forward the message.

## Test Plan

Change API endpoint as localhost in the Dev menu, then reload the app. Observe fetch timeout error message.
