### PR TITLE
Update articleTypePicker.ts

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -34,6 +34,10 @@ const articleTypePicker = (article: IContent): ArticleType => {
     const isReview: boolean = isTagPresent('tone/reviews')
     const isRecipe: boolean = isTagPresent('tone/recipes')
     const isMatchResult: boolean = isTagPresent('tone/matchreports')
+    const isCorrection: boolean = isTagPresent('theguardian/series/correctionsandclarifications')
+    const isBirthday: boolean = isTagPresent('news/birthdays')
+    const isSoundAndVision: boolean = isTagPresent('tv-and-radio/series/the-10-best-tv-shows-in-the-uk-this-week')
+
 
     /**
      * Order of conditionals under each pillar is important as certain conditions take precedent.


### PR DESCRIPTION
## Summary

Attempts to identify the following articles so that they can be mapped to a forthcoming article template which doesn't render the byline:

Corrections and Clarifications
Birthdays
Sound and Vision

Letters are already identified but will also be a candidate for this new article template.

[**Trello Card ->**](https://trello.com/c/yE4bf7oX/868-no-byline-version-of-standard-article-and-mappings)

## Test Plan

A product manager did this in GitHub so E&OE
