### PR TITLE
Remove short tablet size.

### DIFF
--- a/projects/Mallard/src/screens/issue/use-size.tsx
+++ b/projects/Mallard/src/screens/issue/use-size.tsx
@@ -14,9 +14,7 @@ const useIssueScreenSize = () => {
     const card =
         size === PageLayoutSizes.mobile
             ? metrics.fronts.cardSize
-            : layout.height > 980
-            ? metrics.fronts.cardSizeTablet
-            : metrics.fronts.cardSizeTabletShort
+            : metrics.fronts.cardSizeTablet
     const container = {
         height: SLIDER_FRONT_HEIGHT + card.height,
         width: layout.width,

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -30,7 +30,6 @@ export const metrics = {
         sides: basicMetrics.horizontal * 1.5,
         cardSize: toSize(540, 530),
         cardSizeTablet: toSize(650, 725),
-        cardSizeTabletShort: toSize(650, 660),
         circleButtonDiameter: 36,
     },
     gridRowSplit: {


### PR DESCRIPTION
## Summary
This removes the smaller card size for 'shorter' tablets, which originates in this PR https://github.com/guardian/editions/pull/280 - though I can't work out what the original motivation was

I've had a play with the fronts UI on a few tablet simulators of different sizes and this change doesn't seem too problematic. In the process it resolves the trail text disappearing bug we had - which is the result of the landscape view being seen as a 'short tablet' so that when rotating back there isn't enough space for the trail text

[**Trello Card ->**](https://trello.com/c/EjTyZN2v/1157-trail-disappears-in-the-first-two-containers-after-rotating-the-ipad)

## Test Plan

Test fronts on ios9 and any iPad available - when rotating the trail text should always remain at the bottom of the card and never disappear
