### PR TITLE
Serve 'immersive' images for all picture content.

### DIFF
--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -10,6 +10,7 @@ import {
     ElementType,
     IAsset,
     AssetType,
+    ContentType,
 } from '@guardian/capi-ts'
 import { articleTypePicker } from '../articleTypePicker'
 import { ArticleType } from '../../../Apps/common/src'
@@ -172,6 +173,16 @@ describe('getImageRole', () => {
 
     it('returns immersive for ArticleType=Immersive when capirole is undefined', async () => {
         const role = getImageRole(ArticleType.Immersive, undefined, undefined)
+        expect(role).toBe('immersive')
+    })
+
+    it('returns immersive for picture content when capirole is undefined', async () => {
+        const role = getImageRole(
+            ArticleType.Feature,
+            undefined,
+            undefined,
+            ContentType.PICTURE,
+        )
         expect(role).toBe('immersive')
     })
 })

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -8,20 +8,26 @@ import {
 import { oc } from 'ts-optchain'
 import { getImage, getCreditedImage } from './assets'
 import { ArticleType } from '../../Apps/common/src'
+import { ContentType } from '@guardian/capi-ts'
 
 /**
- * if no role is included in capi and content is immersive, set role to immersive
- * this makes it easier for the archiver/backend to identify images that will be stretched to full screen
+ * This function exploits the 'role'field that is passed to the backend when generating image urls
+ * to add some image quality overrides in certain scenarios. Any content with displayhint or articleType 'immersive'
+ * gets it's images bumped to 'immersive' quality. The same happens to 'picture' content
  * @param displayHint
  * @param capiRole the image role specified in the content API (if any)
+ * @param contetnType e.g. gallery/picture/article - we want big pictures for the picture type
  */
 export const getImageRole = (
     articleType: ArticleType,
     displayHint?: string,
     capiRole?: string,
+    contentType?: ContentType,
 ): ImageRole | undefined => {
     if (
-        (displayHint === 'immersive' || articleType == ArticleType.Immersive) &&
+        (displayHint === 'immersive' ||
+            articleType === ArticleType.Immersive ||
+            contentType === ContentType.PICTURE) &&
         !capiRole
     ) {
         return 'immersive'
@@ -48,6 +54,7 @@ const getMainImage = (
                   articleType,
                   displayHint,
                   maybeCreditedMainImage.role,
+                  result.type,
               ),
           }
         : maybeCreditedMainImage


### PR DESCRIPTION
## Summary
Following from https://github.com/guardian/editions/pull/1173 this PR exploits the 'role' field some more in order to increase the quality of picture images.

The main motivation here is to work around cartoons being blurry on ios9. Having lower quality images is a compromise that we accepted to get memory usage down on ios9 - we force them onto phone quality images in [screen.ts](https://github.com/guardian/editions/blob/master/projects/Mallard/src/helpers/screen.ts#L61)

We got a lot of complaints about blurry cartoons when we released to ios9 so it seems a good idea to try do something about it. Furthermore, there aren't very many cartoons in a given edition, so it seems safe to make them a special, higher quality case, as the overall impact on bundle size should be small. 

So this change is a sort of hack to change the role of 'picture content' to being 'immersive' so that the backend generates a bigger image for them. 

[**Trello Card ->**](https://trello.com/c/n7kMZP7I/935-immersives-images-are-pixelated-on-ipad-and-android)

## Test Plan
This is a backend only change so release this then publish an edition and check cartoon quality! You can find cartoons normally in the 'Journal' section. I suggest using a Martin Rowson cartoon (e.g. tuesday 12th May) rather than a Steve Bell one, as Steve Bell only provides us with low quality images for the web
