### PR TITLE
Feat: bring back the bounce

### DIFF
--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -85,7 +85,6 @@ const WebviewWithArticle = ({
     return (
         <WebView
             {...webViewProps}
-            bounces={false}
             originWhitelist={['*']}
             scrollEnabled={true}
             source={{

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -51,6 +51,8 @@ const WebviewWithArticle = ({
     // FIXME: pass this as article data instead so it's never out-of-sync?
     const [, { pillar }] = useArticle()
 
+    const largeDeviceMemory = useLargeDeviceMemory()
+
     const res = useQuery<QueryValue>(QUERY)
     // Hold off rendering until we have all the necessary data.
     if (res.loading) return null
@@ -86,7 +88,7 @@ const WebviewWithArticle = ({
     return (
         <WebView
             {...webViewProps}
-            bounces={useLargeDeviceMemory() ? true : false}
+            bounces={largeDeviceMemory ? true : false}
             originWhitelist={['*']}
             scrollEnabled={true}
             source={{

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -11,6 +11,7 @@ import { useQuery } from 'src/hooks/apollo'
 import { FSPaths, APIPaths, PathToArticle } from 'src/paths'
 import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
+import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
@@ -85,6 +86,7 @@ const WebviewWithArticle = ({
     return (
         <WebView
             {...webViewProps}
+            bounces={useLargeDeviceMemory() ? true : false}
             originWhitelist={['*']}
             scrollEnabled={true}
             source={{


### PR DESCRIPTION
## Summary
This brings back the bounce on the article screen for higher end devices.

This was originally removed as a performance improvement. But now we have a better way to differentiate between low and high end devices.

Trello: https://trello.com/c/H4OdxtJ9/1207-end-of-article-is-abrupt-and-not-clean-and-like-traditional-scrolling