### PR TITLE
[Needs design review] Design realignment/megatweak

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/sizes.ts
+++ b/projects/Mallard/src/components/front/items/helpers/sizes.ts
@@ -7,21 +7,58 @@ import { PageLayoutSizes, ItemSizes } from '../../../../common'
  */
 export const getImageHeight = ({ story, layout }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
-        if (story.height >= 4) {
-            return '50%'
-        }
-        if (story.height == 3) {
+        // 1 story main
+        if (story.height == 4 && story.width === 3) {
             return '66.66%'
         }
-        if (story.height == 2) {
+        // 3 story main
+        if (story.height === 4 && story.width == 2) {
             return '50%'
+        }
+        // 2 story main
+        if (story.height === 3) {
+            return '66.66%'
+        }
+        // 3/4/5 story secondary
+        if (story.height === 2) {
+            return '50%'
+        }
+        // 2/4 story secondary
+        if (story.height === 1 && (story.width === 2 || story.width === 3)) {
+            return '100%'
         }
         return '75.5%'
     }
     if (layout === PageLayoutSizes.mobile) {
-        if (story.height >= 4) {
-            return '65%'
+        // 1 story main
+        if (story.height === 6) {
+            return '68%'
         }
+        // 2/3 story main
+        if (story.height === 4) {
+            return '66%'
+        }
+        // 3/4/5 story secondary
+        if (story.height == 3) {
+            return '51%'
+        }
+        // 2 story secondary
+        if (story.height == 2) {
+            return '98%'
+        }
+        return '50%'
+    }
+}
+
+// most image widths are 100% - this is use in SplitImageItem - where text and images are on the same row
+export const getImageWidth = ({ story, layout }: ItemSizes) => {
+    if (layout === PageLayoutSizes.tablet) {
+        if (story.width === 3) {
+            return '33%'
+        }
+        return '50%'
+    }
+    if (layout === PageLayoutSizes.mobile) {
         return '50%'
     }
 }

--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -39,12 +39,16 @@ const getFontSize = ({ layout, story }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
         if (story.width == 3) {
             if (story.height > 3) return 1.5
-            if (story.height == 3) return 1.75
+            if (story.height == 3) return 1.5
             if (story.height == 2) return 1
+            if (story.height == 1) return 1.25
         }
         if (story.width == 2) {
             if (story.height == 4) return 1.5
             if (story.height >= 3) return 1.25
+            return 0.75
+        }
+        if (story.width == 1) {
             return 0.75
         }
         return 0.75

--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -37,29 +37,35 @@ const styles = {
 
 const getFontSize = ({ layout, story }: ItemSizes) => {
     if (layout === PageLayoutSizes.tablet) {
+        // full width cards
         if (story.width == 3) {
-            if (story.height > 3) return 1.5
-            if (story.height == 3) return 1.5
-            if (story.height == 2) return 1
+            // 1 and 2 story (non journal) main
+            if (story.height == 3 || story.height == 4) return 1.5
+            // 2 story secondary
             if (story.height == 1) return 1.25
         }
+        // 2/3 width cards
         if (story.width == 2) {
+            // 3 story card main
             if (story.height == 4) return 1.5
-            if (story.height >= 3) return 1.25
+            // 4 story card main
+            if (story.height == 3) return 1.25
+            // 4 story card bottom left secondary
+            if (story.height == 1) return 0.9
             return 0.75
         }
+        // 1/3 width cards - 3,4,5 story secondary
         if (story.width == 1) {
-            return 0.75
+            return 0.9
         }
-        return 0.75
+        return 0.75 // this should never happen but is a safe 'small' size
     }
     // mobile layout
-    // top story for 2 and 3 story cards should have a larger font
-    if (story.height == 4 && story.width === 2) {
-        return 1.25
-    }
     if (story.height > 4) {
         return 1.5
+    }
+    if (story.height == 4 && story.width === 2) {
+        return 1.25
     }
     return 1
 }

--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -36,6 +36,9 @@ const styles = {
 }
 
 const getFontSize = ({ layout, story }: ItemSizes) => {
+    // this should be 0.9 pending production changes
+    const tabletSecondaryFontSize = 0.75
+
     if (layout === PageLayoutSizes.tablet) {
         // full width cards
         if (story.width == 3) {
@@ -51,12 +54,12 @@ const getFontSize = ({ layout, story }: ItemSizes) => {
             // 4 story card main
             if (story.height == 3) return 1.25
             // 4 story card bottom left secondary
-            if (story.height == 1) return 0.9
+            if (story.height == 1) return tabletSecondaryFontSize
             return 0.75
         }
         // 1/3 width cards - 3,4,5 story secondary
         if (story.width == 1) {
-            return 0.9
+            return tabletSecondaryFontSize
         }
         return 0.75 // this should never happen but is a safe 'small' size
     }

--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -200,7 +200,7 @@ const SidekickImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
 */
 const splitImageStyles = StyleSheet.create({
     image: {
-        width: '50%',
+        width: '33%',
         height: '100%',
         marginLeft: metrics.horizontal,
     },

--- a/projects/Mallard/src/components/front/items/image-items.tsx
+++ b/projects/Mallard/src/components/front/items/image-items.tsx
@@ -13,6 +13,7 @@ import {
     isFullHeightItem,
     isFullWidthItem,
     isSmallItem,
+    getImageWidth,
 } from './helpers/sizes'
 import { SportItemBackground } from './helpers/sports'
 import { Standfirst } from './helpers/standfirst'
@@ -200,7 +201,6 @@ const SidekickImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
 */
 const splitImageStyles = StyleSheet.create({
     image: {
-        width: '33%',
         height: '100%',
         marginLeft: metrics.horizontal,
     },
@@ -229,7 +229,11 @@ const SplitImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
                     {...{ size }}
                 />
                 <TrailImageView
-                    style={splitImageStyles.image}
+                    style={[
+                        splitImageStyles.image,
+                        { width: getImageWidth(size) },
+                        { height: getImageHeight(size) },
+                    ]}
                     article={article}
                 />
             </View>

--- a/projects/Mallard/src/components/front/items/super-items.tsx
+++ b/projects/Mallard/src/components/front/items/super-items.tsx
@@ -125,20 +125,20 @@ const opinionStyles = StyleSheet.create({
         height: '66.66666%',
     },
     titleText: {
-        ...getFont('headline', 1.5, 'light'),
+        ...getFont('headline', 2.5, 'light'),
         paddingTop: metrics.vertical / 2,
         color: color.text,
     },
     trailText: {
-        ...getFont('headline', 0.75, 'light'),
+        ...getFont('headline', 1.25, 'light'),
         color: color.textOverDarkBackground,
     },
     trailTextPadding: {
         paddingRight: '40%',
     },
     bylineText: {
-        ...getFont('headline', 1.5),
-        fontFamily: getFont('titlepiece', 1.5).fontFamily,
+        ...getFont('headline', 2.5),
+        fontFamily: getFont('titlepiece', 2).fontFamily,
         color: color.textOverDarkBackground,
     },
     cutout: {

--- a/projects/Mallard/src/components/front/items/super-items.tsx
+++ b/projects/Mallard/src/components/front/items/super-items.tsx
@@ -5,7 +5,6 @@ import Quote from 'src/components/icons/Quote'
 import { useArticle } from 'src/hooks/use-article'
 import { color } from 'src/theme/color'
 import { getFont } from 'src/theme/typography'
-import { getItemRectanglePerc, toPercentage } from '../helpers/helpers'
 import {
     ItemTappable,
     PropTypes,
@@ -17,20 +16,13 @@ import { metrics } from 'src/theme/spacing'
 import { useIsOpinionCard } from './helpers/types'
 import { PageLayoutSizes } from '../../../common'
 import { TrailImageView } from './trail-image-view'
+import { getImageHeight } from './helpers/sizes'
 
 /*
 SUPERHERO IMAGE ITEM
 Text below image. To use in news & sport supers
 */
 const superHeroImageStyles = StyleSheet.create({
-    image: {
-        height: toPercentage(
-            getItemRectanglePerc(
-                { width: 2, height: 4, top: 0, left: 0 },
-                PageLayoutSizes.mobile,
-            ).height,
-        ),
-    },
     textBlock: {
         ...tappablePadding,
     },
@@ -48,7 +40,7 @@ const NormalSuper = ({ article, size, ...tappableProps }: PropTypes) => {
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
             <TrailImageView
                 article={article}
-                style={superHeroImageStyles.image}
+                style={{ height: getImageHeight(size) }}
             />
             <TextBlock
                 byline={article.byline}
@@ -83,7 +75,7 @@ const SportSuper = ({ article, size, ...tappableProps }: PropTypes) => {
         <ItemTappable {...tappableProps} {...{ article }} hasPadding={false}>
             <TrailImageView
                 article={article}
-                style={superHeroImageStyles.image}
+                style={{ height: getImageHeight(size) }}
             />
             <TextBlock
                 byline={article.byline}

--- a/projects/Mallard/src/components/front/items/super-items.tsx
+++ b/projects/Mallard/src/components/front/items/super-items.tsx
@@ -125,6 +125,9 @@ const opinionStyles = StyleSheet.create({
         ...getFont('headline', 1.25, 'light'),
         color: color.textOverDarkBackground,
     },
+    trailTextMobile: {
+        ...getFont('headline', 1, 'light'),
+    },
     trailTextPadding: {
         paddingRight: '40%',
     },
@@ -188,6 +191,8 @@ const OpinionSuper = ({ article, ...tappableProps }: PropTypes) => {
                 <Text
                     style={[
                         opinionStyles.trailText,
+                        tappableProps.size.layout === PageLayoutSizes.mobile &&
+                            opinionStyles.trailTextMobile,
                         article.bylineImages &&
                             article.bylineImages.cutout &&
                             opinionStyles.trailTextPadding,

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -30,7 +30,7 @@ export const metrics = {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
         cardSize: toSize(540, 530),
-        cardSizeTablet: toSize(650, 650),
+        cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },
     gridRowSplit: {

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -30,7 +30,7 @@ export const metrics = {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
         cardSize: toSize(540, 530),
-        cardSizeTablet: toSize(650, 725),
+        cardSizeTablet: toSize(650, 650),
         circleButtonDiameter: 36,
     },
     gridRowSplit: {

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -29,7 +29,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 530),
+        cardSize: toSize(540, 500),
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -29,7 +29,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 500),
+        cardSize: toSize(540, 530), // height should be 500 pending shorter headlines in production
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -233,6 +233,21 @@ const scale = {
                 lineHeight: 44,
             },
         },
+        // currently only used by journal cards. not in design system
+        2.5: {
+            [Breakpoints.smallPhone]: {
+                fontSize: 32,
+                lineHeight: 37,
+            },
+            [Breakpoints.phone]: {
+                fontSize: 32,
+                lineHeight: 37,
+            },
+            [Breakpoints.tabletVertical]: {
+                fontSize: 50,
+                lineHeight: 58,
+            },
+        },
     },
     titlepiece: {
         1: {

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -83,16 +83,16 @@ const scale = {
     text: {
         0.9: {
             [Breakpoints.smallPhone]: {
-                fontSize: 14,
-                lineHeight: 18,
+                fontSize: 15,
+                lineHeight: 17,
             },
             [Breakpoints.phone]: {
-                fontSize: 14,
-                lineHeight: 16,
+                fontSize: 15,
+                lineHeight: 17,
             },
             [Breakpoints.tabletVertical]: {
-                fontSize: 18,
-                lineHeight: 22,
+                fontSize: 17,
+                lineHeight: 20,
             },
         },
         1: {
@@ -151,6 +151,21 @@ const scale = {
             [Breakpoints.tabletVertical]: {
                 fontSize: 21,
                 lineHeight: 22,
+            },
+        },
+        // this block defies the design system - size 22 isn't a thing normally but we need it
+        0.9: {
+            [Breakpoints.smallPhone]: {
+                fontSize: 18,
+                lineHeight: 20,
+            },
+            [Breakpoints.phone]: {
+                fontSize: 18,
+                lineHeight: 20,
+            },
+            [Breakpoints.tabletVertical]: {
+                fontSize: 22,
+                lineHeight: 25,
             },
         },
         1: {


### PR DESCRIPTION
## Summary
The fronts cards currently don't match the designs - the most notable issue being that they're too long. 


This change
 - Adds a lot of specificity to the image height calculator function - along with documentation explaining what each set of magic numbers means. 
 - Changes the height of images for loads of cards
 - Adds more specificity to the getFontSize calculator - and changes a load of font sizes, including...
 - Introduces a new `0.9` headline typography level which is used in secondary stories on tablet view so that we can have a size 22 font (up from 21). This non-design-systemy font size is needed to get the maxmimum density without the text running off the edge of the card
 - Adds new `2.5` titlepiece font size - this is design system sanctioned, just unused in editions till now. 
 - Adds new `getImageWidth` calculator for the pesky bottom left card on 3/4 story cards on tablet and 2 story cards on phone - as unlike other images these aren't 100% width
![Screenshot 2020-03-05 at 16 07 36](https://user-images.githubusercontent.com/3606555/76000358-7e7aca00-5efb-11ea-917f-5637de571292.png)

[**Trello Card tablet->**](https://trello.com/c/AZ9CtB3a/1183-density-work-tablet-summary-of-text-and-image-styles)
[**Trello Card mobile->**](https://trello.com/c/Od8HjK1o/1184-density-work-mobile-summary-of-image-and-text-sizes)

## Test Plan
It looks like this at the moment. I'm happy to release this as a build if that would be useful, or sit down and swipe through it on the simulator.

Tablet: https://recordit.co/u2XoS0HCYC
Mobile: https://recordit.co/F6P7xKgBhX
