### PR TITLE
Fix/immersive videos

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -736,7 +736,9 @@ const Header = ({
             ${Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
                 <header
-                    class=${headerProps.mainMedia && headerProps.showMedia
+                    class=${immersive &&
+                    headerProps.mainMedia &&
+                    headerProps.showMedia
                         ? 'header-immersive-video'
                         : 'header'}
                 >
@@ -756,9 +758,7 @@ const Header = ({
                                 : undefined,
                             getImagePath,
                         })}
-                    ${immersive &&
-                    headerProps.mainMedia &&
-                    headerProps.showMedia
+                    ${headerProps.mainMedia && headerProps.showMedia
                         ? renderMediaAtom(headerProps.mainMedia)
                         : null}
                     ${headerProps.kicker &&

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -758,9 +758,10 @@ const Header = ({
                                 : undefined,
                             getImagePath,
                         })}
-                    ${headerProps.mainMedia && headerProps.showMedia
-                        ? renderMediaAtom(headerProps.mainMedia)
-                        : null}
+                    ${headerProps.mainMedia &&
+                        (headerProps.showMedia
+                            ? renderMediaAtom(headerProps.mainMedia)
+                            : null)}
                     ${headerProps.kicker &&
                         html`
                             <span class="header-kicker"

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -736,9 +736,7 @@ const Header = ({
             ${Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
                 <header
-                    class=${immersive &&
-                    headerProps.mainMedia &&
-                    headerProps.showMedia
+                    class=${headerProps.mainMedia && headerProps.showMedia
                         ? 'header-immersive-video'
                         : 'header'}
                 >

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -82,7 +82,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         pointer-events: none;
     }
 
-    .header:after {
+    .header:after, .header-immersive-video:after {
         background-image: repeating-linear-gradient(
             to bottom,
             ${color.dimLine},
@@ -99,7 +99,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin: 0;
     }
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-        .header:after {
+        .header:after, .header-immersive-video:after {
             margin-right: ${px(metrics.article.sides * -1)};
         }
     }
@@ -157,7 +157,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         border-bottom: 1px solid ${color.dimLine};
         display: block;
     }
-    .header h1 {
+    .header h1, .header-immersive-video h1 {
         font-size: 30px;
         font-family: ${families.headline.regular};
         font-weight: 400;
@@ -232,46 +232,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
     }
 
-    .header-immersive-video:after {
-        background-image: repeating-linear-gradient(
-            to bottom,
-            ${color.dimLine},
-            ${color.dimLine} 1px,
-            transparent 1px,
-            transparent 4px
-        );
-        background-repeat: repeat-x;
-        background-position: bottom;
-        background-size: 1px 16px;
-        content: '';
-        display: block;
-        height: 16px;
-        margin: 0;
-    }
-    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-        .header-immersive-video:after {
-            margin-right: ${px(metrics.article.sides * -1)};
-        }
-    }
-
-    .header-immersive-video h1 {
-        font-size: 30px;
-        font-family: GHGuardianHeadline-Regular;
-        font-weight: 400;
-        line-height: 1.125em;
-        margin: 0.1em 1em 0.75em 0;
-        word-wrap: none;
-    }
-
-    .header-immersive-video p {
-        font-family: ${families.headline.medium};
-        letter-spacing: 0.2px;
-        line-height: 1.1875em;
-        margin-bottom: 0.875em;
-        font-size: 18px;
-    }
-
-    .header-top p {
+    .header-top p, .header-immersive-video p {
         font-family: ${families.headline.medium};
         letter-spacing: 0.2px;
         line-height: 1.1875em;
@@ -279,7 +240,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         font-size: 18px;
     }
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-        .header-top p {
+        .header-top p, .header-immersive-video p {
             font-size: 18px;
         }
     }

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -166,15 +166,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         word-wrap: none;
     }
 
-    .header-immersive h1 {
-        font-size: 30px;
-        font-family: GHGuardianHeadline-Regular;
-        font-weight: 400;
-        line-height: 1.125em;
-        margin: 0.1em 1em 0.75em 0;
-        word-wrap: none;
-    }
-
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
         .header h1 {
             font-size: 40px;
@@ -241,7 +232,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
     }
 
-    .header-immersive:after {
+    .header-immersive-video:after {
         background-image: repeating-linear-gradient(
             to bottom,
             ${color.dimLine},
@@ -258,9 +249,26 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin: 0;
     }
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-        .header-immersive:after {
+        .header-immersive-video:after {
             margin-right: ${px(metrics.article.sides * -1)};
         }
+    }
+
+    .header-immersive-video h1 {
+        font-size: 30px;
+        font-family: GHGuardianHeadline-Regular;
+        font-weight: 400;
+        line-height: 1.125em;
+        margin: 0.1em 1em 0.75em 0;
+        word-wrap: none;
+    }
+
+    .header-immersive-video p {
+        font-family: ${families.headline.medium};
+        letter-spacing: 0.2px;
+        line-height: 1.1875em;
+        margin-bottom: 0.875em;
+        font-size: 18px;
     }
 
     .header-top p {
@@ -270,15 +278,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin-bottom: 0.875em;
         font-size: 18px;
     }
-
-    .header-immersive p {
-        font-family: ${families.headline.medium};
-        letter-spacing: 0.2px;
-        line-height: 1.1875em;
-        margin-bottom: 0.875em;
-        font-size: 18px;
-    }
-
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
         .header-top p {
             font-size: 18px;
@@ -747,49 +746,6 @@ const getByLine = (
     `
 }
 
-const ImmersiveMediaHeader = (
-    articleHeaderType: HeaderType,
-    type: ArticleType,
-    headerProps: ArticleHeaderProps,
-    publishedId: Issue['publishedId'] | null,
-    getImagePath: GetImagePath,
-    canBeShared: boolean,
-): string | undefined => {
-    const byLineText = getByLineText(articleHeaderType, headerProps)
-    if (headerProps.mainMedia) {
-        return html`
-            <div class="header-container-line-wrap">
-                ${Line({ zIndex: 10 })}
-                <div class="header-container wrapper" data-type="${type}">
-                    <header class="header-immersive">
-                        ${renderMediaAtom(headerProps.mainMedia)}
-                        ${headerProps.kicker &&
-                            html`
-                                <span class="header-kicker"
-                                    >${headerProps.kicker}</span
-                                >
-                            `}
-                        ${getStandFirst(
-                            articleHeaderType,
-                            type,
-                            headerProps,
-                            publishedId,
-                            getImagePath,
-                        )}
-                    </header>
-                    ${hasByLine(byLineText, canBeShared) &&
-                        getByLine(
-                            articleHeaderType,
-                            canBeShared,
-                            headerProps as ArticleHeaderProps,
-                        )}
-                    <div class="header-bg"></div>
-                </div>
-            </div>
-        `
-    }
-}
-
 const Header = ({
     publishedId,
     type,
@@ -806,70 +762,70 @@ const Header = ({
 } & ArticleHeaderProps) => {
     const immersive = isImmersive(type)
     const byLineText = getByLineText(headerType, headerProps)
-    if (immersive && headerProps.mainMedia && headerProps.showMedia) {
-        return ImmersiveMediaHeader(
-            headerType,
-            type,
-            headerProps,
-            publishedId,
-            getImagePath,
-            headerProps.canBeShared,
-        )
-    } else {
-        return html`
-            ${immersive &&
-                headerProps.image &&
-                publishedId &&
-                MainMediaImage({
-                    image: headerProps.image,
-                    className: 'header-image header-image--immersive',
-                    getImagePath,
-                })}
-            <div class="header-container-line-wrap">
-                ${Line({ zIndex: 10 })}
-                <div class="header-container wrapper" data-type="${type}">
-                    <header class="header">
-                        ${!immersive &&
-                            headerProps.image &&
-                            publishedId &&
-                            MainMediaImage({
-                                className: 'header-image',
-                                image: headerProps.image,
-                                preserveRatio: true,
-                                children: headerProps.starRating
-                                    ? Rating(headerProps)
-                                    : headerProps.sportScore
-                                    ? SportScore({
-                                          sportScore: headerProps.sportScore,
-                                      })
-                                    : undefined,
-                                getImagePath,
-                            })}
-                        ${headerProps.kicker &&
-                            html`
-                                <span class="header-kicker"
-                                    >${headerProps.kicker}</span
-                                >
-                            `}
-                        ${getStandFirst(
-                            headerType,
-                            type,
-                            headerProps,
-                            publishedId,
+    return html`
+        ${immersive &&
+            headerProps.image &&
+            publishedId &&
+            MainMediaImage({
+                image: headerProps.image,
+                className: 'header-image header-image--immersive',
+                getImagePath,
+            })}
+        <div class="header-container-line-wrap">
+            ${Line({ zIndex: 10 })}
+            <div class="header-container wrapper" data-type="${type}">
+                <header
+                    class=${immersive &&
+                    headerProps.mainMedia &&
+                    headerProps.showMedia
+                        ? 'header-immersive-video'
+                        : 'header'}
+                >
+                    ${!immersive &&
+                        headerProps.image &&
+                        publishedId &&
+                        MainMediaImage({
+                            className: 'header-image',
+                            image: headerProps.image,
+                            preserveRatio: true,
+                            children: headerProps.starRating
+                                ? Rating(headerProps)
+                                : headerProps.sportScore
+                                ? SportScore({
+                                      sportScore: headerProps.sportScore,
+                                  })
+                                : undefined,
                             getImagePath,
-                        )}
-                    </header>
-                    ${hasByLine(byLineText, headerProps.canBeShared) &&
-                        getByLine(
-                            headerType,
-                            headerProps.canBeShared,
-                            headerProps as ArticleHeaderProps,
-                        )}
-                    <div class="header-bg"></div>
-                </div>
+                        })}
+                    ${immersive &&
+                    headerProps.mainMedia &&
+                    headerProps.showMedia
+                        ? renderMediaAtom(headerProps.mainMedia)
+                        : null}
+                    ${headerProps.kicker &&
+                        html`
+                            <span class="header-kicker"
+                                >${headerProps.kicker}</span
+                            >
+                        `}
+                    ${getStandFirst(
+                        headerType,
+                        type,
+                        headerProps,
+                        publishedId,
+                        getImagePath,
+                    )}
+                </header>
+                ${hasByLine(byLineText, headerProps.canBeShared) &&
+                    getByLine(
+                        headerType,
+                        headerProps.canBeShared,
+                        headerProps as ArticleHeaderProps,
+                    )}
+                <div class="header-bg"></div>
             </div>
-        `
-    }
+        </div>
+    `
 }
 
 export { Header }

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -257,6 +257,11 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         height: 16px;
         margin: 0;
     }
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .header-immersive:after {
+            margin-right: ${px(metrics.article.sides * -1)};
+        }
+    }
 
     .header-top p {
         font-family: ${families.headline.medium};

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -166,6 +166,15 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         word-wrap: none;
     }
 
+    .header-immersive h1 {
+        font-size: 30px;
+        font-family: GHGuardianHeadline-Regular;
+        font-weight: 400;
+        line-height: 1.125em;
+        margin: 0.1em 1em 0.75em 0;
+        word-wrap: none;
+    }
+
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
         .header h1 {
             font-size: 40px;
@@ -232,7 +241,32 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
     }
 
+    .header-immersive:after {
+        background-image: repeating-linear-gradient(
+            to bottom,
+            ${color.dimLine},
+            ${color.dimLine} 1px,
+            transparent 1px,
+            transparent 4px
+        );
+        background-repeat: repeat-x;
+        background-position: bottom;
+        background-size: 1px 16px;
+        content: '';
+        display: block;
+        height: 16px;
+        margin: 0;
+    }
+
     .header-top p {
+        font-family: ${families.headline.medium};
+        letter-spacing: 0.2px;
+        line-height: 1.1875em;
+        margin-bottom: 0.875em;
+        font-size: 18px;
+    }
+
+    .header-immersive p {
         font-family: ${families.headline.medium};
         letter-spacing: 0.2px;
         line-height: 1.1875em;
@@ -459,6 +493,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     .header-container[data-type='immersive'] .header-kicker {
         display: none;
     }
+
     .header-container[data-type='immersive'] .header-top h1 {
         font-family: ${families.titlepiece.regular};
         color: ${colors.dark};
@@ -707,6 +742,49 @@ const getByLine = (
     `
 }
 
+const ImmersiveMediaHeader = (
+    articleHeaderType: HeaderType,
+    type: ArticleType,
+    headerProps: ArticleHeaderProps,
+    publishedId: Issue['publishedId'] | null,
+    getImagePath: GetImagePath,
+    canBeShared: boolean,
+): string | undefined => {
+    const byLineText = getByLineText(articleHeaderType, headerProps)
+    if (headerProps.mainMedia) {
+        return html`
+            <div class="header-container-line-wrap">
+                ${Line({ zIndex: 10 })}
+                <div class="header-container wrapper" data-type="${type}">
+                    <header class="header-immersive">
+                        ${renderMediaAtom(headerProps.mainMedia)}
+                        ${headerProps.kicker &&
+                            html`
+                                <span class="header-kicker"
+                                    >${headerProps.kicker}</span
+                                >
+                            `}
+                        ${getStandFirst(
+                            articleHeaderType,
+                            type,
+                            headerProps,
+                            publishedId,
+                            getImagePath,
+                        )}
+                    </header>
+                    ${hasByLine(byLineText, canBeShared) &&
+                        getByLine(
+                            articleHeaderType,
+                            canBeShared,
+                            headerProps as ArticleHeaderProps,
+                        )}
+                    <div class="header-bg"></div>
+                </div>
+            </div>
+        `
+    }
+}
+
 const Header = ({
     publishedId,
     type,
@@ -723,63 +801,70 @@ const Header = ({
 } & ArticleHeaderProps) => {
     const immersive = isImmersive(type)
     const byLineText = getByLineText(headerType, headerProps)
-    return html`
-        ${immersive &&
-            headerProps.image &&
-            publishedId &&
-            MainMediaImage({
-                image: headerProps.image,
-                className: 'header-image header-image--immersive',
-                getImagePath,
-            })}
-        <div class="header-container-line-wrap">
-            ${Line({ zIndex: 10 })}
-            <div class="header-container wrapper" data-type="${type}">
-                <header class="header">
-                    ${!immersive &&
-                        headerProps.image &&
-                        publishedId &&
-                        MainMediaImage({
-                            className: 'header-image',
-                            image: headerProps.image,
-                            preserveRatio: true,
-                            children: headerProps.starRating
-                                ? Rating(headerProps)
-                                : headerProps.sportScore
-                                ? SportScore({
-                                      sportScore: headerProps.sportScore,
-                                  })
-                                : undefined,
+    if (immersive && headerProps.mainMedia && headerProps.showMedia) {
+        return ImmersiveMediaHeader(
+            headerType,
+            type,
+            headerProps,
+            publishedId,
+            getImagePath,
+            headerProps.canBeShared,
+        )
+    } else {
+        return html`
+            ${immersive &&
+                headerProps.image &&
+                publishedId &&
+                MainMediaImage({
+                    image: headerProps.image,
+                    className: 'header-image header-image--immersive',
+                    getImagePath,
+                })}
+            <div class="header-container-line-wrap">
+                ${Line({ zIndex: 10 })}
+                <div class="header-container wrapper" data-type="${type}">
+                    <header class="header">
+                        ${!immersive &&
+                            headerProps.image &&
+                            publishedId &&
+                            MainMediaImage({
+                                className: 'header-image',
+                                image: headerProps.image,
+                                preserveRatio: true,
+                                children: headerProps.starRating
+                                    ? Rating(headerProps)
+                                    : headerProps.sportScore
+                                    ? SportScore({
+                                          sportScore: headerProps.sportScore,
+                                      })
+                                    : undefined,
+                                getImagePath,
+                            })}
+                        ${headerProps.kicker &&
+                            html`
+                                <span class="header-kicker"
+                                    >${headerProps.kicker}</span
+                                >
+                            `}
+                        ${getStandFirst(
+                            headerType,
+                            type,
+                            headerProps,
+                            publishedId,
                             getImagePath,
-                        })}
-                    ${headerProps.mainMedia &&
-                        (headerProps.showMedia
-                            ? renderMediaAtom(headerProps.mainMedia)
-                            : null)}
-                    ${headerProps.kicker &&
-                        html`
-                            <span class="header-kicker"
-                                >${headerProps.kicker}</span
-                            >
-                        `}
-                    ${getStandFirst(
-                        headerType,
-                        type,
-                        headerProps,
-                        publishedId,
-                        getImagePath,
-                    )}
-                </header>
-                ${hasByLine(byLineText, headerProps.canBeShared) &&
-                    getByLine(
-                        headerType,
-                        headerProps.canBeShared,
-                        headerProps as ArticleHeaderProps,
-                    )}
-                <div class="header-bg"></div>
+                        )}
+                    </header>
+                    ${hasByLine(byLineText, headerProps.canBeShared) &&
+                        getByLine(
+                            headerType,
+                            headerProps.canBeShared,
+                            headerProps as ArticleHeaderProps,
+                        )}
+                    <div class="header-bg"></div>
+                </div>
             </div>
-        </div>
-    `
+        `
+    }
 }
 
 export { Header }


### PR DESCRIPTION
## Summary
This PR fixes the immersive template for the case where we show a media atom. 
I have added a new `header-immersive-video` class in order to avoid an interactive with a media atom inheriting the styling logic specific to immersive articles which have a large background image. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/Qaau9AG2/1236-bug-immersive-template-with-video-as-main-media-sucks)

## Test Plan
These changes should only affect a small percentage of immersive articles which have a video as their main media. 
The two articles shown in the screenshot can be found at the code endpoint in the Sport section on 8th April and 17th April. 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-05-27 at 17 27 55](https://user-images.githubusercontent.com/53755195/83049283-d4669600-a042-11ea-850c-cca4de07dabc.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-27 at 12 13 10](https://user-images.githubusercontent.com/53755195/83049329-e6e0cf80-a042-11ea-993c-8c8c7ae9f133.png)
![Simulator Screen Shot - iPhone 11 - 2020-05-27 at 17 53 50](https://user-images.githubusercontent.com/53755195/83049414-0bd54280-a043-11ea-873b-2bd80dad1416.png)| ![Simulator Screen Shot - iPhone 11 - 2020-05-27 at 17 28 39](https://user-images.githubusercontent.com/53755195/83049382-fbbd6300-a042-11ea-93b0-b3c5fee001d4.png)

  
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
