### PR TITLE
chore: Increase Netinfo Timeout

### DIFF
--- a/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
+++ b/projects/Mallard/src/components/toast/net-info-auto-toast.tsx
@@ -11,7 +11,7 @@ const NetInfoAutoToast = () => {
             if (!isConnected && type !== NetInfoStateType.unknown) {
                 showToast('No internet connection')
             }
-        }, 100)
+        }, 500)
         return () => {
             clearTimeout(time)
         }


### PR DESCRIPTION
## Summary
Increases the timeout before checking to show the message. This is likely a race condition, so this gives older devices the opportunity to catch up a bit.

Hopefully its not too long.

[**Trello Card ->**](https://trello.com/c/U6FT6QaB/1172-ios-12-ios-9-no-connection-popping-up)