### PR TITLE
chore: More info on Unzip Errors for Sentry

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -141,7 +141,10 @@ export const unzipNamedIssueArchive = (zipFilePath: string) => {
         .then(() => {
             return RNFetchBlob.fs.unlink(zipFilePath)
         })
-        .catch(e => errorService.captureException(e))
+        .catch(e => {
+            e.message = `${e.message} - zipFilePath: ${zipFilePath} - outputPath: ${outputPath}`
+            errorService.captureException(e)
+        })
 }
 
 /**


### PR DESCRIPTION
## Summary
Looking at Sentry, we get a fair amount of `failed to open zip file`. This adds a little more information on that error to give us a bit more insight,

[Sentry Error ==>](https://sentry.io/organizations/the-guardian/issues/1634734859/?project=1519156&query=is%3Aunresolved)