### PR TITLE
Only jump to start of front if it has > 0 stories.

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -119,13 +119,14 @@ export const Front = React.memo(
 
         // Whenever we change edition, this resets us back to 0 scroll index for all fronts
         useEffect(() => {
-            flatListRef &&
+            cards.length > 0 &&
+                flatListRef &&
                 flatListRef.current &&
                 flatListRef.current._component.scrollToIndex({
                     animated: false,
                     index: 0,
                 })
-        }, [frontData])
+        }, [frontData, cards])
 
         return (
             <FrontWrapper


### PR DESCRIPTION
## Summary
This fixes a bug introduced by https://github.com/guardian/editions/pull/1104/files where if a front has zero stories the app crashes with an error "Invariant Violation: scrollToIndex out of range: requested index 0 but maximum is -1"

This is a problem in the preview environment where there are often empty fronts as they haven't been worked on yet. 

[**Trello Card ->**](https://trello.com/c/bChIrA4i/1277-preview-mode-on-vpn-broken-on-builds-post-675)

## Test Plan
 - check that the 'scroll to top' functionality still works with this change
 - check that preview now works