### PR TITLE
Fix-Gallery-Links

### DIFF
--- a/projects/backend/capi/__tests__/imageParser.spec.ts
+++ b/projects/backend/capi/__tests__/imageParser.spec.ts
@@ -1,0 +1,35 @@
+import { parseImageElement } from '../elements'
+import {
+    ElementType,
+    AssetType,
+    IBlockElement,
+    IAsset,
+    IImageElementFields,
+} from '@guardian/capi-ts'
+import { BlockElement, ImageElement } from '../../../Apps/common/src'
+
+const createImageAssetLike: IAsset = {
+    type: AssetType.IMAGE,
+    mimeType: 'image/jpeg',
+    file: 'https://test/image/asset.comg',
+}
+
+const createImageElementFields: IImageElementFields = {
+    caption: `£price <a href"http://gallerylink.com"> guardian.com</a>"`,
+}
+const createImageBlockElementLike: IBlockElement = {
+    type: ElementType.IMAGE,
+    assets: [createImageAssetLike],
+    imageTypeData: createImageElementFields,
+}
+
+describe('imageParser', () => {
+    it('the parsed image element contains a href link', () => {
+        const parsed: BlockElement | undefined = parseImageElement(
+            createImageBlockElementLike,
+        )
+        expect((parsed as ImageElement).caption).toContain(
+            '<a href"http://gallerylink.com"> guardian.com</a>',
+        )
+    })
+})

--- a/projects/backend/capi/elements.ts
+++ b/projects/backend/capi/elements.ts
@@ -27,9 +27,7 @@ export const elementParser = (
                     id: 'image',
                     src: image,
                     alt: element.imageTypeData.alt,
-                    caption:
-                        element.imageTypeData.caption &&
-                        cleanupHtml(element.imageTypeData.caption),
+                    caption: element.imageTypeData.caption,
                     copyright: element.imageTypeData.copyright,
                     credit: element.imageTypeData.credit,
                     role: element.imageTypeData.role,

--- a/projects/backend/capi/elements.ts
+++ b/projects/backend/capi/elements.ts
@@ -2,7 +2,6 @@ import { IBlockElement, ElementType } from '@guardian/capi-ts'
 import { BlockElement } from '../common'
 import { getImage } from './assets'
 import { renderAtomElement } from './atoms'
-import { cleanupHtml } from '../utils/html'
 import { IAtom } from '@guardian/capi-ts/dist/com/gu/contentatom/thrift/Atom'
 
 export const elementParser = (


### PR DESCRIPTION
## Summary
Links on gallery items were not previously working. 
This is a small change to leave the caption formatted as it is in CAPI which contains the link. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/t8cJ1HfW/946-gallery-links-dont-work)

## Test Plan
I have added two fashion gallery articles to the "Life" section on the 9th April code edition, the image captions should now have working links. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
