### PR TITLE
am-fix-undefined-standfirst

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -625,6 +625,7 @@ const getStandFirst = (
                     ${headerProps.headline}
                 </h1>
                 ${articleHeaderType === HeaderType.RegularByline &&
+                    headerProps.standfirst &&
                     `<p>
                         ${headerProps.standfirst}
                       </p>`}


### PR DESCRIPTION
## Summary
This fixes a bug found in the internal beta where gallery articles were showing "undefined" as their standfirst. This adds a check to ensure the standfirst exists before adding it as a string in the standfirst. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/VYkl25RG/1247-standfirst-appears-to-be-replaced-by-undefined)

## Test Plan
The gallery article in the ticket can be found in the National section of Wednesday 22nd issue. 
![Simulator Screen Shot - iPhone 11 - 2020-04-23 at 12 50 22](https://user-images.githubusercontent.com/53755195/80096140-032faf00-8561-11ea-956d-daa28d09c873.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
