### PR TITLE
Bump netinfo to 5.6.2

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -192,7 +192,7 @@ PODS:
     - React
   - react-native-in-app-utils (6.0.2):
     - React
-  - react-native-netinfo (5.3.3):
+  - react-native-netinfo (5.6.2):
     - React
   - react-native-safe-area-context (0.6.4):
     - React
@@ -468,7 +468,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
-  react-native-netinfo: 8884d510fe67349940b4399c01db3e3591c922aa
+  react-native-netinfo: 73303369946c2487c600418961bfdc87748b832f
   react-native-safe-area-context: 52342d2d80ea8faadd0ffa76d83b6051f20c5329
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,7 +37,7 @@
         "@react-native-community/async-storage": "^1.5.0",
         "@react-native-community/geolocation": "^2.0.2",
         "@react-native-community/masked-view": "^0.1.1",
-        "@react-native-community/netinfo": "^5.5.1",
+        "@react-native-community/netinfo": "^5.6.2",
         "@react-native-community/push-notification-ios": "^1.0.2",
         "@react-native-community/viewpager": "^2.0.1",
         "@sentry/react-native": "^1.1.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1126,10 +1126,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.1.tgz#dbcfc5ec08efbb02d4142dd9426c8d7a396829d7"
   integrity sha512-EyJVSbarZkOPYq+zCZLx9apMcpwkX9HvH6R+6CeVL29q88kEFemnLO/IhmE4YX/0MfalsduI8eTi7fuQh/5VeA==
 
-"@react-native-community/netinfo@^5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.5.1.tgz#6433d4d9d5fbe836f019e5a88a6a24b6e2dc50b9"
-  integrity sha512-6NKX/WzzC5FP2RSzoq+7CW/iIiRL2S6yN0JKiGvZ8EWAzJ43dbX5KG4kRa1JiKopAal5Vyh80dymbygeylwekQ==
+"@react-native-community/netinfo@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.6.2.tgz#a054db83a1787711f9f69029e2c9b80735ac3f75"
+  integrity sha512-IkzS78nOiPNM/MboBqqbk2eMBrflp8VML/p33pd50KZq+PvBq8Oywt1JKOgdaMxUIbGjP73zVz+f6r2f80u2Eg==
 
 "@react-native-community/push-notification-ios@^1.0.1", "@react-native-community/push-notification-ios@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## Summary
We've seen a return of the bug where users can get signed out when they use the app with poor/no connectivity. This bumps the netinfo version in the hope that our problem has something to do with a [recent fix they made](https://github.com/react-native-community/react-native-netinfo/commit/4e3e981) related to the internet reachability property.


[**Trello Card ->**](https://trello.com/c/kuJzY3KU/1201-ios-671-build-has-signed-me-out-when-i-opened-it-in-the-tube)

## Test Plan
Try using app in places with bad internet, make sure we don't get signed out