### PR TITLE
Reduce space between quote/text on journal. Tighter trail line height.

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/text-block.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/text-block.tsx
@@ -109,7 +109,7 @@ const TextBlock = ({
                         unscaledFont={font}
                         style={styles.opinionHeadline}
                         icon={{
-                            width: 36,
+                            width: 32,
                             // eslint-disable-next-line @typescript-eslint/no-unused-vars
                             element: scale => (
                                 <Quote

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -92,7 +92,7 @@ const scale = {
             },
             [Breakpoints.tabletVertical]: {
                 fontSize: 17,
-                lineHeight: 20,
+                lineHeight: 19.5,
             },
         },
         1: {


### PR DESCRIPTION
## Summary
Requests from Ana - some very tiny tweaks to the design of fronts cards.
 - less space between  the quote and headline on journal cards
 - shorter line height of trail text (this should really be font size * 1.15 everywhere but we've tended to round it up)
before
<img width="207" alt="Screenshot 2020-03-11 at 12 33 05" src="https://user-images.githubusercontent.com/3606555/76417258-7bb52480-6394-11ea-98e2-e5c79f8b152b.png">
after
<img width="160" alt="Screenshot 2020-03-11 at 12 31 07" src="https://user-images.githubusercontent.com/3606555/76417264-7ce65180-6394-11ea-8128-80ed3f14c734.png">
before
<img width="286" alt="Screenshot 2020-03-11 at 12 32 56" src="https://user-images.githubusercontent.com/3606555/76417261-7c4dbb00-6394-11ea-8173-07767e741f23.png">
after
<img width="301" alt="Screenshot 2020-03-11 at 12 31 19" src="https://user-images.githubusercontent.com/3606555/76417263-7ce65180-6394-11ea-913b-0d544a380b0a.png">

Trail text

before 
<img width="440" alt="Screenshot 2020-03-11 at 12 34 26" src="https://user-images.githubusercontent.com/3606555/76417378-ae5f1d00-6394-11ea-8d31-a10a0ec53bdf.png">
after

<img width="425" alt="Screenshot 2020-03-11 at 12 33 59" src="https://user-images.githubusercontent.com/3606555/76417372-ac955980-6394-11ea-86b4-6d0dc72e53c8.png">


