### PR TITLE
chore: File Sentry Logging

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -132,9 +132,11 @@ export const downloadNamedIssueArchive = async (
 export const unzipNamedIssueArchive = (zipFilePath: string) => {
     const outputPath = FSPaths.issuesDir
 
-    return unzip(zipFilePath, outputPath).then(() => {
-        return RNFetchBlob.fs.unlink(zipFilePath)
-    })
+    return unzip(zipFilePath, outputPath)
+        .then(() => {
+            return RNFetchBlob.fs.unlink(zipFilePath)
+        })
+        .catch(e => errorService.captureException(e))
 }
 
 /**
@@ -335,6 +337,9 @@ export const downloadAndUnzipIssue = async (
         await pushTracking(
             'downloadBlocked',
             DownloadBlockedStatus[downloadBlocked],
+        )
+        errorService.captureException(
+            new Error('Download Blocked: Required signal not available'),
         )
         return
     }


### PR DESCRIPTION
## Summary
- When a user has a download blocked, then we log this as an error to Sentry. This maybe a bit overkill and may need removing in future.
- When a zip file fails to unzip, we now log this as a Sentry error. This will help highlight if this is a problem in the push download process.