### PR TITLE
Add basic lightbox (disabled)

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -34,6 +34,8 @@ import { DeprecateVersionModal } from './screens/deprecate-screen'
 import { errorService } from './services/errors'
 import { NetInfoDevOverlay } from './components/NetInfoDevOverlay'
 import { ConfigProvider } from 'src/hooks/use-config-provider'
+import { LightboxWrapper } from './screens/lightbox'
+import { LightboxProvider } from './screens/use-lightbox-modal'
 
 /**
  * Only one global Apollo client. As such, any update done from any component
@@ -125,6 +127,7 @@ const WithProviders = nestProviders(
     ToastProvider,
     NavPositionProvider,
     ConfigProvider,
+    LightboxProvider,
 )
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
@@ -185,6 +188,7 @@ export default class App extends React.Component<{}, {}> {
                                 <ModalRenderer />
                                 <BugButton />
                                 <DeprecateVersionModal />
+                                <LightboxWrapper />
                             </AccessProvider>
                         </WithProviders>
                     </NetInfoDevOverlay>

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -34,7 +34,7 @@ import { DeprecateVersionModal } from './screens/deprecate-screen'
 import { errorService } from './services/errors'
 import { NetInfoDevOverlay } from './components/NetInfoDevOverlay'
 import { ConfigProvider } from 'src/hooks/use-config-provider'
-import { LightboxWrapper } from './screens/lightbox'
+import { Lightbox } from './screens/lightbox'
 import { LightboxProvider } from './screens/use-lightbox-modal'
 
 /**
@@ -188,7 +188,7 @@ export default class App extends React.Component<{}, {}> {
                                 <ModalRenderer />
                                 <BugButton />
                                 <DeprecateVersionModal />
-                                <LightboxWrapper />
+                                <Lightbox />
                             </AccessProvider>
                         </WithProviders>
                     </NetInfoDevOverlay>

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -16,6 +16,7 @@ import { renderMediaAtom } from './components/media-atoms'
 import { GetImagePath } from 'src/hooks/use-image-paths'
 import { Image as TImage, Content } from '../../../../../Apps/common/src'
 import { getPillarColors } from 'src/helpers/transform'
+import { getLightboxImages } from '../types/article'
 
 interface ArticleContentProps {
     showMedia: boolean
@@ -48,6 +49,7 @@ const renderArticleContent = (
     elements: BlockElement[],
     { showMedia, publishedId, getImagePath }: ArticleContentProps,
 ) => {
+    const imagePaths = getLightboxImages(elements).map(i => i.src.path)
     return elements
         .map(el => {
             switch (el.id) {
@@ -64,10 +66,12 @@ const renderArticleContent = (
                     return showMedia ? renderMediaAtom(el) : ''
                 case 'image': {
                     const path = getImagePath(el.src)
+                    const index = imagePaths.findIndex(e => e === el.src.path)
                     return publishedId
                         ? Image({
                               imageElement: el,
                               path,
+                              index,
                           })
                         : ''
                 }

--- a/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
+++ b/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
@@ -9,7 +9,13 @@ export const NativeArrow = ({
     fill: string
     direction: Direction
 }) => (
-    <Svg width={11} height={9} viewBox="0 0 11 9" fill="none">
+    <Svg
+        width={11}
+        height={9}
+        viewBox="0 0 11 9"
+        fill="none"
+        rotate={direction}
+    >
         <G opacity="0.5">
             <Path
                 fill-rule="evenodd"

--- a/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
+++ b/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Svg, { G, Path } from 'react-native-svg'
-import { Direction } from '../../../../../../Apps/common/src'
+import { Direction } from '../../../../../../../Apps/common/src'
 
 export const NativeArrow = ({
     fill,

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -191,7 +191,7 @@ const ImageBase = ({
     // add onclick="openLightbox(${index})" to re-enable lightbox
     return html`
         <figure class="image" data-role="${role || 'inline'}">
-            <img src="${path}" alt="${alt}" />
+            <img src="${path}" alt="${alt}" id="img-${index}" />
             ${figcaption &&
                 html`
                     <figcaption>
@@ -209,7 +209,7 @@ const Image = ({
 }: {
     imageElement: ImageElement
     path: string | undefined
-    index: number | undefined
+    index?: number | undefined
 }) => {
     if (path) {
         return ImageBase({ path, index, ...imageElement })

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -188,9 +188,10 @@ const ImageBase = ({
     role?: ImageElement['role']
 }) => {
     const figcaption = renderCaption({ caption, credit })
+    // add onclick="openLightbox(${index})" to re-enable lightbox
     return html`
         <figure class="image" data-role="${role || 'inline'}">
-            <img src="${path}" alt="${alt}" onclick="selectImage(${index})" />
+            <img src="${path}" alt="${alt}" />
             ${figcaption &&
                 html`
                     <figcaption>

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -174,12 +174,14 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
 
 const ImageBase = ({
     path,
+    index,
     alt,
     caption,
     credit,
     role,
 }: {
     path: string
+    index?: number
     alt?: string
     caption?: string
     credit?: string
@@ -188,7 +190,7 @@ const ImageBase = ({
     const figcaption = renderCaption({ caption, credit })
     return html`
         <figure class="image" data-role="${role || 'inline'}">
-            <img src="${path}" alt="${alt}" />
+            <img src="${path}" alt="${alt}" onclick="selectImage(${index})" />
             ${figcaption &&
                 html`
                     <figcaption>
@@ -202,12 +204,14 @@ const ImageBase = ({
 const Image = ({
     imageElement,
     path,
+    index,
 }: {
     imageElement: ImageElement
     path: string | undefined
+    index: number | undefined
 }) => {
     if (path) {
-        return ImageBase({ path, ...imageElement })
+        return ImageBase({ path, index, ...imageElement })
     }
     return null
 }

--- a/projects/Mallard/src/components/article/html/components/native-arrow.tsx
+++ b/projects/Mallard/src/components/article/html/components/native-arrow.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import Svg, { G, Path } from 'react-native-svg'
+import { Direction } from '../../../../../../Apps/common/src'
+
+export const NativeArrow = ({
+    fill,
+    direction,
+}: {
+    fill: string
+    direction: Direction
+}) => (
+    <Svg width={11} height={9} viewBox="0 0 11 9" fill="none">
+        <G opacity="0.5">
+            <Path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M5.5 0L10.5 9H0.5L5.5 0Z"
+                fill={fill}
+            />
+        </G>
+    </Svg>
+)

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useContext } from 'react'
 import { StyleSheet, Share, Platform } from 'react-native'
 import WebView from 'react-native-webview'
 import { parsePing } from 'src/helpers/webview'
@@ -9,7 +9,16 @@ import { WebviewWithArticle } from './article/webview'
 import { Article as ArticleT, PictureArticle, GalleryArticle } from 'src/common'
 import DeviceInfo from 'react-native-device-info'
 import { PathToArticle } from 'src/paths'
-import { IssueOrigin } from '../../../../../Apps/common/src'
+import {
+    IssueOrigin,
+    BlockElement,
+    ImageElement,
+} from '../../../../../Apps/common/src'
+import {
+    useLightboxModal,
+    useLightboxProvider,
+    LightboxContext,
+} from '../../../screens/use-lightbox-modal'
 
 const styles = StyleSheet.create({
     block: {
@@ -60,6 +69,12 @@ export type HeaderControlProps = HeaderControlInnerProps & {
      */
     onIsAtTopChange: (isAtTop: boolean) => void
 }
+export const getLightboxImages = (elements: BlockElement[]): ImageElement[] => {
+    const images: ImageElement[] = elements.filter(
+        (e: BlockElement): e is ImageElement => e.id === 'image',
+    )
+    return images
+}
 
 /**
  * This takes care of updating the value of a global *within* the web
@@ -100,12 +115,15 @@ const Article = ({
 } & HeaderControlProps) => {
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
+    // const { setShowLightbox } = useLightboxModal()
 
     const wasShowingHeader = useUpdateWebviewVariable(
         ref,
         'shouldShowHeader',
         shouldShowHeader,
     )
+
+    const lbv = useContext(LightboxContext)
 
     return (
         <Fader>
@@ -133,6 +151,12 @@ const Article = ({
                     }
                     if (parsed.type === 'isAtTopChange') {
                         onIsAtTopChange(parsed.isAtTop)
+                    }
+                    if (parsed.type === 'imageSelected') {
+                        console.log('image selected yay!')
+                        const lbimages = getLightboxImages(article.elements)
+                        lbv.setLightboxData(lbimages, parsed.index)
+                        lbv.setLightboxVisible(true)
                     }
                 }}
             />

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -14,11 +14,7 @@ import {
     BlockElement,
     ImageElement,
 } from '../../../../../Apps/common/src'
-import {
-    useLightboxModal,
-    useLightboxProvider,
-    LightboxContext,
-} from '../../../screens/use-lightbox-modal'
+import { LightboxContext } from '../../../screens/use-lightbox-modal'
 
 const styles = StyleSheet.create({
     block: {
@@ -152,10 +148,9 @@ const Article = ({
                     if (parsed.type === 'isAtTopChange') {
                         onIsAtTopChange(parsed.isAtTop)
                     }
-                    if (parsed.type === 'imageSelected') {
-                        console.log('image selected yay!')
+                    if (parsed.type === 'openLightbox') {
                         const lbimages = getLightboxImages(article.elements)
-                        lbv.setLightboxData(lbimages, parsed.index)
+                        lbv.setLightboxData(lbimages, parsed.index, 'sport')
                         lbv.setLightboxVisible(true)
                     }
                 }}

--- a/projects/Mallard/src/components/button/close-modal-button.tsx
+++ b/projects/Mallard/src/components/button/close-modal-button.tsx
@@ -3,26 +3,43 @@ import { StyleSheet } from 'react-native'
 import { Button } from '../button/button'
 import { color } from 'src/theme/color'
 
-const closeModalButtonStyles = StyleSheet.create({
-    dismissButton: {
-        paddingHorizontal: 0,
-        backgroundColor: 'transparent',
-        borderColor: color.primary,
-        borderWidth: 1,
-    },
-    dismissText: {
-        color: color.primary,
-    },
-})
+const closeModalButtonStyles = (buttonColor?: string) =>
+    StyleSheet.create({
+        dismissText: {
+            color: buttonColor ? 'white' : color.primary,
+        },
+        dismissButton: {
+            paddingHorizontal: 0,
+            backgroundColor: buttonColor ? buttonColor : 'transparent',
+            borderColor: buttonColor ? buttonColor : color.primary,
+            borderWidth: 1,
+        },
+    })
 
-const CloseModalButton = ({ onPress }: { onPress: () => void }) => (
-    <Button
-        icon=""
-        alt="Dismiss"
-        buttonStyles={closeModalButtonStyles.dismissButton}
-        textStyles={closeModalButtonStyles.dismissText}
-        onPress={onPress}
-    />
-)
+// const buttonColorStyle = (buttonColor: string) =>
+//     StyleSheet.create({
+//         style: {
+//             backgroundColor: buttonColor,
+//             borderWidth: 0,
+//         },
+//     })
+
+const CloseModalButton = ({
+    onPress,
+    color,
+}: {
+    onPress: () => void
+    color?: string
+}) => {
+    return (
+        <Button
+            icon=""
+            alt="Dismiss"
+            buttonStyles={[closeModalButtonStyles(color).dismissButton]}
+            textStyles={closeModalButtonStyles(color).dismissText}
+            onPress={onPress}
+        />
+    )
+}
 
 export { CloseModalButton }

--- a/projects/Mallard/src/components/button/close-modal-button.tsx
+++ b/projects/Mallard/src/components/button/close-modal-button.tsx
@@ -16,14 +16,6 @@ const closeModalButtonStyles = (buttonColor?: string) =>
         },
     })
 
-// const buttonColorStyle = (buttonColor: string) =>
-//     StyleSheet.create({
-//         style: {
-//             backgroundColor: buttonColor,
-//             borderWidth: 0,
-//         },
-//     })
-
 const CloseModalButton = ({
     onPress,
     color,

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -12,7 +12,7 @@ export type WebViewPing =
           type: 'share'
       }
     | {
-          type: 'imageSelected'
+          type: 'openLightbox'
           index: number
       }
 
@@ -217,11 +217,10 @@ const makeJavaScript = (topPadding: number) => html`
             passive: true,
         })
 
-        const selectImage = index => {
-            console.log('hi hi hi ')
+        const openLightbox = index => {
             window.ReactNativeWebView.postMessage(
                 JSON.stringify({
-                    type: 'imageSelected',
+                    type: 'openLightbox',
                     index: index,
                 }),
             )

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -11,6 +11,10 @@ export type WebViewPing =
     | {
           type: 'share'
       }
+    | {
+          type: 'imageSelected'
+          index: number
+      }
 
 /*
 this tricks vs code into thinking
@@ -212,6 +216,16 @@ const makeJavaScript = (topPadding: number) => html`
         document.addEventListener('scroll', debounce(onScroll), {
             passive: true,
         })
+
+        const selectImage = index => {
+            console.log('hi hi hi ')
+            window.ReactNativeWebView.postMessage(
+                JSON.stringify({
+                    type: 'imageSelected',
+                    index: index,
+                }),
+            )
+        }
     </script>
 `
 

--- a/projects/Mallard/src/navigation/routes.ts
+++ b/projects/Mallard/src/navigation/routes.ts
@@ -18,6 +18,7 @@ export const routeNames = {
     SignIn: 'SignIn',
     CasSignIn: 'CasSignIn',
     WeatherGeolocationConsent: 'WeatherGeolocationConsent',
+    Lightbox: 'Lightbox',
     onboarding: {
         OnboardingStart: 'OnboardingStart',
         OnboardingConsent: 'OnboardingConsent',

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -1,0 +1,158 @@
+import React, { useContext } from 'react'
+import {
+    Modal,
+    SafeAreaView,
+    View,
+    Image,
+    Dimensions,
+    Animated,
+    Text,
+    StyleSheet,
+} from 'react-native'
+import { LightboxContext, LightboxContextType } from './use-lightbox-modal'
+import {
+    ImageElement,
+    Direction,
+    ArticlePillar,
+} from '../../../Apps/common/src'
+import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
+import { CloseModalButton } from 'src/components/button/close-modal-button'
+import { useImagePath } from 'src/hooks/use-image-paths'
+import { NativeArrow } from 'src/components/article/html/components/native-arrow'
+import { getPillarColors } from 'src/helpers/transform'
+import { useDimensions } from 'src/hooks/use-screen'
+
+const styles = StyleSheet.create({
+    lightboxPage: {
+        width: '100%',
+        height: '100%',
+    },
+    caption: {
+        display: 'flex',
+        flexDirection: 'row',
+        paddingTop: 5,
+    },
+    closeButton: {
+        position: 'absolute',
+        zIndex: 1,
+        right: 0,
+        paddingTop: 10,
+        paddingRight: 10,
+    },
+    lightboxImage: {
+        // display: 'flex',
+        // alignItems: 'center',
+        // flexDirection: 'column',
+    },
+})
+
+const LightboxImage = ({
+    image,
+    arrowColor,
+}: {
+    image: ImageElement
+    arrowColor: string
+}) => {
+    const imagePath = useImagePath(image.src, 'full-size')
+    const aspectRatio = useAspectRatio(imagePath)
+    // console.log(aspectRatio)
+    return (
+        <>
+            <Image
+                source={{
+                    uri: imagePath,
+                }}
+                style={{ aspectRatio }}
+            />
+            <View style={styles.caption}>
+                <NativeArrow fill={arrowColor} direction={Direction.top} />
+                {image.caption && <Text>{image.caption}</Text>}
+            </View>
+        </>
+    )
+}
+
+export const LightboxScreen = ({
+    images,
+    visible,
+    closeLightbox,
+    pillar,
+    index,
+}: {
+    images: ImageElement[]
+    visible: boolean
+    closeLightbox: () => void
+    pillar: ArticlePillar
+    index: number
+}) => {
+    // const [, { pillar }] = useArticle()
+    // console.log('PILLAR: ', pillar)
+    const pillarColors = getPillarColors(pillar)
+    const { width } = useDimensions()
+    return (
+        <Modal visible={visible}>
+            <SafeAreaView>
+                <View>
+                    <View style={styles.closeButton}>
+                        <CloseModalButton
+                            onPress={closeLightbox}
+                            color={pillarColors.main}
+                        />
+                    </View>
+
+                    <Animated.FlatList
+                        showsHorizontalScrollIndicator={false}
+                        showsVerticalScrollIndicator={false}
+                        scrollEventThrottle={1}
+                        maxToRenderPerBatch={1}
+                        windowSize={2}
+                        initialNumToRender={1}
+                        horizontal={true}
+                        initialScrollIndex={index}
+                        pagingEnabled
+                        keyExtractor={(item: ImageElement) => item.src.path}
+                        data={images}
+                        getItemLayout={(_: never, index: number) => ({
+                            length: width,
+                            offset: width * index,
+                            index,
+                        })}
+                        renderItem={({
+                            item,
+                        }: // index,
+                        {
+                            item: ImageElement
+                            index: number
+                        }) => (
+                            <View style={[{ width }, styles.lightboxImage]}>
+                                <LightboxImage
+                                    image={item}
+                                    arrowColor={pillarColors.main}
+                                />
+                            </View>
+                        )}
+                    />
+                    {/* {images && images[0] && (
+                        <LightboxImage
+                            image={images[0]}
+                            arrowColor={pillarColors.main}
+                        />
+                    )} */}
+                </View>
+            </SafeAreaView>
+        </Modal>
+    )
+}
+
+export const LightboxWrapper = () => {
+    const lightboxContext: LightboxContextType = useContext(LightboxContext)
+    return (
+        <LightboxScreen
+            images={lightboxContext.images}
+            visible={lightboxContext.visible}
+            closeLightbox={() => lightboxContext.setLightboxVisible(false)}
+            pillar={'sport'}
+            index={lightboxContext.index}
+        />
+    )
+}

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -4,7 +4,6 @@ import {
     SafeAreaView,
     View,
     Image,
-    Dimensions,
     Animated,
     Text,
     StyleSheet,
@@ -18,7 +17,7 @@ import {
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 import { CloseModalButton } from 'src/components/button/close-modal-button'
 import { useImagePath } from 'src/hooks/use-image-paths'
-import { NativeArrow } from 'src/components/article/html/components/native-arrow'
+import { NativeArrow } from 'src/components/article/html/components/icon/native-arrow'
 import { getPillarColors } from 'src/helpers/transform'
 import { useDimensions } from 'src/hooks/use-screen'
 
@@ -39,11 +38,6 @@ const styles = StyleSheet.create({
         paddingTop: 10,
         paddingRight: 10,
     },
-    lightboxImage: {
-        // display: 'flex',
-        // alignItems: 'center',
-        // flexDirection: 'column',
-    },
 })
 
 const LightboxImage = ({
@@ -55,7 +49,6 @@ const LightboxImage = ({
 }) => {
     const imagePath = useImagePath(image.src, 'full-size')
     const aspectRatio = useAspectRatio(imagePath)
-    // console.log(aspectRatio)
     return (
         <>
             <Image
@@ -85,8 +78,6 @@ export const LightboxScreen = ({
     pillar: ArticlePillar
     index: number
 }) => {
-    // const [, { pillar }] = useArticle()
-    // console.log('PILLAR: ', pillar)
     const pillarColors = getPillarColors(pillar)
     const { width } = useDimensions()
     return (
@@ -117,14 +108,8 @@ export const LightboxScreen = ({
                             offset: width * index,
                             index,
                         })}
-                        renderItem={({
-                            item,
-                        }: // index,
-                        {
-                            item: ImageElement
-                            index: number
-                        }) => (
-                            <View style={[{ width }, styles.lightboxImage]}>
+                        renderItem={({ item }: { item: ImageElement }) => (
+                            <View style={[{ width }]}>
                                 <LightboxImage
                                     image={item}
                                     arrowColor={pillarColors.main}
@@ -132,19 +117,13 @@ export const LightboxScreen = ({
                             </View>
                         )}
                     />
-                    {/* {images && images[0] && (
-                        <LightboxImage
-                            image={images[0]}
-                            arrowColor={pillarColors.main}
-                        />
-                    )} */}
                 </View>
             </SafeAreaView>
         </Modal>
     )
 }
 
-export const LightboxWrapper = () => {
+export const Lightbox = () => {
     const lightboxContext: LightboxContextType = useContext(LightboxContext)
     return (
         <LightboxScreen

--- a/projects/Mallard/src/screens/use-lightbox-modal.tsx
+++ b/projects/Mallard/src/screens/use-lightbox-modal.tsx
@@ -1,0 +1,71 @@
+import React, { useState, createContext, useCallback } from 'react'
+import { ImageElement, ArticlePillar } from '../../../Apps/common/src'
+
+export interface LightboxContextType {
+    visible: boolean
+    setLightboxVisible: (newVisible: boolean) => void
+    images: ImageElement[]
+    setLightboxData: (
+        images: ImageElement[],
+        index: number,
+        pillar: ArticlePillar,
+    ) => void
+    pillar: ArticlePillar
+    index: number
+}
+
+export const LIGHTBOX_VISIBLE_DEFAULT: LightboxContextType = {
+    visible: false,
+    setLightboxVisible: () => {},
+    images: [],
+    setLightboxData: () => {},
+    pillar: 'news',
+    index: 0,
+}
+
+export const LightboxContext = createContext<LightboxContextType>(
+    LIGHTBOX_VISIBLE_DEFAULT,
+)
+
+type Props = { children: React.ReactNode }
+
+export const useLightboxProvider = (): LightboxContextType => {
+    const [visible, setVisible] = useState<boolean>(false)
+    const setLightboxVisible = useCallback((newVisible: boolean): void => {
+        setVisible(newVisible)
+    }, [])
+
+    const [images, setImages] = useState<ImageElement[]>([])
+    const [pillar, setPillar] = useState<ArticlePillar>('news')
+    const [index, setIndex] = useState<number>(0)
+    const setLightboxData = useCallback(
+        (
+            newImages: ImageElement[],
+            newIndex: number,
+            newPillar: ArticlePillar,
+        ): void => {
+            setImages(newImages)
+            setIndex(newIndex)
+            setPillar(newPillar)
+        },
+        [],
+    )
+
+    return {
+        visible,
+        setLightboxVisible,
+        images,
+        setLightboxData,
+        pillar,
+        index,
+    }
+}
+
+export const LightboxProvider = ({ children }: Props) => {
+    const lightboxVisible = useLightboxProvider()
+    return (
+        <LightboxContext.Provider value={lightboxVisible}>
+            {children}
+        </LightboxContext.Provider>
+    )
+}


### PR DESCRIPTION
NOTE: currently includes this revert https://github.com/guardian/editions/pull/1003 - best not to review till that's been untangled

## Summary
This PR is just to get my work on the lightbox into master so it doesn't get mega out of sync. I've removed the actual component from App.tsx and removed the onclick handler from images.ts so this should have no impact on the app itself.

It looks like this at the moment - getting there....

![lightbox gif](http://g.recordit.co/BQi6tOVZHM.gif)

TODO:
 - center image for landscape images
 - add instagram style navigation
 - fix blank pages loading if you scroll too fast
 - animation on open
 - check landscape mode on iPad
 - check it works on android
 - caption should only be visible when the photo is tapped
 - fix flash as the image resizes when you open the lightbox
 - find a way of passing in the pillar colour - currently it's hardcoded to 'sport'
 - check performance generally!


## Test Plan

There should be no visible changes to the app.