### PR TITLE
Avoid deprecation logic does for dev build

### DIFF
--- a/projects/Mallard/src/hooks/use-deprecation-screen.ts
+++ b/projects/Mallard/src/hooks/use-deprecation-screen.ts
@@ -18,7 +18,9 @@ const useDeprecationModal = (): {
                         ? buildNumbers.ios
                         : buildNumbers.android
                 const buildNumber = DeviceInfo.getBuildNumber()
+                console.warn('Build:' + DeviceInfo.getBuildNumber())
                 if (
+                    !__DEV__ &&
                     buildNumber &&
                     buildNumber <= platformDeprecationBuildNumber
                 ) {


### PR DESCRIPTION
## Summary
Local builds do not have an actual build number that PROD build has (generated by TC). This PR updated the deprecation logic so it does not apply to dev build.

