### PR TITLE
Increase javaMaxHeapSize to 6 GB in builds

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -161,7 +161,7 @@ android {
     }
 
     dexOptions {
-       javaMaxHeapSize "3g"
+       javaMaxHeapSize "6g"
     }
 
     buildTypes {

--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -161,7 +161,7 @@ android {
     }
 
     dexOptions {
-       javaMaxHeapSize "6g"
+       javaMaxHeapSize "8g"
     }
 
     buildTypes {

--- a/projects/Mallard/android/gradle.properties
+++ b/projects/Mallard/android/gradle.properties
@@ -4,4 +4,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/projects/Mallard/android/gradlew
+++ b/projects/Mallard/android/gradlew
@@ -42,7 +42,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='"-Xmx8g" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/projects/Mallard/android/gradlew
+++ b/projects/Mallard/android/gradlew
@@ -43,6 +43,7 @@ APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx8g" "-Xms64m"'
+GRADLE_OPTS='-Dorg.gradle.jvmargs="-Xmx8192m -XX:+HeapDumpOnOutOfMemoryError"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
...in an attempt to fix our teamcity builds let's throw loads of memory at this. The machines teamcity runs on have [16gb of memory](https://www.ec2instances.info/?region=eu-west-1&cost_duration=annually&reserved_term=yrTerm1Standard.allUpfront)