### PR TITLE
Allow cover cards on more sections

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -230,18 +230,12 @@ export const getCardsForFront = (
                 0: [],
                 1: [2],
             }
-
         case 'Life':
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage, true)
-        case 'Food':
-        case 'Review':
-        case 'Travel':
-        case 'Books':
-            return defaultLayout(FrontCardAppearance.splashPage, true)
         case 'Sport':
             return defaultLayout(1, true)
         default:
-            return defaultLayout(1)
+            return defaultLayout(FrontCardAppearance.splashPage, true)
     }
 }


### PR DESCRIPTION
Allow cover cards on all sections except: National, World, Financial which use dense layout. Crosswords remain a special case. Life and Culture are unchanged using thirdPageCoverLayout. Sport unchanged on default.

## Summary

Frequently there are 'Specials' that can benefit from cover cards. This PR attempts to lessen the restriction on where cover maybe used.

## Test Plan

This needs testing - just a github edit, by a Product Manager :-(
