### PR TITLE
Fix section nav, add padding under dots

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderDots.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderDots.tsx
@@ -28,7 +28,7 @@ const styles = (color: string, location: string, isTablet: boolean) => {
     return StyleSheet.create({
         dotsContainer: {
             flexDirection: 'row',
-            paddingTop: 2,
+            paddingVertical: 2,
         },
         dot,
         selected: {

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -7,12 +7,14 @@ import { SliderDots } from './SliderDots'
 const getSliderHeight = (): number => {
     const isTablet = DeviceInfo.isTablet()
     if (Platform.OS === 'android') {
-        return isTablet ? 66 : 52
+        return isTablet ? 68 : 54
     } else {
-        return isTablet ? 59 : 46
+        return isTablet ? 61 : 48
     }
 }
 
+// SLIDER_FRONT_HEIGHT isn't actually used in this file but is important for calculating the layout of fronts in issue-screen.
+// the 'jump to section' feature from the nav depends on this value being accurate
 const SLIDER_FRONT_HEIGHT = getSliderHeight()
 
 const FIRST_SUBTITLE_DATE = new Date('2020-03-05').getTime()

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -7,9 +7,9 @@ import { SliderDots } from './SliderDots'
 const getSliderHeight = (): number => {
     const isTablet = DeviceInfo.isTablet()
     if (Platform.OS === 'android') {
-        return isTablet ? 95 : 76
+        return isTablet ? 66 : 52
     } else {
-        return isTablet ? 81 : 65
+        return isTablet ? 59 : 46
     }
 }
 

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`SliderTitle - Android - Mobile should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -136,7 +136,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -212,7 +212,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -300,7 +300,7 @@ exports[`SliderTitle - Android - Mobile should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -389,7 +389,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -465,7 +465,7 @@ exports[`SliderTitle - Android - Mobile should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -553,7 +553,7 @@ exports[`SliderTitle - Android - Mobile should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.android.tablet.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`SliderTitle - Android - Tablet should display a Front SliderTitle with 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -136,7 +136,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -212,7 +212,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -300,7 +300,7 @@ exports[`SliderTitle - Android - Tablet should display an Article SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -389,7 +389,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -465,7 +465,7 @@ exports[`SliderTitle - Android - Tablet should display an Front SliderTitle with
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -553,7 +553,7 @@ exports[`SliderTitle - Android - Tablet should display an default SliderTitle wi
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`SliderTitle - iOS - Mobile should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -136,7 +136,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -212,7 +212,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -300,7 +300,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -389,7 +389,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -465,7 +465,7 @@ exports[`SliderTitle - iOS - Mobile should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -553,7 +553,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.ios.tablet.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -136,7 +136,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -212,7 +212,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -300,7 +300,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -389,7 +389,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -465,7 +465,7 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >
@@ -553,7 +553,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
     style={
       Object {
         "flexDirection": "row",
-        "paddingTop": 2,
+        "paddingVertical": 2,
       }
     }
   >


### PR DESCRIPTION
## Summary
In the latest master build the section nav is broken - I think because all the cards got shorter. This remedies that, though 

## Test Plan
The navigation should succesfully jump to 'Sport'


Before:
![Screenshot 2020-03-10 at 16 44 13](https://user-images.githubusercontent.com/3606555/76336802-6be30500-62ee-11ea-9607-e59b2d12a307.png)
After:
![Screenshot 2020-03-10 at 16 43 57](https://user-images.githubusercontent.com/3606555/76336813-6eddf580-62ee-11ea-808f-af012df3d00b.png)

