### PR TITLE
feat: No Dots on a Single Card

### DIFF
--- a/projects/Mallard/src/components/front/helpers/wrapper.tsx
+++ b/projects/Mallard/src/components/front/helpers/wrapper.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from 'react'
 import { View, Platform, StyleSheet } from 'react-native'
 import { metrics } from 'src/theme/spacing'
 import { useIssueScreenSize } from 'src/screens/issue/use-size'
-import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 
 const styles = StyleSheet.create({
     outer: {
@@ -10,7 +9,7 @@ const styles = StyleSheet.create({
         paddingRight: metrics.horizontal,
         marginBottom: Platform.OS === 'android' ? 5 : 0,
         marginTop: 0,
-        height: SLIDER_FRONT_HEIGHT,
+        paddingBottom: metrics.vertical,
     },
 })
 

--- a/projects/Mallard/src/screens/article/slider/SliderDots.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderDots.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Animated, Platform, StyleSheet, Text, View } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
+import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
+import { metrics } from 'src/theme/spacing'
+
+interface SliderDotsProps {
+    numOfItems: number
+    color: string
+    location?: 'article' | 'front'
+    position: Animated.AnimatedInterpolation
+    startIndex?: number
+}
+
+const styles = (color: string, location: string, isTablet: boolean) => {
+    const dotBuilder = (size: number, marginRight: number) => ({
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        marginRight,
+    })
+
+    const dotFront = isTablet ? dotBuilder(14, 7) : dotBuilder(10, 4)
+
+    const dotArticle = dotBuilder(8, 2)
+
+    const dot = location === 'article' ? dotArticle : dotFront
+
+    return StyleSheet.create({
+        dotsContainer: {
+            flexDirection: 'row',
+            paddingTop: metrics.vertical,
+        },
+        dot,
+        selected: {
+            backgroundColor: color,
+        },
+    })
+}
+
+const SliderDots = React.memo(
+    ({
+        numOfItems,
+        color,
+        location = 'article',
+        position,
+        startIndex,
+    }: SliderDotsProps) => {
+        const dots = []
+        const isTablet = DeviceInfo.isTablet()
+        const appliedStyle = styles(color, location, isTablet)
+
+        const newPos: any =
+            Platform.OS === 'android' && startIndex
+                ? Number(position) - startIndex
+                : startIndex
+                ? Animated.subtract(position, startIndex)
+                : position
+
+        const largeDeviceMemory = useLargeDeviceMemory()
+        const range = (i: number) =>
+            largeDeviceMemory
+                ? {
+                      inputRange: [
+                          i - 0.50000000001,
+                          i - 0.5,
+                          i,
+                          i + 0.5,
+                          i + 0.50000000001,
+                      ],
+                      outputRange: ['#DCDCDC', color, color, color, '#DCDCDC'],
+                  }
+                : {
+                      inputRange: [i - 1, i, i + 1],
+                      outputRange: ['#DCDCDC', color, '#DCDCDC'],
+                  }
+
+        for (let i = 0; i < numOfItems; i++) {
+            const backgroundColor =
+                Platform.OS === 'android' && location === 'article'
+                    ? i === newPos
+                        ? color
+                        : '#DCDCDC'
+                    : newPos.interpolate({
+                          ...range(i),
+                          extrapolate: 'clamp',
+                      })
+
+            dots.push(
+                <Animated.View
+                    key={i}
+                    style={[
+                        appliedStyle.dot,
+                        {
+                            backgroundColor,
+                        },
+                    ]}
+                ></Animated.View>,
+            )
+        }
+
+        return <View style={appliedStyle.dotsContainer}>{dots}</View>
+    },
+)
+
+export { SliderDots, SliderDotsProps }

--- a/projects/Mallard/src/screens/article/slider/SliderDots.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderDots.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Animated, Platform, StyleSheet, Text, View } from 'react-native'
+import { Animated, Platform, StyleSheet, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { metrics } from 'src/theme/spacing'

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { Animated, Platform, StyleSheet, Text, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { getFont } from 'src/theme/typography'
-import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
-import { metrics } from 'src/theme/spacing'
+import { SliderDots } from './SliderDots'
 
 const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'android'
@@ -39,19 +38,6 @@ const styles = (color: string, location: string, isTablet: boolean) => {
 
     const title = location === 'article' ? titleArticle : titleFront
 
-    const dotBuilder = (size: number, marginRight: number) => ({
-        width: size,
-        height: size,
-        borderRadius: size / 2,
-        marginRight,
-    })
-
-    const dotFront = isTablet ? dotBuilder(14, 7) : dotBuilder(10, 4)
-
-    const dotArticle = dotBuilder(8, 2)
-
-    const dot = location === 'article' ? dotArticle : dotFront
-
     return StyleSheet.create({
         container: {
             paddingLeft: location === 'front' ? 10 : 0,
@@ -67,14 +53,6 @@ const styles = (color: string, location: string, isTablet: boolean) => {
             ...title,
             color: 'grey', //TBC
         },
-        dotsContainer: {
-            flexDirection: 'row',
-            paddingTop: metrics.vertical,
-        },
-        dot,
-        selected: {
-            backgroundColor: color,
-        },
     })
 }
 
@@ -88,61 +66,11 @@ const SliderTitle = React.memo(
         position,
         startIndex,
     }: SliderTitleProps) => {
-        const dots = []
         const isTablet = DeviceInfo.isTablet()
         const appliedStyle = styles(color, location, isTablet)
         // takes a key e.g. O:Top Stories and provides the end part
         const transformedSubtitle =
             subtitle && subtitle.split(':')[subtitle.split(':').length - 1]
-
-        const newPos: any =
-            Platform.OS === 'android' && startIndex
-                ? Number(position) - startIndex
-                : startIndex
-                ? Animated.subtract(position, startIndex)
-                : position
-
-        const largeDeviceMemory = useLargeDeviceMemory()
-        const range = (i: number) =>
-            largeDeviceMemory
-                ? {
-                      inputRange: [
-                          i - 0.50000000001,
-                          i - 0.5,
-                          i,
-                          i + 0.5,
-                          i + 0.50000000001,
-                      ],
-                      outputRange: ['#DCDCDC', color, color, color, '#DCDCDC'],
-                  }
-                : {
-                      inputRange: [i - 1, i, i + 1],
-                      outputRange: ['#DCDCDC', color, '#DCDCDC'],
-                  }
-
-        for (let i = 0; i < numOfItems; i++) {
-            const backgroundColor =
-                Platform.OS === 'android' && location === 'article'
-                    ? i === newPos
-                        ? color
-                        : '#DCDCDC'
-                    : newPos.interpolate({
-                          ...range(i),
-                          extrapolate: 'clamp',
-                      })
-
-            dots.push(
-                <Animated.View
-                    key={`${title}${i}`}
-                    style={[
-                        appliedStyle.dot,
-                        {
-                            backgroundColor,
-                        },
-                    ]}
-                ></Animated.View>,
-            )
-        }
 
         return (
             <View style={appliedStyle.container}>
@@ -155,7 +83,15 @@ const SliderTitle = React.memo(
                         </Text>
                     )}
                 </View>
-                <View style={appliedStyle.dotsContainer}>{dots}</View>
+                {numOfItems > 1 && (
+                    <SliderDots
+                        numOfItems={numOfItems}
+                        color={color}
+                        location={location}
+                        position={position}
+                        startIndex={startIndex}
+                    />
+                )}
             </View>
         )
     },

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle-BaseTests.tsx
@@ -76,6 +76,13 @@ const baseTests = (title: string) =>
             ).toJSON()
             expect(component).toMatchSnapshot()
         })
+
+        it('should display no dots when numOfItems is 1 or less', () => {
+            const component: ReactTestRendererJSON | null = TestRenderer.create(
+                <SliderTitle {...sliderDetails} numOfItems={1} />,
+            ).toJSON()
+            expect(component).toMatchSnapshot()
+        })
     })
 
 export { baseTests }

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
@@ -581,3 +581,47 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
   </View>
 </View>
 `;
+
+exports[`SliderTitle - Android - Mobile should display no dots when numOfItems is 1 or less 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": 800,
+      "paddingLeft": 0,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#000000",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 20,
+        }
+      }
+    >
+      Top Stories
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "grey",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 20,
+        }
+      }
+    >
+       
+    </Text>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
@@ -581,3 +581,47 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
   </View>
 </View>
 `;
+
+exports[`SliderTitle - Android - Tablet should display no dots when numOfItems is 1 or less 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": 800,
+      "paddingLeft": 0,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#000000",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+        }
+      }
+    >
+      Top Stories
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "grey",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+        }
+      }
+    >
+       
+    </Text>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
@@ -581,3 +581,47 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
   </View>
 </View>
 `;
+
+exports[`SliderTitle - iOS - Mobile should display no dots when numOfItems is 1 or less 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": 800,
+      "paddingLeft": 0,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#000000",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 20,
+        }
+      }
+    >
+      Top Stories
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "grey",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 20,
+        }
+      }
+    >
+       
+    </Text>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
@@ -581,3 +581,47 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
   </View>
 </View>
 `;
+
+exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 or less 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "maxWidth": 800,
+      "paddingLeft": 0,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#000000",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+        }
+      }
+    >
+      Top Stories
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "grey",
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+        }
+      }
+    >
+       
+    </Text>
+  </View>
+</View>
+`;


### PR DESCRIPTION
## Summary
Separates dots out into its own component to reduce complexity. 
Has new logic to only show dots if its greater than 1 card
Updated tests for this logic

[**Trello Card ->**](https://trello.com/c/LEvjyTHl/1158-new-slider-crosswords-shouldnt-display-dots)

## Test Plan
- Scroll down to Crosswords, see no dots