### PR TITLE
Reimplement higher quality picture content

### DIFF
--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -10,6 +10,7 @@ import {
     ElementType,
     IAsset,
     AssetType,
+    ContentType,
 } from '@guardian/capi-ts'
 import { articleTypePicker } from '../articleTypePicker'
 import { ArticleType } from '../../../Apps/common/src'
@@ -172,6 +173,16 @@ describe('getImageRole', () => {
 
     it('returns immersive for ArticleType=Immersive when capirole is undefined', async () => {
         const role = getImageRole(ArticleType.Immersive, undefined, undefined)
+        expect(role).toBe('immersive')
+    })
+
+    it('returns immersive for picture content when capirole is undefined', async () => {
+        const role = getImageRole(
+            ArticleType.Feature,
+            undefined,
+            undefined,
+            ContentType.PICTURE,
+        )
         expect(role).toBe('immersive')
     })
 })

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -8,20 +8,26 @@ import {
 import { oc } from 'ts-optchain'
 import { getImage, getCreditedImage } from './assets'
 import { ArticleType } from '../../Apps/common/src'
+import { ContentType } from '@guardian/capi-ts'
 
 /**
- * if no role is included in capi and content is immersive, set role to immersive
- * this makes it easier for the archiver/backend to identify images that will be stretched to full screen
+ * This function exploits the 'role'field that is passed to the backend when generating image urls
+ * to add some image quality overrides in certain scenarios. Any content with displayhint or articleType 'immersive'
+ * gets it's images bumped to 'immersive' quality. The same happens to 'picture' content
  * @param displayHint
  * @param capiRole the image role specified in the content API (if any)
+ * @param contetnType e.g. gallery/picture/article - we want big pictures for the picture type
  */
 export const getImageRole = (
     articleType: ArticleType,
     displayHint?: string,
     capiRole?: string,
+    contentType?: ContentType,
 ): ImageRole | undefined => {
     if (
-        (displayHint === 'immersive' || articleType == ArticleType.Immersive) &&
+        (displayHint === 'immersive' ||
+            articleType === ArticleType.Immersive ||
+            contentType === ContentType.PICTURE) &&
         !capiRole
     ) {
         return 'immersive'
@@ -48,6 +54,7 @@ const getMainImage = (
                   articleType,
                   displayHint,
                   maybeCreditedMainImage.role,
+                  result.type,
               ),
           }
         : maybeCreditedMainImage


### PR DESCRIPTION
Reverts guardian/editions#1190 - maybe this wasn't what was causing the app to crash on ios9 after all.

Testing
=====
I did some testing on last weekend's editions.

Sat 16th May mobile zip before: 40.0MB after: 40.3MB
Sun 17th May mobile zip before: 36.8 after: 36.8MB