### PR TITLE
Reduce space under weather on tablet

### DIFF
--- a/projects/Mallard/src/components/front/helpers/front-wrapper.tsx
+++ b/projects/Mallard/src/components/front/helpers/front-wrapper.tsx
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
     },
 })
 
-const Wrapper = ({
+const FrontWrapper = ({
     children,
     scrubber,
 }: {
@@ -31,4 +31,4 @@ const Wrapper = ({
     )
 }
 
-export { Wrapper }
+export { FrontWrapper }

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../hooks/use-article'
 import { CollectionPage, PropTypes } from './collection-page'
 import { AnimatedFlatListRef, getTranslateForPage } from './helpers/helpers'
-import { Wrapper } from './helpers/wrapper'
+import { FrontWrapper } from './helpers/front-wrapper'
 import { ArticleNavigator } from 'src/screens/article-screen'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { SliderTitle } from 'src/screens/article/slider/SliderTitle'
@@ -112,7 +112,7 @@ export const Front = React.memo(
         >(new Animated.Value(0))
 
         return (
-            <Wrapper
+            <FrontWrapper
                 scrubber={
                     <SliderTitle
                         title={frontData.displayName || 'News'}
@@ -220,7 +220,7 @@ export const Front = React.memo(
                         />
                     )}
                 />
-            </Wrapper>
+            </FrontWrapper>
         )
     },
 )

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -15,6 +15,7 @@ import { routeNames } from 'src/navigation/routes'
 import { NavigationInjectedProps } from 'react-navigation'
 import { useQuery, QueryResult } from 'src/hooks/apollo'
 import { ErrorBoundary } from 'src/components/layout/ui/errors/error-boundary'
+import DeviceInfo from 'react-native-device-info'
 
 type Weather = {
     locationName: string
@@ -37,7 +38,7 @@ export const WEATHER_QUERY = gql`
 
 const narrowSpace = String.fromCharCode(8201)
 
-export const WEATHER_HEIGHT = 65
+export const WEATHER_HEIGHT = DeviceInfo.isTablet() ? 50 : 65
 export const EMPTY_WEATHER_HEIGHT = 8
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
On tablet view the weather spreads out more horizontally, making it shorter. We should reflect this in the fixed height of the weather component to avoid having lots of empty space between the weather and 'Top Stories'

I've also given the component that wraps fronts a slightly more descriptive name.

[**Trello Card ->** - (sort of)](https://trello.com/c/ysLk7D4B/1153-font-size-of-the-titles-and-the-dots-and-space-between-weather-and-top-stories-reduce-them-on-ipad-only)

## Test Plan

Before:
![Screenshot 2020-03-03 at 15 32 53](https://user-images.githubusercontent.com/3606555/75791295-48efa880-5d64-11ea-9767-9e084462c383.png)
After:
![Screenshot 2020-03-03 at 15 32 38](https://user-images.githubusercontent.com/3606555/75791303-4a20d580-5d64-11ea-8434-d667a9446b82.png)
