### PR TITLE
Fix subsection navigation alignment.

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -4,11 +4,16 @@ import DeviceInfo from 'react-native-device-info'
 import { getFont } from 'src/theme/typography'
 import { SliderDots } from './SliderDots'
 
-const SLIDER_FRONT_HEIGHT = DeviceInfo.isTablet()
-    ? Platform.OS === 'android'
-        ? 100
-        : 70
-    : 60
+const getSliderHeight = (): number => {
+    const isTablet = DeviceInfo.isTablet()
+    if (Platform.OS === 'android') {
+        return isTablet ? 95 : 76
+    } else {
+        return isTablet ? 81 : 65
+    }
+}
+
+const SLIDER_FRONT_HEIGHT = getSliderHeight()
 
 const FIRST_SUBTITLE_DATE = new Date('2020-03-05').getTime()
 


### PR DESCRIPTION
## Summary
The SliderTitle height has changed - possibly as part of  https://github.com/guardian/editions/pull/1038. We need to update the SLIDER_FRONT_HEIGHT constant accordingly as this is used in the `getItemLayout` bit of the flatlist 

[**Trello Card ->**](https://trello.com/c/CoRBlCi9/1170-top-edge-of-fronts-is-not-consistently-positioned-when-navigated-to-via-menu)

## Test Plan

Load app on phone/tablet/ios/android. Nav should take you accurately to the right place