### PR TITLE
Disable api key for logging service

### DIFF
--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -23,7 +23,9 @@ export const createApp = (): express.Application => {
 
     app.post('/log/mallard', express.json(), (req: Request, res: Response) => {
         const apiKeyHeader = req.headers.apikey
-        if (apiKeyHeader !== process.env.API_KEY) {
+        // the below check has been disabled until we're able to do a new release of the app
+        // it now passes if apiKeyHeader is missing or undefined
+        if (apiKeyHeader && apiKeyHeader !== process.env.API_KEY) {
             logger.warn(
                 `Missing or invalid api key. Key received: ${apiKeyHeader}`,
             )


### PR DESCRIPTION
## Summary
Due to an issue fixed by this PR: https://github.com/guardian/editions/pull/1196 the currently released version of the app doesn't have a logging API key bundled with it so we're throwing away all logging data before sending it to ELK. 

This change disables the requirement for there to be an apikey included in requests to the logging service.

If we're switching this off it raises the question 'why bother with an api key at all'? Anyone would be able to decompile the app to get hold of the api key if they wished.

The motivation is that having an api key of some kind allows us to potentially rotate the key should we experience an incident on the logging endpoint. At the moment that would mean breaking logging for all current users of the app, but potentiall some kind of remote config service in future could allow us to rotate the key for all users remotely.

An alternative approach would be to get rid of the api key, but just have the logging service switch off (rather than scaling forever) if the log traffic gets too much - as the only attack vector here really is filling our logging stack with a load of junk. I'm going to look into doing this, but in the meantime this gets the service up and running. 

(As a side note, we should move the api key out of the lambda and into api gateway if we decide to keep it)


## Test Plan
This is a backend change. We should start seeing logs pull through [here](https://logs.gutools.co.uk/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,interval:auto,query:(language:kuery,query:'app:%22editions-logging%22'),sort:!(!('@timestamp',desc)))) when this is released