### PR TITLE
Increase 1.5 headline font size on small phones to 24

### DIFF
--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -198,8 +198,8 @@ const scale = {
         },
         1.5: {
             [Breakpoints.smallPhone]: {
-                fontSize: 21,
-                lineHeight: 22,
+                fontSize: 24,
+                lineHeight: 26,
             },
             [Breakpoints.phone]: {
                 fontSize: 24,


### PR DESCRIPTION
## Summary
On small screens (common on android phones but also iPhone 5s) the font for single story cards is smaller than that of 2 story cards - I think because the 'small phone' font size hasn't been updated inthe various other changes we've made. This rectifies that situation following a request from Ana. 

[**Trello Card ->**](https://trello.com/c/Od8HjK1o/1184-density-work-mobile-summary-of-image-and-text-sizes)

## Test Plan
Test on android device with small screen or iPhone 5s - text of 1 story cards should be a bit bigger:

Before

![Screenshot 2020-04-07 at 16 24 11](https://user-images.githubusercontent.com/3606555/78687628-47c61400-78ec-11ea-932d-f6ba03ec2926.png)
After
![Screenshot 2020-04-07 at 16 22 58](https://user-images.githubusercontent.com/3606555/78687973-a25f7000-78ec-11ea-90df-90f5f9310068.png)


