### PR TITLE
Correct name for API_KEY env. var.

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -69,7 +69,7 @@ export class LoggingStack extends cdk.Stack {
                     STAGE: stageParameter.valueAsString,
                     STACK: stackParameter.valueAsString,
                     APP: 'editions-logging',
-                    API_Key: apiKeyParameter.valueAsString,
+                    API_KEY: apiKeyParameter.valueAsString,
                 },
             })
             Tag.add(fn, 'App', `editions-logging`)


### PR DESCRIPTION
This is a a typo/mistake - API_KEY is referred to elsewhere in the code using all CAPS, let's be consistent else it won't work!! 