### PR TITLE
Dense layout changes (3 story start card, enable national/world)

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -172,7 +172,7 @@ const thirdPageCoverLayout = (
 const denseLayout = (): FrontCardsForArticleCount => {
     // Delete this once the client-side changes are running in the released
     // non-beta version of the app.
-    // if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled') return defaultLayout(1)
+    if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled') return defaultLayout(1)
     return {
         0: [],
         1: [1],
@@ -217,6 +217,7 @@ const denseLayout = (): FrontCardsForArticleCount => {
     }
 }
 
+// as of Feb 2020 this function is only used in the backend
 export const getCardsForFront = (
     frontName: string,
 ): FrontCardsForArticleCount => {

--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -180,11 +180,11 @@ const denseLayout = (): FrontCardsForArticleCount => {
         // We do not want to switch to 2 articles on front page right away. Prod
         // team can decide to add more articles if they need a denser layout.
         2: [1, 1],
-        3: [3, 2],
+        3: [1, 2],
         4: [2, 2],
         // Growing up to 2 articles on front page to distribute density.
         5: [3, 2],
-        6: [3, 3],
+        6: [2, 4],
         7: [2, 5],
 
         8: [3, 5],

--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -172,7 +172,7 @@ const thirdPageCoverLayout = (
 const denseLayout = (): FrontCardsForArticleCount => {
     // Delete this once the client-side changes are running in the released
     // non-beta version of the app.
-    if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled') return defaultLayout(1)
+    // if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled') return defaultLayout(1)
     return {
         0: [],
         1: [1],
@@ -180,19 +180,19 @@ const denseLayout = (): FrontCardsForArticleCount => {
         // We do not want to switch to 2 articles on front page right away. Prod
         // team can decide to add more articles if they need a denser layout.
         2: [1, 1],
-        3: [1, 2],
-        4: [1, 3],
+        3: [3, 2],
+        4: [2, 2],
         // Growing up to 2 articles on front page to distribute density.
-        5: [2, 3],
-        6: [2, 4],
+        5: [3, 2],
+        6: [3, 3],
         7: [2, 5],
 
-        // We want to avoid [2, 6], so breakdown into more cards at this point.
-        8: [2, 3, 3],
+        8: [3, 5],
+        // We want to avoid [3, 6], so breakdown into more cards at this point.
         // 4-article cards have more pictures than 3x ones so let's swap them.
-        9: [2, 4, 3],
-        10: [2, 3, 5],
-        11: [2, 4, 5],
+        9: [3, 2, 4],
+        10: [3, 2, 5],
+        11: [3, 3, 5],
         // Growing up to 3 articles on front page to avoid additional cards yet.
         12: [3, 4, 5],
         13: [3, 4, 6],
@@ -222,7 +222,9 @@ export const getCardsForFront = (
 ): FrontCardsForArticleCount => {
     switch (frontName) {
         case 'National':
+            return denseLayout()
         case 'World':
+            return denseLayout()
         case 'Financial':
             return denseLayout()
         case 'Crosswords':

--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -217,7 +217,6 @@ const denseLayout = (): FrontCardsForArticleCount => {
     }
 }
 
-// as of Feb 2020 this function is only used in the backend
 export const getCardsForFront = (
     frontName: string,
 ): FrontCardsForArticleCount => {


### PR DESCRIPTION
## Summary
Modify dense layout so that we start with 3 story cards wherever suitable and enable the dense layout for national and world containers.

These changes only affect the backend app, and are behind a server side switch.

[**Trello Card ->**](https://trello.com/c/MEa6tI8e/1010-story-density-first-cut)

## Test Plan

This change is currently on CODE so can be viewed by changing the backend API to 'CODE published'