### PR TITLE
Padding reduction in header/weather

### DIFF
--- a/projects/Mallard/src/components/front/helpers/front-wrapper.tsx
+++ b/projects/Mallard/src/components/front/helpers/front-wrapper.tsx
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
         paddingRight: metrics.horizontal,
         marginBottom: Platform.OS === 'android' ? 5 : 0,
         marginTop: 0,
-        paddingBottom: metrics.vertical,
+        paddingBottom: 2,
     },
 })
 

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -38,7 +38,7 @@ export const WEATHER_QUERY = gql`
 
 const narrowSpace = String.fromCharCode(8201)
 
-export const WEATHER_HEIGHT = DeviceInfo.isTablet() ? 50 : 65
+export const WEATHER_HEIGHT = DeviceInfo.isTablet() ? 45 : 65
 export const EMPTY_WEATHER_HEIGHT = 8
 
 const styles = StyleSheet.create({
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         paddingLeft: metrics.horizontal * 0.5,
         paddingRight: metrics.horizontal,
-        paddingVertical: metrics.vertical,
+        paddingVertical: metrics.vertical / 2,
     },
     forecastText: {
         display: 'flex',

--- a/projects/Mallard/src/screens/article/slider/SliderDots.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderDots.tsx
@@ -29,7 +29,7 @@ const styles = (color: string, location: string, isTablet: boolean) => {
     return StyleSheet.create({
         dotsContainer: {
             flexDirection: 'row',
-            paddingTop: metrics.vertical,
+            paddingTop: 2,
         },
         dot,
         selected: {

--- a/projects/Mallard/src/screens/article/slider/SliderDots.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderDots.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Animated, Platform, StyleSheet, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
-import { metrics } from 'src/theme/spacing'
 
 interface SliderDotsProps {
     numOfItems: number

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
@@ -9,6 +9,7 @@ const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 65 : 55
 
 const styles = StyleSheet.create({
     slider: {
+        paddingTop: 2,
         paddingBottom: metrics.vertical,
         justifyContent: 'center',
         alignItems: 'center',

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderHighEnd.tsx
@@ -5,7 +5,7 @@ import { metrics } from 'src/theme/spacing'
 import { SliderTitleProps, SliderTitle } from './SliderTitle'
 import DeviceInfo from 'react-native-device-info'
 
-const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 65 : 55
+const HEADER_HIGH_END_HEIGHT = DeviceInfo.isTablet() ? 50 : 40
 
 const styles = StyleSheet.create({
     slider: {

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -11,8 +11,8 @@ import DeviceInfo from 'react-native-device-info'
 const HEADER_LOW_END_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'ios'
         ? 160
-        : 140
-    : 135
+        : 100
+    : 100
 
 const styles = StyleSheet.create({
     slider: {

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -12,11 +12,12 @@ const HEADER_LOW_END_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'ios'
         ? 160
         : 100
-    : 100
+    : 110
 
 const styles = StyleSheet.create({
     slider: {
         paddingBottom: metrics.vertical,
+        paddingTop: metrics.vertical / 2,
         justifyContent: 'center',
         alignItems: 'center',
         borderBottomWidth: StyleSheet.hairlineWidth,

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -37,11 +37,13 @@ const styles = (color: string, location: string, isTablet: boolean) => {
     const titleArticle = {
         ...titleShared,
         fontSize: isTablet ? 30 : 20,
+        lineHeight: isTablet ? 33 : 22,
     }
 
     const titleFront = {
         ...titleShared,
         fontSize: isTablet ? 38 : 28,
+        lineHeight: isTablet ? 42 : 32,
     }
 
     const title = location === 'article' ? titleArticle : titleFront

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`SliderTitle - Android - Mobile should display a Front SliderTitle with 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -35,6 +36,7 @@ exports[`SliderTitle - Android - Mobile should display a Front SliderTitle with 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -45,7 +47,7 @@ exports[`SliderTitle - Android - Mobile should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -110,6 +112,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -121,6 +124,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -132,7 +136,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -197,6 +201,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -207,7 +212,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -272,6 +277,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -283,6 +289,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -293,7 +300,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -358,6 +365,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -369,6 +377,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -380,7 +389,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -445,6 +454,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -455,7 +465,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -520,6 +530,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -531,6 +542,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -541,7 +553,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -606,6 +618,7 @@ exports[`SliderTitle - Android - Mobile should display no dots when numOfItems i
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -617,6 +630,7 @@ exports[`SliderTitle - Android - Mobile should display no dots when numOfItems i
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -35,6 +36,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -45,7 +47,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -110,6 +112,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -121,6 +124,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -132,7 +136,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -197,6 +201,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -207,7 +212,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -272,6 +277,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -283,6 +289,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -293,7 +300,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -358,6 +365,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -369,6 +377,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -380,7 +389,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -445,6 +454,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -455,7 +465,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -520,6 +530,7 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -531,6 +542,7 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -541,7 +553,7 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -606,6 +618,7 @@ exports[`SliderTitle - Android - Tablet should display no dots when numOfItems i
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -617,6 +630,7 @@ exports[`SliderTitle - Android - Tablet should display no dots when numOfItems i
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`SliderTitle - iOS - Mobile should display a Front SliderTitle with the 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -35,6 +36,7 @@ exports[`SliderTitle - iOS - Mobile should display a Front SliderTitle with the 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -45,7 +47,7 @@ exports[`SliderTitle - iOS - Mobile should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -110,6 +112,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -121,6 +124,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -132,7 +136,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -197,6 +201,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -207,7 +212,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -272,6 +277,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -283,6 +289,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -293,7 +300,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -358,6 +365,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -369,6 +377,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -380,7 +389,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -445,6 +454,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -455,7 +465,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -520,6 +530,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -531,6 +542,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -541,7 +553,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -606,6 +618,7 @@ exports[`SliderTitle - iOS - Mobile should display no dots when numOfItems is 1 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -617,6 +630,7 @@ exports[`SliderTitle - iOS - Mobile should display no dots when numOfItems is 1 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -35,6 +36,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -45,7 +47,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -110,6 +112,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -121,6 +124,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -132,7 +136,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -197,6 +201,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -207,7 +212,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -272,6 +277,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -283,6 +289,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -293,7 +300,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -358,6 +365,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -369,6 +377,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -380,7 +389,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -445,6 +454,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 38,
+          "lineHeight": 42,
         }
       }
     >
@@ -455,7 +465,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -520,6 +530,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -531,6 +542,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -541,7 +553,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 10,
+        "paddingTop": 2,
       }
     }
   >
@@ -606,6 +618,7 @@ exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >
@@ -617,6 +630,7 @@ exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
           "fontSize": 30,
+          "lineHeight": 33,
         }
       }
     >


### PR DESCRIPTION
## Summary
This PR aims to reduce padding
 - between weather and the header on tablet
 - between the slider and the article across the board (mobile/tablet/ios/android)
 - between the dots on the slider and the section name

Note: I haven't changed the ios9 header height - pending on being in the office to have an ipad to test on. 

Note that this might still not quite match the designs - I've just aimed for making things a bit better - we've got so many moving parts design wise at the moment I'm not sure it makes sense to try and get it perfectly accurate till things have settled down

[**Trello Card ->**](https://trello.com/c/ysLk7D4B/1153-font-size-of-the-titles-and-the-dots-and-space-between-weather-and-top-stories-reduce-them-on-ipad-only)

## Test Plan

Here are some screenshots, but this should be checked fairly thoroughly on a few different devices.
<img width="371" alt="Screenshot 2020-03-06 at 18 01 49" src="https://user-images.githubusercontent.com/3606555/76109634-bf92dd00-5fd4-11ea-859e-06ad0d25b2af.png">
<img width="749" alt="Screenshot 2020-03-06 at 18 01 43" src="https://user-images.githubusercontent.com/3606555/76109637-c3266400-5fd4-11ea-9c02-d51386abc116.png">
<img width="741" alt="Screenshot 2020-03-06 at 18 01 33" src="https://user-images.githubusercontent.com/3606555/76109641-c4579100-5fd4-11ea-85d6-0576177dc7d4.png">
<img width="372" alt="Screenshot 2020-03-06 at 18 01 24" src="https://user-images.githubusercontent.com/3606555/76109645-c588be00-5fd4-11ea-86d1-4e9123f6696e.png">
<img width="380" alt="Screenshot 2020-03-06 at 18 01 08" src="https://user-images.githubusercontent.com/3606555/76109646-c6215480-5fd4-11ea-9f8a-d72b81c3edef.png">