### PR TITLE
chore: Apple Functionality Consent

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -7,8 +7,9 @@ import { defaultSettings } from './settings/defaults'
  * v1 - The initial version that CMP was released with
  * v2 - Move Braze from ESSENTIAL to PERSONALISED_ADS
  * v3 - Add Logging to PERFORMANCE
+ * v4 - Add Apple in FUNCTIONALITY
  */
-export const CURRENT_CONSENT_VERSION = 3
+export const CURRENT_CONSENT_VERSION = 4
 
 export interface GdprDefaultSettings {
     gdprAllowEssential: boolean

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -118,9 +118,9 @@ const GdprConsent = ({
         gdprAllowFunctionality: {
             key: gdprAllowFunctionalityKey,
             name: 'Functionality',
-            services: 'Google - Facebook',
+            services: 'Apple - Google - Facebook',
             description:
-                'Enabling these allow us to provide you with a range of functionality and store related information. For example, you can use social media credentials such as your Google account to log into your Guardian account. If you disable this, some features of our services may not function.',
+                'Enabling these allow us to provide extra sign-in functionality. It enables us to offer alternative options for you to sign-in to your Guardian account using your Apple, Google, or Facebook credentials. If you disable this, you won’t be able to sign-in with the third-party services above.',
         },
     }
 


### PR DESCRIPTION
## Summary
Update functionality consent to include Apple and the new wording.

I have also made the app re-consent as this will change for users.

[**Trello Card ->**](https://trello.com/c/1zUv505q/1338-add-apple-sign-in-on-the-consent-screen-under-functional)