### PR TITLE
Fix section jump navigation on new slider

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -201,7 +201,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         font-weight: 600;
         color: ${colors.main};
     }
-    
+
     .header-top-byline > a {
         font-style: normal !important;
         text-decoration: none;
@@ -310,8 +310,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         background-color: ${colors.main};
         color: ${color.textOverDarkBackground};
         border:none;
-        width: ${metrics.fronts.sliderRadius * 2}px;
-        height: ${metrics.fronts.sliderRadius * 2}px;
+        width: ${metrics.fronts.circleButtonDiameter}px;
+        height: ${metrics.fronts.circleButtonDiameter}px;
         display: block;
         line-height: .9;
         text-align: center;
@@ -330,8 +330,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
     .share-button {
         display: flex;
-        width:  ${metrics.fronts.sliderRadius * 2}px;
-        height: ${metrics.fronts.sliderRadius * 2}px;
+        width:  ${metrics.fronts.circleButtonDiameter}px;
+        height: ${metrics.fronts.circleButtonDiameter}px;
         border: 1px solid ${colors.main};
         color: ${colors.main};
         border-radius: 100%;

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -66,6 +66,7 @@ import {
 import { FrontSpec } from './article-screen'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
+import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -293,9 +294,9 @@ const IssueFronts = ({
                 </>
             )}
             getItemLayout={(_: any, index: number) => ({
-                length: card.height + metrics.fronts.sliderRadius * 2,
+                length: card.height + SLIDER_FRONT_HEIGHT,
                 offset:
-                    (card.height + metrics.fronts.sliderRadius * 2) * index +
+                    (card.height + SLIDER_FRONT_HEIGHT) * index +
                     (isWeatherActuallyShown
                         ? WEATHER_HEIGHT
                         : EMPTY_WEATHER_HEIGHT),

--- a/projects/Mallard/src/screens/issue/use-size.tsx
+++ b/projects/Mallard/src/screens/issue/use-size.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react'
 import { metrics } from 'src/theme/spacing'
 import { Dimensions, LayoutRectangle } from 'react-native'
 import { PageLayoutSizes } from 'src/common'
+import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 
 const BreakpointContext = createContext<[PageLayoutSizes, LayoutRectangle]>([
     PageLayoutSizes.mobile,
@@ -17,7 +18,7 @@ const useIssueScreenSize = () => {
             ? metrics.fronts.cardSizeTablet
             : metrics.fronts.cardSizeTabletShort
     const container = {
-        height: metrics.fronts.cardContainerHeightExtra + card.height,
+        height: SLIDER_FRONT_HEIGHT + card.height,
         width: layout.width,
     }
 

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -12,7 +12,6 @@ const basicMetrics = {
 
 const buttonHeight = getFont('sans', 1).fontSize + basicMetrics.vertical * 2.5
 const sides = basicMetrics.horizontal
-const sliderRadius = 18
 
 export const metrics = {
     ...basicMetrics,
@@ -29,11 +28,10 @@ export const metrics = {
     },
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
-        cardContainerHeightExtra: sliderRadius * 2,
         cardSize: toSize(540, 530),
         cardSizeTablet: toSize(650, 725),
         cardSizeTabletShort: toSize(650, 660),
-        sliderRadius,
+        circleButtonDiameter: 36,
     },
     gridRowSplit: {
         narrow: (width: number) => width * 0.65,


### PR DESCRIPTION
## Summary
The main aim of this change is to fix a bug with the 'jump to section' nav where we end up in the wrong place - because we're assuming the container header is narrower than it actually is. 

This also removes all references to `sliderRadius` from the codebase now that the slider has been removed. 

[**Trello Card ->**](https://trello.com/c/8kg9Axpc/1140-bug-section-name-is-not-always-at-the-top-of-screen)

## Test Plan

I already tested it!

![section nav](http://g.recordit.co/mKndhao6Mx.gif)
