### PR TITLE
fix: Remove storybook server

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -10,9 +10,9 @@
         "test:watch": "jest --watch",
         "shake-android": "echo '👋 📱' && adb shell input keyevent 82 && echo '🙌📲🙌'",
         "wifi-android": "ip=$(adb shell ifconfig wlan0  | awk '/inet addr/{print substr($2,6)}') && adb tcpip 5555 && adb connect $ip:5555",
-        "run-android": "yarn pre-run && adb reverse tcp:8081 tcp:8081 && adb reverse tcp:8097 tcp:8097 && adb reverse tcp:3131 tcp:3131 && react-native run-android && yarn storybook",
-        "run-ios": "yarn pre-run && yarn install-pods && react-native run-ios && yarn storybook",
-        "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\" && yarn storybook",
+        "run-android": "yarn pre-run && adb reverse tcp:8081 tcp:8081 && adb reverse tcp:8097 tcp:8097 && adb reverse tcp:3131 tcp:3131 && react-native run-android && yarn prestorybook",
+        "run-ios": "yarn pre-run && yarn install-pods && react-native run-ios && yarn prestorybook",
+        "run-ipad": "yarn pre-run && react-native run-ios --simulator=\"iPad Air 2\" && yarn prestorybook",
         "validate": "cd ../.. && make validate-mallard",
         "fix": "cd ../.. && make fix-mallard",
         "bundle-android": "yarn pre-bundle && react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/build/generated/res/react/release",
@@ -24,7 +24,6 @@
         "write-prod-env": "node ../Apps/scripts/src/.env.production.js",
         "update-settings-pages-html": "node ./scripts/get-settings-pages-html.js",
         "install-pods": "cd ios && pod install",
-        "storybook": "start-storybook -p 7007",
         "prestorybook": "rnstl"
     },
     "rnpm": {


### PR DESCRIPTION
## Summary
Removes Storybook server from start up. Its not required as we use standalone server.

Tested with a clean install and all seemed fine.