### PR TITLE
Add 20% sample rate to sentry client.

### DIFF
--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -47,7 +47,8 @@ class ErrorServiceImpl implements ErrorService {
         if (hasConsent === false || hasConsent === null) return
 
         if (!this.hasConfigured) {
-            Sentry.init({ dsn: SENTRY_DSN_URL })
+            // sampleRate helps keep our sentry costs down
+            Sentry.init({ dsn: SENTRY_DSN_URL, sampleRate: 0.2 })
 
             Sentry.setTag(
                 'environment',


### PR DESCRIPTION
## Summary

We keep hitting our sentry quota. This will help alleviate this problem by only posting 20% of error events to Sentry. Looking at the [dashboard](https://sentry.io/organizations/the-guardian/issues/?project=1519156&query=&statsPeriod=14d) most events happen thousands of times so this won't reduce our ability to spot bugs (should help it as it won't go dark all the time!)

## Test Plan
Release this, check that Sentry logging still works (and event count has gone down)
