### PR TITLE
Add editionsDate param to determine subtitle visibility

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -21,6 +21,7 @@ import { Wrapper } from './helpers/wrapper'
 import { ArticleNavigator } from 'src/screens/article-screen'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { SliderTitle } from 'src/screens/article/slider/SliderTitle'
+import { issueDateFromId } from 'src/screens/article/slider/slider-helpers'
 
 const CollectionPageInFront = ({
     index,
@@ -124,6 +125,7 @@ export const Front = React.memo(
                             cards[cardIndex].collection.key
                         }
                         position={position}
+                        editionDate={issueDateFromId(publishedIssueId)}
                     />
                 }
             >

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -10,7 +10,7 @@ const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
         : 70
     : 60
 
-const FIRST_SUBTITLE_DATE = new Date('2020-02-17').getTime()
+const FIRST_SUBTITLE_DATE = new Date('2020-03-05').getTime()
 
 interface SliderTitleProps {
     title: string

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -10,6 +10,8 @@ const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
         : 70
     : 60
 
+const FIRST_SUBTITLE_DATE = new Date('2020-02-17').getTime()
+
 interface SliderTitleProps {
     title: string
     numOfItems: number
@@ -18,6 +20,7 @@ interface SliderTitleProps {
     subtitle?: string
     position: Animated.AnimatedInterpolation
     startIndex?: number
+    editionDate: Date | undefined //temporary until we have subtitles for the last 30 editions
 }
 
 const styles = (color: string, location: string, isTablet: boolean) => {
@@ -65,18 +68,24 @@ const SliderTitle = React.memo(
         subtitle,
         position,
         startIndex,
+        editionDate,
     }: SliderTitleProps) => {
         const isTablet = DeviceInfo.isTablet()
         const appliedStyle = styles(color, location, isTablet)
         // takes a key e.g. O:Top Stories and provides the end part
         const transformedSubtitle =
             subtitle && subtitle.split(':')[subtitle.split(':').length - 1]
+        const showSubtitle =
+            transformedSubtitle !== title &&
+            // this check (and associated editionDate prop) can be removed one month after HIDE_SUBTITLE_BEFORE
+            // this is to hide subtitles on past issues created before subtitles were a thing
+            (!editionDate || editionDate.getTime() > FIRST_SUBTITLE_DATE)
 
         return (
             <View style={appliedStyle.container}>
                 <View style={appliedStyle.titleContainer}>
                     <Text style={appliedStyle.title}>{title}</Text>
-                    {transformedSubtitle !== title && (
+                    {showSubtitle && (
                         <Text style={appliedStyle.subtitle}>
                             {' '}
                             {transformedSubtitle}

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
@@ -9,7 +9,7 @@ const sliderDetails = {
     numOfItems: 3,
     color: '#000000',
     position: new Animated.Value(3),
-    editionDate: new Date(),
+    editionDate: new Date('2020-03-30'),
 }
 
 const baseTests = (title: string) =>

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { SliderTitle } from '../SliderTitle'
 import { Animated } from 'react-native'
+import { issueDateFromId } from '../slider-helpers'
 
 const sliderDetails = {
     title: 'Top Stories',
     numOfItems: 3,
     color: '#000000',
     position: new Animated.Value(3),
+    editionDate: new Date(),
 }
 
 const baseTests = (title: string) =>
@@ -82,6 +84,13 @@ const baseTests = (title: string) =>
                 <SliderTitle {...sliderDetails} numOfItems={1} />,
             ).toJSON()
             expect(component).toMatchSnapshot()
+        })
+
+        it('should correctly extract dates from an edition id', () => {
+            const id = 'daily-edition/2020-02-18/2020-02-18T01:55:13.3'
+            const extractedDate = issueDateFromId(id)
+            expect(extractedDate).toStrictEqual(new Date('2020-02-18'))
+            expect(issueDateFromId('jasdhklasdfa')).toBe(undefined)
         })
     })
 

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -21,6 +21,7 @@ import { HEADER_LOW_END_HEIGHT, SliderHeaderLowEnd } from './SliderHeaderLowEnd'
 import { SliderSection } from './types'
 import { useIsPreview } from 'src/hooks/use-settings'
 import { PreviewControls } from 'src/components/article/preview-controls'
+import { issueDateFromId } from './slider-helpers'
 
 export interface PathToArticle {
     collection: Collection['key']
@@ -129,6 +130,7 @@ const ArticleSlider = React.memo(
                 subtitle: currentArticle.collection,
                 startIndex: displaySection[0].startIndex,
                 position,
+                editionDate: issueDateFromId(path.publishedIssueId),
             }
         }
         const sliderDetails = getFrontNameAndPosition()

--- a/projects/Mallard/src/screens/article/slider/slider-helpers.ts
+++ b/projects/Mallard/src/screens/article/slider/slider-helpers.ts
@@ -1,0 +1,6 @@
+export const issueDateFromId = (id: string) => {
+    const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}/
+    const dateString = id.match(dateRegex)
+    const date = dateString ? new Date(dateString[0]) : undefined
+    return date
+}


### PR DESCRIPTION
## Summary
We will need to prepare the fronts tool/future issues to be ready for the new subtitle/container title design implemented in #1028

This change adds an editionDate parameter (extracted from the edition id) so that we can prevent the subtitle from showing on issues published before a certain date.

Replaces https://github.com/guardian/editions/pull/1032

Test Plan

Check FIRST_SUBTITLE_DATE in SliderTitle.tsx. Subtitles should not be showing on issues published before this date.