### PR TITLE
fix: Alternative article animation for iOS13

### DIFF
--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { StyleSheet, View, StatusBar, Dimensions } from 'react-native'
+import { StyleSheet, View, StatusBar } from 'react-native'
 import { Highlight } from 'src/components/highlight'
 import { GridRowSplit, IssueTitle } from 'src/components/issue/issue-title'
 import { useInsets } from 'src/hooks/use-screen'

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -89,7 +89,7 @@ const Header = ({
             {white && (
                 <StatusBar barStyle="dark-content" backgroundColor="#fff" />
             )}
-            <View style={[bg, { width: Dimensions.get('screen').width }]}>
+            <View style={[bg]}>
                 {layout === 'issue' ? (
                     <GridRowSplit
                         proxy={


### PR DESCRIPTION
## Summary

`transform -> scaleX` is having the strange effect that it maintains its zoomed state when used and the user puts the app in the background. For example a user clicks on an article. `scaleX` becomes 0.9. Go into the background and back again. `scaleX` is still 0.9, but to some degree its reset as 1 in ios13. So when you then close the article, scaleX has the visual appearance of 1.1. This can build up to a point where it stops getting bigger. Ultimately, the animation is calculated by props passed into it from `React Navigation` which seems to lose state when it goes into the background on ios13.

A plan B approach is to avoid using scale for iOS13 - but you then lose the nice animation 😢 

![alternative animation](https://user-images.githubusercontent.com/935975/80592354-35388980-8a17-11ea-98c8-8323dd02761c.gif)
