### PR TITLE
feat: Add NetInfo state to the push tracking

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/push-tracking.spec.ts
@@ -1,46 +1,55 @@
 import MockDate from 'mockdate'
 import { findLastXDaysPushTracking } from '../push-tracking'
+import { NetInfoStateType } from '@react-native-community/netinfo'
 
 const fixtures = [
     {
         time: '2020-01-04T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2020-01-03T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2020-01-02T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2020-01-01T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2019-12-31T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2019-12-30T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2019-12-29T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
     {
         time: '2019-12-28T12:43:01Z',
         id: 'unzipImages',
         value: 'complete',
+        networkStatus: NetInfoStateType.wifi,
     },
 ]
 

--- a/projects/Mallard/src/helpers/push-tracking.ts
+++ b/projects/Mallard/src/helpers/push-tracking.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { londonTime } from 'src/helpers/date'
 import { lastNDays } from 'src/helpers/issues'
 import { Feature, loggingService, Level } from 'src/services/logging'
+import NetInfo, { NetInfoStateType } from '@react-native-community/netinfo'
 
 const PUSH_TRACKING_KEY = '@push-tracking'
 
@@ -34,6 +35,7 @@ interface Tracking {
     time: string
     id: string
     value: string
+    networkStatus: NetInfoStateType
 }
 
 const getPushTracking = async (): Promise<string | null> =>
@@ -72,10 +74,12 @@ const pushTracking = async (
         }
 
         const storedTracking = await AsyncStorage.getItem(PUSH_TRACKING_KEY)
+        const { type } = await NetInfo.fetch()
         const tracking: Tracking = {
             time: londonTime().format(),
             id,
             value,
+            networkStatus: type,
         }
 
         const saveTracking = storedTracking


### PR DESCRIPTION
## Summary
Push downloads rely on being connected. To help diagnose false bugs, having this as part of the push tracking stored locally will give us more information on if this was a factor in the process of downloading an edition.

[Trello Card ==>](https://trello.com/c/Eb0vUhj3/1249-add-network-status-in-push-tracking)