### PR TITLE
feat: Remove image resizer

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -188,8 +188,6 @@ PODS:
     - React
   - react-native-geolocation (2.0.2):
     - React
-  - react-native-image-resizer (1.0.1):
-    - React
   - react-native-in-app-utils (6.0.2):
     - React
   - react-native-netinfo (5.6.2):
@@ -301,7 +299,6 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-config (from `../node_modules/react-native-config`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
-  - react-native-image-resizer (from `../node_modules/react-native-image-resizer`)
   - react-native-in-app-utils (from `../node_modules/react-native-in-app-utils`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -338,9 +335,8 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
-    - boost-for-react-native
   https://github.com/cocoapods/specs.git:
+    - boost-for-react-native
     - Sentry
     - SSZipArchive
 
@@ -379,8 +375,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-config"
   react-native-geolocation:
     :path: "../node_modules/@react-native-community/geolocation"
-  react-native-image-resizer:
-    :path: "../node_modules/react-native-image-resizer"
   react-native-in-app-utils:
     :path: "../node_modules/react-native-in-app-utils"
   react-native-netinfo:
@@ -467,7 +461,6 @@ SPEC CHECKSUMS:
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
   react-native-config: 55548054279d92e0e4566ea15a8b9b81028ec342
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
-  react-native-image-resizer: 48eb06a18a6d0a632ffa162a51ca61a68fb5322f
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
   react-native-netinfo: 73303369946c2487c600418961bfdc87748b832f
   react-native-safe-area-context: 52342d2d80ea8faadd0ffa76d83b6051f20c5329

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -63,7 +63,6 @@
         "react-native-device-info": "^5.3.0",
         "react-native-gesture-handler": "^1.5.3",
         "react-native-iap": "^3.3.9",
-        "react-native-image-resizer": "^1.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",
         "react-native-keychain": "^3.1.3",

--- a/projects/Mallard/src/apollo.ts
+++ b/projects/Mallard/src/apollo.ts
@@ -7,7 +7,6 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { SETTINGS_RESOLVERS } from './helpers/settings/resolvers'
 import { resolveWeather } from './helpers/weather'
 import { resolveLocationPermissionStatus } from './helpers/location-permission'
-import { createScaledImageResolver } from './hooks/use-image-paths'
 import { createNetInfoResolver } from './hooks/use-net-info'
 import { createIssueSummaryResolver } from './hooks/use-issue-summary'
 import { createImageSizeResolver } from './helpers/screen'
@@ -33,7 +32,6 @@ export const createApolloClient = () => {
             ...SETTINGS_RESOLVERS,
             weather: resolveWeather,
             locationPermissionStatus: resolveLocationPermissionStatus,
-            scaledImage: createScaledImageResolver(),
             netInfo: createNetInfoResolver(),
             issueSummary: createIssueSummaryResolver(),
             imageSize: createImageSizeResolver(),

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -8,7 +8,7 @@ import {
     PixelRatio,
 } from 'react-native'
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
-import { useImagePath, useScaledImage } from 'src/hooks/use-image-paths'
+import { useImagePath } from 'src/hooks/use-image-paths'
 import { Image as IImage, ImageUse } from '../../../../Apps/common/src'
 
 /**
@@ -27,27 +27,6 @@ type ImageResourceProps = {
     setAspectRatio?: boolean
 } & Omit<ImageProps, 'source'>
 
-const ScaledImageResource = ({
-    imagePath,
-    style,
-    width,
-    ...props
-}: {
-    width: number
-    imagePath: string
-    style?: StyleProp<ImageStyle>
-}) => {
-    const uri = useScaledImage(imagePath, width)
-    return (
-        <Image
-            resizeMethod={'resize'}
-            {...props}
-            style={style}
-            source={{ uri }}
-        />
-    )
-}
-
 const ImageResource = ({
     image,
     style,
@@ -61,13 +40,13 @@ const ImageResource = ({
     const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
 
     return width && imagePath ? (
-        <ScaledImageResource
-            key={imagePath} // an attempt to fix https://github.com/facebook/react-native/issues/9195
-            width={width}
-            imagePath={imagePath}
-            style={styles}
+        <Image
+            key={imagePath}
+            resizeMethod={'resize'}
             {...props}
-        ></ScaledImageResource>
+            style={style}
+            source={{ uri: imagePath }}
+        />
     ) : (
         <View
             style={styles}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6305,11 +6305,6 @@ react-native-iap@^3.3.9:
   dependencies:
     dooboolab-welcome "^1.1.0"
 
-react-native-image-resizer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-resizer/-/react-native-image-resizer-1.0.1.tgz#e9eeb7f81596ffc490f822897952b046c07ee95c"
-  integrity sha512-upBF/9TIs4twg19dSkSaDW/MzMpNbysEXtPuapu3GqvOuGIYHKQ30v6httDn7rIb6uCcNIWL1BwZJM2cDt/C9Q==
-
 react-native-in-app-utils@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.2.tgz#b44498c7cce772fe1cebb00af082ff7bf4000a55"


### PR DESCRIPTION
## Summary
During the testing of Storybook, the main reason it wasn't working was down to the Image Resizer. I experimented with removing it and saw speed improvements on loading images in iOS9 and iPad Pro latest OS. Which was a surprise.

I tested my iOS9 device and it didn't seem to cause any crashes. This is likely down to using `phone` images on low end devices and therefore the resize was doing nothing other than eating up memory.

There may be an edge case device where it helps so we will need to keep an eye out on our error logging services.