### PR TITLE
More logging around logging service 

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -58,8 +58,8 @@ export class LoggingStack extends cdk.Stack {
             const fn = new lambda.Function(this, `EditionsLogging`, {
                 functionName: `editions-logging-${stageParameter.valueAsString}`,
                 runtime: lambda.Runtime.NODEJS_10_X,
-                memorySize: 256,
-                timeout: Duration.seconds(10),
+                memorySize: 128,
+                timeout: Duration.seconds(5),
                 code: Code.bucket(
                     deployBucket,
                     `${stackParameter.valueAsString}/${stageParameter.valueAsString}/logging/logging.zip`,

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -22,17 +22,21 @@ export const createApp = (): express.Application => {
     })
 
     app.post('/log/mallard', express.json(), (req: Request, res: Response) => {
-        if (req.headers.apikey !== process.env.API_KEY) {
-            res.status(403).send('Missing or invalid apikey header')
+        const apiKeyHeader = req.headers.apikey
+        if (apiKeyHeader !== process.env.API_KEY) {
+            logger.warn(
+                `Missing or invalid api key. Key received: ${apiKeyHeader}`,
+            )
+            res.status(403).send(
+                `Missing or invalid apikey header: ${apiKeyHeader} is invalid`,
+            )
         } else if (req.body) {
             const data = Array.isArray(req.body) ? req.body : [req.body]
             processLog(data)
             res.send('Log success')
         } else {
-            logger.info(
-                `Missing or invalid api key. Key received: ${req.headers.apikey}`,
-            )
-            res.status(400).send('Missing apikey or request body')
+            logger.info(`Missing request body`)
+            res.status(400).send('Missing request body')
         }
     })
 


### PR DESCRIPTION
This fixes the log line in https://github.com/guardian/editions/pull/1187 - adding the logs in the right place this time. I've also dropped the memory and max. execution time for the service as over several thousand invocations it hasn't gone over 100MB memory usage so far.