### PR TITLE
Chore: Resolve handbars security warning

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -107,7 +107,8 @@
     },
     "resolutions": {
         "@types/react": "16.9.1",
-        "@types/react-native": "0.60.5"
+        "@types/react-native": "0.60.5",
+        "handlebars": "4.6.0"
     },
     "jest": {
         "preset": "react-native"

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -3691,10 +3691,10 @@ hammerjs@^2.0.8:
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
   integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
-handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@4.6.0, handlebars@^4.1.2:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.6.0.tgz#33af6c3eda930d7a924f5d8f1c6d8edc3180512e"
+  integrity sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"

--- a/projects/archiver/package.json
+++ b/projects/archiver/package.json
@@ -41,5 +41,8 @@
         "ts-optchain": "^0.1.8",
         "uuidv4": "5.0.1",
         "moment": "^2.24.0"
+    },
+    "resolutions": {
+        "handlebars": "4.6.0"
     }
 }

--- a/projects/archiver/yarn.lock
+++ b/projects/archiver/yarn.lock
@@ -1469,10 +1469,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@4.6.0, handlebars@^4.1.2:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.6.0.tgz#33af6c3eda930d7a924f5d8f1c6d8edc3180512e"
+  integrity sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -48,5 +48,8 @@
         "striptags": "^3.1.1",
         "ts-optchain": "^0.1.8",
         "utility-types": "^3.7.0"
+    },
+    "resolutions": {
+        "handlebars": "4.6.0"
     }
 }

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -1746,10 +1746,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@4.6.0, handlebars@^4.1.2:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.6.0.tgz#33af6c3eda930d7a924f5d8f1c6d8edc3180512e"
+  integrity sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
## Summary
Attempting to resolve the handlebars security warnings by forcing a resolution in the project.

Handlebars in our case is a dependency of Commander, which is a dependency of React Native CLI projects used by React Native. Therefore should have no negative impact.