### PR TITLE
chore: More info on Issue summary error

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -468,6 +468,7 @@ export const readIssueSummary = async (): Promise<IssueSummary[]> =>
                 e.message = `readIssueSummary: ${e.message} - with: ${data}`
                 console.log(e.message)
                 errorService.captureException(e)
+                throw e
             }
         })
         .catch(e => {

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -461,7 +461,15 @@ export const downloadTodaysIssue = async (client: ApolloClient<object>) => {
 export const readIssueSummary = async (): Promise<IssueSummary[]> =>
     RNFetchBlob.fs
         .readFile(FSPaths.contentPrefixDir + defaultSettings.issuesPath, 'utf8')
-        .then(data => JSON.parse(data))
+        .then(data => {
+            try {
+                return JSON.parse(data)
+            } catch (e) {
+                e.message = `readIssueSummary: ${e.message} - with: ${data}`
+                console.log(e.message)
+                errorService.captureException(e)
+            }
+        })
         .catch(e => {
             throw e
         })


### PR DESCRIPTION
## Summary
There are multiple errors in Sentry that state that the issue summary cannot be read due to a `JSON.parse` error. This will capture that error and provide a bit more information.

This isnt a fix, but an attempt to get more feedback.