### PR TITLE
feat: Reset the front scroll when the edition changes

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useMemo, useRef, useState, useEffect } from 'react'
 import { Animated, StyleSheet, View } from 'react-native'
 import {
     ArticlePillar,
@@ -117,6 +117,11 @@ export const Front = React.memo(
             Animated.AnimatedInterpolation
         >(new Animated.Value(0))
 
+        // Whenever we change edition, this resets us back to 0 scroll index for all fronts
+        useEffect(() => {
+            flatListRef.current?._component.scrollToIndex({animated: false, index: 0})
+        }, [frontData])
+
         return (
             <FrontWrapper
                 scrubber={
@@ -148,7 +153,7 @@ export const Front = React.memo(
                     pagingEnabled={true}
                     decelerationRate="fast"
                     snapToInterval={card.width}
-                    ref={flatListRef}
+                    ref={r => (flatListRef.current = r)}
                     getItemLayout={(_: never, index: number) => ({
                         length: card.width,
                         offset: card.width * index,

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -158,7 +158,7 @@ export const Front = React.memo(
                     pagingEnabled={true}
                     decelerationRate="fast"
                     snapToInterval={card.width}
-                    ref={r => (flatListRef.current = r)}
+                    ref={(r: AnimatedFlatListRef) => (flatListRef.current = r)}
                     getItemLayout={(_: never, index: number) => ({
                         length: card.width,
                         offset: card.width * index,

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -119,7 +119,12 @@ export const Front = React.memo(
 
         // Whenever we change edition, this resets us back to 0 scroll index for all fronts
         useEffect(() => {
-            flatListRef.current?._component.scrollToIndex({animated: false, index: 0})
+            flatListRef &&
+                flatListRef.current &&
+                flatListRef.current._component.scrollToIndex({
+                    animated: false,
+                    index: 0,
+                })
         }, [frontData])
 
         return (


### PR DESCRIPTION
## Summary
This one is Shraddha's favourite.

Here we look for a change in the data for the flatlist. If it occurs we scroll back to the start.

[**Trello Card ->**](https://trello.com/c/bNpXGpgU/1118-not-for-ios-9-current-build-625-ios-switching-between-editions-sub-section-it-keeps-the-position-from-earlier-issue)

## Test Plan
- Scroll on a front on the issue screen
- Change editions, all should be reset.
