### PR TITLE
Only log requests below a certain size. Override app,stack,stage params.

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -37,6 +37,12 @@ export class LoggingStack extends cdk.Stack {
             description: 'Hostname for logging endpoint',
         })
 
+        const maxLogSize = new cdk.CfnParameter(this, 'max-log-size', {
+            type: 'String',
+            description:
+                'Maximum size (in bytes) of log data from an individual request',
+        })
+
         const loggingCertificate = acm.Certificate.fromCertificateArn(
             this,
             'logging-certificate',
@@ -63,6 +69,7 @@ export class LoggingStack extends cdk.Stack {
                     STAGE: stageParameter.valueAsString,
                     STACK: stackParameter.valueAsString,
                     APP: 'editions-logging',
+                    MAX_LOG_SIZE: maxLogSize.valueAsString,
                 },
             })
             Tag.add(fn, 'App', `editions-logging`)

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -2,11 +2,21 @@ import express = require('express')
 import { Request, Response } from 'express'
 import { logger } from './logger'
 import { MallardLogFormat } from '../Apps/common/src/logging'
+import sizeOf from 'object-sizeof'
+
+const maxLogSize = parseInt(process.env.MAX_LOG_SIZE || '0')
 
 const processLog = (rawData: MallardLogFormat[]) => {
     rawData.forEach(logData => {
         if (logData.timestamp && logData.message) {
-            logger.info({ '@timestamp': logData.timestamp, ...logData })
+            logger.info({
+                '@timestamp': logData.timestamp,
+                ...logData,
+                // override any stage/stack/app properties included in logData
+                stack: process.env.STACK,
+                stage: process.env.STAGE,
+                app: process.env.APP,
+            })
         } else {
             logger.info('Missing timestamp or message fields')
         }
@@ -24,8 +34,15 @@ export const createApp = (): express.Application => {
     app.post('/log/mallard', express.json(), (req: Request, res: Response) => {
         if (req.body) {
             const data = Array.isArray(req.body) ? req.body : [req.body]
-            processLog(data)
-            res.send('Log success')
+            const dataSize = sizeOf(data)
+            if (dataSize < maxLogSize) {
+                processLog(data)
+                res.send('Log success')
+            } else {
+                res.status(413).send(
+                    `Request body too large. Estimated size: ${dataSize} bytes`,
+                )
+            }
         } else {
             logger.info(`Missing request body`)
             res.status(400).send('Missing request body')

--- a/projects/logging/package.json
+++ b/projects/logging/package.json
@@ -34,7 +34,8 @@
         "encoding": "^0.1.12",
         "express": "^4.17.1",
         "jest": "^24.8.0",
-        "log4js": "^6.2.1"
+        "log4js": "^6.2.1",
+        "object-sizeof": "^1.6.0"
     },
     "resolutions": {
         "handlebars": "4.6.0"

--- a/projects/logging/yarn.lock
+++ b/projects/logging/yarn.lock
@@ -833,6 +833,14 @@ buffer@4.9.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -3130,6 +3138,13 @@ object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-sizeof@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-sizeof/-/object-sizeof-1.6.0.tgz#847d0b67d96cbf1f8dda63c58ad3d8fbd1adeba8"
+  integrity sha512-Z+suoK94o8WjEMYItJjpPyG6I78STcI1CxM7rjxM8LhbgegAY+jhGSFY0c5Ez20LXgDGtyKzYZNXHpDyr6hj8Q==
+  dependencies:
+    buffer "^5.5.0"
 
 object-visit@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Summary

Following from https://github.com/guardian/editions/pull/1200 this sets a limit on the max size of log data, to keep costs down (as api gateway requests can be up to 10MB in size).

It also modifies the backend to automatically override the app,stack,stage params as these should be consistent with the logging endpoint used (currently we are logging uk.co.guardian.gce as the app, which doesn't work very well for filtering in ELK - which isn't too into full stops I think)
