### PR TITLE
Improving immersive qualiity: Use ArticleType to determine image role

### DIFF
--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -72,6 +72,8 @@ const thumbnailExpected = {
     source: 'test',
 }
 
+const articleType = articleTypePicker(sharedGiven)
+
 describe('articleImgPicker.getImages', () => {
     it('should extract both images', () => {
         const given: IContent = {
@@ -80,7 +82,7 @@ describe('articleImgPicker.getImages', () => {
             elements: [thumbnailElem],
         }
 
-        const actual = getImages(given, articleTypePicker(given))
+        const actual = getImages(given, articleType)
 
         const withBoth: ImageAndTrailImage = {
             image: { ...mainImgExpected },
@@ -103,7 +105,7 @@ describe('articleImgPicker.getImages', () => {
             elements: [thumbnailElem],
         }
 
-        const actual = getImages(given, articleTypePicker(given))
+        const actual = getImages(given, articleType)
 
         const withTrailOnly: ImageAndTrailImage = {
             image: undefined,
@@ -126,7 +128,7 @@ describe('articleImgPicker.getImages', () => {
             blocks: blocks,
         }
 
-        const actual = getImages(given, articleTypePicker(given))
+        const actual = getImages(given, articleType)
 
         const withMainOnly: ImageAndTrailImage = {
             image: { ...mainImgExpected },
@@ -141,7 +143,7 @@ describe('articleImgPicker.getImages', () => {
             ...sharedGiven,
         }
 
-        const actual = getImages(given, articleTypePicker(given))
+        const actual = getImages(given, articleType)
 
         const withNoImages: ImageAndTrailImage = {
             image: undefined,

--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -11,6 +11,8 @@ import {
     IAsset,
     AssetType,
 } from '@guardian/capi-ts'
+import { articleTypePicker } from '../articleTypePicker'
+import { ArticleType } from '../../../Apps/common/src'
 
 const masterAsset: IAsset = {
     type: AssetType.IMAGE,
@@ -78,7 +80,7 @@ describe('articleImgPicker.getImages', () => {
             elements: [thumbnailElem],
         }
 
-        const actual = getImages(given)
+        const actual = getImages(given, articleTypePicker(given))
 
         const withBoth: ImageAndTrailImage = {
             image: { ...mainImgExpected },
@@ -101,7 +103,7 @@ describe('articleImgPicker.getImages', () => {
             elements: [thumbnailElem],
         }
 
-        const actual = getImages(given)
+        const actual = getImages(given, articleTypePicker(given))
 
         const withTrailOnly: ImageAndTrailImage = {
             image: undefined,
@@ -124,7 +126,7 @@ describe('articleImgPicker.getImages', () => {
             blocks: blocks,
         }
 
-        const actual = getImages(given)
+        const actual = getImages(given, articleTypePicker(given))
 
         const withMainOnly: ImageAndTrailImage = {
             image: { ...mainImgExpected },
@@ -139,7 +141,7 @@ describe('articleImgPicker.getImages', () => {
             ...sharedGiven,
         }
 
-        const actual = getImages(given)
+        const actual = getImages(given, articleTypePicker(given))
 
         const withNoImages: ImageAndTrailImage = {
             image: undefined,
@@ -152,17 +154,22 @@ describe('articleImgPicker.getImages', () => {
 
 describe('getImageRole', () => {
     it('should return immersive for displayHint=immersive when capirole is undefined', async () => {
-        const role = getImageRole('immersive', undefined)
+        const role = getImageRole(ArticleType.Feature, 'immersive', undefined)
         expect(role).toBe('immersive')
     })
 
     it('should return the capi role when it is defined', async () => {
-        const role = getImageRole('immersive', 'showcase')
+        const role = getImageRole(ArticleType.Feature, 'immersive', 'showcase')
         expect(role).toBe('showcase')
     })
 
     it('returns undefined when no valid roles provided', async () => {
-        const role = getImageRole('hehe', 'megabigimage')
+        const role = getImageRole(ArticleType.Feature, 'hehe', 'megabigimage')
         expect(role).toBe(undefined)
+    })
+
+    it('returns immersive for ArticleType=Immersive when capirole is undefined', async () => {
+        const role = getImageRole(ArticleType.Immersive, undefined, undefined)
+        expect(role).toBe('immersive')
     })
 })

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -7,6 +7,7 @@ import {
 } from '../../Apps/common/src'
 import { oc } from 'ts-optchain'
 import { getImage, getCreditedImage } from './assets'
+import { ArticleType } from '../../Apps/common/src'
 
 /**
  * if no role is included in capi and content is immersive, set role to immersive
@@ -15,15 +16,22 @@ import { getImage, getCreditedImage } from './assets'
  * @param capiRole the image role specified in the content API (if any)
  */
 export const getImageRole = (
+    articleType: ArticleType,
     displayHint?: string,
     capiRole?: string,
 ): ImageRole | undefined => {
-    if (displayHint === 'immersive' && !capiRole) {
-        return displayHint
+    if (
+        (displayHint === 'immersive' || articleType == ArticleType.Immersive) &&
+        !capiRole
+    ) {
+        return 'immersive'
     } else return imageRoles.find(r => r === capiRole)
 }
 
-const getMainImage = (result: IContent): CreditedImage | undefined => {
+const getMainImage = (
+    result: IContent,
+    articleType: ArticleType,
+): CreditedImage | undefined => {
     const maybeMainElement = oc(result).blocks.main.elements[0]()
     const maybeCreditedMainImage =
         maybeMainElement && getCreditedImage(maybeMainElement)
@@ -36,12 +44,19 @@ const getMainImage = (result: IContent): CreditedImage | undefined => {
     return maybeCreditedMainImage
         ? {
               ...maybeCreditedMainImage,
-              role: getImageRole(displayHint, maybeCreditedMainImage.role),
+              role: getImageRole(
+                  articleType,
+                  displayHint,
+                  maybeCreditedMainImage.role,
+              ),
           }
         : maybeCreditedMainImage
 }
 
-const getTrailImage = (result: IContent): TrailImage | undefined => {
+const getTrailImage = (
+    result: IContent,
+    articleType: ArticleType,
+): TrailImage | undefined => {
     const maybeThumbnailElement =
         result.elements &&
         result.elements.find(element => element.relation === 'thumbnail')
@@ -58,7 +73,11 @@ const getTrailImage = (result: IContent): TrailImage | undefined => {
                   mobile: 'full-size',
                   tablet: 'full-size',
               },
-              role: getImageRole(displayHint, maybeThumbnailImage.role),
+              role: getImageRole(
+                  articleType,
+                  displayHint,
+                  maybeThumbnailImage.role,
+              ),
           }
         : undefined
 }
@@ -68,12 +87,15 @@ interface ImageAndTrailImage {
     trailImage: TrailImage | undefined
 }
 
-const getImages = (result: IContent): ImageAndTrailImage => {
+const getImages = (
+    result: IContent,
+    articleType: ArticleType,
+): ImageAndTrailImage => {
     const images = {
-        image: getMainImage(result),
-        trailImage: getTrailImage(result),
+        image: getMainImage(result, articleType),
+        trailImage: getTrailImage(result, articleType),
     }
-    console.log('Found images: ' + JSON.stringify(images))
+    console.debug('Found images: ' + JSON.stringify(images))
     return images
 }
 

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -17,8 +17,10 @@ const articleTypePicker = (article: IContent): ArticleType => {
     const isTypePresent = (tagType: TagType): boolean =>
         doesTypeExist(article, tagType)
 
+    // NOTE: most interviews are also immersive - see switch statement below
     const isImmersive: boolean =
         (article.fields && article.fields.displayHint === 'immersive') || false
+
     const isLongRead: boolean = isTagPresent(
         'theguardian/journal/the-long-read',
     )

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -111,7 +111,7 @@ const parseArticleResult = async (
     const bylineHtml = result.fields && result.fields.bylineHtml
     const bylineImages = getBylineImages(result)
 
-    const images = getImages(result)
+    const images = getImages(result, articleType)
 
     const starRating = result.fields && result.fields.starRating
 
@@ -341,7 +341,6 @@ export const getArticles = async (
 
     //If we fail to get an article in a collection we just ignore it and move on.
     articlePromises.forEach(attempt => {
-        console.debug('Got article: ' + JSON.stringify(attempt))
         if (hasFailed(attempt)) {
             console.log('failure when parsing', attempt.error)
         }

--- a/projects/backend/controllers/fronts.ts
+++ b/projects/backend/controllers/fronts.ts
@@ -32,11 +32,10 @@ export const frontController = (req: Request, res: Response) => {
                 }
                 return
             }
-            const json = JSON.stringify(data)
-            console.debug(`Got front: ${json}`)
+            const frontData = JSON.stringify(data)
             res.setHeader('Last-Modifed', date())
             res.setHeader('Content-Type', 'application/json')
-            res.send(json)
+            res.send(frontData)
         })
         .catch(error => {
             console.error('Error in the fronts controller.')


### PR DESCRIPTION
## Summary
The work in https://github.com/guardian/editions/pull/1150 missed out any immersive images used on 'Interview' content - as this content is immersive in editions despite not having a `displayHint` set. This change passes `ArticleType` through to the `getImageRole` function so that it can be used to determine the image role, I've also added a comment above the  `isImmersive` function in the article type picker as this isn't the only thing that triggers immersive style articles. 

In my testing this definitely improved the quality of interview content. There may still be some more work needed on this card for cartoons, but I think this is good to ship for now.

[**Trello Card ->**](https://trello.com/c/n7kMZP7I/935-immersives-images-are-pixelated-on-ipad-and-android)

## Test Plan
This is a backend only change, and the changes will only be reflected for users for editions published after the time of merging
