### PR TITLE
Reduce space between front containers

### DIFF
--- a/projects/Mallard/src/components/front/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page.tsx
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
         marginTop: DeviceInfo.isTablet()
             ? metrics.fronts.sides / 2
             : metrics.fronts.sides / 10,
-        marginBottom: metrics.fronts.sides * 1.85,
+        marginBottom: metrics.fronts.marginBottom,
     },
     itemHolder: {
         overflow: 'hidden',
@@ -157,7 +157,8 @@ const Item = React.memo(
                             getItemRectanglePerc(story, layout),
                             {
                                 width: card.width - metrics.fronts.sides * 2,
-                                height: card.height - metrics.fronts.sides * 2,
+                                height:
+                                    card.height - metrics.fronts.marginBottom,
                             },
                         ),
                     ]}

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -28,6 +28,7 @@ export const metrics = {
     },
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
+        marginBottom: basicMetrics.horizontal * 2,
         cardSize: toSize(540, 530),
         cardSizeTablet: toSize(650, 725),
         circleButtonDiameter: 36,


### PR DESCRIPTION
## Summary
There's a bit too much space between cards on the fronts at the moment. I think this comes as a side effect of this change https://github.com/guardian/editions/pull/1040 - turns out 1.35 was a magic number used in more than one place. I've put the magic number stuff into metrics and simplified it a bit (1.35*1.5 is almost 2) 


[**Trello Card ->**](https://trello.com/c/VQA96zue/1180-extra-padding-seems-to-be-between-sub-sections-on-fronts-and-between-slider-and-content-in-article-see-screenshot)

## Test Plan

Before
<img width="415" alt="Screenshot 2020-03-04 at 11 10 51" src="https://user-images.githubusercontent.com/3606555/75874050-e4d2f000-5e08-11ea-9bfb-d34f6c740da2.png">
After

<img width="429" alt="Screenshot 2020-03-04 at 11 10 13" src="https://user-images.githubusercontent.com/3606555/75874043-e3092c80-5e08-11ea-82a7-a51af5ffb3b1.png">


