### PR TITLE
chore: Front feedback on touch

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -4,7 +4,7 @@ import {
     Easing,
     StyleProp,
     StyleSheet,
-    TouchableWithoutFeedback,
+    TouchableHighlight,
     View,
     ViewStyle,
 } from 'react-native'
@@ -122,7 +122,7 @@ const ItemTappable = withNavigation(
                     }}
                 />
 
-                <TouchableWithoutFeedback
+                <TouchableHighlight
                     onPress={() => {
                         supportsTransparentCards() && fade(opacity, 'out')
                         navigateToArticle(navigation, {
@@ -131,6 +131,7 @@ const ItemTappable = withNavigation(
                             prefersFullScreen: article.type === 'crossword',
                         })
                     }}
+                    activeOpacity={0.95}
                 >
                     <View
                         style={[
@@ -141,7 +142,7 @@ const ItemTappable = withNavigation(
                     >
                         {children}
                     </View>
-                </TouchableWithoutFeedback>
+                </TouchableHighlight>
 
                 <Animated.View
                     {...ariaHidden}


### PR DESCRIPTION
## Summary
Bit of creative license here...

When tapping on an article, there is no way to know if you have tapped on it particularly on slower devices. There is no feedback. This is how it will look, top left tapped (very subtle)

![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2020-02-03 at 11 55 58](https://user-images.githubusercontent.com/935975/73651475-6ace1080-467c-11ea-9a24-8e9e16d84117.png)
