### PR TITLE
chore: Replace sign in name with email

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -131,7 +131,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
             ? [
                   {
                       key: `Sign out`,
-                      title: identityData.userDetails.publicFields.displayName,
+                      title: identityData.userDetails.primaryEmailAddress,
                       onPress: async () => {
                           await signOutIdentity()
                       },


### PR DESCRIPTION
## Summary
Due to a change in identity, names were taken out of the sign in response unless a user has expressly stated to share it. We are displaying these names as part of the sign in.

As a result we are changed this for the email address.

This will require further work to complete the ticket.

[**Trello Card ->**](https://trello.com/c/JkkpLZQ6/1208-change-the-information-we-display-on-the-sign-in-are-when-users-are-signed-in-from-name-username-to-email)