### PR TITLE
chore: Run clean and download on first mount

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -127,6 +127,7 @@ const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {
         SplashScreen.hide()
+        clearAndDownloadIssue(apolloClient)
 
         AppState.addEventListener('change', async appState => {
             if (appState === 'active') {


### PR DESCRIPTION
## Summary
Noticed that when starting the app on a cold start, the issue was not downloading. This should ensure this happens on the first mount.

[**Trello Card ->**](https://trello.com)

## Test Plan
1. Cold start the app
2. Check the download of the days edition has started.