### PR TITLE
Fix less than sign wrong way round

### DIFF
--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -35,7 +35,7 @@ export const createApp = (): express.Application => {
         if (req.body) {
             const data = Array.isArray(req.body) ? req.body : [req.body]
             const dataSize = sizeOf(data)
-            if (dataSize < maxLogSize) {
+            if (dataSize > maxLogSize) {
                 processLog(data)
                 res.send('Log success')
             } else {


### PR DESCRIPTION
## Summary
OOPS! Doh. @jimhunty spotted a lot of 413 errors in Sentry which were probably caused by this. We are blocking requests BELOW a certain size rather than above.

[**Trello Card ->**](https://trello.com)

## Test Plan

Backend only change
