### PR TITLE
Fix: Subnav speed boost

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -145,8 +145,6 @@ export const isIssueOnDevice = async (
     (await Promise.all([
         RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
         RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
-        RNFetchBlob.fs.exists(`${FSPaths.issueRoot(localIssueId)}/front`),
-        RNFetchBlob.fs.exists(`${FSPaths.issueRoot(localIssueId)}/thumbs`),
     ])).every(_ => _)
 
 /*

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -145,6 +145,8 @@ export const isIssueOnDevice = async (
     (await Promise.all([
         RNFetchBlob.fs.exists(FSPaths.issue(localIssueId)),
         RNFetchBlob.fs.exists(FSPaths.mediaRoot(localIssueId)),
+        RNFetchBlob.fs.exists(`${FSPaths.issueRoot(localIssueId)}/front`),
+        RNFetchBlob.fs.exists(`${FSPaths.issueRoot(localIssueId)}/thumbs`),
     ])).every(_ => _)
 
 /*

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -120,7 +120,11 @@ const IssueRowContainer = React.memo(
         const setNavPosition = useSetNavPosition()
 
         const navToIssue = useCallback(
-            (initialFrontKey: string | null) =>
+            (initialFrontKey: string | null) => {
+                // Are we within the same edition? If so no need to navigate
+                if(issueId?.localIssueId === issue.localId && issueId?.publishedIssueId === issue.publishedId ){
+                    navigation.goBack()
+                } else {
                 navigateToIssue({
                     navigation,
                     navigationProps: {
@@ -131,7 +135,9 @@ const IssueRowContainer = React.memo(
                         initialFrontKey,
                     },
                     setIssueId,
-                }),
+                })
+            }
+            },
             [navigation, setIssueId, localId, publishedId],
         )
 

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -122,23 +122,27 @@ const IssueRowContainer = React.memo(
         const navToIssue = useCallback(
             (initialFrontKey: string | null) => {
                 // Are we within the same edition? If so no need to navigate
-                if(issueId?.localIssueId === issue.localId && issueId?.publishedIssueId === issue.publishedId ){
+                if (
+                    issueId &&
+                    issueId.localIssueId === localId &&
+                    issueId.publishedIssueId === publishedId
+                ) {
                     navigation.goBack()
                 } else {
-                navigateToIssue({
-                    navigation,
-                    navigationProps: {
-                        path: {
-                            localIssueId: localId,
-                            publishedIssueId: publishedId,
+                    navigateToIssue({
+                        navigation,
+                        navigationProps: {
+                            path: {
+                                localIssueId: localId,
+                                publishedIssueId: publishedId,
+                            },
+                            initialFrontKey,
                         },
-                        initialFrontKey,
-                    },
-                    setIssueId,
-                })
-            }
+                        setIssueId,
+                    })
+                }
             },
-            [navigation, setIssueId, localId, publishedId],
+            [navigation, setIssueId, localId, publishedId, issueId],
         )
 
         const onPress = useCallback(() => {


### PR DESCRIPTION
## Summary
Currently when we are in the same edition, we do a lot of "expensive" navigation when clicking on a sibling sub nav item.

This small change just puts as back to the previous view and removes a lot of required processing.

I imagine this is the largest use case of the sub navigation.