### PR TITLE
Feat: Revive Animated Dots (spinner)

### DIFF
--- a/projects/Mallard/src/components/spinner.tsx
+++ b/projects/Mallard/src/components/spinner.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View } from 'react-native'
 import { ariaHidden } from 'src/helpers/a11y'
 import { color } from 'src/theme/color'
 import { safeInterpolation } from 'src/helpers/math'
+import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 
 const styles = StyleSheet.create({
     ball: {
@@ -21,6 +22,14 @@ const pillars = [
     color.palette.culture.main,
     color.palette.lifestyle.main,
 ]
+
+const StaticBall = ({ color }: { color: string }) => {
+    return (
+        <Animated.View
+            style={[styles.ball, { backgroundColor: color }]}
+        ></Animated.View>
+    )
+}
 
 const Ball = ({ color, jump }: { color: string; jump: Animated.Value }) => {
     return (
@@ -63,6 +72,7 @@ const animateJumps = (value: Animated.Value, delay = 0) => {
 }
 
 const Spinner = () => {
+    const largeDeviceMemory = useLargeDeviceMemory()
     const [visible, setVisible] = useState(false)
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -89,13 +99,17 @@ const Spinner = () => {
         <View accessibilityLabel={'Loading content'}>
             {visible && (
                 <View {...ariaHidden} style={styles.container}>
-                    {pillars.map((color, index) => (
-                        <Ball
-                            key={index}
-                            jump={jumps[index]}
-                            color={color}
-                        ></Ball>
-                    ))}
+                    {pillars.map((color, index) =>
+                        largeDeviceMemory ? (
+                            <Ball
+                                key={index}
+                                jump={jumps[index]}
+                                color={color}
+                            />
+                        ) : (
+                            <StaticBall key={index} color={color} />
+                        ),
+                    )}
                 </View>
             )}
         </View>

--- a/projects/Mallard/src/components/spinner.tsx
+++ b/projects/Mallard/src/components/spinner.tsx
@@ -2,11 +2,12 @@ import React, { useState, useEffect } from 'react'
 import { Animated, StyleSheet, View } from 'react-native'
 import { ariaHidden } from 'src/helpers/a11y'
 import { color } from 'src/theme/color'
+import { safeInterpolation } from 'src/helpers/math'
 
 const styles = StyleSheet.create({
     ball: {
-        width: 20,
-        height: 20,
+        width: 22,
+        height: 22,
         margin: 2,
         borderRadius: 100,
     },
@@ -21,12 +22,44 @@ const pillars = [
     color.palette.lifestyle.main,
 ]
 
-const Ball = ({ color }: { color: string }) => {
+const Ball = ({ color, jump }: { color: string; jump: Animated.Value }) => {
     return (
         <Animated.View
-            style={[styles.ball, { backgroundColor: color }]}
+            style={[
+                styles.ball,
+                { backgroundColor: color },
+                {
+                    transform: [
+                        {
+                            scale: jump.interpolate({
+                                inputRange: safeInterpolation([0, 1]),
+                                outputRange: safeInterpolation([0.8, 1]),
+                            }),
+                        },
+                    ],
+                },
+            ]}
         ></Animated.View>
     )
+}
+
+const animateJumps = (value: Animated.Value, delay = 0) => {
+    const makeTimingConfig = (toValue: number) => ({
+        toValue,
+        duration: 400,
+        useNativeDriver: true,
+    })
+
+    return Animated.sequence([
+        Animated.delay(200 * delay),
+        Animated.loop(
+            Animated.sequence([
+                Animated.timing(value, makeTimingConfig(1)),
+                Animated.timing(value, makeTimingConfig(0)),
+                Animated.timing(value, makeTimingConfig(0)),
+            ]),
+        ),
+    ])
 }
 
 const Spinner = () => {
@@ -37,12 +70,31 @@ const Spinner = () => {
         }, 100)
         return () => clearTimeout(timer)
     }, [])
+
+    const [jumps] = useState(() => [
+        new Animated.Value(0),
+        new Animated.Value(0),
+        new Animated.Value(0),
+        new Animated.Value(0),
+        new Animated.Value(0),
+    ])
+    /* eslint-disable react-hooks/exhaustive-deps */
+
+    useEffect(() => {
+        Animated.parallel(jumps.map((j, i) => animateJumps(j, i))).start()
+    }, [])
+    // Ignored linter rule because we don't want to interfere with the animation
+    /* eslint-enable react-hooks/exhaustive-deps */
     return (
         <View accessibilityLabel={'Loading content'}>
             {visible && (
                 <View {...ariaHidden} style={styles.container}>
                     {pillars.map((color, index) => (
-                        <Ball key={index} color={color}></Ball>
+                        <Ball
+                            key={index}
+                            jump={jumps[index]}
+                            color={color}
+                        ></Ball>
                     ))}
                 </View>
             )}


### PR DESCRIPTION
## Summary
This revives the dots to be animated on higher performing devices. A little bit of duplication here to maintain a separate implementation.

Based on this commit: https://github.com/guardian/editions/commit/ccaa7bddd094cc9b2105e655dd88a548844112bc#diff-122fbd8305d1772cbbf83eef6f64dd02

[**Trello Card ->**](https://trello.com/c/6KDYH45v/1176-return-animation-to-dots-splash-screen)

![spinner](https://user-images.githubusercontent.com/935975/77935377-40c65280-72a9-11ea-971c-01c70543d7c3.gif)
