### PR TITLE
feat: Weather Hider

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -35,6 +35,7 @@ import { NetInfoDevOverlay } from './components/NetInfoDevOverlay'
 import { ConfigProvider } from 'src/hooks/use-config-provider'
 import { Lightbox } from './screens/lightbox'
 import { LightboxProvider } from './screens/use-lightbox-modal'
+import { weatherHider } from './helpers/weather-hider'
 
 /**
  * Only one global Apollo client. As such, any update done from any component
@@ -135,6 +136,7 @@ const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {
         SplashScreen.hide()
+        weatherHider(apolloClient)
         clearAndDownloadIssue(apolloClient)
 
         AppState.addEventListener('change', async appState => {

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -1,0 +1,25 @@
+import ApolloClient from 'apollo-client'
+import { largeDeviceMemory } from 'src/hooks/use-config-provider'
+import { setIsWeatherShown } from './settings/setters'
+import AsyncStorage from '@react-native-community/async-storage'
+import { errorService } from 'src/services/errors'
+
+// Purpose: To hide the weahter on the first load unless the user turns it on
+// Intended for use on lower powered devices
+
+const KEY = '@weatherLowRAMCheck'
+
+const weatherHider = async (client: ApolloClient<object>) => {
+    try {
+        const weatherLowRamCheck = await AsyncStorage.getItem(KEY)
+        if (!weatherLowRamCheck) {
+            const largeRAM = await largeDeviceMemory()
+            await AsyncStorage.setItem(KEY, 'true')
+            !largeRAM && setIsWeatherShown(client, false)
+        }
+    } catch (e) {
+        errorService.captureException(e)
+    }
+}
+
+export { weatherHider }


### PR DESCRIPTION
## Summary
This is a "run once" script that checks if you are on a low powered device and turns the weather off for it. The user is able to turn it back on in the settings.

The hope is less requests and less need for rendering on the lower powered devices.