### PR TITLE
Lightbox: View images in the gallery 

### DIFF
--- a/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
+++ b/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
@@ -14,9 +14,10 @@ export const NativeArrow = ({
         height={9}
         viewBox="0 0 11 9"
         fill="none"
+        style={{ marginTop: 4 }}
         rotation={direction}
     >
-        <G opacity="0.5">
+        <G opacity="1.0">
             <Path
                 fill-rule="evenodd"
                 clip-rule="evenodd"

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -191,7 +191,12 @@ const ImageBase = ({
     // add onclick="openLightbox(${index})" to re-enable lightbox
     return html`
         <figure class="image" data-role="${role || 'inline'}">
-            <img src="${path}" alt="${alt}" id="img-${index}" />
+            <img
+                src="${path}"
+                alt="${alt}"
+                id="img-${index}"
+                onclick="openLightbox(${index})"
+            />
             ${figcaption &&
                 html`
                     <figcaption>

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -188,7 +188,6 @@ const ImageBase = ({
     role?: ImageElement['role']
 }) => {
     const figcaption = renderCaption({ caption, credit })
-    // add onclick="openLightbox(${index})" to re-enable lightbox
     return html`
         <figure class="image" data-role="${role || 'inline'}">
             <img

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -120,6 +120,8 @@ const Article = ({
 
     const lbv = useContext(LightboxContext)
 
+    const [, { pillar }] = useArticle()
+
     return (
         <Fader>
             <WebviewWithArticle
@@ -150,7 +152,7 @@ const Article = ({
                     }
                     if (parsed.type === 'openLightbox') {
                         const lbimages = getLightboxImages(article.elements)
-                        lbv.setLightboxData(lbimages, parsed.index, 'sport')
+                        lbv.setLightboxData(lbimages, parsed.index, pillar)
                         lbv.setLightboxVisible(true)
                     }
                 }}

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -7,7 +7,6 @@ import {
     Animated,
     Text,
     StyleSheet,
-    Dimensions,
 } from 'react-native'
 import { LightboxContext, LightboxContextType } from './use-lightbox-modal'
 import {

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -258,7 +258,7 @@ export const Lightbox = () => {
             images={lightboxContext.images}
             visible={lightboxContext.visible}
             closeLightbox={() => lightboxContext.setLightboxVisible(false)}
-            pillar={'sport'}
+            pillar={lightboxContext.pillar}
             index={lightboxContext.index}
         />
     )

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -121,7 +121,7 @@ const LightboxImage = ({ image }: { image: ImageElement }) => {
                 source={{
                     uri: imagePath,
                 }}
-                style={[{ aspectRatio }]}
+                style={{ aspectRatio }}
             />
         </View>
     )

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -52,17 +52,18 @@ const styles = StyleSheet.create({
         height: '100%',
     },
     image: {
-        position: 'absolute',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
         width: '100%',
-        // bottom: '30%',
+        height: '100%',
     },
     captionWrapper: {
         position: 'absolute',
         zIndex: 1,
         opacity: 0.8,
         backgroundColor: themeColors(ArticleTheme.Dark).background,
-        bottom: 0,
-        height: '30%',
+        bottom: 50,
         width: '100%',
     },
     captionText: {
@@ -84,14 +85,6 @@ const styles = StyleSheet.create({
         width: '100%',
     },
 })
-
-const imageBottom = (portrait: boolean, imageHeight: number) => {
-    const tallImage = imageHeight / Dimensions.get('window').height > 0.7
-    const bottom = portrait || tallImage ? '0%' : '30%'
-    return StyleSheet.create({
-        bottomOffset: { bottom: bottom },
-    })
-}
 
 const LightboxCaption = ({
     caption,
@@ -125,7 +118,7 @@ const LightboxImage = ({ image }: { image: ImageElement }) => {
     // console.warn(aspectRatio)
     // console.warn('fixed: ' + aspectRatio.toFixed())
     return (
-        <View style={[styles.image, imageBottom(false, 500)]}>
+        <View style={styles.image}>
             <Image
                 source={{
                     uri: imagePath,

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -122,8 +122,8 @@ const LightboxCaption = ({
 const LightboxImage = ({ image }: { image: ImageElement }) => {
     const imagePath = useImagePath(image.src, 'full-size')
     const aspectRatio = useAspectRatio(imagePath)
-    console.warn(aspectRatio)
-    console.warn('fixed: ' + aspectRatio.toFixed())
+    // console.warn(aspectRatio)
+    // console.warn('fixed: ' + aspectRatio.toFixed())
     return (
         <View style={[styles.image, imageBottom(false, 500)]}>
             <Image

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -63,12 +63,13 @@ const styles = StyleSheet.create({
         zIndex: 1,
         opacity: 0.8,
         backgroundColor: themeColors(ArticleTheme.Dark).background,
-        bottom: 50,
+        bottom: 0,
         width: '100%',
     },
     captionText: {
         color: themeColors(ArticleTheme.Dark).dimText,
         paddingLeft: 2,
+        paddingBottom: 50,
     },
     closeButton: {
         position: 'absolute',
@@ -151,7 +152,16 @@ export const LightboxScreen = ({
 
     const [captionVisible, setCaptionVisible] = useState(false)
 
+    const handleScrollEndEvent = (ev: any) => {
+        const newIndex = Math.ceil(ev.nativeEvent.contentOffset.x / width)
+        setCurrentIndex(newIndex)
+        setWindowsStart(
+            getNewWindowStart(newIndex, windowStart, images.length, numDots),
+        )
+    }
+
     useEffect(() => {
+        setCaptionVisible(true)
         setCurrentIndex(index)
         setWindowsStart(getWindowStart(index, numDots, images.length))
     }, [visible, index, numDots, images.length])
@@ -185,20 +195,7 @@ export const LightboxScreen = ({
                                     item.src.path
                                 }
                                 data={images}
-                                onScrollEndDrag={(ev: any) => {
-                                    const newIndex =
-                                        ev.nativeEvent.targetContentOffset.x /
-                                        width
-                                    setCurrentIndex(newIndex)
-                                    setWindowsStart(
-                                        getNewWindowStart(
-                                            newIndex,
-                                            windowStart,
-                                            images.length,
-                                            numDots,
-                                        ),
-                                    )
-                                }}
+                                onScrollEndDrag={handleScrollEndEvent}
                                 getItemLayout={(_: never, index: number) => ({
                                     length: width,
                                     offset: width * index,

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -116,8 +116,6 @@ const LightboxCaption = ({
 const LightboxImage = ({ image }: { image: ImageElement }) => {
     const imagePath = useImagePath(image.src, 'full-size')
     const aspectRatio = useAspectRatio(imagePath)
-    // console.warn(aspectRatio)
-    // console.warn('fixed: ' + aspectRatio.toFixed())
     return (
         <View style={styles.image}>
             <Image
@@ -194,6 +192,7 @@ export const LightboxScreen = ({
                                 keyExtractor={(item: ImageElement) =>
                                     item.src.path
                                 }
+                                key={width}
                                 data={images}
                                 onScrollEndDrag={handleScrollEndEvent}
                                 getItemLayout={(_: never, index: number) => ({


### PR DESCRIPTION
## Summary

To display the images in the gallery mode we have implemented the Lightbox gallery feature. The original design has changed little bit to have a consistent design for portrait and non-portrait images. Please see the screenshot.

Note: there is a known issue (maybe existed prior to this work) with the current gallery. When there are more images then progress dots the animation of the dots stops after the last dot. There is also another issue, on tablet/iPad after rotating the device a few times when Lightbox/Gallery is open then clicking on the `X` button leads you to the home front instead of the gallery article.

[**Trello Card ->**](https://trello.com/c/cHzA5VHs/940-fullscreen-gallery-slideshows)

![Screenshot_1583851458](https://user-images.githubusercontent.com/6583174/76325907-c88af380-62df-11ea-8372-6d21df5840ce.png)
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-03-10 at 14 45 01](https://user-images.githubusercontent.com/6583174/76325922-ccb71100-62df-11ea-98a0-73cfda758271.png)
