### PR TITLE
chore: Move theme further down render tree

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -7,7 +7,6 @@ import {
     ImageSize,
     Issue,
 } from '../../../common'
-import { ArticleTheme } from '../types/article'
 import { Header, ArticleHeaderProps } from './components/header'
 import { Image } from './components/images'
 import { Line } from './components/line'
@@ -15,7 +14,7 @@ import { Pullquote } from './components/pull-quote'
 import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
 import { GetImagePath } from 'src/hooks/use-image-paths'
-import { Image as TImage } from '../../../../../Apps/common/src'
+import { Image as TImage, Content } from '../../../../../Apps/common/src'
 import { getPillarColors } from 'src/helpers/transform'
 
 interface ArticleContentProps {
@@ -24,6 +23,14 @@ interface ArticleContentProps {
     imageSize: ImageSize
     getImagePath: GetImagePath
 }
+
+export enum ArticleTheme {
+    Default = 'default',
+    Dark = 'dark',
+}
+
+const usesDarkTheme = (type: Content['type']) =>
+    ['picture', 'gallery'].includes(type)
 
 const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
     const path = getImagePath(image)
@@ -88,7 +95,6 @@ export const renderArticle = (
         article,
         imageSize,
         type,
-        theme,
         getImagePath,
     }: {
         pillar: ArticlePillar
@@ -97,11 +103,11 @@ export const renderArticle = (
         type: ArticleType
         showWebHeader: boolean
         headerProps?: ArticleHeaderProps & { type: ArticleType }
-        theme: ArticleTheme
     } & ArticleContentProps,
 ) => {
     let content, header
     const canBeShared = article.webUrl != null
+
     switch (article.type) {
         case 'picture':
             header = Header({
@@ -154,6 +160,10 @@ export const renderArticle = (
             })
             break
     }
+
+    const theme: ArticleTheme = usesDarkTheme(article.type)
+        ? ArticleTheme.Dark
+        : ArticleTheme.Default
 
     const styles = makeCss(
         {

--- a/projects/Mallard/src/components/article/html/helpers/css.ts
+++ b/projects/Mallard/src/components/article/html/helpers/css.ts
@@ -1,5 +1,5 @@
 import { PillarColours } from '@guardian/pasteup/palette'
-import { ArticleTheme } from '../../types/article'
+import { ArticleTheme } from '../article'
 import { color } from 'src/theme/color'
 
 export interface CssProps {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -6,12 +6,7 @@ import { useArticle } from 'src/hooks/use-article'
 import { metrics } from 'src/theme/spacing'
 import { Fader } from '../../layout/animators/fader'
 import { WebviewWithArticle } from './article/webview'
-import {
-    Article as ArticleT,
-    PictureArticle,
-    Content,
-    GalleryArticle,
-} from 'src/common'
+import { Article as ArticleT, PictureArticle, GalleryArticle } from 'src/common'
 import DeviceInfo from 'react-native-device-info'
 import { PathToArticle } from 'src/paths'
 import { IssueOrigin } from '../../../../../Apps/common/src'
@@ -39,14 +34,6 @@ const styles = StyleSheet.create({
                 : 1,
     },
 })
-
-export enum ArticleTheme {
-    Default = 'default',
-    Dark = 'dark',
-}
-
-const usesDarkTheme = (type: Content['type']) =>
-    ['picture', 'gallery'].includes(type)
 
 export type HeaderControlInnerProps = {
     /**
@@ -114,10 +101,6 @@ const Article = ({
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
 
-    const theme = usesDarkTheme(article.type)
-        ? ArticleTheme.Dark
-        : ArticleTheme.Default
-
     const wasShowingHeader = useUpdateWebviewVariable(
         ref,
         'shouldShowHeader',
@@ -130,7 +113,6 @@ const Article = ({
                 type={type}
                 article={article}
                 path={path}
-                theme={theme}
                 scrollEnabled={true}
                 style={[styles.webview]}
                 _ref={r => {

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -4,7 +4,6 @@ import { ArticleType } from 'src/common'
 import { useArticle } from 'src/hooks/use-article'
 import { Article, PictureArticle, GalleryArticle, ImageSize } from 'src/common'
 import { renderArticle } from '../../html/article'
-import { ArticleTheme } from '../article'
 import { onShouldStartLoadWithRequest } from './helpers'
 import { useApolloClient } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
@@ -26,7 +25,6 @@ const WebviewWithArticle = ({
     path,
     type,
     _ref,
-    theme,
     topPadding,
     origin,
     ...webViewProps
@@ -34,7 +32,6 @@ const WebviewWithArticle = ({
     article: Article | PictureArticle | GalleryArticle
     path: PathToArticle
     type: ArticleType
-    theme: ArticleTheme
     _ref?: (ref: WebView) => void
     topPadding: number
     origin: IssueOrigin
@@ -78,7 +75,6 @@ const WebviewWithArticle = ({
         article,
         type,
         imageSize,
-        theme,
         showWebHeader: true,
         showMedia: isConnected,
         publishedId: publishedIssueId || null,


### PR DESCRIPTION
## Summary
Theme is something that is calculated higher up the render tree and only used in generating the HTML. This gives more opportunities for re-renders and adds complications.

This small refactor puts this code where it is used. This will aid future refactoring of the articles.
