### PR TITLE
chore: Only download on open on large Ram devices

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -10,7 +10,6 @@ import { useScreens } from 'react-native-screens'
 import SplashScreen from 'react-native-splash-screen'
 import { NavigationState } from 'react-navigation'
 import { clearAndDownloadIssue } from 'src/helpers/clear-download-issue'
-import { pushDownloadFailsafe } from 'src/helpers/push-download-failsafe'
 import { NavPositionProvider } from 'src/hooks/use-nav-position'
 import { RootNavigator } from 'src/navigation'
 import {
@@ -143,8 +142,6 @@ export default class App extends React.Component<{}, {}> {
                 clearAndDownloadIssue(apolloClient)
             }
         })
-
-        pushDownloadFailsafe(apolloClient)
     }
 
     async componentDidCatch(e: Error) {

--- a/projects/Mallard/src/helpers/clear-download-issue.ts
+++ b/projects/Mallard/src/helpers/clear-download-issue.ts
@@ -1,7 +1,9 @@
-import { prepFileSystem, clearOldIssues, downloadTodaysIssue } from './files'
-import { fetchCacheClear } from './fetch'
 import ApolloClient from 'apollo-client'
+import { pushDownloadFailsafe } from 'src/helpers/push-download-failsafe'
+import { fetchCacheClear } from './fetch'
+import { clearOldIssues, downloadTodaysIssue, prepFileSystem } from './files'
 import { cleanPushTrackingByDays } from './push-tracking'
+import { largeDeviceMemory } from 'src/hooks/use-config-provider'
 
 const clearAndDownloadIssue = async (client: ApolloClient<object>) => {
     await prepFileSystem()
@@ -9,7 +11,13 @@ const clearAndDownloadIssue = async (client: ApolloClient<object>) => {
     await cleanPushTrackingByDays()
     const weOk = await fetchCacheClear()
     if (weOk) {
-        return await downloadTodaysIssue(client)
+        // Check to see if the device has a decent amount of memory before doing intensive tasks
+        const largeRAM = await largeDeviceMemory()
+        if (largeRAM) {
+            pushDownloadFailsafe(client)
+            return await downloadTodaysIssue(client)
+        }
+        return
     }
 }
 


### PR DESCRIPTION
## Summary
Multiple observations suggest that upon opening the app for the first time that day, there is some slowdown. This is because of the download that is kicked off in the background.

This PR looks to turn this off for low powered devices to make that first experience better.

The downside of this is that offline reading will be purely reliant on push notifications or manual download by a user for low powered devices.