### PR TITLE
(try) fix signout bug on poor connections

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -192,7 +192,7 @@ PODS:
     - React
   - react-native-in-app-utils (6.0.2):
     - React
-  - react-native-netinfo (3.2.1):
+  - react-native-netinfo (5.3.3):
     - React
   - react-native-safe-area-context (0.6.4):
     - React
@@ -468,7 +468,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
-  react-native-netinfo: 0da34082d2cec3100c9b5073bb217e35f1142bdd
+  react-native-netinfo: 8884d510fe67349940b4399c01db3e3591c922aa
   react-native-safe-area-context: 52342d2d80ea8faadd0ffa76d83b6051f20c5329
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,7 +37,7 @@
         "@react-native-community/async-storage": "^1.5.0",
         "@react-native-community/geolocation": "^2.0.2",
         "@react-native-community/masked-view": "^0.1.1",
-        "@react-native-community/netinfo": "^3.2.1",
+        "@react-native-community/netinfo": "^5.3.3",
         "@react-native-community/push-notification-ios": "^1.0.2",
         "@react-native-community/viewpager": "^2.0.1",
         "@sentry/react-native": "^1.1.0",

--- a/projects/Mallard/src/authentication/AccessContext.tsx
+++ b/projects/Mallard/src/authentication/AccessContext.tsx
@@ -105,11 +105,14 @@ const AccessProvider = ({
         const unsubIAP = controller.authorizerMap.iap.subscribe(setIAPAuth)
         client
             .watchQuery({
-                query: gql('{ netInfo @client { isConnected @client } }'),
+                query: gql(
+                    '{ netInfo @client { isConnected @client, isPoorConnection @client } }',
+                ),
             })
             .subscribe(res => {
                 controller.handleConnectionStatusChanged(
                     res.data.netInfo.isConnected,
+                    res.data.netInfo.isPoorConnection,
                 )
             })
         return () => {

--- a/projects/Mallard/src/authentication/lib/AccessController.ts
+++ b/projects/Mallard/src/authentication/lib/AccessController.ts
@@ -54,14 +54,18 @@ class AccessController<I extends AuthMap, S extends AuthName<I>> {
         return hasRun(this.attempt) && isOnline(this.attempt)
     }
 
-    public handleConnectionStatusChanged(isConnected: boolean) {
+    public handleConnectionStatusChanged(
+        isConnected: boolean,
+        isPoorConnection = false,
+    ) {
+        const hasConnection = isConnected && !isPoorConnection
         if (!this.hasAuthRun) {
-            if (isConnected) {
+            if (hasConnection) {
                 return this.runCachedAuth('online')
             } else {
                 return this.runCachedAuth('offline')
             }
-        } else if (!this.isAuthOnline && isConnected) {
+        } else if (!this.isAuthOnline && hasConnection) {
             return this.runCachedAuth('online')
         }
     }

--- a/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
@@ -102,6 +102,7 @@ describe('use-net-info', () => {
                 isForcedOffline: false,
                 setIsDevButtonShown: expect.any(Function),
                 setIsForcedOffline: expect.any(Function),
+                isPoorConnection: false,
             })
         })
 
@@ -122,6 +123,7 @@ describe('use-net-info', () => {
                 isForcedOffline: false,
                 setIsDevButtonShown: expect.any(Function),
                 setIsForcedOffline: expect.any(Function),
+                isPoorConnection: false,
             })
         })
 
@@ -169,6 +171,7 @@ describe('use-net-info', () => {
                 isForcedOffline: true,
                 setIsDevButtonShown: expect.any(Function),
                 setIsForcedOffline: expect.any(Function),
+                isPoorConnection: false,
             })
         })
     })

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1126,10 +1126,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.1.tgz#dbcfc5ec08efbb02d4142dd9426c8d7a396829d7"
   integrity sha512-EyJVSbarZkOPYq+zCZLx9apMcpwkX9HvH6R+6CeVL29q88kEFemnLO/IhmE4YX/0MfalsduI8eTi7fuQh/5VeA==
 
-"@react-native-community/netinfo@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-3.2.1.tgz#cd073b81a4b978f7f55f1a960a0b56c462813e02"
-  integrity sha512-A2qANOnlRDVe+8kMbKMwy3/0bOlOA2+y8DyWg2Rv2KHICIfin+oxixbG0ewAOLQdLkSEyyumZXRmIVl7VI/KJg==
+"@react-native-community/netinfo@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.3.3.tgz#2e627456d83c1d75d4c43ab6cef70fe125b9691d"
+  integrity sha512-L4BsdIEEuG5rKkVNzjESdJ1wvusn0kflj/FrwctaW+xkLxiFs1+mdBg/mvqqfXvVFuBEphbyXJTFT4aG4Okkow==
 
 "@react-native-community/push-notification-ios@^1.0.1", "@react-native-community/push-notification-ios@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## Summary
Currently we have a bug where users can get 'signed out' if they use the app with a poor network connection. This change:

 - Bumps the version of netinfo that we're using
- Uses info from 'isInternetReachable' to determine connectivity
 - Adds a new 'isPoorConnection' property to indicate a 2G connection - in this scenario we will assume offline for the purposes of authentication

Since I made these changes I've not reproduced this bug, I'm not 100% confident though!!

[**Trello Card ->**](https://trello.com/c/0Du77n0C/1058-poor-connectivity-can-cause-you-to-be-signed-out)

## Test Plan
This shouldn't happen:

**Steps**
0. Be signed into the app (see fig 1)
1. Find an area with very poor connectivity (3rd floor mens toilets works, or on android settings>connections>mobile networks>network mode>2g, or london bridge station 🚋  )
2. Foreground the app and notice that it's not showing content (fig2)
3. Open the issue picker (notice that is has no list) (fig 3)
4. Force quit app and relaunch

**Actual Result**
5. On relaunch the user is "signed out" (fig 4)
