### PR TITLE
Logs for the log service in the event of api key mismatch

### DIFF
--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -29,6 +29,9 @@ export const createApp = (): express.Application => {
             processLog(data)
             res.send('Log success')
         } else {
+            logger.info(
+                `Missing or invalid api key. Key received: ${req.headers.apikey}`,
+            )
             res.status(400).send('Missing apikey or request body')
         }
     })


### PR DESCRIPTION
This change just adds an extra log line to the logging service to help diagnose why logs are currently failing.