### PR TITLE
Design tweaks for new slider design

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -100,7 +100,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
     }
     .header {
-        padding-top: ${px(metrics.vertical)};
+        padding-top: ${px(metrics.vertical / 2)};
     }
     .header-container-line-wrap,
     .header-container {

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -37,8 +37,8 @@ export const WEATHER_QUERY = gql`
 
 const narrowSpace = String.fromCharCode(8201)
 
-export const WEATHER_HEIGHT = 78
-export const EMPTY_WEATHER_HEIGHT = 16
+export const WEATHER_HEIGHT = 65
+export const EMPTY_WEATHER_HEIGHT = 8
 
 const styles = StyleSheet.create({
     shownWeather: {
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
         display: 'flex',
         flexDirection: 'row-reverse',
         width: 'auto',
-        marginBottom: 24,
+        marginBottom: 5,
     },
     forecastItem: {
         borderStyle: 'solid',
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
         borderLeftColor: color.line,
     },
     forecastItemNarrow: {
-        height: 64,
+        height: WEATHER_HEIGHT - 1,
         width: 45,
         paddingTop: 2,
         paddingLeft: 4,

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
@@ -5,7 +5,7 @@ import { metrics } from 'src/theme/spacing'
 import { SliderTitleProps, SliderTitle } from './SliderTitle'
 import DeviceInfo from 'react-native-device-info'
 
-const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 60 : 55
+const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 65 : 55
 
 const styles = StyleSheet.create({
     slider: {

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
@@ -9,7 +9,7 @@ const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 60 : 55
 
 const styles = StyleSheet.create({
     slider: {
-        paddingVertical: metrics.vertical,
+        paddingBottom: metrics.vertical,
         justifyContent: 'center',
         alignItems: 'center',
         borderBottomWidth: StyleSheet.hairlineWidth,

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
@@ -5,7 +5,7 @@ import { metrics } from 'src/theme/spacing'
 import { SliderTitleProps, SliderTitle } from './SliderTitle'
 import DeviceInfo from 'react-native-device-info'
 
-const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 75 : 67
+const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 60 : 55
 
 const styles = StyleSheet.create({
     slider: {

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -16,7 +16,7 @@ const HEADER_LOW_END_HEIGHT = DeviceInfo.isTablet()
 
 const styles = StyleSheet.create({
     slider: {
-        paddingVertical: metrics.vertical,
+        paddingBottom: metrics.vertical,
         justifyContent: 'center',
         alignItems: 'center',
         borderBottomWidth: StyleSheet.hairlineWidth,

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -8,7 +8,7 @@ import { metrics } from 'src/theme/spacing'
 const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'android'
         ? 100
-        : 90
+        : 70
     : 60
 
 interface SliderTitleProps {

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -3,6 +3,7 @@ import { Animated, Platform, StyleSheet, Text, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { getFont } from 'src/theme/typography'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
+import { metrics } from 'src/theme/spacing'
 
 const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'android'
@@ -68,7 +69,7 @@ const styles = (color: string, location: string, isTablet: boolean) => {
         },
         dotsContainer: {
             flexDirection: 'row',
-            paddingTop: 8,
+            paddingTop: metrics.vertical,
         },
         dot,
         selected: {

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -28,12 +28,12 @@ const styles = (color: string, location: string, isTablet: boolean) => {
 
     const titleArticle = {
         ...titleShared,
-        fontSize: isTablet ? 30 : 26,
+        fontSize: isTablet ? 30 : 20,
     }
 
     const titleFront = {
         ...titleShared,
-        fontSize: isTablet ? 50 : 28,
+        fontSize: isTablet ? 38 : 28,
     }
 
     const title = location === 'article' ? titleArticle : titleFront
@@ -45,7 +45,7 @@ const styles = (color: string, location: string, isTablet: boolean) => {
         marginRight,
     })
 
-    const dotFront = isTablet ? dotBuilder(16, 7) : dotBuilder(10, 4)
+    const dotFront = isTablet ? dotBuilder(14, 7) : dotBuilder(10, 4)
 
     const dotArticle = dotBuilder(8, 2)
 

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`SliderTitle - Android - Mobile should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -109,7 +109,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -120,7 +120,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -132,7 +132,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -196,7 +196,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -207,7 +207,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -271,7 +271,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -282,7 +282,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -293,7 +293,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -380,7 +380,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -455,7 +455,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -519,7 +519,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -530,7 +530,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -541,7 +541,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -34,7 +34,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -45,7 +45,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -53,10 +53,10 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -64,10 +64,10 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -75,10 +75,10 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -132,7 +132,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -207,7 +207,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -293,7 +293,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -357,7 +357,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -368,7 +368,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -380,7 +380,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -388,10 +388,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -399,10 +399,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -410,10 +410,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -444,7 +444,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -455,7 +455,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -463,10 +463,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -474,10 +474,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -485,10 +485,10 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -541,7 +541,7 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
@@ -45,7 +45,7 @@ exports[`SliderTitle - iOS - Mobile should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -109,7 +109,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -120,7 +120,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -132,7 +132,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -196,7 +196,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -207,7 +207,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -271,7 +271,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -282,7 +282,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -293,7 +293,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -380,7 +380,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -455,7 +455,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -519,7 +519,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -530,7 +530,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 26,
+          "fontSize": 20,
         }
       }
     >
@@ -541,7 +541,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -34,7 +34,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -45,7 +45,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -53,10 +53,10 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -64,10 +64,10 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -75,10 +75,10 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -132,7 +132,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -207,7 +207,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -293,7 +293,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -357,7 +357,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -368,7 +368,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -380,7 +380,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -388,10 +388,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -399,10 +399,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -410,10 +410,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -444,7 +444,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 50,
+          "fontSize": 38,
         }
       }
     >
@@ -455,7 +455,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >
@@ -463,10 +463,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -474,10 +474,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -485,10 +485,10 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
       style={
         Object {
           "backgroundColor": "rgba(220, 220, 220, 1)",
-          "borderRadius": 8,
-          "height": 16,
+          "borderRadius": 7,
+          "height": 14,
           "marginRight": 7,
-          "width": 16,
+          "width": 14,
         }
       }
     />
@@ -541,7 +541,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 8,
+        "paddingTop": 10,
       }
     }
   >

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -70,7 +70,7 @@ import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
-        height: 16,
+        height: EMPTY_WEATHER_HEIGHT,
     },
     illustrationImage: {
         width: '100%',


### PR DESCRIPTION
## Summary
This tweaks some of the font sizes and spacing in the new slider:

 - Reduced height of the weather component/weather empty space (mainly removing empty space underneath
 - Reduce height of the slider title on article pages (by an arbitrary amount)
 - Update font sizes on tablet fronts/phone article pages

[**Trello Card ->**](https://trello.com/c/ysLk7D4B/1153-font-size-of-the-titles-and-the-dots-and-space-between-weather-and-top-stories-reduce-them-on-ipad-only)

Looks like this now:

<img width="925" alt="Screenshot 2020-02-24 at 15 49 24" src="https://user-images.githubusercontent.com/3606555/75167958-0f90ba80-571e-11ea-848b-d705aea8ae34.png">
<img width="376" alt="Screenshot 2020-02-24 at 15 49 10" src="https://user-images.githubusercontent.com/3606555/75167970-13244180-571e-11ea-894c-61c2c56036e9.png">
<img width="942" alt="Screenshot 2020-02-24 at 15 49 01" src="https://user-images.githubusercontent.com/3606555/75167972-13bcd800-571e-11ea-856d-c0fe54b59e18.png">
<img width="361" alt="Screenshot 2020-02-24 at 15 48 49" src="https://user-images.githubusercontent.com/3606555/75167974-14ee0500-571e-11ea-8a7a-391510d8cd62.png">


## Test Plan

Have a look at the above screenshots and see what you think! 

