### PR TITLE
fix: Issue Summary read error

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -40,13 +40,6 @@ interface IssueFile extends BasicFile {
     type: 'issue'
 }
 
-class IssueSummaryError extends Error {
-    constructor(message: string) {
-        super(message)
-        this.name = 'IssueSummaryError'
-    }
-}
-
 export type File = OtherFile | IssueFile
 export const fileIsIssue = (file: File): file is IssueFile =>
     file.type === 'issue'


### PR DESCRIPTION
## Summary
This one is a long running error. This seems to be because the `fetch` method on `RNFetchBlob` doesn't have a `json` method on the resolved promise. 

Also trying to read the written file using `readFile` always gives an empty object.

What I think is happening is **every** time someone goes to fetch the `IssueSummary` we are actually being pushed into the `catch` block and returning the file read from the file system. Which happened to be what was initially written.

So we were always throwing errors but also having the latest `IssueSummary`

This now doesn't attempt to return JSON from the RNFetchBlob but just read from the file system once RNFetchBlob has finished. This may have been initially caused by an update to `RNFetchBlob`

[**Sentry Error ->**](https://sentry.io/organizations/the-guardian/issues/1355238363/events/7cd86f1a21d244fc982861cb80df8420/?project=1519156&query=is%3Aunresolved)