### PR TITLE
Fix: Input field pushed out of window in android

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
         android:launchMode="singleTask"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize"
+        android:windowSoftInputMode="adjustPan"
         android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Changed the soft keyboard adjustment so uses Pan rather than window adjust

## Summary
When a user tries to enter subscription details the soft keyboard pops up and the input field pushed outside of the visible window. This PR change soft keyboard behaviour to fix this issue. 


[**Trello Card ->**](https://trello.com/c/QDIpoJPL/1226-android-unable-to-signin-using-subscriber-id-keyboard-missing)

**Screenshots**:

| Before | After |
| --- | --- |
|![Screenshot_1586862760](https://user-images.githubusercontent.com/6583174/79247319-48255880-7e72-11ea-9cf7-d86280c16578.png)|![Screenshot_1586880006](https://user-images.githubusercontent.com/6583174/79247463-7c991480-7e72-11ea-95b7-89edd775413e.png)|



