### PR TITLE
change header name for logging api key.

### DIFF
--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -133,7 +133,7 @@ class Logging extends AsyncQueue {
                 headers: {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
-                    apiKey: LOGGING_API_KEY,
+                    'x-api-key': LOGGING_API_KEY,
                 },
                 body: JSON.stringify(log),
             })


### PR DESCRIPTION
## Summary

Following from https://github.com/guardian/editions/pull/1200 we are now using the api key functionality built into [API Gateway usage plans](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)

This expects the key to be included in a header called `x-api-key`

## Test Plan

Currently we don't require an api key so no change expected, but this supports us being able to switch on requiring a key in feature.