### PR TITLE
fix: Crossword working on iOS9

### DIFF
--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -133,7 +133,6 @@ const ArticleScreenWithProps = ({
                 ref={r => {
                     if (r) viewRef.current = r
                 }}
-                removeClippedSubviews
             >
                 {prefersFullScreen ? (
                     <>


### PR DESCRIPTION
## Summary
This prop was causing the crossword not to load on iOS9.

Its effect is to clip items outside of the view to enable performance. So we need to see the effect on the article pages.
