### PR TITLE
Simplify front image/font size logic

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/sizes.ts
+++ b/projects/Mallard/src/components/front/items/helpers/sizes.ts
@@ -10,10 +10,10 @@ export const getImageHeight = ({ story, layout }: ItemSizes) => {
         if (story.height >= 4) {
             return '50%'
         }
-        if (story.height >= 3) {
+        if (story.height == 3) {
             return '66.66%'
         }
-        if (story.height >= 2) {
+        if (story.height == 2) {
             return '50%'
         }
         return '75.5%'

--- a/projects/Mallard/src/components/front/items/helpers/sizes.ts
+++ b/projects/Mallard/src/components/front/items/helpers/sizes.ts
@@ -5,28 +5,24 @@ import { PageLayoutSizes, ItemSizes } from '../../../../common'
  * "starter" cards use a bigger font, so we need to reduce the size taken by
  * the image a little bit in all cases.
  */
-export const getImageHeight = (
-    { story, layout }: ItemSizes,
-    type: 'starter' | 'default' = 'default',
-) => {
-    const isDefault = type === 'default'
+export const getImageHeight = ({ story, layout }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
         if (story.height >= 4) {
-            return isDefault ? '50%' : '40%'
+            return '50%'
         }
         if (story.height >= 3) {
-            return isDefault ? '66.66%' : '60%'
+            return '66.66%'
         }
         if (story.height >= 2) {
-            return isDefault ? '50%' : '40%'
+            return '50%'
         }
-        return isDefault ? '75.5%' : '60%'
+        return '75.5%'
     }
     if (layout === PageLayoutSizes.mobile) {
         if (story.height >= 4) {
-            return isDefault ? '65%' : '60%'
+            return '65%'
         }
-        return isDefault ? '50%' : '40%'
+        return '50%'
     }
 }
 

--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -37,18 +37,19 @@ const styles = {
 
 const getFontSize = ({ layout, story }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
-        if (story.width >= 3) {
+        if (story.width == 3) {
+            if (story.height > 3) return 1.5
             if (story.height == 3) return 1.75
-            if (story.height >= 3) return 1.5
-            if (story.height >= 2) return 1
+            if (story.height == 2) return 1
         }
-        if (story.width >= 2) {
+        if (story.width == 2) {
             if (story.height == 4) return 1.5
             if (story.height >= 3) return 1.25
             return 0.75
         }
         return 0.75
     }
+    // mobile layout
     // top story for 2 and 3 story cards should have a larger font
     if (story.height == 4 && story.width === 2) {
         return 1.25

--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -89,7 +89,7 @@ export const StarterItem = ({ article, size, ...tappableProps }: PropTypes) => {
         <ItemTappable {...tappableProps} {...{ article }}>
             <TrailImageView
                 article={article}
-                style={{ height: getImageHeight(size, 'starter') }}
+                style={{ height: getImageHeight(size) }}
             />
 
             <TextBlock


### PR DESCRIPTION
## Summary
This change shouldn't actually change anything - just simplifies the logic we're using to determine font/image size on fronts.

As far as I can tell we aren't using the 'starter' image size at the moment so I've removed it. 

I've also tried to use `==` rather than `>=` where there's actually only one value we're targeting.

## Test Plan
Verify that no changes occur when this is released. 