### PR TITLE
fix: Reduce reliance on RN Fetch Blob

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -186,7 +186,7 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
         )
 
         // The above saves it locally, if successful we return it
-        return await readIssueSummary()
+        return issueSummary
     } catch (e) {
         e.message = `Failed to fetch valid issue summary: ${e.message}`
         errorService.captureException(e)

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -172,13 +172,18 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
     const fetchIssueSummaryUrl = `${apiUrl}${edition}/issues`
 
     try {
-        await RNFetchBlob.config({
-            overwrite: true,
-            path: FSPaths.contentPrefixDir + defaultSettings.issuesPath,
-            IOSBackgroundTask: true,
-        }).fetch('GET', fetchIssueSummaryUrl, {
-            'Content-Type': 'application/json',
-        })
+        const issueSummaryRequest = await fetch(fetchIssueSummaryUrl)
+        const issueSummary = await issueSummaryRequest.json()
+        if (!issueSummary) {
+            throw new Error('No Issume Summary Avaialble')
+        }
+
+        const issueSummaryString = JSON.stringify(issueSummary)
+        await RNFetchBlob.fs.writeFile(
+            FSPaths.contentPrefixDir + defaultSettings.issuesPath,
+            issueSummaryString,
+            'utf8',
+        )
 
         // The above saves it locally, if successful we return it
         return await readIssueSummary()


### PR DESCRIPTION
## Summary
RNFtechBlob's fetch causes us a lot of I/O errors. This will reduce the reliance by returning what we get back from the API rather than trying to read a file in a write state. The promises in this library seem a bit wonky so this will help.