### PR TITLE
Add logging api key as env. var to ios build.

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -37,6 +37,7 @@ jobs:
               env:
                   ID_ACCESS_TOKEN: ${{ secrets.ID_ACCESS_TOKEN }}
                   ID_API_URL: ${{ secrets.ID_API_URL }}
+                  LOGGING_API_KEY: ${{ secrets.LOGGING_API_KEY }}
                   ITUNES_CONNECT_SHARED_SECRET: ${{ secrets.ITUNES_CONNECT_SHARED_SECRET }}
                   MEMBERS_DATA_API_URL: ${{ secrets.MEMBERS_DATA_API_URL }}
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -32,6 +32,7 @@ jobs:
               env:
                   ID_ACCESS_TOKEN: ${{ secrets.ID_ACCESS_TOKEN }}
                   ID_API_URL: ${{ secrets.ID_API_URL }}
+                  LOGGING_API_KEY: ${{ secrets.LOGGING_API_KEY }}
                   ITUNES_CONNECT_SHARED_SECRET: ${{ secrets.ITUNES_CONNECT_SHARED_SECRET }}
                   MEMBERS_DATA_API_URL: ${{ secrets.MEMBERS_DATA_API_URL }}
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
We need to bundle this key with the app otherwise logging won't work! 

