### PR TITLE
Larger headlines on 2/3 story cards

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/sizes.ts
+++ b/projects/Mallard/src/components/front/items/helpers/sizes.ts
@@ -24,7 +24,7 @@ export const getImageHeight = (
     }
     if (layout === PageLayoutSizes.mobile) {
         if (story.height >= 4) {
-            return isDefault ? '75.5%' : '60%'
+            return isDefault ? '65%' : '60%'
         }
         return isDefault ? '50%' : '40%'
     }

--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -38,14 +38,20 @@ const styles = {
 const getFontSize = ({ layout, story }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
         if (story.width >= 3) {
+            if (story.height == 3) return 1.75
             if (story.height >= 3) return 1.5
             if (story.height >= 2) return 1
         }
         if (story.width >= 2) {
+            if (story.height == 4) return 1.5
             if (story.height >= 3) return 1.25
             return 0.75
         }
         return 0.75
+    }
+    // top story for 2 and 3 story cards should have a larger font
+    if (story.height == 4 && story.width === 2) {
+        return 1.25
     }
     if (story.height > 4) {
         return 1.5


### PR DESCRIPTION
## Summary
This change aims to reduce the amount of empty space on the editions fronts by increasing the font size. It should only affect 2 and 3 story cards. On mobile, as well as increasing the font size we reduce the size of the image to make space.

[**Trello Card ->**](https://trello.com/c/MEa6tI8e/1010-story-density-first-cut)

Phone 2 story before/after
<img width="400" alt="Screenshot 2020-02-03 at 11 39 49" src="https://user-images.githubusercontent.com/3606555/73651202-d9f73500-467b-11ea-85b9-bff99f93a396.png">
<img width="400" alt="Screenshot 2020-02-03 at 11 39 39" src="https://user-images.githubusercontent.com/3606555/73651208-dcf22580-467b-11ea-9073-120469fcfac5.png">

Phone 3 story before/after:

<img width="482" alt="Screenshot 2020-02-03 at 11 37 03" src="https://user-images.githubusercontent.com/3606555/73651333-204c9400-467c-11ea-886b-05dbd5dacfa8.png">

<img width="424" alt="Screenshot 2020-02-03 at 11 36 50" src="https://user-images.githubusercontent.com/3606555/73651332-204c9400-467c-11ea-9d9b-448a5664c991.png">

Tablet 2 story before/after:
<img width="680" alt="Screenshot 2020-02-03 at 11 37 22" src="https://user-images.githubusercontent.com/3606555/73651423-4d00ab80-467c-11ea-822c-d5a06d9fe1e4.png">

<img width="486" alt="Screenshot 2020-02-03 at 11 33 57" src="https://user-images.githubusercontent.com/3606555/73651422-4d00ab80-467c-11ea-9bb9-f99ec44d62d4.png">

Tablet 3 story before/after
<img width="567" alt="Screenshot 2020-02-03 at 11 50 35" src="https://user-images.githubusercontent.com/3606555/73651156-c2b84780-467b-11ea-9de8-9dd007823414.png">
<img width="502" alt="Screenshot 2020-02-03 at 11 50 28" src="https://user-images.githubusercontent.com/3606555/73651155-c21fb100-467b-11ea-9455-4395bdce9ff5.png">


This builds on some of the work in [this change](https://github.com/guardian/editions/pull/977). 

## Test Plan

Verify larger headlines on 2/3 story cards. No other cards should be affected.
