### PR TITLE
Include specific version of cocoapods in readme

### DIFF
--- a/projects/Mallard/README.md
+++ b/projects/Mallard/README.md
@@ -4,10 +4,12 @@
 
 Follow the instructions in the [main README](https://github.com/guardian/editions/blob/master/README.md).
 
-For iOS development you will need to install Xcode from the App Store and then open it once and select "Install" on the pop up asking whether to install other required Xcode dependencies - specifically the simulator. If this doesn't appear go to `Preferences > Components` and download the latest simulator iOS version. Additionally, you need to have CocoaPods installed. CocoaPods is a ruby thing, for a reliable install it's worth installing [Ruby Version Manager](https://rvm.io/rvm/install) first.
+For iOS development you will need to install Xcode from the App Store and then open it once and select "Install" on the pop up asking whether to install other required Xcode dependencies - specifically the simulator. If this doesn't appear go to `Preferences > Components` and download the latest simulator iOS version. Additionally, you need to have the right version of CocoaPods installed. CocoaPods is a ruby thing, for a reliable install it's worth installing [Ruby Version Manager](https://rvm.io/rvm/install) first.
+
+It's best to install the same version of cocoapods as is in the Podfile.lock - see [here](https://github.com/guardian/editions/blob/master/projects/Mallard/ios/Podfile.lock#L509)
 
 ```sh
-gem install cocoapods # this may require `sudo` if you're not using rvm or rbenv
+gem install cocoapods -v 1.7.5 # this may require `sudo` if you're not using rvm or rbenv
 ```
 
 The following guides allow you to run the app locally on device emulators, or on real devices connected to your dev machine via USB.


### PR DESCRIPTION
The latest version of cocoapods is 1.9 when we're currently using 1.7. This readme change encourages people to install the version of cocoapods we're currently using
