### PR TITLE
Stop scheduled build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,6 @@ on:
     push:
         branches:
             - master
-    schedule:
-        # * is a special character in YAML so you have to quote this string
-        - cron: '0 14 * * 1-5' # every day at 2pm
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Since we're buildiing on every merge to master it doesn't make sense to also run a scheduled build every day