### PR TITLE
Add limit to log message length.

### DIFF
--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,10 +1,6 @@
-import { Logging, Level } from '../logging'
+import { Logging, Level, cropMessage } from '../logging'
 import MockDate from 'mockdate'
-import {
-    ReleaseChannel,
-    OS,
-    cropMessage,
-} from '../../../../Apps/common/src/logging'
+import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
 jest.mock('@react-native-community/netinfo', () => ({
@@ -152,16 +148,12 @@ describe('logging service', () => {
 describe('cropMessage', () => {
     it('should crop strings to a max length', () => {
         const longstring = 'do you want to build a snowman?'
-        const croppedString = cropMessage(
-            longstring,
-            6,
-            ' want to go and play?',
-        )
-        expect(croppedString).toEqual('do you want to go and play?')
+        const croppedString = cropMessage(longstring, 6)
+        expect(croppedString).toEqual('do you... (message cropped)')
     })
     it('shouldnt crop short strings', () => {
         const longstring = 'hehe'
-        const croppedString = cropMessage(longstring, 6, '')
+        const croppedString = cropMessage(longstring, 6)
         expect(croppedString).toEqual('hehe')
     })
 })

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,6 +1,10 @@
 import { Logging, Level } from '../logging'
 import MockDate from 'mockdate'
-import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
+import {
+    ReleaseChannel,
+    OS,
+    cropMessage,
+} from '../../../../Apps/common/src/logging'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
 jest.mock('@react-native-community/netinfo', () => ({
@@ -142,5 +146,22 @@ describe('logging service', () => {
                 expect(loggingService.clearItems).toHaveBeenCalled()
             }
         })
+    })
+})
+
+describe('cropMessage', () => {
+    it('should crop strings to a max length', () => {
+        const longstring = 'do you want to build a snowman?'
+        const croppedString = cropMessage(
+            longstring,
+            6,
+            ' want to go and play?',
+        )
+        expect(croppedString).toEqual('do you want to go and play?')
+    })
+    it('shouldnt crop short strings', () => {
+        const longstring = 'hehe'
+        const croppedString = cropMessage(longstring, 6, '')
+        expect(croppedString).toEqual('hehe')
     })
 })

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -36,12 +36,10 @@ interface LogParams {
 type QueryData = { gdprAllowPerformance: GdprSwitchSetting }
 const QUERY = gql('{ gdprAllowPerformance @client }')
 
-const cropMessage = (
-    message: string,
-    maxLength: number,
-    overflowMessage = '... (message cropped)',
-): string => {
-    return message.length > maxLength ? `${message}${overflowMessage}` : message
+const cropMessage = (message: string, maxLength: number): string => {
+    return message.length > maxLength
+        ? `${message.slice(0, 6)}... (message cropped)`
+        : message
 }
 
 class Logging extends AsyncQueue {


### PR DESCRIPTION
## Summary
We should try to keep log messages reasonably small unless we find it's particularly valuable to have big blobs of json there. This replaces https://github.com/guardian/editions/pull/1214 with a more general solution

## Test Plan
After release check logs in elk to verify that critical info is still coming through