### PR TITLE
Remove ELK specific syntax from log format.

### DIFF
--- a/projects/Apps/common/src/logging.ts
+++ b/projects/Apps/common/src/logging.ts
@@ -9,18 +9,13 @@ export enum Level {
     DEBUG = 'DEBUG',
 }
 
-export interface LogFormat {
-    '@timestamp': Date
+export interface MallardLogFormat {
+    timestamp: Date
     level: Level
     message: string
-    metadata?: LogMetaData
-}
-
-interface LogMetaData {
     app: string
     version: string
     buildNumber: string
-    message: object
     release_channel: 'BETA' | 'RELEASE'
     os: 'android' | 'ios'
     device: string

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -1,18 +1,15 @@
 import express = require('express')
 import { Request, Response } from 'express'
 import { logger } from './logger'
-import { LogFormat, Level } from '../Apps/common/src/logging'
+import { MallardLogFormat } from '../Apps/common/src/logging'
 
-const processLog = (rawData: LogFormat[]) => {
+const processLog = (rawData: MallardLogFormat[]) => {
     rawData.forEach(logData => {
-        logger.info({
-            '@timestamp': logData['@timestamp']
-                ? new Date(logData['@timestamp'])
-                : new Date(),
-            level: logData.level || Level.INFO,
-            message: logData.message || '',
-            ...logData.metadata,
-        })
+        if (logData.timestamp && logData.message) {
+            logger.info({ '@timestamp': logData.timestamp, ...logData })
+        } else {
+            logger.info('Missing timestamp or message fields')
+        }
     })
 }
 
@@ -24,7 +21,7 @@ export const createApp = (): express.Application => {
         res.send('I am the editions logger')
     })
 
-    app.post('/log', express.json(), (req: Request, res: Response) => {
+    app.post('/log/mallard', express.json(), (req: Request, res: Response) => {
         if (req.headers.apikey !== process.env.API_KEY) {
             res.status(403).send('Missing or invalid apikey header')
         } else if (req.body) {


### PR DESCRIPTION
Following from discussion - this change modifies the log service to make the endpoint more specific to mallard rather than elasticsearch, and updates the endpoint path in line with this. 

I've removed the nested `metadata` type to simplify things on the client side.