### PR TITLE
Feat/add sign in logging

### DIFF
--- a/projects/Apps/common/src/logging.ts
+++ b/projects/Apps/common/src/logging.ts
@@ -14,6 +14,7 @@ export enum Feature {
     PUSH_NOTIFICATION = 'PUSH_NOTIFICATION',
     BACKGROUNG_DOWNLOAD = 'BACKGROUND_DOWNLOAD',
     CLEAR_ISSUES = 'CLEAR_ISSUES',
+    SIGN_IN = 'SIGN_IN',
 }
 
 export interface MallardLogFormat {

--- a/projects/Mallard/src/authentication/lib/AccessController.ts
+++ b/projects/Mallard/src/authentication/lib/AccessController.ts
@@ -8,6 +8,7 @@ import {
     Connectivity,
     hasRun,
 } from './Attempt'
+import { Feature, loggingService, Level } from 'src/services/logging'
 
 type UpdateHandler<S> = (attempt: AnyAttempt<S>) => void
 
@@ -70,6 +71,15 @@ class AccessController<I extends AuthMap, S extends AuthName<I>> {
         return cachedValidAttempt && Date.now() - cachedValidAttempt < ONE_MONTH
     }
 
+    private logReAuthentication = (connection: string) => {
+        const feature = Feature.SIGN_IN
+        loggingService.log({
+            level: Level.INFO,
+            message: `Previous cached auth expired - re-authenticating user`,
+            optionalFields: { connection, feature },
+        })
+    }
+
     public async handleConnectionStatusChanged(
         isConnected: boolean,
         isPoorConnection = false,
@@ -81,11 +91,14 @@ class AccessController<I extends AuthMap, S extends AuthName<I>> {
         }
         if (!this.hasAuthRun) {
             if (hasConnection) {
+                this.logReAuthentication('online')
                 return this.runCachedAuth('online')
             } else {
+                this.logReAuthentication('offline')
                 return this.runCachedAuth('offline')
             }
         } else if (!this.isAuthOnline && hasConnection) {
+            this.logReAuthentication('online')
             return this.runCachedAuth('online')
         }
     }
@@ -127,6 +140,13 @@ class AccessController<I extends AuthMap, S extends AuthName<I>> {
         // when we get a valid attempt we want to store this (only for new valid attempts)
         const isPreviousAuthValid = await this.isPreviousAuthValid()
         if (isValid(attempt) && !isPreviousAuthValid) {
+            const feature = Feature.SIGN_IN
+            loggingService.log({
+                level: Level.INFO,
+                message:
+                    'Updating authentication cache with valid attempt date',
+                optionalFields: { feature },
+            })
             this.validAttemptCache.set(attempt.time)
         }
         this.updateAttempt(attempt)

--- a/projects/Mallard/src/authentication/lib/AccessController.ts
+++ b/projects/Mallard/src/authentication/lib/AccessController.ts
@@ -71,12 +71,12 @@ class AccessController<I extends AuthMap, S extends AuthName<I>> {
         return cachedValidAttempt && Date.now() - cachedValidAttempt < ONE_MONTH
     }
 
-    private logReAuthentication = (connection: string) => {
+    private logReAuthentication = (expectedConnection: string) => {
         const feature = Feature.SIGN_IN
         loggingService.log({
             level: Level.INFO,
             message: `Previous cached auth expired - re-authenticating user`,
-            optionalFields: { connection, feature },
+            optionalFields: { expectedConnection, feature },
         })
     }
 

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -15,6 +15,7 @@ import {
 import { validAttemptCache } from 'src/helpers/storage'
 import { cataResult, AuthResult, ValidResult, InvalidResult } from './Result'
 import { loggingService, Level, Feature } from 'src/services/logging'
+import { errorService } from 'src/services/errors'
 
 type UpdateHandler<T> = (data: AnyAttempt<T>) => void
 
@@ -109,6 +110,7 @@ class Authorizer<
                 },
             })
         } catch (e) {
+            errorService.captureException(e)
             loggingService.log({
                 level: Level.ERROR,
                 message:

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -188,8 +188,9 @@ class Authorizer<
      * This sets the attempt to Invalid
      */
     public signOut() {
+        const feature = Feature.SIGN_IN
         this.updateAttempt(InvalidAttempt('online'))
-        this.logAuthCacheClear('sign out')
+        this.logAuthCacheClear(feature, 'sign out')
         return this.clearCaches()
     }
 

--- a/projects/Mallard/src/authentication/lib/Authorizer.ts
+++ b/projects/Mallard/src/authentication/lib/Authorizer.ts
@@ -78,7 +78,7 @@ class Authorizer<
         const feature = Feature.SIGN_IN
         loggingService.log({
             level: Level.INFO,
-            message: 'clearing all caches',
+            message: 'Clearing all authentication caches',
             optionalFields: { reason, feature },
         })
     }


### PR DESCRIPTION
## Summary
This PR adds some logging around the authentication of users. 
* When a user is outside the 1 month cached authentication period and is going through re-authentication flow.
* When the attempt cache is being set
* When the authentication caches are cleared
* When an error attempt is created after authenticating 
* When an exception attempt is created when authenticating

This should hopefully give us an indicator of any issues around sign-in in the future. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/N5CegQ8W/1257-add-logging-to-track-user-sign-in-issue)

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
