### PR TITLE
chore: Bump netinfo

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -192,7 +192,7 @@ PODS:
     - React
   - react-native-in-app-utils (6.0.2):
     - React
-  - react-native-netinfo (5.3.3):
+  - react-native-netinfo (5.5.1):
     - React
   - react-native-safe-area-context (0.6.4):
     - React
@@ -468,7 +468,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
-  react-native-netinfo: 8884d510fe67349940b4399c01db3e3591c922aa
+  react-native-netinfo: 3bf235d94cc291cf0673ad9fd9eaae82f84ed8a9
   react-native-safe-area-context: 52342d2d80ea8faadd0ffa76d83b6051f20c5329
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,7 +37,7 @@
         "@react-native-community/async-storage": "^1.5.0",
         "@react-native-community/geolocation": "^2.0.2",
         "@react-native-community/masked-view": "^0.1.1",
-        "@react-native-community/netinfo": "^5.3.3",
+        "@react-native-community/netinfo": "^5.5.1",
         "@react-native-community/push-notification-ios": "^1.0.2",
         "@react-native-community/viewpager": "^2.0.1",
         "@sentry/react-native": "^1.1.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1126,10 +1126,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.1.tgz#dbcfc5ec08efbb02d4142dd9426c8d7a396829d7"
   integrity sha512-EyJVSbarZkOPYq+zCZLx9apMcpwkX9HvH6R+6CeVL29q88kEFemnLO/IhmE4YX/0MfalsduI8eTi7fuQh/5VeA==
 
-"@react-native-community/netinfo@^5.3.3":
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.3.3.tgz#2e627456d83c1d75d4c43ab6cef70fe125b9691d"
-  integrity sha512-L4BsdIEEuG5rKkVNzjESdJ1wvusn0kflj/FrwctaW+xkLxiFs1+mdBg/mvqqfXvVFuBEphbyXJTFT4aG4Okkow==
+"@react-native-community/netinfo@^5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.5.1.tgz#6433d4d9d5fbe836f019e5a88a6a24b6e2dc50b9"
+  integrity sha512-6NKX/WzzC5FP2RSzoq+7CW/iIiRL2S6yN0JKiGvZ8EWAzJ43dbX5KG4kRa1JiKopAal5Vyh80dymbygeylwekQ==
 
 "@react-native-community/push-notification-ios@^1.0.1", "@react-native-community/push-notification-ios@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## Summary
iOS12 keeps displaying that the user is offline. Which is a new behaviour.

Bumping the version _appears_ to stop this in local testing. But an update cant hurt too much...