### PR TITLE
mitigate scrolling bug on iOS

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -6,7 +6,7 @@ import React, {
     useMemo,
     Dispatch,
 } from 'react'
-import { View, FlatList, StyleSheet } from 'react-native'
+import { View, FlatList, StyleSheet, Platform } from 'react-native'
 import {
     NavigationInjectedProps,
     NavigationScreenProp,
@@ -403,7 +403,11 @@ const IssueListFetchContainer = () => {
     const data = useIssueSummary()
     const issueSummary = data.issueSummary || NO_ISSUES
     const [issueId, setIssueId] = useState(data.issueId || EMPTY_ISSUE_ID)
-    const [isShown, setIsShown] = useState(false)
+    const [isShown, setIsShown] = useState(
+        // on iOS there is bug that causes wrong rendering of the scroll bar
+        // if this is enabled. See below description of this mechanism.
+        Platform.select({ android: false, default: true }),
+    )
 
     useEffect(() => {
         // Adding a tiny delay before doing full rendering means that the


### PR DESCRIPTION
## Summary

Scrollbar appears in the middle, because the flatlist get instantiated during the animation. Doesn't seem to happen on Android.


<img width="488" alt="Screenshot 2020-01-10 at 17 38 58" src="https://user-images.githubusercontent.com/1733570/72173945-8709c500-33d0-11ea-98a2-f5ca6f6f9c6b.png">


