### PR TITLE
chore: Accessible cover cards

### DIFF
--- a/projects/Mallard/src/components/front/items/items.tsx
+++ b/projects/Mallard/src/components/front/items/items.tsx
@@ -104,6 +104,7 @@ const SplashImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
                     image={cardImage}
                     setAspectRatio
                     use="full-size"
+                    accessibilityLabel={article.headline}
                 />
             </View>
             <HeadlineCardText style={[splashImageStyles.hidden]}>


### PR DESCRIPTION
## Summary
Adds an accessibility label to the cover cards to be picked up with screen readers.
