### PR TITLE
fix: Android crash with React Navigation

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -49,7 +49,7 @@ if (!__DEV__) {
 
 // useScreens is not a hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
-enableScreens()
+Platform.OS === 'ios' && enableScreens()
 pushNotifcationRegistration(apolloClient)
 Platform.OS === 'android' && clearAndDownloadIssue(apolloClient)
 


### PR DESCRIPTION
## Summary
Android is crashing based on the last changed to React Navigation. This lead to this recent thread:

https://github.com/software-mansion/react-native-screens/issues/309

For now, I have gone with the final suggestion but it seems our dependencies are a bit wonky on what is proving a quite unstable plugin.