### PR TITLE
Logging: Rename timestamp field coming from client.

### DIFF
--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -8,15 +8,18 @@ const maxLogSize = parseInt(process.env.MAX_LOG_SIZE || '0')
 
 const processLog = (rawData: MallardLogFormat[]) => {
     rawData.forEach(logData => {
-        if (logData.timestamp && logData.message) {
-            logger.info({
+        if (logData.message) {
+            const elkJsonObject = {
                 clientTimestamp: logData.timestamp,
                 ...logData,
                 // override any stage/stack/app properties included in logData
                 stack: process.env.STACK,
                 stage: process.env.STAGE,
                 app: process.env.APP,
-            })
+            }
+            // let's rely on cloudwatch timestamp
+            delete elkJsonObject.timestamp
+            logger.info(elkJsonObject)
         } else {
             logger.info('Missing timestamp or message fields')
         }

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -10,7 +10,7 @@ const processLog = (rawData: MallardLogFormat[]) => {
     rawData.forEach(logData => {
         if (logData.timestamp && logData.message) {
             logger.info({
-                '@timestamp': logData.timestamp,
+                clientTimestamp: logData.timestamp,
                 ...logData,
                 // override any stage/stack/app properties included in logData
                 stack: process.env.STACK,


### PR DESCRIPTION
## Summary

As detailed [here](https://github.com/guardian/cloudwatch-logs-management#shipping-lambda-logs-to-elk) the cloudwatch logs management service automatically adds a timestamp field based off the server-side time of the log message. I think it would be useful to store both server and client side timestamps, so let's move the client side timestamp into a separate field.

