### PR TITLE
feat: Require consent on version change

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -6,8 +6,9 @@ import { defaultSettings } from './settings/defaults'
  *
  * v1 - The initial version that CMP was released with
  * v2 - Move Braze from ESSENTIAL to PERSONALISED_ADS
+ * v3 - Add Logging to PERFORMANCE
  */
-export const CURRENT_CONSENT_VERSION = 2
+export const CURRENT_CONSENT_VERSION = 3
 
 export interface GdprDefaultSettings {
     gdprAllowEssential: boolean
@@ -32,6 +33,7 @@ export type GDPRBucketKeys =
     | 'gdprAllowEssential'
     | 'gdprAllowPerformance'
     | 'gdprAllowFunctionality'
+    | 'gdprConsentVersion'
 type GDPRBucket = { [K in GDPRBucketKeys]: (keyof GdprSettings)[] }
 
 export const gdprSwitchSettings: (keyof GdprSwitchSettings)[] = [
@@ -43,6 +45,7 @@ export const GdprBuckets: GDPRBucket = {
     gdprAllowEssential: ['gdprAllowOphan'],
     gdprAllowPerformance: ['gdprAllowSentry'],
     gdprAllowFunctionality: ['gdprAllowGoogleLogin', 'gdprAllowFacebookLogin'],
+    gdprConsentVersion: ['gdprConsentVersion'],
 }
 
 export interface GdprSettings {

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -45,6 +45,7 @@ import {
 } from 'src/screens/settings/manage-editions-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 import StorybookScreen from 'src/screens/storybook-screen'
+import { CURRENT_CONSENT_VERSION } from 'src/helpers/settings'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -165,21 +166,21 @@ const ONBOARDING_QUERY = gql(`{
     gdprAllowEssential @client
     gdprAllowPerformance @client
     gdprAllowFunctionality @client
+    gdprConsentVersion @client
 }`)
 
 type OnboardingQueryData = {
     gdprAllowEssential: boolean
     gdprAllowPerformance: boolean
     gdprAllowFunctionality: boolean
+    gdprConsentVersion: number
 }
 
-const hasOnboarded = (data: OnboardingQueryData) => {
-    return (
-        data.gdprAllowEssential != null &&
-        data.gdprAllowFunctionality != null &&
-        data.gdprAllowPerformance != null
-    )
-}
+const hasOnboarded = (data: OnboardingQueryData) =>
+    data.gdprAllowEssential != null &&
+    data.gdprAllowFunctionality != null &&
+    data.gdprAllowPerformance != null &&
+    data.gdprConsentVersion == CURRENT_CONSENT_VERSION
 
 const RootNavigator = createAppContainer(
     createStackNavigator(

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -7,9 +7,15 @@ import {
 import { ButtonAppearance } from 'src/components/button/button'
 import { ModalButton } from 'src/components/modal-button'
 import { LinkNav } from 'src/components/link'
-import { gdprSwitchSettings } from 'src/helpers/settings'
+import {
+    gdprSwitchSettings,
+    CURRENT_CONSENT_VERSION,
+} from 'src/helpers/settings'
 import { GDPR_SETTINGS_FRAGMENT } from 'src/helpers/settings/resolvers'
-import { setGdprFlag } from 'src/helpers/settings/setters'
+import {
+    setGdprFlag,
+    setGdprConsentVersion,
+} from 'src/helpers/settings/setters'
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
 
@@ -55,6 +61,7 @@ const OnboardingConsent = ({
                 setGdprFlag(client, sw, true)
             }
         })
+        setGdprConsentVersion(client, CURRENT_CONSENT_VERSION)
     }
 
     return (

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -74,7 +74,7 @@ const consentToAll = (client: ApolloClient<object>) => {
     setGdprConsentVersion(client, CURRENT_CONSENT_VERSION)
 }
 
-const DEVMODE_resetAll = (client: ApolloClient<object>) => {
+const resetAll = (client: ApolloClient<object>) => {
     gdprSwitchSettings.forEach(sw => {
         setConsent(client, sw, null)
     })
@@ -226,9 +226,9 @@ const GdprConsent = ({
                     Privacy Settings from the Settings menu.
                 </UiBodyCopy>
             </Footer>
-            {data.isUsingProdDevtools ? (
+            {__DEV__ ? (
                 <Footer>
-                    <Button onPress={DEVMODE_resetAll.bind(undefined, client)}>
+                    <Button onPress={resetAll.bind(undefined, client)}>
                         Reset
                     </Button>
                 </Footer>


### PR DESCRIPTION
## Summary
This was partially implemented by @LATaylor-guardian.

When changing the `CURRENT_CONSENT_VERSION` the user will be required to consent again.

Changes:
- Reset now visible when in a simulator on the privacy settings page to make it easier to reset GDPR flags.
- Check that what we have in Async Storage matches the current version. If not then re-consent. As we haven't been saving this you will be asked to re-consent. As will all users.