### PR TITLE
feat: Consent for Logging

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -36,6 +36,7 @@ import { ConfigProvider } from 'src/hooks/use-config-provider'
 import { Lightbox } from './screens/lightbox'
 import { LightboxProvider } from './screens/use-lightbox-modal'
 import { weatherHider } from './helpers/weather-hider'
+import { loggingService } from './services/logging'
 
 /**
  * Only one global Apollo client. As such, any update done from any component
@@ -43,9 +44,11 @@ import { weatherHider } from './helpers/weather-hider'
  */
 const apolloClient = createApolloClient()
 
+// Log Intitialisation
 if (!__DEV__) {
     errorService.init(apolloClient)
 }
+loggingService.init(apolloClient)
 
 // useScreens is not a hook
 // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -111,9 +111,9 @@ const GdprConsent = ({
         gdprAllowPerformance: {
             key: gdprAllowPerformanceKey,
             name: 'Performance',
-            services: 'Sentry',
+            services: 'Sentry - Logging',
             description:
-                'Enabling these allows us to measure how you use our services. We use this information to get a better sense of how our users engage with our journalism and to improve our services, so that users have a better experience. For example, we collect information about which of our pages are most frequently visited, and by which types of users. If you disable this, we will not be able to measure your use of our services, and we will have less information about their performance.',
+                'Enabling these allow us to observe and measure how you use our services. We use this information to fix bugs more quickly so that users have a better experience. For example, we would be able to see the journey you have taken and where the error was encountered. Your data will only be stored in our servers for two weeks. If you disable this, we will not be able to observe and measure your use of our services, and we will have less information about their performance and event details of issues encountered.',
         },
         gdprAllowFunctionality: {
             key: gdprAllowFunctionalityKey,

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -24,6 +24,7 @@ describe('logging service - Offline', () => {
                 iapReceipt: true,
             })
             loggingService.saveQueuedLogs = jest.fn()
+            loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.saveQueuedLogs).toHaveBeenCalled()
         })

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -61,9 +61,29 @@ describe('logging service', () => {
             })
             loggingService.clearLogs = jest.fn()
             loggingService.postLog = jest.fn()
+            loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.postLog).toHaveBeenCalled()
             expect(loggingService.clearLogs).toHaveBeenCalled()
+        })
+        it('should not post a log if there is no consent', async () => {
+            loggingService.getExternalInfo = jest.fn().mockReturnValue({
+                networkStatus: { type: 'wifi' },
+                userData: {
+                    userDetails: { id: 'testId' },
+                    membershipData: {
+                        contentAccess: { digitalPack: true },
+                    },
+                },
+                casCode: 'QWERTYUIOP',
+                iapReceipt: true,
+            })
+            loggingService.clearLogs = jest.fn()
+            loggingService.postLog = jest.fn()
+            loggingService.hasConsent = false
+            await loggingService.log({ level: Level.INFO, message: 'test' })
+            expect(loggingService.postLog).not.toHaveBeenCalled()
+            expect(loggingService.clearLogs).not.toHaveBeenCalled()
         })
     })
 })


### PR DESCRIPTION
## Summary
- Adds in new logging consent wording
- Uses the GDPR performance consent flag
- If set, will allow the use of log. Off by default
- Tests to cover consent.

Please note: `log()` is considered our only public function in the class, but the others remain public for mocking.