### PR TITLE
Add error logging when size too big.

### DIFF
--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -42,6 +42,9 @@ export const createApp = (): express.Application => {
                 processLog(data)
                 res.send('Log success')
             } else {
+                logger.error(
+                    `Request body too large. Estimated size: ${dataSize}, max size: ${maxLogSize}`,
+                )
                 res.status(413).send(
                     `Request body too large. Estimated size: ${dataSize} bytes`,
                 )


### PR DESCRIPTION
## Summary
I'm interested to see the size of requests we're getting in as there are still some errors in sentry (though much lower than before). This should give us a good idea. 
