### PR TITLE
fix/malformed-share-content-iOS

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -140,16 +140,24 @@ const Article = ({
                     const parsed = parsePing(event.nativeEvent.data)
                     if (parsed.type === 'share') {
                         if (article.webUrl == null) return
-                        Share.share(
-                            {
-                                title: article.headline,
+                        if (Platform.OS === 'ios') {
+                            Share.share({
                                 url: article.webUrl,
-                                message: article.webUrl, // 'message' is required as well as 'url' to support wide range of clients (e.g. email/whatsapp etc)
-                            },
-                            {
-                                subject: article.headline,
-                            },
-                        )
+                                message: article.headline,
+                            })
+                        } else {
+                            Share.share(
+                                {
+                                    title: article.headline,
+                                    url: article.webUrl,
+                                    // 'message' is required as well as 'url' to support wide range of clients (e.g. email/whatsapp etc)
+                                    message: article.webUrl,
+                                },
+                                {
+                                    subject: article.headline,
+                                },
+                            )
+                        }
                         return
                     }
                     if (parsed.type === 'shouldShowHeaderChange') {


### PR DESCRIPTION
## Summary
A user reported that when sharing using Gmail on iOS the web URL was duplicated, this PR separates out the logic for iOS and Android so avoid this. 
I have left Android as is, as this was updated recently as part of this [PR](https://github.com/guardian/editions/pull/1064) and android appears to need more parameters. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/UuNMT35O/1280-url-duplicated-in-share-content-on-ios)

## Test Plan
You will need to test this on an iOS device and check different sharing providers, eg. Gmail, Twitter etc. 
| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/81791158-40eb7c00-94fe-11ea-9e8b-2d694864e0d1.png)| ![image](https://user-images.githubusercontent.com/53755195/81791186-4c3ea780-94fe-11ea-958d-150575dd4d73.png)
![image](https://user-images.githubusercontent.com/53755195/81791238-6082a480-94fe-11ea-80fb-dee5a1e22175.png) | ![image](https://user-images.githubusercontent.com/53755195/81791262-68dadf80-94fe-11ea-8271-9130318f6a3c.png)

 

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
