### PR TITLE
Update DEVELOPER_DIR to xcode 11.

### DIFF
--- a/projects/Mallard/Makefile
+++ b/projects/Mallard/Makefile
@@ -1,4 +1,4 @@
-export DEVELOPER_DIR=/Applications/Xcode_10.3.app/Contents/Developer/
+export DEVELOPER_DIR=/Applications/Xcode_11.3.1.app/Contents/Developer/
 export JAVA_OPTS = -Xmx4096m -Dsun.jnu.encoding=UTF-8
 
 debug-android:


### PR DESCRIPTION
## Summary
We need to move to xcode 11 for apple sign in and because apple is gonna force us to. This updates the makefile to tell teamcity which xcode installation to use

[**Trello Card ->**](https://trello.com/c/vmDa7pQl/1210-xcode-11-upgrade)

## Test Plan

Check that we can build/release the app. I've run the ios-debug-deploy config in teamcity which was succesful
