### PR TITLE
Reduce height of half height card images

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/sizes.ts
+++ b/projects/Mallard/src/components/front/items/helpers/sizes.ts
@@ -14,7 +14,7 @@ export const getImageHeight = ({ story, layout }: ItemSizes) => {
             return '66.66%'
         }
         if (story.height == 2) {
-            return '50%'
+            return '45%'
         }
         return '75.5%'
     }


### PR DESCRIPTION
## Summary
Images are looking a bit square on tablet. This reduces their squareness

[**Trello Card (solves a bit of this) ->**](https://trello.com/c/UHpRfeSB/1168-dodgy-aspect-ratio-card-sizes)

Before
![Screenshot 2020-02-28 at 12 28 00](https://user-images.githubusercontent.com/3606555/75548856-1a9d6080-5a26-11ea-99eb-36a49edaccb4.png)
After
![Screenshot 2020-02-28 at 12 27 14](https://user-images.githubusercontent.com/3606555/75548858-1b35f700-5a26-11ea-890a-d64e5cb184cd.png)


