### PR TITLE
xcode11 migration

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 940;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -1059,6 +1059,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1114,6 +1115,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1153,6 +1155,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "${inherit}";
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard-tvOS.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -55,6 +55,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D02E47A1E0B4A5D006451C7"
+            BuildableName = "Mallard-tvOS.app"
+            BlueprintName = "Mallard-tvOS"
+            ReferencedContainer = "container:Mallard.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -67,17 +76,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2D02E47A1E0B4A5D006451C7"
-            BuildableName = "Mallard-tvOS.app"
-            BlueprintName = "Mallard-tvOS"
-            ReferencedContainer = "container:Mallard.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -99,8 +97,6 @@
             ReferencedContainer = "container:Mallard.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
+++ b/projects/Mallard/ios/Mallard.xcodeproj/xcshareddata/xcschemes/Mallard.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -338,8 +338,9 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  trunk:
+  https://cdn.cocoapods.org/:
     - boost-for-react-native
+  https://github.com/cocoapods/specs.git:
     - Sentry
     - SSZipArchive
 
@@ -505,4 +506,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6f3fb3cc2db96d753c4cb301f1618796162d6d7c
 
-COCOAPODS: 1.9.0
+COCOAPODS: 1.7.5

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -338,7 +338,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - Sentry
     - SSZipArchive
@@ -505,4 +505,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6f3fb3cc2db96d753c4cb301f1618796162d6d7c
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.0


### PR DESCRIPTION
Xcode11 migration in preparation for Apple sign-in integration. 

Initial migration was a challenge as directly migrating through xcode led to tons of dependancy errors. In the end the trick was to wipe all configs and build files completely and allow xcode11 to decide settings and such. From there I reran the build and this PR was the net result. 

Looking at the actual config changes I dont think the build system will have a problem. I expect the build system might fail when we introduce a lib that actually depends on Xcode11 (expo apple sign-in). 

Because of the above we will do this in two steps. We will test to see if this works first. If it works fine then lets merge it. The next step will be to introduce unimodules and the expo package into the app without implementation and see if the build system can handle it.
