### PR TITLE
feat: Add device locale to dev settings and diagnostics

### DIFF
--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -23,6 +23,7 @@ import { canViewEdition } from 'src/authentication/helpers'
 import { getFileList } from './files'
 import gql from 'graphql-tag'
 import ApolloClient from 'apollo-client'
+import { locale } from './locale'
 
 const getCASCode = () =>
     Promise.all([
@@ -99,6 +100,7 @@ Product: Daily App
 App Version: ${version} ${buildNumber}
 Release Channel: ${isInBeta() ? 'BETA' : 'RELEASE'}
 App Edition: UK
+Locale: ${locale}
 First app start: ${firstInstallTime}
 Last updated: ${lastUpdateTime}
 

--- a/projects/Mallard/src/helpers/locale.ts
+++ b/projects/Mallard/src/helpers/locale.ts
@@ -1,0 +1,9 @@
+import { NativeModules, Platform } from 'react-native'
+
+const locale =
+    Platform.OS === 'ios'
+        ? NativeModules.SettingsManager.settings.AppleLocale ||
+          NativeModules.SettingsManager.settings.AppleLanguages[0] //iOS 13
+        : NativeModules.I18nManager.localeIdentifier
+
+export { locale }

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -25,6 +25,7 @@ import { deleteIssueFiles } from 'src/helpers/files'
 import { DEV_getLegacyIAPReceipt } from 'src/authentication/services/iap'
 import { Switch } from 'react-native-gesture-handler'
 import { useNetInfo } from 'src/hooks/use-net-info'
+import { locale } from 'src/helpers/locale'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -182,6 +183,11 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         key: 'Build number',
                         title: 'Build number',
                         explainer: buildNumber,
+                    },
+                    {
+                        key: 'Locale',
+                        title: 'Device locale',
+                        explainer: locale,
                     },
                     {
                         key: 'Reports as in test flight',


### PR DESCRIPTION
## Summary
We are aiming to use Device Locale to show content specific to that locale. This gets the basics in and allows us to experiment cross country.

Adds locale to the dev menu and to the diagnostics.

![Simulator Screen Shot - iPhone 11 - 2020-01-23 at 10 03 40](https://user-images.githubusercontent.com/935975/72975096-24e59280-3dc8-11ea-9769-7df74c38b6e1.png)
