### PR TITLE
am-style-gallery-links

### DIFF
--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -5,6 +5,8 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { Arrow } from './arrow'
 import { CssProps, themeColors } from '../helpers/css'
+import { PillarColours } from '@guardian/pasteup/palette'
+import { ArticleTheme } from '../article'
 
 export const renderCaption = ({
     caption,
@@ -27,6 +29,10 @@ const breakoutCaption = (role: ImageElement['role']) => css`
         transform: rotate(-90deg);
     }
 `
+
+const svgFillColor = (colors: PillarColours, theme: ArticleTheme) => {
+    return theme === 'dark' ? colors.bright : colors.main
+}
 
 const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
     const galleryStyles = css`
@@ -58,7 +64,7 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
             position: relative;
         }
         .image figcaption svg path {
-            fill: ${colors.main};
+            fill: ${svgFillColor(colors, theme)};
         }
 
         /* Tablet captions */

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -5,8 +5,6 @@ import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { Arrow } from './arrow'
 import { CssProps, themeColors } from '../helpers/css'
-import { PillarColours } from '@guardian/pasteup/palette'
-import { ArticleTheme } from '../article'
 
 export const renderCaption = ({
     caption,
@@ -29,10 +27,6 @@ const breakoutCaption = (role: ImageElement['role']) => css`
         transform: rotate(-90deg);
     }
 `
-
-const svgFillColor = (colors: PillarColours, theme: ArticleTheme) => {
-    return theme === 'dark' ? colors.bright : colors.main
-}
 
 const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
     const galleryStyles = css`
@@ -64,7 +58,7 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
             position: relative;
         }
         .image figcaption svg path {
-            fill: ${svgFillColor(colors, theme)};
+            fill: ${theme === 'dark' ? colors.bright : colors.main};
         }
 
         /* Tablet captions */

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -16,6 +16,8 @@ import { sportScoreStyles } from './components/sport-score'
 import { CssProps, themeColors } from './helpers/css'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { mediaAtomStyles } from './components/media-atoms'
+import { PillarColours } from '@guardian/pasteup/palette'
+import { ArticleTheme } from './article'
 
 const makeFontsCss = () => css`
     /* text */
@@ -72,6 +74,17 @@ const makeFontsCss = () => css`
         extension: 'otf',
     })}
 `
+
+const getAttributeTextColor = (theme: ArticleTheme, colors: PillarColours) => {
+    return theme == 'dark' ? colors.bright : colors.main
+}
+
+const getAttributeDecorationColor = (
+    theme: ArticleTheme,
+    colors: PillarColours,
+) => {
+    return theme == 'dark' ? colors.bright : colors.pastel
+}
 
 const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
     ${makeFontsCss()}
@@ -134,8 +147,8 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         margin-bottom: ${px(metrics.vertical * 2)};
     }
     .app a {
-        color: ${colors.main};
-        text-decoration-color: ${colors.pastel};
+        color: ${getAttributeTextColor(theme, colors)};
+        text-decoration-color: ${getAttributeDecorationColor(theme, colors)};
     }
     * {
         margin: 0;

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -16,8 +16,6 @@ import { sportScoreStyles } from './components/sport-score'
 import { CssProps, themeColors } from './helpers/css'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { mediaAtomStyles } from './components/media-atoms'
-import { PillarColours } from '@guardian/pasteup/palette'
-import { ArticleTheme } from './article'
 
 const makeFontsCss = () => css`
     /* text */
@@ -74,17 +72,6 @@ const makeFontsCss = () => css`
         extension: 'otf',
     })}
 `
-
-const getAttributeTextColor = (theme: ArticleTheme, colors: PillarColours) => {
-    return theme == 'dark' ? colors.bright : colors.main
-}
-
-const getAttributeDecorationColor = (
-    theme: ArticleTheme,
-    colors: PillarColours,
-) => {
-    return theme == 'dark' ? colors.bright : colors.pastel
-}
 
 const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
     ${makeFontsCss()}
@@ -147,8 +134,10 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         margin-bottom: ${px(metrics.vertical * 2)};
     }
     .app a {
-        color: ${getAttributeTextColor(theme, colors)};
-        text-decoration-color: ${getAttributeDecorationColor(theme, colors)};
+        color: ${theme == 'dark' ? colors.bright : colors.main};
+        text-decoration-color: ${
+            theme == 'dark' ? colors.bright : colors.pastel
+        };
     }
     * {
         margin: 0;


### PR DESCRIPTION
## Summary
This PR improves the appearance of gallery links on dark themed articles. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/t8cJ1HfW/946-gallery-links-dont-work)

## Test Plan
Go to Saturday 2nd May edition and go to the LifeStyle section and open the article "The edit...Softly does it: 10 of the best lilac pieces"
| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/81203994-82d96700-8fc0-11ea-9d08-b3d149882be8.png) | ![image](https://user-images.githubusercontent.com/53755195/81203461-e44d0600-8fbf-11ea-8bb6-8a10feacd839.png) 
<!--
Describe what steps were followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
