### PR TITLE
fix: Header Overflow

### DIFF
--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { StyleSheet, View, StatusBar } from 'react-native'
+import { StyleSheet, View, StatusBar, Dimensions } from 'react-native'
 import { Highlight } from 'src/components/highlight'
 import { GridRowSplit, IssueTitle } from 'src/components/issue/issue-title'
 import { useInsets } from 'src/hooks/use-screen'
@@ -89,7 +89,7 @@ const Header = ({
             {white && (
                 <StatusBar barStyle="dark-content" backgroundColor="#fff" />
             )}
-            <View style={[bg]}>
+            <View style={[bg, { width: Dimensions.get('screen').width }]}>
                 {layout === 'issue' ? (
                     <GridRowSplit
                         proxy={


### PR DESCRIPTION
## Summary
When accessing an article, going into the background and then returning to the issue screen, the header would go a bit wonky. This fixes it.

##### Gif evidence
![header-overflow](https://user-images.githubusercontent.com/935975/80363712-88c2a000-887c-11ea-8eaa-50ea8748325b.gif)
