### PR TITLE
fix/bug-button-on-press

### DIFF
--- a/projects/Mallard/src/components/Button/BugButtonHandler.tsx
+++ b/projects/Mallard/src/components/Button/BugButtonHandler.tsx
@@ -11,9 +11,7 @@ const BugButtonHandler = () => {
     const client = useApolloClient()
     return isInBeta() ? (
         <BugButton
-            onPress={() =>
-                createMailtoHandler(client, 'Report a bug', '', attempt)
-            }
+            onPress={createMailtoHandler(client, 'Report a bug', '', attempt)}
         />
     ) : null
 }


### PR DESCRIPTION
## Summary
The bug button onPress handler is not currently working in beta, this fixes that. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/JiWseKPj/1325-bug-button-not-working-in-version-62)

## Test Plan
![image](https://user-images.githubusercontent.com/53755195/82890605-5d4ad800-9f44-11ea-825d-a494cb57d283.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
