### PR TITLE
chore: Refactor Logging service

### DIFF
--- a/projects/Apps/common/src/logging.ts
+++ b/projects/Apps/common/src/logging.ts
@@ -17,6 +17,16 @@ export enum Feature {
     SIGN_IN = 'SIGN_IN',
 }
 
+export enum ReleaseChannel {
+    BETA = 'BETA',
+    RELEASE = 'RELEASE',
+}
+
+export enum OS {
+    IOS = 'ios',
+    ANDROID = 'android',
+}
+
 export interface MallardLogFormat {
     timestamp: Date
     level: Level
@@ -24,8 +34,8 @@ export interface MallardLogFormat {
     app: string
     version: string
     buildNumber: string
-    release_channel: 'BETA' | 'RELEASE'
-    os: 'android' | 'ios'
+    release_channel: ReleaseChannel
+    os: OS
     device: string
     networkStatus: NetInfoStateType
     deviceId: string

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -147,7 +147,6 @@ export default class App extends React.Component<{}, {}> {
                 clearAndDownloadIssue(apolloClient)
             }
         })
-        loggingService.postQueuedLogs()
     }
 
     async componentDidCatch(e: Error) {

--- a/projects/Mallard/src/helpers/async-queue-cache.ts
+++ b/projects/Mallard/src/helpers/async-queue-cache.ts
@@ -1,0 +1,61 @@
+/**
+ * This is a class based around the asyncCache in helpers/storage.ts.
+ * This provides a base class to inherit for JSON like Async Storage data structures
+ */
+
+import { errorService } from 'src/services/errors'
+
+type AsyncQueueCache = {
+    set: (value: any) => Promise<void>
+    get: () => Promise<any>
+    reset: () => Promise<void>
+}
+
+class AsyncQueue {
+    private cache: AsyncQueueCache
+
+    constructor(cache: AsyncQueueCache) {
+        this.cache = cache
+    }
+
+    async getQueuedItems(): Promise<object[]> {
+        try {
+            return (await this.cache.get()) || [{}]
+        } catch (e) {
+            return [{}]
+        }
+    }
+
+    async saveQueuedItems(item: object[]): Promise<void | Error> {
+        try {
+            return await this.cache.set(item)
+        } catch (e) {
+            errorService.captureException(e)
+            throw new Error(e)
+        }
+    }
+
+    async queueItems(item: object[]) {
+        try {
+            const parsedQueue = await this.getQueuedItems()
+            const newQueue = [...parsedQueue, ...item]
+            const cleanLogs = newQueue.filter(
+                value => Object.keys(value).length !== 0,
+            )
+            return cleanLogs
+        } catch (e) {
+            errorService.captureException(e)
+            throw new Error(e)
+        }
+    }
+
+    async clearItems() {
+        try {
+            return await this.cache.reset()
+        } catch (e) {
+            errorService.captureException(e)
+        }
+    }
+}
+
+export { AsyncQueue }

--- a/projects/Mallard/src/helpers/async-queue-cache.ts
+++ b/projects/Mallard/src/helpers/async-queue-cache.ts
@@ -54,6 +54,7 @@ class AsyncQueue {
             return await this.cache.reset()
         } catch (e) {
             errorService.captureException(e)
+            throw new Error(e)
         }
     }
 }

--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -82,9 +82,6 @@ const pushTracking = async (
             ? [...JSON.parse(storedTracking), tracking]
             : [tracking]
 
-        // Doing this for linting rather than refactor a load of code back again as its used below
-        console.log(feature)
-
         loggingService.log({
             level: Level.INFO,
             message: value,

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -24,10 +24,10 @@ describe('logging service - Offline', () => {
                 casCode: 'QWERTYUIOP',
                 iapReceipt: true,
             })
-            loggingService.saveQueuedLogs = jest.fn()
+            loggingService.saveQueuedItems = jest.fn()
             loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
-            expect(loggingService.saveQueuedLogs).toHaveBeenCalled()
+            expect(loggingService.saveQueuedItems).toHaveBeenCalled()
         })
     })
 })

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -32,21 +32,25 @@ const logFixture = [
     },
 ]
 
+const externalInfoFixture = {
+    networkStatus: { type: 'wifi' },
+    userData: {
+        userDetails: { id: 'testId' },
+        membershipData: {
+            contentAccess: { digitalPack: true },
+        },
+    },
+    casCode: 'QWERTYUIOP',
+    iapReceipt: true,
+}
+
 describe('logging service', () => {
     describe('baseLog', () => {
         it('should return a log object that matches the snapshot', async () => {
             const loggingService = new Logging()
-            loggingService.getExternalInfo = jest.fn().mockReturnValue({
-                networkStatus: { type: 'wifi' },
-                userData: {
-                    userDetails: { id: 'testId' },
-                    membershipData: {
-                        contentAccess: { digitalPack: true },
-                    },
-                },
-                casCode: 'QWERTYUIOP',
-                iapReceipt: true,
-            })
+            loggingService.getExternalInfo = jest
+                .fn()
+                .mockReturnValue(externalInfoFixture)
             const log = await loggingService.baseLog({
                 level: Level.INFO,
                 message: 'test log',
@@ -74,17 +78,9 @@ describe('logging service', () => {
     describe('log', () => {
         it('should have a successful post log', async () => {
             const loggingService = new Logging()
-            loggingService.getExternalInfo = jest.fn().mockReturnValue({
-                networkStatus: { type: 'wifi' },
-                userData: {
-                    userDetails: { id: 'testId' },
-                    membershipData: {
-                        contentAccess: { digitalPack: true },
-                    },
-                },
-                casCode: 'QWERTYUIOP',
-                iapReceipt: true,
-            })
+            loggingService.getExternalInfo = jest
+                .fn()
+                .mockReturnValue(externalInfoFixture)
             loggingService.clearItems = jest.fn()
             loggingService.postLog = jest.fn()
             loggingService.hasConsent = true
@@ -94,17 +90,9 @@ describe('logging service', () => {
         })
         it('should not post a log if there is no consent', async () => {
             const loggingService = new Logging()
-            loggingService.getExternalInfo = jest.fn().mockReturnValue({
-                networkStatus: { type: 'wifi' },
-                userData: {
-                    userDetails: { id: 'testId' },
-                    membershipData: {
-                        contentAccess: { digitalPack: true },
-                    },
-                },
-                casCode: 'QWERTYUIOP',
-                iapReceipt: true,
-            })
+            loggingService.getExternalInfo = jest
+                .fn()
+                .mockReturnValue(externalInfoFixture)
             loggingService.clearItems = jest.fn()
             loggingService.postLog = jest.fn()
 

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,5 +1,7 @@
 import { Logging, Level } from '../logging'
 import MockDate from 'mockdate'
+import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
+import { NetInfoStateType } from '@react-native-community/netinfo'
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
@@ -8,6 +10,27 @@ jest.mock('@react-native-community/netinfo', () => ({
     },
 }))
 MockDate.set('2019-08-21')
+
+const logFixture = [
+    {
+        timestamp: new Date(),
+        level: Level.INFO,
+        message: 'basic log',
+        app: 'com.guardian.gce',
+        version: '2.0',
+        buildNumber: '678',
+        release_channel: ReleaseChannel.BETA,
+        os: OS.IOS,
+        device: 'iPad4,1',
+        networkStatus: NetInfoStateType.wifi,
+        deviceId: '12345qwerty',
+        signedIn: true,
+        userId: null,
+        digitalSub: false,
+        casCode: null,
+        iAP: false,
+    },
+]
 
 describe('logging service', () => {
     describe('baseLog', () => {
@@ -62,12 +85,12 @@ describe('logging service', () => {
                 casCode: 'QWERTYUIOP',
                 iapReceipt: true,
             })
-            loggingService.clearLogs = jest.fn()
+            loggingService.clearItems = jest.fn()
             loggingService.postLog = jest.fn()
             loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.postLog).toHaveBeenCalled()
-            expect(loggingService.clearLogs).toHaveBeenCalled()
+            expect(loggingService.clearItems).toHaveBeenCalled()
         })
         it('should not post a log if there is no consent', async () => {
             const loggingService = new Logging()
@@ -82,11 +105,54 @@ describe('logging service', () => {
                 casCode: 'QWERTYUIOP',
                 iapReceipt: true,
             })
-            loggingService.clearLogs = jest.fn()
+            loggingService.clearItems = jest.fn()
             loggingService.postLog = jest.fn()
+
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.postLog).not.toHaveBeenCalled()
-            expect(loggingService.clearLogs).not.toHaveBeenCalled()
+            expect(loggingService.clearItems).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('postLog', () => {
+        it('should increase the number of attempts if postLog fails', async () => {
+            const loggingService = new Logging()
+            loggingService.postLogToService = jest
+                .fn()
+                .mockImplementation(() => {
+                    throw new Error('unable to post')
+                })
+
+            try {
+                await loggingService.postLog(logFixture)
+            } catch {
+                expect(loggingService.numberOfAttempts).toEqual(1)
+            }
+        })
+        it('should reset the number of attempts on a successful post', async () => {
+            const loggingService = new Logging()
+            loggingService.postLogToService = jest
+                .fn()
+                .mockReturnValue(Promise.resolve(true))
+            await loggingService.postLog(logFixture)
+            expect(loggingService.numberOfAttempts).toEqual(0)
+        })
+        it('should call clearLogs if the threshold is reached when there is an error', async () => {
+            const loggingService = new Logging()
+            loggingService.numberOfAttempts = 10
+            loggingService.postLogToService = jest
+                .fn()
+                .mockImplementation(() => {
+                    throw new Error('unable to post')
+                })
+            loggingService.clearItems = jest.fn()
+
+            try {
+                await loggingService.postLog(logFixture)
+            } catch {
+                expect(loggingService.numberOfAttempts).toEqual(0)
+                expect(loggingService.clearItems).toHaveBeenCalled()
+            }
         })
     })
 })

--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -4,6 +4,8 @@ import { isInBeta } from 'src/helpers/release-stream'
 import ApolloClient from 'apollo-client'
 import gql from 'graphql-tag'
 import { GdprSwitchSetting } from 'src/helpers/settings'
+import { loggingService } from './logging'
+import { Level } from '../../../Apps/common/src/logging'
 
 const { SENTRY_DSN_URL } = Config
 
@@ -72,6 +74,12 @@ class ErrorServiceImpl implements ErrorService {
         } else if (this.hasConsent === true) {
             Sentry.captureException(err)
         }
+        // Also send to the logging service (where it manages its own consent and queue)
+        loggingService.log({
+            level: Level.ERROR,
+            message: 'captureException',
+            optionalFields: { error: err },
+        })
     }
 }
 

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -1,27 +1,31 @@
 // Logging Service that sends event logs to ELK
 import NetInfo, { NetInfoStateType } from '@react-native-community/netinfo'
+import ApolloClient from 'apollo-client'
+import gql from 'graphql-tag'
 import { Platform } from 'react-native'
+import Config from 'react-native-config'
 import DeviceInfo from 'react-native-device-info'
+import { getCASCode } from 'src/authentication/helpers'
 import { isInBeta } from 'src/helpers/release-stream'
+import { GdprSwitchSetting } from 'src/helpers/settings'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import {
     iapReceiptCache,
-    userDataCache,
     loggingQueueCache,
+    userDataCache,
 } from 'src/helpers/storage'
-import { errorService } from './errors'
-import { getCASCode } from 'src/authentication/helpers'
-import Config from 'react-native-config'
 import {
-    Level,
     Feature,
+    Level,
     MallardLogFormat,
+    ReleaseChannel,
+    OS,
 } from '../../../Apps/common/src/logging'
-import { GdprSwitchSetting } from 'src/helpers/settings'
-import gql from 'graphql-tag'
-import ApolloClient from 'apollo-client'
+import { AsyncQueue } from '../helpers/async-queue-cache'
+import { errorService } from './errors'
 
 const { LOGGING_API_KEY } = Config
+const ATTEMPTS_THEN_CLEAR = 10
 
 interface LogParams {
     level: Level
@@ -32,11 +36,14 @@ interface LogParams {
 type QueryData = { gdprAllowPerformance: GdprSwitchSetting }
 const QUERY = gql('{ gdprAllowPerformance @client }')
 
-class Logging {
+class Logging extends AsyncQueue {
     hasConsent: GdprSwitchSetting
+    numberOfAttempts: number
 
     constructor() {
+        super(loggingQueueCache)
         this.hasConsent = false
+        this.numberOfAttempts = 0
     }
 
     init(apolloClient: ApolloClient<object>) {
@@ -98,12 +105,14 @@ class Logging {
             app: DeviceInfo.getBundleId(),
             version: DeviceInfo.getVersion(),
             buildNumber: DeviceInfo.getBuildNumber(),
-            os: Platform.OS === 'ios' ? 'ios' : 'android',
+            os: Platform.OS === 'ios' ? OS.IOS : OS.ANDROID,
             device: DeviceInfo.getDeviceId(),
             networkStatus: networkStatus
                 ? networkStatus.type
                 : NetInfoStateType.unknown,
-            release_channel: isInBeta() ? 'BETA' : 'RELEASE',
+            release_channel: isInBeta()
+                ? ReleaseChannel.BETA
+                : ReleaseChannel.RELEASE,
             timestamp: new Date(),
             level,
             message,
@@ -117,49 +126,7 @@ class Logging {
         }
     }
 
-    async getQueuedLogs(): Promise<string> {
-        try {
-            return (await loggingQueueCache.get()) || '[{}]'
-        } catch (e) {
-            return '[{}]'
-        }
-    }
-
-    async saveQueuedLogs(log: MallardLogFormat[]): Promise<string | Error> {
-        try {
-            const logString = JSON.stringify(log)
-            await loggingQueueCache.set(logString)
-            return 'saved logs'
-        } catch (e) {
-            errorService.captureException(e)
-            throw new Error(e)
-        }
-    }
-
-    async queueLogs(log: MallardLogFormat[]) {
-        try {
-            const currentQueueString = await this.getQueuedLogs()
-            const parsedQueue = JSON.parse(currentQueueString)
-            const newQueue = [...parsedQueue, ...log]
-            const cleanLogs = newQueue.filter(
-                value => Object.keys(value).length !== 0,
-            )
-            return cleanLogs
-        } catch (e) {
-            errorService.captureException(e)
-            throw new Error(e)
-        }
-    }
-
-    async clearLogs() {
-        try {
-            return await loggingQueueCache.reset()
-        } catch (e) {
-            errorService.captureException(e)
-        }
-    }
-
-    async postLog(log: MallardLogFormat[]): Promise<Response | Error> {
+    async postLogToService(log: object[]): Promise<Response | Error> {
         try {
             const response = await fetch(defaultSettings.logging, {
                 method: 'POST',
@@ -177,23 +144,24 @@ class Logging {
             }
             return response
         } catch (e) {
-            this.saveQueuedLogs(log)
+            await this.saveQueuedItems(log)
             throw new Error(e)
         }
     }
 
-    // Designed to post logs that have been queued but havent sent
-    async postQueuedLogs(): Promise<void> {
+    async postLog(log: object[]) {
         try {
-            const queuedLogsString = await this.getQueuedLogs()
-            const queuedLogs = JSON.parse(queuedLogsString)
-            await this.postLog(queuedLogs)
-        } catch {
-            // Assumes there is a problem sending logs and clears them
-            const { isConnected } = await NetInfo.fetch()
-            if (isConnected) {
-                await this.clearLogs()
+            await this.postLogToService(log)
+            this.numberOfAttempts = 0
+        } catch (e) {
+            if (this.numberOfAttempts >= ATTEMPTS_THEN_CLEAR) {
+                await this.clearItems()
+                this.numberOfAttempts = 0
+            } else {
+                await this.saveQueuedItems(log)
+                this.numberOfAttempts++
             }
+            throw new Error(e)
         }
     }
 
@@ -208,16 +176,16 @@ class Logging {
                 message,
                 ...optionalFields,
             })
-            const logsToPost = await this.queueLogs([currentLog])
+            const logsToPost = await this.queueItems([currentLog])
 
             const { isConnected } = await NetInfo.fetch()
             // Not connected, save the log queue
             if (!isConnected) {
-                return this.saveQueuedLogs(logsToPost)
+                return this.saveQueuedItems(logsToPost)
             }
 
             const postLogToService = await this.postLog(logsToPost)
-            await this.clearLogs()
+            await this.clearItems()
             return postLogToService
         } catch (e) {
             errorService.captureException(e)


### PR DESCRIPTION
## Summary
This includes:
- Better test coverage
- Number of attempts feature
- Split out of async cache methods into their own class, which is then used in Logging
- Removal of now not needed `console.log`
- Add logging to the error service