### PR TITLE
cleanup useNetInfo

### DIFF
--- a/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
+++ b/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
@@ -1,13 +1,31 @@
-import { useNetInfo } from 'src/hooks/use-net-info'
+import { NetInfo } from 'src/hooks/use-net-info'
 import { useEffect } from 'react'
 import { useToast } from 'src/hooks/use-toast'
 import { NetInfoStateType } from '@react-native-community/netinfo'
+import { useQuery } from 'src/hooks/apollo'
+import gql from 'graphql-tag'
+
+const NET_INFO_QUERY = gql`
+    {
+        netInfo @client {
+            type @client
+            isConnected @client
+        }
+    }
+`
+type NetInfoQueryValue = {
+    netInfo: Pick<NetInfo, 'type' | 'isConnected'>
+}
 
 const NetInfoAutoToast = () => {
     const { showToast } = useToast()
-    const { isConnected, type } = useNetInfo()
+    const res = useQuery<NetInfoQueryValue>(NET_INFO_QUERY)
+    const isConnected = res.loading || res.data.netInfo.isConnected
+
     useEffect(() => {
+        if (res.loading) return
         const time = setTimeout(() => {
+            const { type } = res.data.netInfo
             if (!isConnected && type !== NetInfoStateType.unknown) {
                 showToast('No internet connection')
             }

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -3,7 +3,6 @@ import { NetInfoState, NetInfoStateType } from '@react-native-community/netinfo'
 import { Dispatch } from 'react'
 import gql from 'graphql-tag'
 import ApolloClient from 'apollo-client'
-import { useQuery } from './apollo'
 import { isEqual } from 'apollo-utilities'
 
 /**
@@ -207,34 +206,3 @@ export const createNetInfoResolver = () => {
         return statePromise.then(assembleNetInfo)
     }
 }
-
-/**
- * Deprecated. Instead, one should directly use `useQuery` with the specific
- * fields one wish to query. This is because otherwise, your React component
- * will re-render whenever any of the fields change, even ones not in use
- * by the component.
- */
-const useNetInfo = (() => {
-    const LOADING: NetInfo = {
-        __typename,
-        type: NetInfoStateType.unknown,
-        isConnected: false,
-        details: null,
-        isForcedOffline: false,
-        downloadBlocked: DownloadBlockedStatus.NotBlocked,
-        setIsForcedOffline: () => {},
-        isDevButtonShown: false,
-        setIsDevButtonShown: () => {},
-    }
-
-    return (): NetInfo => {
-        const res = useQuery<{ netInfo: NetInfo }>(QUERY)
-        // FIXME: having a fake 'loading' set of data causes the UI to render
-        // with some invalid values at first only to re-render later with the
-        // final values. Instead we shouldn't render until it's finished
-        // loading.
-        return res.loading ? LOADING : res.data.netInfo
-    }
-})()
-
-export { useNetInfo }

--- a/projects/Mallard/src/screens/deprecate-screen.tsx
+++ b/projects/Mallard/src/screens/deprecate-screen.tsx
@@ -13,8 +13,10 @@ import { useDeprecationModal } from 'src/hooks/use-deprecation-screen'
 import { color } from 'src/theme/color'
 import { getFont } from 'src/theme/typography'
 import { TitlepieceText } from '../components/styled-text'
-import { useNetInfo } from '../hooks/use-net-info'
 import { defaultSettings } from 'src/helpers/settings/defaults'
+import { useQuery } from 'src/hooks/apollo'
+import { NetInfo } from 'src/hooks/use-net-info'
+import gql from 'graphql-tag'
 
 const styles = StyleSheet.create({
     container: {
@@ -61,10 +63,21 @@ const StoreLink = () => {
     )
 }
 
+const NET_INFO_QUERY = gql`
+    {
+        netInfo @client {
+            isConnected @client
+        }
+    }
+`
+type NetInfoQueryValue = { netInfo: Pick<NetInfo, 'isConnected'> }
+
 const DeprecateVersionModal = () => {
-    const { isConnected } = useNetInfo()
+    const res = useQuery<NetInfoQueryValue>(NET_INFO_QUERY)
     const { showModal } = useDeprecationModal()
 
+    if (res.loading) return null
+    const { isConnected } = res.data.netInfo
     return (
         <Modal visible={isConnected && showModal}>
             <SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Summary

Let's go full Apollo style, I'd say :) ie. using queries instead of separate "use..." funtions for getting data. We can eventually get rid of cachedOrPromise with this.

Note that might look like this is adding more code, but in fact if we generalise having data in the Apollo store, then it's all fairly centralised around the concept of queries.

## Test Plan

Load up the app, check things are working correctly, that it's possible to download editions with the button, that the dev button to force offline works and make the toast show up.
