### PR TITLE
fix: Invalidate Issue Cache when download an issue

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -15,6 +15,7 @@ import { localIssueListStore } from 'src/hooks/use-issue-on-device'
 import { NetInfo, DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import gql from 'graphql-tag'
 import ApolloClient from 'apollo-client'
+import { withCache } from './fetch/cache'
 
 interface BasicFile {
     filename: string
@@ -74,6 +75,9 @@ export const downloadNamedIssueArchive = async (
     }).fetch('GET', zipUrl)
     return {
         promise: returnable.then(async res => {
+            // Ensure issue is removed from the cache on completion
+            const { clear } = withCache('issue')
+            clear(localIssueId)
             await prepFileSystem()
             await ensureDirExists(FSPaths.issueRoot(localIssueId))
             return res


### PR DESCRIPTION
## Summary
When an issue was first accessed, its origin is set as API. However, once an issue has been downloaded, this origin doesn't change. This means when a user goes offline, the images are attempted to fetch from the API. No internet access = no images. So when we download the issue, we need to invalidate the cache

[**Trello Card ->**](https://trello.com/c/CoZYS8Fn/1119-latest-ios-build-images-disappear-at-article-level-in-offline-mode-for-todays-edition-only)
