### PR TITLE
chore: Improve article list perf

### DIFF
--- a/projects/Mallard/src/screens/article/slider.tsx
+++ b/projects/Mallard/src/screens/article/slider.tsx
@@ -451,7 +451,8 @@ const ArticleSlider = ({
                     },
                 )}
                 maxToRenderPerBatch={1}
-                windowSize={2}
+                windowSize={1.5}
+                removeClippedSubviews={true}
                 initialNumToRender={1}
                 horizontal={true}
                 initialScrollIndex={startingPoint}


### PR DESCRIPTION
## Summary
Window size takes the height of the viewport multiplied the number stated. by dropping this, we assume that users will be reading not fast scrolling for no reason.

removeClippedSubviews removes offscreen content to improve performance.

Tested on iO9 on device and latest iOS in an emulator.