### PR TITLE
fix: Error flash on App Load

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -419,7 +419,7 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
             e.message = `Failed to fetch valid issue summary: ${e.message}`
             errorService.captureException(e)
             console.log(e.message)
-            throw e
+            return readIssueSummary()
         })
 }
 

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -418,7 +418,6 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
         .catch(e => {
             e.message = `Failed to fetch valid issue summary: ${e.message}`
             errorService.captureException(e)
-            console.log(e.message)
             return readIssueSummary()
         })
 }


### PR DESCRIPTION
## Summary
Randomly, when loading the app you will see a flash of error text along the lines of `Failed to fetch valid issue summary`. This is because RNFetchBlob has some underlying issues which causes it to fail.

As everything seems to work even when it fails, it makes sense not to throw an error when this happens but suppress it.The error is still being captured in Sentry.

Instead of throwing this error, we read from the local file store instead to ensure a valid issue summary is delivered.