### PR TITLE
Revert "Serve 'immersive' images for all picture content."

### DIFF
--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -10,7 +10,6 @@ import {
     ElementType,
     IAsset,
     AssetType,
-    ContentType,
 } from '@guardian/capi-ts'
 import { articleTypePicker } from '../articleTypePicker'
 import { ArticleType } from '../../../Apps/common/src'
@@ -173,16 +172,6 @@ describe('getImageRole', () => {
 
     it('returns immersive for ArticleType=Immersive when capirole is undefined', async () => {
         const role = getImageRole(ArticleType.Immersive, undefined, undefined)
-        expect(role).toBe('immersive')
-    })
-
-    it('returns immersive for picture content when capirole is undefined', async () => {
-        const role = getImageRole(
-            ArticleType.Feature,
-            undefined,
-            undefined,
-            ContentType.PICTURE,
-        )
         expect(role).toBe('immersive')
     })
 })

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -8,26 +8,20 @@ import {
 import { oc } from 'ts-optchain'
 import { getImage, getCreditedImage } from './assets'
 import { ArticleType } from '../../Apps/common/src'
-import { ContentType } from '@guardian/capi-ts'
 
 /**
- * This function exploits the 'role'field that is passed to the backend when generating image urls
- * to add some image quality overrides in certain scenarios. Any content with displayhint or articleType 'immersive'
- * gets it's images bumped to 'immersive' quality. The same happens to 'picture' content
+ * if no role is included in capi and content is immersive, set role to immersive
+ * this makes it easier for the archiver/backend to identify images that will be stretched to full screen
  * @param displayHint
  * @param capiRole the image role specified in the content API (if any)
- * @param contetnType e.g. gallery/picture/article - we want big pictures for the picture type
  */
 export const getImageRole = (
     articleType: ArticleType,
     displayHint?: string,
     capiRole?: string,
-    contentType?: ContentType,
 ): ImageRole | undefined => {
     if (
-        (displayHint === 'immersive' ||
-            articleType === ArticleType.Immersive ||
-            contentType === ContentType.PICTURE) &&
+        (displayHint === 'immersive' || articleType == ArticleType.Immersive) &&
         !capiRole
     ) {
         return 'immersive'
@@ -54,7 +48,6 @@ const getMainImage = (
                   articleType,
                   displayHint,
                   maybeCreditedMainImage.role,
-                  result.type,
               ),
           }
         : maybeCreditedMainImage


### PR DESCRIPTION
Reverts guardian/editions#1179 - I suspect this has caused crashing problems in ios9. Perhaps there's more 'picture' type content than we previously thought.