### PR TITLE
Clear temp files when deleting all downloads.

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -61,31 +61,41 @@ export const prepFileSystem = (): Promise<void> =>
         ensureDirExists(`${FSPaths.issuesDir}/daily-edition`),
     )
 
-const removeOrphanedTempFiles = async (dir: string) => {
-    try {
-        if (RNFetchBlob.fs.isDir(dir)) {
-            RNFetchBlob.fs.ls(dir).then(files => {
-                files
-                    .filter(f => f.startsWith(RN_FETCH_TEMP_PREFIX))
-                    .map(f => dir + f)
-                    .map(RNFetchBlob.fs.unlink)
-            })
+/**
+ * rn-fetch-blob stores the zip file we donwnload in a temporary file. Sometimes,
+ * the process that deletes these post extraction fails. This function attempts
+ * to clean up such files in a fairly stupid way - just searching for files
+ * with RNFetchBlobTmp at the start of the filename
+ */
+
+const removeTempFiles = () => {
+    const removeOrphanedTempFiles = async (dir: string) => {
+        try {
+            if (RNFetchBlob.fs.isDir(dir)) {
+                RNFetchBlob.fs.ls(dir).then(files => {
+                    files
+                        .filter(f => f.startsWith(RN_FETCH_TEMP_PREFIX))
+                        .map(f => dir + f)
+                        .map(RNFetchBlob.fs.unlink)
+                })
+            }
+        } catch (error) {
+            await pushTracking('tempFileRemoveError', JSON.stringify(error))
+            console.log(
+                `Error cleaning up temp issue files in directory ${dir}: `,
+                error,
+            )
+            errorService.captureException(error)
         }
-    } catch (error) {
-        await pushTracking('tempFileRemoveError', JSON.stringify(error))
-        console.log(
-            `Error cleaning up temp issue files in directory ${dir}: `,
-            error,
-        )
-        errorService.captureException(error)
     }
+    TEMP_FILE_LOCATIONS.forEach(removeOrphanedTempFiles)
 }
 
 export const deleteIssueFiles = async (): Promise<void> => {
     await RNFetchBlob.fs.unlink(FSPaths.issuesDir)
     localIssueListStore.reset()
 
-    TEMP_FILE_LOCATIONS.forEach(removeOrphanedTempFiles)
+    removeTempFiles()
 
     await prepFileSystem()
 }
@@ -369,6 +379,9 @@ export const issuesToDelete = async (files: string[]) => {
 }
 
 export const clearOldIssues = async (): Promise<void> => {
+    // remove any temp files at this point too
+    removeTempFiles()
+
     const files = await getLocalIssues()
 
     const iTD: string[] = await issuesToDelete(files)


### PR DESCRIPTION
## Summary
The way the rn-fetch-blob library we're using works, it downloads the zip files of issues to files called something like RNFetchBlobTemp_*. We then unzip these files to the 'issues' directory. After the unzip completes, we [delete the zip file](https://github.com/guardian/editions/blob/master/projects/Mallard/src/helpers/files.ts#L94). However, if something goes wrong (e.g. connection loss) during this time the 'delete' never happens, and we end up with orphaned files (which can be big if it's the images zip). 

This PR is a fairly hacky fix for this issue but in my head it makes sense as it feels like this is a state we can always get into no matter how carefully we write the download code - the app could crash for any reason during the download, resulting in orphaned files. 

This change adds a new step to 'delete all downloads' so that it also results in temp files being deleted. 

Future work:
 - make the delete code more resilient
 - maybe call this function more often - not just when the user presses 'delete all downloads'

  https://github.com/joltup/rn-fetch-blob#user-content-cache-file-management

[**Trello Card ->**](https://trello.com/c/Dup8ghEZ/1188-data-not-getting-deleted-from-users-phone)

## Test Plan

Press 'delete all downloads', check the app doesn't crash...