### PR TITLE
Added more fields to the share function to support wide range of sharing clients

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -138,7 +138,16 @@ const Article = ({
                     const parsed = parsePing(event.nativeEvent.data)
                     if (parsed.type === 'share') {
                         if (article.webUrl == null) return
-                        Share.share({ message: article.webUrl })
+                        Share.share(
+                            {
+                                title: article.headline,
+                                url: article.webUrl,
+                                message: article.webUrl, // 'message' is required as well as 'url' to support wide range of clients (e.g. email/whatsapp etc)
+                            },
+                            {
+                                subject: article.headline,
+                            },
+                        )
                         return
                     }
                     if (parsed.type === 'shouldShowHeaderChange') {


### PR DESCRIPTION
## Summary
To support sharing `title` and `url` of the Article we needed to pass more params to `share` function. This is is just for that.
 

[**Trello Card ->**](https://trello.com/c/UXtfgVbs/1097-share-include-the-title-of-the-article-followed-by-the-article-link-itself)

## Test Plan
Tested on android and ios. Below are the example screenshots of the share feature on twitter, before and after the fix.

| Before | After |
| --- | --- |
|![IMG_0101](https://user-images.githubusercontent.com/6583174/76417481-da7a9e00-6394-11ea-95ad-0f1bc74acfb9.PNG)|![Image-1](https://user-images.githubusercontent.com/6583174/76417493-dea6bb80-6394-11ea-8989-fb02cc295a2e.jpg)|

