### PR TITLE
Update username to email on subscription details

### DIFF
--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -28,8 +28,8 @@ const IdentityDetails = ({
         <List
             data={[
                 keyValueItem(
-                    'Display name',
-                    identityData.userDetails.publicFields.displayName,
+                    'Email Address',
+                    identityData.userDetails.primaryEmailAddress,
                 ),
                 keyValueItem('User ID', identityData.membershipData.userId),
             ]}


### PR DESCRIPTION
## Summary
This PR contains a swap of username to email in the subscription details. An identity account is not guaranteed to have a username set but it will have an email address.

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/r9zLNZr0/1221-replace-the-username-on-the-subscription-details-screen-to-email-address)

![image](https://user-images.githubusercontent.com/5294853/81923427-8fb81500-95d5-11ea-90ee-c56f74c98ba3.png)