### PR TITLE
Add usage plan to logging service, move api key into api gateway

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -89,13 +89,14 @@ export class LoggingStack extends cdk.Stack {
 
         const loggingApi = new apigateway.LambdaRestApi(
             this,
-            `editions-logging-${stageParameter.valueAsString}`,
+            'editions-logging-api',
             {
                 handler: loggingBackend,
                 endpointTypes: [EndpointType.EDGE],
                 policy: new iam.PolicyDocument({
                     statements: [loggingApiPolicyStatement],
                 }),
+                restApiName: `editions-logging-${stageParameter.valueAsString}`,
             },
         )
 

--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -89,7 +89,7 @@ export class LoggingStack extends cdk.Stack {
 
         const loggingApi = new apigateway.LambdaRestApi(
             this,
-            'editions-logging',
+            `editions-logging-${stageParameter.valueAsString}`,
             {
                 handler: loggingBackend,
                 endpointTypes: [EndpointType.EDGE],
@@ -98,6 +98,16 @@ export class LoggingStack extends cdk.Stack {
                 }),
             },
         )
+
+        new apigateway.UsagePlan(this, 'usage-plan', {
+            apiStages: [{ stage: loggingApi.deploymentStage, api: loggingApi }],
+            name: `editions-logging-usage-plan-${stageParameter.valueAsString}`,
+            // max of 5 million requests a day (100 log messages per user)
+            quota: {
+                period: apigateway.Period.DAY,
+                limit: 5000000,
+            },
+        })
 
         const loggingDomainName = new apigateway.DomainName(
             this,

--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -96,7 +96,6 @@ export class LoggingStack extends cdk.Stack {
                 policy: new iam.PolicyDocument({
                     statements: [loggingApiPolicyStatement],
                 }),
-                restApiName: `editions-logging-${stageParameter.valueAsString}`,
             },
         )
 

--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -23,12 +23,6 @@ export class LoggingStack extends cdk.Stack {
             description: 'Stage',
         })
 
-        const apiKeyParameter = new cdk.CfnParameter(this, 'apiKey', {
-            type: 'String',
-            description: 'Shared secret for log endpoint.',
-            default: 'changeme',
-        })
-
         const loggingCertificateArn = new cdk.CfnParameter(
             this,
             'logging-certificate-arn',
@@ -69,7 +63,6 @@ export class LoggingStack extends cdk.Stack {
                     STAGE: stageParameter.valueAsString,
                     STACK: stackParameter.valueAsString,
                     APP: 'editions-logging',
-                    API_KEY: apiKeyParameter.valueAsString,
                 },
             })
             Tag.add(fn, 'App', `editions-logging`)

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -22,17 +22,7 @@ export const createApp = (): express.Application => {
     })
 
     app.post('/log/mallard', express.json(), (req: Request, res: Response) => {
-        const apiKeyHeader = req.headers.apikey
-        // the below check has been disabled until we're able to do a new release of the app
-        // it now passes if apiKeyHeader is missing or undefined
-        if (apiKeyHeader && apiKeyHeader !== process.env.API_KEY) {
-            logger.warn(
-                `Missing or invalid api key. Key received: ${apiKeyHeader}`,
-            )
-            res.status(403).send(
-                `Missing or invalid apikey header: ${apiKeyHeader} is invalid`,
-            )
-        } else if (req.body) {
+        if (req.body) {
             const data = Array.isArray(req.body) ? req.body : [req.body]
             processLog(data)
             res.send('Log success')


### PR DESCRIPTION
## Summary
This limits the logging service to serve a maximum of 5 million requests per day. We currently have around 50,000 users, so this allows for 100 requests per user.

This would lead to a maximum no. requests of 150 million per month. 

Based off the [api gateway pricing](https://aws.amazon.com/api-gateway/pricing/) $165

For [lambda](https://aws.amazon.com/lambda/pricing/) we pay $0.2 per million invocations plus a small amount per 100ms of execution time which I think adds up to around  $40.

The cloudwatch logs pricing is $0.57 per gb of data ingested. Assuming a log request size of 5KB, 150 million requests would cost 150*5/1000000 = $407. This is the most worrying number which we should keep an eye on. I am hoping in practice this will be a lot lower with fewer and smaller requests.

Unfortunately api gatway doesn't allow for more granular usage plans - e.g. max requests per minute or per hour - but this daily limit seems a sensible thing to have in place. 

As part of this change I've moved the api key out of the application and into api gatway which makes the code a fair bit tidier.

[**Trello Card ->**](https://trello.com)

## Test Plan
Merge and check that a usage plan shows up in the [api gateway console](https://eu-west-1.console.aws.amazon.com/apigateway/main/apis?region=eu-west-1)
