### PR TITLE
Improve immersive image quality

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -19,7 +19,7 @@ import { getPillarColors } from 'src/helpers/transform'
 import { getLightboxImages } from '../types/article'
 
 interface ArticleContentProps {
-    showMedia: boolean
+    showMediaAtom: boolean
     publishedId: Issue['publishedId'] | null
     imageSize: ImageSize
     getImagePath: GetImagePath
@@ -47,7 +47,7 @@ const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
 
 const renderArticleContent = (
     elements: BlockElement[],
-    { showMedia, publishedId, getImagePath }: ArticleContentProps,
+    { showMediaAtom, publishedId, getImagePath }: ArticleContentProps,
 ) => {
     const imagePaths = getLightboxImages(elements).map(i => i.src.path)
     return elements
@@ -63,7 +63,7 @@ const renderArticleContent = (
                     }
                     return el.html
                 case 'media-atom':
-                    return showMedia ? renderMediaAtom(el) : ''
+                    return showMediaAtom ? renderMediaAtom(el) : ''
                 case 'image': {
                     const path = getImagePath(el.src)
                     const index = imagePaths.findIndex(e => e === el.src.path)
@@ -92,7 +92,7 @@ export const renderArticle = (
     elements: BlockElement[],
     {
         pillar,
-        showMedia,
+        showMediaAtom,
         topPadding,
         publishedId,
         showWebHeader,
@@ -120,7 +120,7 @@ export const renderArticle = (
                 headline: article.headline,
                 byline: article.byline,
                 bylineHtml: article.bylineHtml,
-                showMedia,
+                showMediaAtom,
                 canBeShared,
                 getImagePath,
             })
@@ -136,12 +136,12 @@ export const renderArticle = (
                 byline: article.byline,
                 bylineHtml: article.bylineHtml,
                 image: article.image,
-                showMedia,
+                showMediaAtom,
                 canBeShared,
                 getImagePath,
             })
             content = renderArticleContent(elements, {
-                showMedia,
+                showMediaAtom,
                 publishedId,
                 imageSize,
                 getImagePath,
@@ -152,12 +152,12 @@ export const renderArticle = (
                 ...article,
                 type,
                 publishedId,
-                showMedia,
+                showMediaAtom,
                 canBeShared,
                 getImagePath,
             })
             content = renderArticleContent(elements, {
-                showMedia,
+                showMediaAtom,
                 publishedId,
                 imageSize,
                 getImagePath,

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -585,7 +585,7 @@ const Header = ({
     getImagePath,
     ...headerProps
 }: {
-    showMedia: boolean
+    showMediaAtom: boolean
     publishedId: Issue['publishedId'] | null
     type: ArticleType
     canBeShared: boolean
@@ -642,7 +642,7 @@ const Header = ({
                             getImagePath,
                         })}
                     ${headerProps.mainMedia &&
-                        (headerProps.showMedia
+                        (headerProps.showMediaAtom
                             ? renderMediaAtom(headerProps.mainMedia)
                             : null)}
                     ${headerProps.kicker &&

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -536,15 +536,16 @@ const MainMediaImage = ({
     children,
     preserveRatio,
     getImagePath,
+    immersive,
 }: {
     image: CreditedImage
     className?: string
     children?: string
     preserveRatio?: boolean
     getImagePath: GetImagePath
+    immersive: boolean
 }) => {
-    const path = getImagePath(image)
-
+    const path = getImagePath(image, 'full-size', immersive)
     return html`
         <div
             class="image-as-bg ${className}"
@@ -620,6 +621,7 @@ const Header = ({
                 image: headerProps.image,
                 className: 'header-image header-image--immersive',
                 getImagePath,
+                immersive,
             })}
         <div class="header-container-line-wrap">
             ${Line({ zIndex: 10 })}
@@ -640,6 +642,7 @@ const Header = ({
                                   })
                                 : undefined,
                             getImagePath,
+                            immersive,
                         })}
                     ${headerProps.mainMedia &&
                         (headerProps.showMediaAtom

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -79,7 +79,7 @@ const WebviewWithArticle = ({
         type,
         imageSize,
         showWebHeader: true,
-        showMedia: isConnected,
+        showMediaAtom: isConnected,
         publishedId: publishedIssueId || null,
         topPadding,
         getImagePath,

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -21,6 +21,17 @@ const QUERY = gql`
     }
 `
 
+// Landscape immersive images get stretched into portrait mode
+// to prevent this resulting in pixelated images, use a larger image
+const immersiveSize = (imageSize: ImageSize): ImageSize => {
+    switch (imageSize) {
+        case 'phone':
+            return 'tablet'
+        default:
+            return 'tabletXL'
+    }
+}
+
 const WebviewWithArticle = ({
     article,
     path,
@@ -59,8 +70,14 @@ const WebviewWithArticle = ({
     const { imageSize, apiUrl } = res.data
     const { localIssueId, publishedIssueId } = path
 
-    const getImagePath = (image?: Image, use: ImageUse = 'full-size') => {
+    const getImagePath = (
+        image?: Image,
+        use: ImageUse = 'full-size',
+        immersive = false,
+    ) => {
         if (image == null) return undefined
+
+        const scaledSize = immersive ? immersiveSize(imageSize) : imageSize
 
         if (origin === 'filesystem') {
             const fs = FSPaths.image(localIssueId, imageSize, image, use)
@@ -69,7 +86,7 @@ const WebviewWithArticle = ({
         if (origin !== 'api') throw new Error('unrecognized "origin"')
 
         const issueId = publishedIssueId
-        const imagePath = APIPaths.image(issueId, imageSize, image, use)
+        const imagePath = APIPaths.image(issueId, scaledSize, image, use)
         return `${apiUrl}${imagePath}`
     }
 

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -7,7 +7,11 @@ import { useIssueSummary } from './use-issue-summary'
 import { Platform } from 'react-native'
 import { useApiUrl } from './use-settings'
 
-export type GetImagePath = (image?: Image, use?: ImageUse) => string | undefined
+export type GetImagePath = (
+    image?: Image,
+    use?: ImageUse,
+    immersive?: boolean,
+) => string | undefined
 
 const getFsPath = (
     localIssueId: Issue['localId'],

--- a/projects/backend/image.ts
+++ b/projects/backend/image.ts
@@ -31,7 +31,7 @@ export const getImageURL = (
     size: ImageSize,
     imageUse: ImageUse,
 ) => {
-    const newPath = `${image.path}?q=50&dpr=2&w=${imageUseSizes[imageUse][size]}`
+    const newPath = `${image.path}?quality=50&dpr=2&width=${imageUseSizes[imageUse][size]}`
     return `https://i.guim.co.uk/img/${
         image.source
     }/${newPath}&s=${getSignature(newPath)}`


### PR DESCRIPTION
## Summary
When we have an 'immersive' article, it has a full-width portrait-oriented image at the top of the article. If a landscape image is use for this location then it ends up getting stretched till it's at a suitable height by the [background-size:cover](https://github.com/guardian/editions/blob/master/projects/Mallard/src/components/article/html/components/header.ts#L270) property, resulting in pixelated images.

The ideal way to remedy this situation would be to provide an 'immersive' crop for immersive articles, cropped to a 4:5 aspect ratio - whereas currently we're taking the normal 'main media' style image and scaling it up.

However, as we've potentially got more 'main media' work coming up I've opted for a lazier option - which is to detect immersive images on the client side, and to use the next device size up (so tablet for phone, tablet XL for tablet) - see `immersiveSize` function. This won't change XL tablets (as there's no next size up for these) - but my understanding is that the blurry images problem mainly exists on ios9 and android devices rather than XL iPads... 

This achieves an improvement without changing the size of the issue bundle, with fairly minimal code changes so I *think* it's the right thing to do here - but I'm very happy to try do something smarter.

cc @AWare in case you've got any words of wisdom re adding a new 'immersive' image type on top of 'full-size' in the backend - it looks very possible, do you forsee issues if we only include it for some articles (so some articles have an extra 'immersive' image as well as 'full-size' and the thumbnails, and others don't)?  

[**Trello Card ->**](https://trello.com/c/n7kMZP7I/935-immersives-images-are-pixelated-on-ipad-and-android)

As part of the pr I've also given the `showMediaAtom` param a sensible name, and fixed the parameter names we're passing to the image resizer service. 

Before:

<img width="442" alt="Screenshot 2020-04-09 at 18 11 49" src="https://user-images.githubusercontent.com/3606555/78923193-bc858380-7a8f-11ea-9a0a-75f4b3501056.png">

After:
<img width="384" alt="Screenshot 2020-04-09 at 18 15 53" src="https://user-images.githubusercontent.com/3606555/78923205-c0190a80-7a8f-11ea-890b-310215d3c014.png">

Before:

<img width="354" alt="Screenshot 2020-04-09 at 18 28 18" src="https://user-images.githubusercontent.com/3606555/78923395-0e2e0e00-7a90-11ea-8071-493e4ded1a7f.png">

After:
<img width="349" alt="Screenshot 2020-04-09 at 18 29 19" src="https://user-images.githubusercontent.com/3606555/78923389-0cfce100-7a90-11ea-939f-84c41d461d11.png">


## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
