### PR TITLE
Allow splash/cover cards on more fronts (not Journal).

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -236,14 +236,11 @@ export const getCardsForFront = (
         case 'Life':
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage, true)
-        case 'Food':
-        case 'Review':
-        case 'Travel':
-        case 'Books':
-            return defaultLayout(FrontCardAppearance.splashPage, true)
         case 'Sport':
             return defaultLayout(1, true)
-        default:
+        case 'Journal':
             return defaultLayout(1)
+        default:
+            return defaultLayout(FrontCardAppearance.splashPage, true)
     }
 }


### PR DESCRIPTION
## Summary
This reimplements https://github.com/guardian/editions/pull/1029 with a restriction that the Journal front should stay the same - the goal is to 'Allow cover cards on all sections except: National, World, Financial which use dense layout.' 

[**Trello Card ->**](https://trello.com/c/pKeo62Sc/1165-allow-any-card-to-be-a-cover-card)

## Test Plan

We should check a few issues going forwards. This change will only become visible when fronts are newly published or republished - so we'll need to check either on CODE or just wait for new editions to go out whilst testing internally