### PR TITLE
Accessibility of buttons

### DIFF
--- a/projects/Mallard/src/components/BugButton.tsx
+++ b/projects/Mallard/src/components/BugButton.tsx
@@ -21,9 +21,8 @@ const BugButton = () => {
     const client = useApolloClient()
     return isInBeta() ? (
         <Button
-            accessible={true}
             accessibilityLabel="Report a bug button"
-            accessibilitHint="Opens a dialog asking if you want to include diagnostic information to your report"
+            accessibilityHint="Opens a dialog asking if you want to include diagnostic information to your report"
             style={styles.button}
             onPress={createMailtoHandler(client, 'Report a bug', '', attempt)}
             alt="Report a bug"

--- a/projects/Mallard/src/components/BugButton.tsx
+++ b/projects/Mallard/src/components/BugButton.tsx
@@ -21,6 +21,9 @@ const BugButton = () => {
     const client = useApolloClient()
     return isInBeta() ? (
         <Button
+            accessible={true}
+            accessibilityLabel="Report a bug button"
+            accessibilitHint="Opens a dialog asking if you want to include diagnostic information to your report"
             style={styles.button}
             onPress={createMailtoHandler(client, 'Report a bug', '', attempt)}
             alt="Report a bug"

--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -84,6 +84,9 @@ const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
             </ImageBackground>
             {image.credit && (
                 <Button
+                    accessible={true}
+                    accessibilityLabel="Image captions button"
+                    accessibilityHint="Tells you the image credits and description"
                     alt="Toggle credit"
                     icon={showCredit ? '' : ''}
                     onPress={toggleCredit}

--- a/projects/Mallard/src/components/article/article-image.tsx
+++ b/projects/Mallard/src/components/article/article-image.tsx
@@ -84,7 +84,6 @@ const ArticleImage = ({ image, style, proxy, aspectRatio }: PropTypes) => {
             </ImageBackground>
             {image.credit && (
                 <Button
-                    accessible={true}
                     accessibilityLabel="Image captions button"
                     accessibilityHint="Tells you the image credits and description"
                     alt="Toggle credit"

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -666,6 +666,7 @@ const getByLine = (
         ? ''
         : html`
               <button
+                  name="Share button"
                   class="share-touch-zone"
                   onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'share'}))"
               >

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -179,7 +179,6 @@ const IssueButton = ({
             color={color.primary}
         >
             <Button
-                accessible={true}
                 accessibilityLabel="Download edition"
                 accessibilityHint="Downloads the edition to your device, so you can listen to it when offline"
                 onPress={onDownloadIssue}

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -179,6 +179,9 @@ const IssueButton = ({
             color={color.primary}
         >
             <Button
+                accessible={true}
+                accessibilityLabel="Download edition"
+                accessibilityHint="Downloads the edition to your device, so you can listen to it when offline"
                 onPress={onDownloadIssue}
                 icon={
                     isOnDevice === ExistsStatus.doesExist ? '\uE062' : '\uE077'

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -217,7 +217,6 @@ const SetLocationButton = withNavigation(
 
         return (
             <Button
-                accessible={true}
                 accessibilityLabel="Use location button"
                 accessibilityHint="Opens a device location consent screen"
                 onPress={onSetLocation}

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -217,6 +217,9 @@ const SetLocationButton = withNavigation(
 
         return (
             <Button
+                accessible={true}
+                accessibilityLabel="Use location button"
+                accessibilityHint="Opens a device location consent screen"
                 onPress={onSetLocation}
                 appearance={ButtonAppearance.skeleton}
                 style={[

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -99,9 +99,6 @@ const HomeScreenHeader = withNavigation(
         )
         return (
             <IssuePickerHeader
-                accessible={true}
-                accessibilityLabel="Recent editions button"
-                accessibilityHint="Returns to the edition"
                 leftAction={settings}
                 onPress={onReturn}
                 action={action}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -78,7 +78,6 @@ const HomeScreenHeader = withNavigation(
     } & NavigationInjectedProps) => {
         const action = (
             <Button
-                accessible={true}
                 accessibilityLabel="Close button"
                 accessibilityHint="Returns to the edition"
                 icon={'\uE04F'}
@@ -88,7 +87,6 @@ const HomeScreenHeader = withNavigation(
         )
         const settings = (
             <Button
-                accessible={true}
                 accessibilityLabel="Settings button"
                 accessibilityHint="Navigates to settings screen"
                 icon={'\uE040'}
@@ -217,7 +215,6 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
         <View style={styles.issueListFooter}>
             <GridRowSplit style={styles.issueListFooterGrid}>
                 <Button
-                    accessible={true}
                     accessibilityLabel="Manage editions button"
                     accessibilityHint="Navigates to manage editions screen"
                     appearance={ButtonAppearance.skeleton}
@@ -233,7 +230,6 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
             {isUsingProdDevtools ? (
                 <GridRowSplit>
                     <Button
-                        accessible={true}
                         accessibilityLabel="Go to the latest edition button"
                         accessibilityHint="Navigates to the latest edition"
                         appearance={ButtonAppearance.skeleton}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -77,10 +77,20 @@ const HomeScreenHeader = withNavigation(
         onSettings: () => void
     } & NavigationInjectedProps) => {
         const action = (
-            <Button icon={'\uE04F'} alt="Return to issue" onPress={onReturn} />
+            <Button 
+                accessible={true}
+                accessibilityLabel="Close button"
+                accessibilityHint="Returns to edition"
+                icon={'\uE04F'} 
+                alt="Return to edition" 
+                onPress={onReturn} 
+            />
         )
         const settings = (
             <Button
+                accessible={true}
+                accessibilityLabel="Settings button"
+                accessibilityHint="Navigates to settings screen"
                 icon={'\uE040'}
                 alt="Settings"
                 onPress={() => {
@@ -91,8 +101,9 @@ const HomeScreenHeader = withNavigation(
         )
         return (
             <IssuePickerHeader
+                accessible={true}    
+                accessibilityHint="Returns to edition"
                 leftAction={settings}
-                accessibilityHint={'Return to issue'}
                 onPress={onReturn}
                 action={action}
             />
@@ -205,6 +216,9 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
         <View style={styles.issueListFooter}>
             <GridRowSplit style={styles.issueListFooterGrid}>
                 <Button
+                    accessible={true}
+                    accessibilityLabel={"Manage editions button"}
+                    accessibilityHint={"Navigates to manage editions screen"}
                     appearance={ButtonAppearance.skeleton}
                     onPress={() => {
                         navigation.navigate({
@@ -218,6 +232,9 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
             {isUsingProdDevtools ? (
                 <GridRowSplit>
                     <Button
+                        accessible={true}
+                        accessibilityLabel={"Go to latest button"}
+                        accessibilityHint={"Navigates to the latest edition"}
                         appearance={ButtonAppearance.skeleton}
                         onPress={() => {
                             navigateToIssue({

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -218,8 +218,8 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
             <GridRowSplit style={styles.issueListFooterGrid}>
                 <Button
                     accessible={true}
-                    accessibilityLabel={'Manage editions button'}
-                    accessibilityHint={'Navigates to manage editions screen'}
+                    accessibilityLabel="Manage editions button"
+                    accessibilityHint="Navigates to manage editions screen"
                     appearance={ButtonAppearance.skeleton}
                     onPress={() => {
                         navigation.navigate({

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -77,13 +77,13 @@ const HomeScreenHeader = withNavigation(
         onSettings: () => void
     } & NavigationInjectedProps) => {
         const action = (
-            <Button 
+            <Button
                 accessible={true}
                 accessibilityLabel="Close button"
                 accessibilityHint="Returns to edition"
-                icon={'\uE04F'} 
-                alt="Return to edition" 
-                onPress={onReturn} 
+                icon={'\uE04F'}
+                alt="Return to edition"
+                onPress={onReturn}
             />
         )
         const settings = (
@@ -101,7 +101,7 @@ const HomeScreenHeader = withNavigation(
         )
         return (
             <IssuePickerHeader
-                accessible={true}    
+                accessible={true}
                 accessibilityHint="Returns to edition"
                 leftAction={settings}
                 onPress={onReturn}
@@ -176,7 +176,7 @@ const IssueRowContainer = React.memo(
         ])
 
         const onPressFront = useCallback(
-            frontKey => {
+            (frontKey) => {
                 if (
                     issueId != null &&
                     issueId.publishedIssueId === publishedId &&
@@ -217,8 +217,8 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
             <GridRowSplit style={styles.issueListFooterGrid}>
                 <Button
                     accessible={true}
-                    accessibilityLabel={"Manage editions button"}
-                    accessibilityHint={"Navigates to manage editions screen"}
+                    accessibilityLabel={'Manage editions button'}
+                    accessibilityHint={'Navigates to manage editions screen'}
                     appearance={ButtonAppearance.skeleton}
                     onPress={() => {
                         navigation.navigate({
@@ -233,8 +233,8 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
                 <GridRowSplit>
                     <Button
                         accessible={true}
-                        accessibilityLabel={"Go to latest button"}
-                        accessibilityHint={"Navigates to the latest edition"}
+                        accessibilityLabel={'Go to latest button'}
+                        accessibilityHint={'Navigates to the latest edition'}
                         appearance={ButtonAppearance.skeleton}
                         onPress={() => {
                             navigateToIssue({
@@ -283,7 +283,7 @@ const IssueListView = withNavigation(
 
             // We want to scroll to the current issue.
             const currentIssueIndex = issueList.findIndex(
-                issue =>
+                (issue) =>
                     issue.localId === localId &&
                     issue.publishedId === publishedId,
             )

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -80,7 +80,7 @@ const HomeScreenHeader = withNavigation(
             <Button
                 accessible={true}
                 accessibilityLabel="Close button"
-                accessibilityHint="Returns to edition"
+                accessibilityHint="Returns to the edition"
                 icon={'\uE04F'}
                 alt="Return to edition"
                 onPress={onReturn}
@@ -102,7 +102,8 @@ const HomeScreenHeader = withNavigation(
         return (
             <IssuePickerHeader
                 accessible={true}
-                accessibilityHint="Returns to edition"
+                accessibilityLabel="Recent editions button"
+                accessibilityHint="Returns to the edition"
                 leftAction={settings}
                 onPress={onReturn}
                 action={action}
@@ -176,7 +177,7 @@ const IssueRowContainer = React.memo(
         ])
 
         const onPressFront = useCallback(
-            (frontKey) => {
+            frontKey => {
                 if (
                     issueId != null &&
                     issueId.publishedIssueId === publishedId &&
@@ -233,8 +234,8 @@ const IssueListFooter = ({ navigation }: NavigationInjectedProps) => {
                 <GridRowSplit>
                     <Button
                         accessible={true}
-                        accessibilityLabel={'Go to latest button'}
-                        accessibilityHint={'Navigates to the latest edition'}
+                        accessibilityLabel="Go to the latest edition button"
+                        accessibilityHint="Navigates to the latest edition"
                         appearance={ButtonAppearance.skeleton}
                         onPress={() => {
                             navigateToIssue({
@@ -283,7 +284,7 @@ const IssueListView = withNavigation(
 
             // We want to scroll to the current issue.
             const currentIssueIndex = issueList.findIndex(
-                (issue) =>
+                issue =>
                     issue.localId === localId &&
                     issue.publishedId === publishedId,
             )


### PR DESCRIPTION
Adding accessibility labels and hints for users who use screen readers.

## Summary

<!--
Why are we doing this?

Making the app more accessible to users using screen readers.
This is a first pull request to see if that works. 
(There are still other labels to add)

-->

[**Trello Card ->**](https://trello.com/c/KlhS5zcI/1214-accessibility-voice-over-not-describing-buttons-and-skipping-special-containers-on-the-front)

## Test Plan

<!--
Once we publish to internal beta, we can turn the accessibility VoiceOver (iOS) and TalkBack (Android) and manually test if the buttons are being read to the user.
-->
