### PR TITLE
Don't log full issue summary

### DIFF
--- a/projects/Mallard/src/download-edition/download-via-notification.ts
+++ b/projects/Mallard/src/download-edition/download-via-notification.ts
@@ -21,7 +21,9 @@ const downloadViaNotification = async (
 
         await pushTracking(
             'pushIssueSummaries',
-            JSON.stringify(issueSummaries),
+            `First 3 issues fetched: ${JSON.stringify(
+                issueSummaries.slice(0, 3),
+            )}`,
             Feature.DOWNLOAD,
         )
 


### PR DESCRIPTION
## Summary
The issue summary is around 20kb. We queue up logs to send in batches of up to 10, so in theory we could end up with a 200kb request if there are 10 issue summary log lines. This change modifies the logging so that we only log the first 3 issues we get back from the /issues endpoint.


[**Trello Card ->**](https://trello.com)

## Test Plan
Check the [logs](https://logs.gutools.co.uk/app/kibana#/discover?_g=(filters:!())&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,key:lambdaEvent,negate:!t,params:(query:END),type:phrase,value:END),query:(match:(lambdaEvent:(query:END,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,key:lambdaEvent,negate:!t,params:(query:REPORT),type:phrase,value:REPORT),query:(match:(lambdaEvent:(query:REPORT,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,key:lambdaEvent,negate:!t,params:(query:START),type:phrase,value:START),query:(match:(lambdaEvent:(query:START,type:phrase))))),index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,interval:auto,query:(language:kuery,query:'app:%22editions-logging%22'),sort:!(!('@timestamp',desc)))) for 'payload too large' errors - they should disappear following this change.