### PR TITLE
Fix: Missing cover cards

### DIFF
--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,12 +1,5 @@
-import React, { useState } from 'react'
-import {
-    Image,
-    ImageProps,
-    ImageStyle,
-    StyleProp,
-    View,
-    PixelRatio,
-} from 'react-native'
+import React from 'react'
+import { Image, ImageProps, ImageStyle, StyleProp, View } from 'react-native'
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio'
 import { useImagePath } from 'src/hooks/use-image-paths'
 import { Image as IImage, ImageUse } from '../../../../Apps/common/src'

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -34,30 +34,20 @@ const ImageResource = ({
     use,
     ...props
 }: ImageResourceProps) => {
-    const [width, setWidth] = useState<number | null>(null)
     const imagePath = useImagePath(image, use)
     const aspectRatio = useAspectRatio(imagePath)
     const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
 
-    return width && imagePath ? (
+    return imagePath ? (
         <Image
             key={imagePath}
             resizeMethod={'resize'}
             {...props}
-            style={style}
+            style={[styles, style]}
             source={{ uri: imagePath }}
         />
     ) : (
-        <View
-            style={styles}
-            onLayout={ev => {
-                setWidth(
-                    PixelRatio.getPixelSizeForLayoutSize(
-                        ev.nativeEvent.layout.width,
-                    ),
-                )
-            }}
-        ></View>
+        <View style={styles}></View>
     )
 }
 


### PR DESCRIPTION
## Summary
Cover cards disappeared when removing the image resizer. This puts them back.
