### PR TITLE
feat: Delete logs on first startup

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -36,6 +36,7 @@ import { ConfigProvider } from 'src/hooks/use-config-provider'
 import { Lightbox } from './screens/lightbox'
 import { LightboxProvider } from './screens/use-lightbox-modal'
 import { weatherHider } from './helpers/weather-hider'
+import { loggingService } from './services/logging'
 
 /**
  * Only one global Apollo client. As such, any update done from any component
@@ -144,6 +145,7 @@ export default class App extends React.Component<{}, {}> {
                 clearAndDownloadIssue(apolloClient)
             }
         })
+        loggingService.postQueuedLogs()
     }
 
     async componentDidCatch(e: Error) {

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -166,7 +166,10 @@ class Logging {
             await this.postLog(queuedLogs)
         } catch {
             // Assumes there is a problem sending logs and clears them
-            await this.clearLogs()
+            const { isConnected } = await NetInfo.fetch()
+            if (isConnected) {
+                await this.clearLogs()
+            }
         }
     }
 

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -159,14 +159,14 @@ class Logging {
     }
 
     // Designed to post logs that have been queued but havent sent
-    async postQueuedLogs() {
+    async postQueuedLogs(): Promise<void> {
         try {
             const queuedLogsString = await this.getQueuedLogs()
             const queuedLogs = JSON.parse(queuedLogsString)
             await this.postLog(queuedLogs)
         } catch {
             // Assumes there is a problem sending logs and clears them
-            this.clearLogs()
+            await this.clearLogs()
         }
     }
 

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -158,6 +158,18 @@ class Logging {
         }
     }
 
+    // Designed to post logs that have been queued but havent sent
+    async postQueuedLogs() {
+        try {
+            const queuedLogsString = await this.getQueuedLogs()
+            const queuedLogs = JSON.parse(queuedLogsString)
+            await this.postLog(queuedLogs)
+        } catch {
+            // Assumes there is a problem sending logs and clears them
+            this.clearLogs()
+        }
+    }
+
     async log({ level, message, ...optionalFields }: LogParams) {
         try {
             const currentLog = await this.baseLog({


### PR DESCRIPTION
## Summary
If we have an issue sending logs, there could be a large backlog of logs stored on a users device taking up precious space.

This will attempt to push those logs on a cold start of the app. If it fails, then we clear them.