### PR TITLE
Fix call to RNFetchBlob.isDir - deal with it being a promise.

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -71,7 +71,8 @@ export const prepFileSystem = (): Promise<void> =>
 const removeTempFiles = () => {
     const removeOrphanedTempFiles = async (dir: string) => {
         try {
-            if (RNFetchBlob.fs.isDir(dir)) {
+            const isDir = await RNFetchBlob.fs.isDir(dir)
+            if (isDir) {
                 RNFetchBlob.fs.ls(dir).then(files => {
                     files
                         .filter(f => f.startsWith(RN_FETCH_TEMP_PREFIX))


### PR DESCRIPTION
This change https://github.com/guardian/editions/pull/1076 made incorrect use of the [isDir](https://github.com/joltup/rn-fetch-blob/wiki/File-System-Access-API#isdirpathstringpromise) function provided by RNFetchBlob - it actually returns a promise! This mistake results in errors that look like this when you run the app:
![Screenshot 2020-04-08 at 18 03 40](https://user-images.githubusercontent.com/3606555/78812432-54696b80-79c3-11ea-894a-5d75f389cb5b.png)
This change remedies the situation. cc @mohammad-haque 

