### PR TITLE
feat: Smoother scrolling images

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -19,6 +19,15 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
+  - libwebp (1.1.0):
+    - libwebp/demux (= 1.1.0)
+    - libwebp/mux (= 1.1.0)
+    - libwebp/webp (= 1.1.0)
+  - libwebp/demux (1.1.0):
+    - libwebp/webp
+  - libwebp/mux (1.1.0):
+    - libwebp/demux
+  - libwebp/webp (1.1.0)
   - Permission-LocationWhenInUse (2.0.3):
     - RNPermissions
   - RCTRequired (0.61.5)
@@ -249,6 +258,10 @@ PODS:
     - React
   - RNDeviceInfo (5.3.1):
     - React
+  - RNFastImage (7.0.2):
+    - React
+    - SDWebImage (~> 5.0)
+    - SDWebImageWebPCoder (~> 0.2.3)
   - RNGestureHandler (1.5.3):
     - React
   - RNIap (3.3.9):
@@ -273,6 +286,12 @@ PODS:
   - RNZipArchive/Core (5.0.0):
     - React
     - SSZipArchive (= 2.2.2)
+  - SDWebImage (5.4.2):
+    - SDWebImage/Core (= 5.4.2)
+  - SDWebImage/Core (5.4.2)
+  - SDWebImageWebPCoder (0.2.5):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.0)
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
@@ -323,6 +342,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - RNFastImage (from `../node_modules/react-native-fast-image`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNIap (from `../node_modules/react-native-iap`)
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
@@ -337,6 +357,9 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - boost-for-react-native
+    - libwebp
+    - SDWebImage
+    - SDWebImageWebPCoder
     - Sentry
     - SSZipArchive
 
@@ -421,6 +444,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNFastImage:
+    :path: "../node_modules/react-native-fast-image"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNIap:
@@ -449,6 +474,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
   Permission-LocationWhenInUse: 5cb8e0df1463dfab567d2a3d2589ab557fda68cb
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
@@ -484,6 +510,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: b79e193409a90bf6b5170d421684f437ff4e2278
   RNCPushNotificationIOS: 0b8d06ff190d84627dd17501bfb96652375970e4
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
+  RNFastImage: 9b0c22643872bb7494c8d87bbbb66cc4c0d9e7a2
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
@@ -493,6 +520,8 @@ SPEC CHECKSUMS:
   RNSentry: 932ac1c8b2f581b1c8be5812f88ff556c99e7fb7
   RNSVG: ff9b094e39dd4a437ebe17d1c7ceed286e75f426
   RNZipArchive: be636657a6630e9771d4a3223dc8fd0bd0137b55
+  SDWebImage: 4ca2dc4eefae4224bea8f504251cda485a363745
+  SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -61,6 +61,7 @@
         "react-native-background-fetch": "^2.7.1",
         "react-native-config": "^0.11.7",
         "react-native-device-info": "^5.3.0",
+        "react-native-fast-image": "^7.0.2",
         "react-native-gesture-handler": "^1.5.3",
         "react-native-iap": "^3.3.9",
         "react-native-image-resizer": "^1.0.1",

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
 import {
-    Image,
     ImageProps,
     ImageStyle,
+    PixelRatio,
     StyleProp,
     View,
-    PixelRatio,
 } from 'react-native'
+import FastImage from 'react-native-fast-image'
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 import { useImagePath, useScaledImage } from 'src/hooks/use-image-paths'
 import { Image as IImage, ImageUse } from '../../../../Apps/common/src'
@@ -38,14 +38,7 @@ const ScaledImageResource = ({
     style?: StyleProp<ImageStyle>
 }) => {
     const uri = useScaledImage(imagePath, width)
-    return (
-        <Image
-            resizeMethod={'resize'}
-            {...props}
-            style={style}
-            source={{ uri }}
-        />
-    )
+    return <FastImage {...props} style={style} source={{ uri }} />
 }
 
 const ImageResource = ({

--- a/projects/Mallard/src/components/front/items/helpers/opinion.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/opinion.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Image, ImageStyle, StyleProp } from 'react-native'
+import { ImageStyle, StyleProp } from 'react-native'
+import FastImage from 'react-native-fast-image'
 import { Image as ImageType } from 'src/common'
 import { useImagePath } from 'src/hooks/use-image-paths'
 
@@ -17,7 +18,7 @@ export const BylineCutout = ({
     cutout: ImageType
     style?: StyleProp<ImageStyle>
 }) => (
-    <Image
+    <FastImage
         resizeMode={'contain'}
         source={{
             uri: useImagePath(cutout),

--- a/projects/Mallard/src/hooks/use-config.ts
+++ b/projects/Mallard/src/hooks/use-config.ts
@@ -16,7 +16,7 @@ const useConfig = () => {
                 deviceMemory > oneGB &&
                 setConfig({ ...config, optimisedFlatList: false }),
         )
-    }, [])
+    }, [config])
 
     return {
         config,

--- a/projects/Mallard/src/hooks/use-config.ts
+++ b/projects/Mallard/src/hooks/use-config.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+import DeviceInfo from 'react-native-device-info'
+
+const oneGB = 1073741824
+
+type Config = {
+    optimisedFlatList: boolean
+}
+
+const useConfig = () => {
+    const [config, setConfig] = useState<Config>({ optimisedFlatList: true })
+
+    useEffect(() => {
+        DeviceInfo.getTotalMemory().then(
+            deviceMemory =>
+                deviceMemory > oneGB &&
+                setConfig({ ...config, optimisedFlatList: false }),
+        )
+    }, [])
+
+    return {
+        config,
+    }
+}
+
+export { useConfig }

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -68,7 +68,6 @@ import {
 } from 'src/helpers/transform'
 import { FrontSpec } from './article-screen'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
-import DeviceInfo from 'react-native-device-info'
 import { useConfig } from 'src/hooks/use-config'
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -68,6 +68,8 @@ import {
 } from 'src/helpers/transform'
 import { FrontSpec } from './article-screen'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
+import DeviceInfo from 'react-native-device-info'
+import { useConfig } from 'src/hooks/use-config'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -274,6 +276,12 @@ const IssueFronts = ({
 
     useScrollToFrontBehavior(frontWithCards, initialFrontKey, ref)
     const isWeatherActuallyShown = useIsWeatherActuallyShown()
+    const { config } = useConfig()
+    const flatListOptimisationProps = config.optimisedFlatList && {
+        initialNumToRender: 2,
+        windowSize: 2,
+        maxToRenderPerBatch: 2,
+    }
 
     /* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
     return (
@@ -283,9 +291,7 @@ const IssueFronts = ({
             ListHeaderComponent={ListHeaderComponent}
             // These three props are responsible for the majority of
             // performance improvements
-            initialNumToRender={2}
-            windowSize={2}
-            maxToRenderPerBatch={2}
+            {...flatListOptimisationProps}
             showsVerticalScrollIndicator={false}
             scrollEventThrottle={1}
             ListFooterComponent={() => (

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6620,6 +6620,11 @@ react-native-device-info@^5.3.0:
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.3.1.tgz#d764732c4841b6b6c2f42516e8840075717ea88a"
   integrity sha512-e/fRDoah+HxItscOJTGJY8zyVKmBUdf53VWIDGLGV4VVZ0mfzIQ2uo0ULGri0vjGUYqgyqgnW3jybPSznMxKcA==
 
+react-native-fast-image@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-7.0.2.tgz#e06b21f42f4a9786eaa86f3db35d919070fb8403"
+  integrity sha512-MfuzJbC0RjYobR2gFCdqe1I7jvNOCfDkjQ7VGOHXniqjohhULMkcWNBE9Umovi9Dx93lJ6t5utcE2wf/09zvlg==
+
 react-native-gesture-handler@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.3.tgz#191b44701fab7ba54c27a2438cb5eaa252666e66"


### PR DESCRIPTION
## Summary
A couple of optimisations here:
1. Use Fast Image package to aggressively cache our images. This saw an instant improvement in scrolling
2. Only apply flatlist optimisations when the device has less than 1GB of memory.

As a result, smoother scrolling across all supported devices.

[**Trello Card ->**](https://trello.com)