### PR TITLE
feat: Move Article Webview to Webkit

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -132,7 +132,7 @@ const Article = ({
                 path={path}
                 theme={theme}
                 scrollEnabled={true}
-                useWebKit={false}
+                useWebKit={true}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -72,7 +72,7 @@ export const generateAssetsFontCss = ({
     extension?: string
 }) => {
     const fileName = Platform.select({
-        ios: `file:///assets/fonts/${fontFamily}.${extension}`,
+        ios: `${fontFamily}.${extension}`,
         android: `file:///android_asset/fonts/${fontFamily}.${extension}`,
     })
 


### PR DESCRIPTION
## Summary
Previously we couldn't use the upgraded Webview due to our usage of custom fonts. A bit of investigation shows that actually we didn't have the correct path.

These things happen.