### PR TITLE
remove-touch-from-byline-text

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -702,7 +702,7 @@ const getByLine = (
     return html`
         <aside class="${headerClass}">
             ${shareButton}
-            <span>${bylineText}</span>
+            <span style="pointer-events: none">${bylineText}</span>
             <div class="clearfix"></div>
         </aside>
     `


### PR DESCRIPTION
## Summary
As found in the beta, the byline is tappable when there is a link. 
This commonly happens when there is a profile name with a link to a profile that the app cannot open. 
This is a small change to ensure that the byline text cannot be tapped by the user and avoids an error screen being shown. 
![image0](https://user-images.githubusercontent.com/53755195/82196741-0153d400-98f2-11ea-8078-7d1702cf4714.png)

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/WEcQlMvl/1291-ensure-byline-text-cannot-be-tapped)

## Test Plan
Open an article which has a profile name in the byline, ensure it doesn't respond to touch events and doesn't show an error page. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
