### PR TITLE
Revert "chore: Small update to Webview"

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -200,7 +200,7 @@ PODS:
     - React
   - react-native-viewpager (2.0.1):
     - React
-  - react-native-webview (7.6.0):
+  - react-native-webview (6.9.0):
     - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -467,7 +467,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-viewpager: f41b42bba71407e916654d64e87ff2680edecc92
-  react-native-webview: db4682f1698ab4b17a5e88f951031d203ff8aea8
+  react-native-webview: 2d8de2be422f0f8b9ba38db3f013f9ebfdb9b78f
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -74,7 +74,7 @@
         "react-native-splash-screen": "^3.2.0",
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.6.2",
-        "react-native-webview": "^7.6.0",
+        "react-native-webview": "^6.9.0",
         "react-native-zip-archive": "5.0.0",
         "react-navigation": "3.11.1",
         "react-navigation-fluid-transitions": "^0.3.2",

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -132,6 +132,7 @@ const Article = ({
                 path={path}
                 theme={theme}
                 scrollEnabled={true}
+                useWebKit={false}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -99,7 +99,6 @@ const WebviewWithArticle = ({
             ref={_ref}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
             allowFileAccess={true}
-            allowFileAccessFromFileURLs={true}
         />
     )
 }

--- a/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
+++ b/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
@@ -43,6 +43,7 @@ const DefaultInfoTextWebview = ({ html }: { html: string }) => {
                 originWhitelist={['*']}
                 source={{ html: makeHtml({ styles, body: html }), baseUrl: '' }}
                 style={{ flex: 1 }}
+                useWebKit={false}
                 onShouldStartLoadWithRequest={(event: WebViewNavigation) => {
                     /**
                      * Open any non-local documents in the external browser

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -3054,12 +3054,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -6718,12 +6713,12 @@ react-native-tab-view@^1.2.0, react-native-tab-view@^1.4.1:
   dependencies:
     prop-types "^15.6.1"
 
-react-native-webview@^7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-7.6.0.tgz#6bae76430200be5e5ead7d986af2fa341b650186"
-  integrity sha512-IQWtIpCTYb4dTshAJO3hMM9Ms5T6KRpk6qWqgBTGMdmgeEvSxWz9l7Og1ALhb7T7NoAnPy8w/dQmD9LlbGGs5g==
+react-native-webview@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-6.9.0.tgz#d637618fe65ddc9972a55a1d181fd6879a2fcebd"
+  integrity sha512-pipcyQNhSjSfMyle+JugLwYXJBJ0rQCnJOgkz7EcsZbrAvGjFbQOAjDRYi86y9Ibw+h+sjdhPWcLi/kSHScc+w==
   dependencies:
-    escape-string-regexp "2.0.0"
+    escape-string-regexp "1.0.5"
     invariant "2.2.4"
 
 react-native-zip-archive@5.0.0:


### PR DESCRIPTION
Reverts guardian/editions#1005

This is due to the newer versions of `react-native-webview` not supporting images from the file system.