### PR TITLE
Don't requeue failed logs.

### DIFF
--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -127,26 +127,21 @@ class Logging extends AsyncQueue {
     }
 
     async postLogToService(log: object[]): Promise<Response | Error> {
-        try {
-            const response = await fetch(defaultSettings.logging, {
-                method: 'POST',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                    'x-api-key': LOGGING_API_KEY,
-                },
-                body: JSON.stringify(log),
-            })
-            if (response.status !== 200) {
-                throw new Error(
-                    `Bad response from Logging Service - status: ${response.status}`,
-                )
-            }
-            return response
-        } catch (e) {
-            errorService.captureException(e)
-            throw new Error(e)
+        const response = await fetch(defaultSettings.logging, {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'x-api-key': LOGGING_API_KEY,
+            },
+            body: JSON.stringify(log),
+        })
+        if (response.status !== 200) {
+            throw new Error(
+                `Bad response from Logging Service - status: ${response.status}`,
+            )
         }
+        return response
     }
 
     async postLog(log: object[]) {

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -144,7 +144,7 @@ class Logging extends AsyncQueue {
             }
             return response
         } catch (e) {
-            await this.saveQueuedItems(log)
+            errorService.captureException(e)
             throw new Error(e)
         }
     }


### PR DESCRIPTION
## Summary
Currently if we try to post some logging data to the log service and it returns an error code (anything non 200) we 'queue' the message to send again in future. The downside of this is that it can result in a 'loop' where a log fails and gets queued again repeatedly if e.g. the backend service is down. 

I'm not certain this is the best way to fix this but is a quick way to make us more resilient to backend failures (which willl always happen at some point). Happy to do something else too.

## Test Plan
This should have no noticeable user facing change but should reduce the number of logging related errors we see in Sentry