### PR TITLE
Bump javaMaxHeapSize in build.gradle

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -160,6 +160,10 @@ android {
         }
     }
 
+    dexOptions {
+       javaMaxHeapSize "3g"
+    }
+
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds


### PR DESCRIPTION
I needed to add this to get android builds working on the teamcity ubuntu boxes. If we get any failed builds I'd be tempted to push this higher (as the agents should have 8G available) but this setting has worked 3 times in a row now..!

Any changes to this value should be kept in sync with https://github.com/guardian/editions/blob/master/projects/Mallard/android/gradle.properties#L7 