### PR TITLE
fix: Better dot to card spacing for Android

### DIFF
--- a/projects/Mallard/src/components/front/helpers/wrapper.tsx
+++ b/projects/Mallard/src/components/front/helpers/wrapper.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, Platform, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { useIssueScreenSize } from 'src/screens/issue/use-size'
 import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
@@ -8,7 +8,7 @@ const styles = StyleSheet.create({
     outer: {
         paddingLeft: metrics.horizontal,
         paddingRight: metrics.horizontal,
-        marginBottom: 0,
+        marginBottom: Platform.OS === 'android' ? 5 : 0,
         marginTop: 0,
         height: SLIDER_FRONT_HEIGHT,
     },


### PR DESCRIPTION
## Summary
Dots were sitting next to the cards on the fronts. Given them a little room.

![Screen Shot 2020-02-25 at 11 27 06](https://user-images.githubusercontent.com/935975/75243564-08bb8380-57c2-11ea-8a73-0861ee544cb3.png)

