### PR TITLE
fix/lightbox-not-gallery

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -734,6 +734,7 @@ const Header = ({
             publishedId &&
             MainMediaImage({
                 image: headerProps.image,
+                isGallery: isGallery,
                 className: 'header-image header-image--immersive',
                 getImagePath,
             })}


### PR DESCRIPTION
## Summary
I noticed that some gallery articles were opening lightbox from the main image, this is to prevent any gallery articles opening lightbox from the main media
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/d6XXQPgW/1203-lightbox-bugs)

## Test Plan
Try opening lightbox from a gallery article, this should ensure the main media image will not cause lightbox to open. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
