### PR TITLE
chore: Logging Test Independence

### DIFF
--- a/projects/Mallard/src/services/__tests__/logging.android.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.android.spec.ts
@@ -1,4 +1,4 @@
-import { Level, loggingService } from '../logging'
+import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
 MockDate.set('2019-08-21')
@@ -16,6 +16,7 @@ jest.mock('react-native/Libraries/Utilities/Platform', () => {
 describe('logging service (Android and Release)', () => {
     describe('baseLog', () => {
         it('should return a log object that matches the snapshot', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: { type: 'wifi' },
                 userData: {

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -1,4 +1,4 @@
-import { Level, loggingService } from '../logging'
+import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
 jest.mock('@react-native-community/netinfo', () => ({
@@ -12,6 +12,7 @@ MockDate.set('2019-08-21')
 describe('logging service - Offline', () => {
     describe('log', () => {
         it('should save queued logs when there is no internet connection', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: { type: 'wifi' },
                 userData: {

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,4 +1,4 @@
-import { loggingService, Level } from '../logging'
+import { Logging, Level } from '../logging'
 import MockDate from 'mockdate'
 
 jest.mock('@react-native-community/netinfo', () => ({
@@ -12,6 +12,7 @@ MockDate.set('2019-08-21')
 describe('logging service', () => {
     describe('baseLog', () => {
         it('should return a log object that matches the snapshot', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: { type: 'wifi' },
                 userData: {
@@ -31,6 +32,7 @@ describe('logging service', () => {
             expect(log).toMatchSnapshot()
         })
         it('should return an object with default values if they are missing and match snapshot', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: null,
                 userData: null,
@@ -48,6 +50,7 @@ describe('logging service', () => {
 
     describe('log', () => {
         it('should have a successful post log', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: { type: 'wifi' },
                 userData: {
@@ -67,6 +70,7 @@ describe('logging service', () => {
             expect(loggingService.clearLogs).toHaveBeenCalled()
         })
         it('should not post a log if there is no consent', async () => {
+            const loggingService = new Logging()
             loggingService.getExternalInfo = jest.fn().mockReturnValue({
                 networkStatus: { type: 'wifi' },
                 userData: {
@@ -80,7 +84,6 @@ describe('logging service', () => {
             })
             loggingService.clearLogs = jest.fn()
             loggingService.postLog = jest.fn()
-            loggingService.hasConsent = false
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.postLog).not.toHaveBeenCalled()
             expect(loggingService.clearLogs).not.toHaveBeenCalled()

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -228,4 +228,4 @@ class Logging {
 
 const loggingService = new Logging()
 
-export { Level, Feature, loggingService }
+export { Level, Feature, Logging, loggingService }


### PR DESCRIPTION
## Summary
As pointed out by @mohammad-haque, our tests were not running independent of each other as they should. This now creates a clean logging instance for each test.