### PR TITLE
Am add standfirst to gallery

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -138,6 +138,7 @@ export const renderArticle = (
                 headline: article.headline,
                 byline: article.byline,
                 bylineHtml: article.bylineHtml,
+                standfirst: article.standfirst,
                 image: article.image,
                 showMedia,
                 canBeShared,

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -71,6 +71,10 @@ const outieHeader = (type: ArticleType) => css`
     ${outieKicker(type)}
 `
 
+const shareButtonColor = ({ colors, theme }: CssProps) => {
+    return theme === 'dark' ? color.palette.neutral[100] : colors.main
+}
+
 export const headerStyles = ({ colors, theme }: CssProps) => css`
 
     /* prevent clicks on byline links */
@@ -343,15 +347,15 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         display: flex;
         width:  ${metrics.fronts.circleButtonDiameter}px;
         height: ${metrics.fronts.circleButtonDiameter}px;
-        border: 1px solid ${colors.main};
-        color: ${colors.main};
+        border: 1px solid ${shareButtonColor({ theme, colors })};;
+        color: ${shareButtonColor({ theme, colors })};
         border-radius: 100%;
         align-items: center;
         justify-content: center;
     }
     .share-icon {
         padding-bottom: .1em;
-        color: ${colors.main};
+        color: ${shareButtonColor({ theme, colors })};
     }
 
     .clearfix {

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -651,17 +651,35 @@ const getHeaderClassForType = (headerType: HeaderType): string => {
     }
 }
 
+const getByLineText = (
+    headerType: HeaderType,
+    headerProps: ArticleHeaderProps,
+): string | undefined => {
+    const byLineText =
+        headerType === HeaderType.NoByline ||
+        headerType === HeaderType.LargeByline
+            ? headerProps.standfirst
+            : headerProps.bylineHtml
+    return byLineText
+}
+
+const hasByLine = (
+    byLineText: string | undefined,
+    canBeShared: boolean,
+): boolean => {
+    if (byLineText || canBeShared) {
+        return true
+    }
+    return false
+}
+
 const getByLine = (
     headerType: HeaderType,
     canBeShared: boolean,
     headerProps: ArticleHeaderProps,
 ): string => {
     const headerClass = getHeaderClassForType(headerType)
-    const bylineText =
-        headerType === HeaderType.NoByline ||
-        headerType === HeaderType.LargeByline
-            ? headerProps.standfirst
-            : headerProps.bylineHtml
+    const bylineText = getByLineText(headerType, headerProps)
     const shareButton = !canBeShared
         ? ''
         : html`
@@ -700,6 +718,7 @@ const Header = ({
     getImagePath: GetImagePath
 } & ArticleHeaderProps) => {
     const immersive = isImmersive(type)
+    const byLineText = getByLineText(headerType, headerProps)
     return html`
         ${immersive &&
             headerProps.image &&
@@ -747,11 +766,12 @@ const Header = ({
                         getImagePath,
                     )}
                 </header>
-                ${getByLine(
-                    headerType,
-                    headerProps.canBeShared,
-                    headerProps as ArticleHeaderProps,
-                )}
+                ${hasByLine(byLineText, headerProps.canBeShared) &&
+                    getByLine(
+                        headerType,
+                        headerProps.canBeShared,
+                        headerProps as ArticleHeaderProps,
+                    )}
                 <div class="header-bg"></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
This PR includes: 
- Adding standfirsts to gallery articles 
- Removing unused byline space when there is no text or share button 
- Fixes a bug on gallery articles which meant that the share button was hidden
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/yE4bf7oX/868-no-byline-version-of-standard-article-and-mappings)

## Test Plan

I have attached screenshots of gallery articles from the coronavirus front on April 29th edition. 

| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/81284519-1dd05080-9056-11ea-8856-61f32aa15676.png) | ![image](https://user-images.githubusercontent.com/53755195/81284868-96371180-9056-11ea-9716-919e1ce01654.png)
![image](https://user-images.githubusercontent.com/53755195/81284623-3fc9d300-9056-11ea-8f8b-72019710ae9d.png) | ![image](https://user-images.githubusercontent.com/53755195/81284985-c1b9fc00-9056-11ea-8b36-9137f21e3634.png)
![image](https://user-images.githubusercontent.com/53755195/81285039-d4cccc00-9056-11ea-8f7b-9a1e12ae1a3d.png) | ![image](https://user-images.githubusercontent.com/53755195/81284765-71db3500-9056-11ea-8429-a7e7c1dd74b4.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
