### PR TITLE
chore: Update to horizontal scroll perf

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -100,11 +100,17 @@ export const Front = React.memo(
         const stops = cards.length
         const { card, container } = useIssueScreenSize()
         const largeDeviceMemory = useLargeDeviceMemory()
-        const flatListOptimisationProps = !largeDeviceMemory && {
-            windowSize: 2,
-            maxToRenderPerBatch: 1,
-            initialNumToRender: 2,
-        }
+        const flatListOptimisationProps = largeDeviceMemory
+            ? {
+                  windowSize: 3,
+                  maxToRenderPerBatch: 2,
+                  initialNumToRender: 3,
+              }
+            : {
+                  windowSize: 2,
+                  maxToRenderPerBatch: 1,
+                  initialNumToRender: 2,
+              }
 
         const [cardIndex, setCardIndex] = useState(0)
         const [position, setPosition] = useState<


### PR DESCRIPTION
## Summary

Complaint that midtier devices are crashing. This could be due to the flatlist performance.

I have left the vertical scroll the same, but this may need to be paired back as well.