### PR TITLE
Revert "Allow cover cards on more sections"

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -232,12 +232,18 @@ export const getCardsForFront = (
                 0: [],
                 1: [2],
             }
+
         case 'Life':
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage, true)
+        case 'Food':
+        case 'Review':
+        case 'Travel':
+        case 'Books':
+            return defaultLayout(FrontCardAppearance.splashPage, true)
         case 'Sport':
             return defaultLayout(1, true)
         default:
-            return defaultLayout(FrontCardAppearance.splashPage, true)
+            return defaultLayout(1)
     }
 }


### PR DESCRIPTION
Reverts guardian/editions#1029

An unintended consequence of this change was that there were different card designs unleashed in Journal which were very unhelpful for Production. This PR reverts that change. There is a separate ticket in Trello for us to work out how to unleash the beauty of cover cards throughout the edition.