### PR TITLE
Remote config for apple sign in, lightbox

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "io.fabric"
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile

--- a/projects/Mallard/android/app/google-services.json
+++ b/projects/Mallard/android/app/google-services.json
@@ -1,55 +1,55 @@
 {
-  "project_info": {
-    "project_number": "493559488652",
-    "firebase_url": "https://guardian-daily-edition.firebaseio.com",
-    "project_id": "guardian-daily-edition",
-    "storage_bucket": "guardian-daily-edition.appspot.com"
-  },
-  "client": [
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:493559488652:android:fe3039069f699f9e",
-        "android_client_info": {
-          "package_name": "com.guardian.editions"
-        }
-      },
-      "oauth_client": [
+    "project_info": {
+        "project_number": "493559488652",
+        "firebase_url": "https://guardian-daily-edition.firebaseio.com",
+        "project_id": "guardian-daily-edition",
+        "storage_bucket": "guardian-daily-edition.appspot.com"
+    },
+    "client": [
         {
-          "client_id": "493559488652-ipm9s93pgcov7oukr6j24dfvuvknig3m.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.guardian.editions",
-            "certificate_hash": "856c633e65892af86ab8081ec135ee08047e9dc7"
-          }
-        },
-        {
-          "client_id": "493559488652-055c0jnt3lkemhmsar7hllidgnp48jha.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyAi_qKXs81FaHWI2qalRW5FtimqvcDRIjk"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "493559488652-055c0jnt3lkemhmsar7hllidgnp48jha.apps.googleusercontent.com",
-              "client_type": 3
+            "client_info": {
+                "mobilesdk_app_id": "1:493559488652:android:fe3039069f699f9e",
+                "android_client_info": {
+                    "package_name": "com.guardian.editions"
+                }
             },
-            {
-              "client_id": "493559488652-n5m7i14mfflicgidf2o3mi7gher35ujc.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "uk.co.guardian.gce"
-              }
+            "oauth_client": [
+                {
+                    "client_id": "493559488652-ipm9s93pgcov7oukr6j24dfvuvknig3m.apps.googleusercontent.com",
+                    "client_type": 1,
+                    "android_info": {
+                        "package_name": "com.guardian.editions",
+                        "certificate_hash": "856c633e65892af86ab8081ec135ee08047e9dc7"
+                    }
+                },
+                {
+                    "client_id": "493559488652-055c0jnt3lkemhmsar7hllidgnp48jha.apps.googleusercontent.com",
+                    "client_type": 3
+                }
+            ],
+            "api_key": [
+                {
+                    "current_key": "AIzaSyAi_qKXs81FaHWI2qalRW5FtimqvcDRIjk"
+                }
+            ],
+            "services": {
+                "appinvite_service": {
+                    "other_platform_oauth_client": [
+                        {
+                            "client_id": "493559488652-055c0jnt3lkemhmsar7hllidgnp48jha.apps.googleusercontent.com",
+                            "client_type": 3
+                        },
+                        {
+                            "client_id": "493559488652-n5m7i14mfflicgidf2o3mi7gher35ujc.apps.googleusercontent.com",
+                            "client_type": 2,
+                            "ios_info": {
+                                "bundle_id": "uk.co.guardian.gce"
+                            }
+                        }
+                    ]
+                }
             }
-          ]
         }
-      }
-    }
-  ],
-  "configuration_version": "1"
+    ],
+    "configuration_version": "1"
 }

--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -17,10 +17,15 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.2")
         classpath("com.google.gms:google-services:4.2.0")
+
+        classpath 'io.fabric.tools:gradle:1.28.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/projects/Mallard/ios/GoogleService-Info.plist
+++ b/projects/Mallard/ios/GoogleService-Info.plist
@@ -3,23 +3,23 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>43377569438-e54t618jfilsgvs8josj9l21nbdrajhl.apps.googleusercontent.com</string>
+	<string>493559488652-n5m7i14mfflicgidf2o3mi7gher35ujc.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.43377569438-e54t618jfilsgvs8josj9l21nbdrajhl</string>
+	<string>com.googleusercontent.apps.493559488652-n5m7i14mfflicgidf2o3mi7gher35ujc</string>
 	<key>ANDROID_CLIENT_ID</key>
-	<string>43377569438-s6jrife6hnio9ri66t9ekhij4t6gpnde.apps.googleusercontent.com</string>
+	<string>493559488652-ipm9s93pgcov7oukr6j24dfvuvknig3m.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
-	<string>AIzaSyC0CREFA2t_J_kKuzI7zXI6LlT9SS2Cm10</string>
+	<string>AIzaSyCbwdxS_ridity_UsLvpI7zGQbOMkhJPKk</string>
 	<key>GCM_SENDER_ID</key>
-	<string>43377569438</string>
+	<string>493559488652</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>uk.co.guardian.gce</string>
 	<key>PROJECT_ID</key>
-	<string>guardian-daily-edition-code</string>
+	<string>guardian-daily-edition</string>
 	<key>STORAGE_BUCKET</key>
-	<string>guardian-daily-edition-code.appspot.com</string>
+	<string>guardian-daily-edition.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -31,8 +31,8 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:43377569438:ios:ce75494a6a5ea60bf4558f</string>
+	<string>1:493559488652:ios:7c36c9d743989eec</string>
 	<key>DATABASE_URL</key>
-	<string>https://guardian-daily-edition-c-d5ba4.firebaseio.com</string>
+	<string>https://guardian-daily-edition.firebaseio.com</string>
 </dict>
 </plist>

--- a/projects/Mallard/ios/GoogleService-Info.plist
+++ b/projects/Mallard/ios/GoogleService-Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>43377569438-e54t618jfilsgvs8josj9l21nbdrajhl.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.43377569438-e54t618jfilsgvs8josj9l21nbdrajhl</string>
+	<key>ANDROID_CLIENT_ID</key>
+	<string>43377569438-s6jrife6hnio9ri66t9ekhij4t6gpnde.apps.googleusercontent.com</string>
+	<key>API_KEY</key>
+	<string>AIzaSyC0CREFA2t_J_kKuzI7zXI6LlT9SS2Cm10</string>
+	<key>GCM_SENDER_ID</key>
+	<string>43377569438</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>uk.co.guardian.gce</string>
+	<key>PROJECT_ID</key>
+	<string>guardian-daily-edition-code</string>
+	<key>STORAGE_BUCKET</key>
+	<string>guardian-daily-edition-code.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:43377569438:ios:ce75494a6a5ea60bf4558f</string>
+	<key>DATABASE_URL</key>
+	<string>https://guardian-daily-edition-c-d5ba4.firebaseio.com</string>
+</dict>
+</plist>

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2DCD954D1E0B4F2C00145EB5 /* MallardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* MallardTests.m */; };
 		30A65E2732C54D5E94DFE6CD /* GuardianWeatherIcons-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1B8F9A4ED48041FBB588FDD5 /* GuardianWeatherIcons-Regular.ttf */; };
 		7836FF3F0ADEA9274CAD15ED /* libPods-Mallard-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11C512E12ECC343D6E33F7A1 /* libPods-Mallard-tvOSTests.a */; };
+		896089CE248679CF00DCBF7D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 896089CD248679CF00DCBF7D /* GoogleService-Info.plist */; };
 		950E1C012317E06F00F38B92 /* Ophan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950E1C002317E06F00F38B92 /* Ophan.swift */; };
 		9553F9242396A2B700AB0CA3 /* RNBackgroundFetch+AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9553F9232396A2B700AB0CA3 /* RNBackgroundFetch+AppDelegate.m */; };
 		95610CA8232BF0FF006B5DF2 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 95610CA7232BF0FF006B5DF2 /* LaunchScreen.xib */; };
@@ -156,6 +157,7 @@
 		78F4F0CCE3DEAAA92756A4D3 /* Pods-MallardTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MallardTests.debug.xcconfig"; path = "Target Support Files/Pods-MallardTests/Pods-MallardTests.debug.xcconfig"; sourceTree = "<group>"; };
 		79BBF3A13361423996CF9307 /* GuardianIcons-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianIcons-Regular.otf"; path = "../src/assets/fonts/GuardianIcons-Regular.otf"; sourceTree = "<group>"; };
 		7FE20416D3D243E5A4320927 /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		896089CD248679CF00DCBF7D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		90A50D1828ED405BB7AD9145 /* GuardianTextEgyptian-Reg.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GuardianTextEgyptian-Reg.ttf"; path = "../src/assets/fonts/GuardianTextEgyptian-Reg.ttf"; sourceTree = "<group>"; };
 		92C66C5662CA467DB9BDFDCB /* GHGuardianHeadline-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "GHGuardianHeadline-MediumItalic.ttf"; path = "../src/assets/fonts/GHGuardianHeadline-MediumItalic.ttf"; sourceTree = "<group>"; };
 		950E1BFF2317E06E00F38B92 /* Mallard-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Mallard-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -335,6 +337,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				896089CD248679CF00DCBF7D /* GoogleService-Info.plist */,
 				4F62AA35231E8D660052ADBA /* ophan.framework */,
 				A10F237623191F62004C70CC /* ReleaseStream */,
 				4F62AA2D23198E500052ADBA /* ophan.framework */,
@@ -425,6 +428,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				8BA3F98B2BC24E3096C77568 /* Upload Debug Symbols to Sentry */,
 				95B08635238D6EEA00828D1E /* Embed Frameworks */,
+				B2C2068495DC306BC77F077D /* [CP-User] [RNFB] Core Configuration */,
 			);
 			buildRules = (
 			);
@@ -562,6 +566,7 @@
 				C549378822B149BB00B1D9A2 /* (null) in Resources */,
 				C549378922B149BB00B1D9A2 /* (null) in Resources */,
 				C549378A22B149BB00B1D9A2 /* (null) in Resources */,
+				896089CE248679CF00DCBF7D /* GoogleService-Info.plist in Resources */,
 				C549378B22B149BB00B1D9A2 /* (null) in Resources */,
 				C549378C22B149BB00B1D9A2 /* (null) in Resources */,
 				C549378D22B149BB00B1D9A2 /* (null) in Resources */,
@@ -728,6 +733,16 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/../../Apps/ophan/gradlew\" -p \"$SRCROOT/../../Apps/ophan\" copyFatFramework \\\n-Pconfiguration.build.dir=\"$CONFIGURATION_BUILD_DIR\"          \\\n-Pkotlin.build.type=\"$KOTLIN_BUILD_TYPE\" \\\n-Pkotlin.valid.archs=\"$VALID_ARCHS\"\n";
 		};
+		B2C2068495DC306BC77F077D /* [CP-User] [RNFB] Core Configuration */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [RNFB] Core Configuration";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\nset -e\n\n_MAX_LOOKUPS=2;\n_SEARCH_RESULT=''\n_RN_ROOT_EXISTS=''\n_CURRENT_LOOKUPS=1\n_JSON_ROOT=\"'react-native'\"\n_JSON_FILE_NAME='firebase.json'\n_JSON_OUTPUT_BASE64='e30=' # { }\n_CURRENT_SEARCH_DIR=${PROJECT_DIR}\n_PLIST_BUDDY=/usr/libexec/PlistBuddy\n_TARGET_PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n_DSYM_PLIST=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n# plist arrays\n_PLIST_ENTRY_KEYS=()\n_PLIST_ENTRY_TYPES=()\n_PLIST_ENTRY_VALUES=()\n\nfunction setPlistValue {\n  echo \"info:      setting plist entry '$1' of type '$2' in file '$4'\"\n  ${_PLIST_BUDDY} -c \"Add :$1 $2 '$3'\" $4 || echo \"info:      '$1' already exists\"\n}\n\nfunction getFirebaseJsonKeyValue () {\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    ruby -e \"require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']\"\n  else\n    echo \"\"\n  fi;\n}\n\nfunction jsonBoolToYesNo () {\n  if [[ $1 == \"false\" ]]; then\n    echo \"NO\"\n  elif [[ $1 == \"true\" ]]; then\n    echo \"YES\"\n  else echo \"NO\"\n  fi\n}\n\necho \"info: -> RNFB build script started\"\necho \"info: 1) Locating ${_JSON_FILE_NAME} file:\"\n\nif [[ -z ${_CURRENT_SEARCH_DIR} ]]; then\n  _CURRENT_SEARCH_DIR=$(pwd)\nfi;\n\nwhile true; do\n  _CURRENT_SEARCH_DIR=$(dirname \"$_CURRENT_SEARCH_DIR\")\n  if [[ \"$_CURRENT_SEARCH_DIR\" == \"/\" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;\n  echo \"info:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file.\"\n  _SEARCH_RESULT=$(find \"$_CURRENT_SEARCH_DIR\" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | head -n 1)\n  if [[ ${_SEARCH_RESULT} ]]; then\n    echo \"info:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT\"\n    break;\n  fi;\n  _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))\ndone\n\nif [[ ${_SEARCH_RESULT} ]]; then\n  _JSON_OUTPUT_RAW=$(cat \"${_SEARCH_RESULT}\")\n  _RN_ROOT_EXISTS=$(ruby -e \"require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]\" || echo '')\n\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    _JSON_OUTPUT_BASE64=$(python -c 'import json,sys,base64;print(base64.b64encode(json.dumps(json.loads(open('\"'${_SEARCH_RESULT}'\"').read())['${_JSON_ROOT}'])))' || echo \"e30=\")\n  fi\n\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n\n  # config.messaging_auto_init_enabled\n  _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"messaging_auto_init_enabled\")\n  if [[ $_MESSAGING_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseMessagingAutoInitEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_MESSAGING_AUTO_INIT\")\")\n  fi\n\n  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes usful\n  _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"crashlytics_disable_auto_disabler\")\n  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == \"true\" ]]; then\n    echo \"Disabled Crashlytics auto disabler.\" # do nothing\n  else\n    _PLIST_ENTRY_KEYS+=(\"firebase_crashlytics_collection_enabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"NO\")\n  fi\n\n  # config.admob_delay_app_measurement_init\n  _ADMOB_DELAY_APP_MEASUREMENT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"admob_delay_app_measurement_init\")\n  if [[ $_ADMOB_DELAY_APP_MEASUREMENT == \"true\" ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GADDelayAppMeasurementInit\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"YES\")\n  fi\n\n  # config.admob_ios_app_id\n  _ADMOB_IOS_APP_ID=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"admob_ios_app_id\")\n  if [[ $_ADMOB_IOS_APP_ID ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GADApplicationIdentifier\")\n    _PLIST_ENTRY_TYPES+=(\"string\")\n    _PLIST_ENTRY_VALUES+=(\"$_ADMOB_IOS_APP_ID\")\n  fi\nelse\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n  echo \"warning:   A firebase.json file was not found, whilst this file is optional it is recommended to include it to configure firebase services in React Native Firebase.\"\nfi;\n\necho \"info: 2) Injecting Info.plist entries: \"\n\n# Log out the keys we're adding\nfor i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n  echo \"    ->  $i) ${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\"\ndone\n\nfor plist in \"${_TARGET_PLIST}\" \"${_DSYM_PLIST}\" ; do\n  if [[ -f \"${plist}\" ]]; then\n\n    # paths with spaces break the call to setPlistValue. temporarily modify\n    # the shell internal field separator variable (IFS), which normally \n    # includes spaces, to consist only of line breaks\n    oldifs=$IFS\n    IFS=\"\n\"\n\n    for i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n      setPlistValue \"${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\" \"${plist}\"\n    done\n\n    # restore the original internal field separator value\n    IFS=$oldifs\n  else\n    echo \"warning:   A Info.plist build output file was not found (${plist})\"\n  fi\ndone\n\necho \"info: <- RNFB build script finished\"\n\n";
+		};
 		B8712F2A6735954686D599F6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -885,10 +900,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../../Apps/ophan/build/bin/ios/universalFramework",
-					"$(PROJECT_DIR)/../node_modules/react-native-background-fetch/ios/**",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -919,10 +931,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 998P9U5NGJ;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../../Apps/ophan/build/bin/ios/universalFramework",
-					"$(PROJECT_DIR)/../node_modules/react-native-background-fetch/ios/**",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Mallard/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/projects/Mallard/ios/Mallard/AppDelegate.m
+++ b/projects/Mallard/ios/Mallard/AppDelegate.m
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Firebase.h>
 #import "AppDelegate.h"
 
 #import <React/RCTBridge.h>
@@ -23,6 +24,10 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"Mallard"
                                             initialProperties:nil];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  
+  if ([FIRApp defaultApp] == nil) {
+    [FIRApp configure];
+  }
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -9,6 +9,52 @@ PODS:
     - React-Core (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/turbomodule/core (= 0.61.5)
+  - Firebase/Core (6.13.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 6.1.6)
+  - Firebase/CoreOnly (6.13.0):
+    - FirebaseCore (= 6.4.0)
+  - Firebase/RemoteConfig (6.13.0):
+    - Firebase/CoreOnly
+    - FirebaseRemoteConfig (~> 4.4.5)
+  - FirebaseABTesting (3.2.0):
+    - FirebaseAnalyticsInterop (~> 1.3)
+    - FirebaseCore (~> 6.1)
+    - Protobuf (>= 3.9.2, ~> 3.9)
+  - FirebaseAnalytics (6.1.6):
+    - FirebaseCore (~> 6.4)
+    - FirebaseInstanceID (~> 4.2)
+    - GoogleAppMeasurement (= 6.1.6)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - FirebaseAnalyticsInterop (1.5.0)
+  - FirebaseCore (6.4.0):
+    - FirebaseCoreDiagnostics (~> 1.0)
+    - FirebaseCoreDiagnosticsInterop (~> 1.0)
+    - GoogleUtilities/Environment (~> 6.2)
+    - GoogleUtilities/Logger (~> 6.2)
+  - FirebaseCoreDiagnostics (1.2.4):
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleDataTransportCCTSupport (~> 3.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+    - nanopb (~> 0.3.901)
+  - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseInstanceID (4.2.7):
+    - FirebaseCore (~> 6.0)
+    - GoogleUtilities/Environment (~> 6.0)
+    - GoogleUtilities/UserDefaults (~> 6.0)
+  - FirebaseRemoteConfig (4.4.9):
+    - FirebaseABTesting (~> 3.1)
+    - FirebaseAnalyticsInterop (~> 1.4)
+    - FirebaseCore (~> 6.2)
+    - FirebaseInstanceID (~> 4.2)
+    - GoogleUtilities/Environment (~> 6.2)
+    - "GoogleUtilities/NSData+zlib (~> 6.2)"
+    - Protobuf (>= 3.9.2, ~> 3.9)
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
@@ -19,8 +65,44 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
+  - GoogleAppMeasurement (6.1.6):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - GoogleDataTransport (6.1.1)
+  - GoogleDataTransportCCTSupport (3.0.0):
+    - GoogleDataTransport (~> 6.0)
+    - nanopb (~> 0.3.901)
+  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.6.0):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/Logger (6.6.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.6.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.6.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.6.0)"
+  - GoogleUtilities/Reachability (6.6.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (6.6.0):
+    - GoogleUtilities/Logger
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
   - Permission-LocationWhenInUse (2.0.3):
     - RNPermissions
+  - PromisesObjC (1.2.8)
+  - Protobuf (3.12.0)
   - RCTRequired (0.61.5)
   - RCTTypeSafety (0.61.5):
     - FBLazyVector (= 0.61.5)
@@ -251,6 +333,14 @@ PODS:
     - React
   - RNDeviceInfo (5.3.1):
     - React
+  - RNFBApp (6.7.1):
+    - Firebase/Core (~> 6.13.0)
+    - React
+  - RNFBRemoteConfig (6.7.1):
+    - Firebase/Core (~> 6.13.0)
+    - Firebase/RemoteConfig (~> 6.13.0)
+    - React
+    - RNFBApp
   - RNGestureHandler (1.5.3):
     - React
   - RNIap (3.3.9):
@@ -275,9 +365,9 @@ PODS:
   - RNZipArchive/Core (5.0.1):
     - React
     - SSZipArchive (= 2.2.2)
-  - Sentry (4.4.0):
-    - Sentry/Core (= 4.4.0)
-  - Sentry/Core (4.4.0)
+  - Sentry (4.4.3):
+    - Sentry/Core (= 4.4.3)
+  - Sentry/Core (4.4.3)
   - SSZipArchive (2.2.2)
   - Yoga (1.14.0)
 
@@ -326,6 +416,8 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
+  - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNIap (from `../node_modules/react-native-iap`)
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
@@ -338,8 +430,24 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - boost-for-react-native
+    - Firebase
+    - FirebaseABTesting
+    - FirebaseAnalytics
+    - FirebaseAnalyticsInterop
+    - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseCoreDiagnosticsInterop
+    - FirebaseInstanceID
+    - FirebaseRemoteConfig
+    - GoogleAppMeasurement
+    - GoogleDataTransport
+    - GoogleDataTransportCCTSupport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
+    - Protobuf
     - Sentry
     - SSZipArchive
 
@@ -426,6 +534,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNFBApp:
+    :path: "../node_modules/@react-native-firebase/app"
+  RNFBRemoteConfig:
+    :path: "../node_modules/@react-native-firebase/remote-config"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNIap:
@@ -452,9 +564,25 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: aaeaf388755e4f29cd74acbc9e3b8da6d807c37f
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
+  Firebase: 458d109512200d1aca2e1b9b6cf7d68a869a4a46
+  FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
+  FirebaseAnalytics: 45f36d9c429fc91d206283900ab75390cd05ee8a
+  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
+  FirebaseCore: 307ea2508df730c5865334e41965bd9ea344b0e5
+  FirebaseCoreDiagnostics: b59c024493a409f8aecba02c99928d0d8431d159
+  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseInstanceID: ebd2ea79ee38db0cb5f5167b17a0d387e1cc7b6e
+  FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  GoogleAppMeasurement: dfe55efa543e899d906309eaaac6ca26d249862f
+  GoogleDataTransport: ad884314b81cdb808fb1d23787b367ff8da4e28a
+  GoogleDataTransportCCTSupport: 0f39025e8cf51f168711bd3fb773938d7e62ddb5
+  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   Permission-LocationWhenInUse: 5cb8e0df1463dfab567d2a3d2589ab557fda68cb
+  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  Protobuf: 2793fcd0622a00b546c60e7cbbcc493e043e9bb9
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -490,6 +618,8 @@ SPEC CHECKSUMS:
   RNCMaskedView: b79e193409a90bf6b5170d421684f437ff4e2278
   RNCPushNotificationIOS: 0b8d06ff190d84627dd17501bfb96652375970e4
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
+  RNFBApp: 7b539bb25520fa73d6a240f5c6ea569e27683645
+  RNFBRemoteConfig: 59818c5933149b5a6b7fe5159e3d4df09199e858
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
@@ -499,7 +629,7 @@ SPEC CHECKSUMS:
   RNSentry: 9c9783b13fb5cba387fff55f085cc1da3854ce71
   RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
   RNZipArchive: 87111bb6130a38edd68c8d2059d46ac94d53ffe4
-  Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
+  Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -42,6 +42,8 @@
         "@react-native-community/netinfo": "^5.6.2",
         "@react-native-community/push-notification-ios": "^1.0.2",
         "@react-native-community/viewpager": "^2.0.1",
+        "@react-native-firebase/app": "^6.7.1",
+        "@react-native-firebase/remote-config": "^6.7.1",
         "@sentry/react-native": "^1.3.9",
         "@types/react-native-htmlview": "^0.12.2",
         "apollo-cache-inmemory": "^1.6.3",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -40,6 +40,7 @@ import { loggingService } from './services/logging'
 import ApolloClient from 'apollo-client'
 import { pushDownloadFailsafe } from './helpers/push-download-failsafe'
 import { prepareAndDownloadTodaysIssue } from './download-edition/prepare-and-download-issue'
+import { initialiseRemoteConfig } from './services/remote-config'
 
 /**
  * Only one global Apollo client. As such, any update done from any component
@@ -149,6 +150,8 @@ export default class App extends React.Component<{}, {}> {
     componentDidMount() {
         SplashScreen.hide()
         weatherHider(apolloClient)
+        initialiseRemoteConfig()
+
         prepareAndDownloadTodaysIssue(apolloClient)
         shouldHavePushFailsafe(apolloClient)
 

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -2,6 +2,12 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { LightboxCaption } from '../LightboxCaption'
 
+jest.mock('@react-native-firebase/remote-config', () => {
+    remoteConfig: jest.fn(() => ({
+        getValue: jest.fn(),
+    }))
+})
+
 describe('LightboxCaption', () => {
     it('should show a LightboxCaption with a pillar colour', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -1,5 +1,11 @@
 import { renderCaption } from '../components/images'
 
+jest.mock('@react-native-firebase/remote-config', () => {
+    remoteConfig: jest.fn(() => ({
+        getValue: jest.fn(),
+    }))
+})
+
 describe('html', () => {
     describe('renderCaption', () => {
         it('renders just the caption when the credit is undefined', () => {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -17,6 +17,7 @@ import {
     CreditedImage,
 } from '../../../../../Apps/common/src'
 import { navigateToLightbox } from 'src/navigation/helpers/base'
+import remoteConfig from '@react-native-firebase/remote-config'
 
 const styles = StyleSheet.create({
     block: {
@@ -186,24 +187,29 @@ const Article = ({
                         onIsAtTopChange(parsed.isAtTop)
                     }
                     if (parsed.type === 'openLightbox') {
-                        const lbimages = getLightboxImages(article.elements)
-                        const lbCreditedImages = getCreditedImages(lbimages)
-                        let index = parsed.index
-                        // to avoid image duplication we don't add the main image of gallery articles to the array
-                        if (article.type !== 'gallery' && article.image) {
-                            lbCreditedImages.unshift(article.image)
-                            if (parsed.isMainImage === 'false') {
-                                index++
+                        const lightboxEnabled = remoteConfig().getValue(
+                            'lightbox_enabled',
+                        ).value
+                        if (lightboxEnabled) {
+                            const lbimages = getLightboxImages(article.elements)
+                            const lbCreditedImages = getCreditedImages(lbimages)
+                            let index = parsed.index
+                            // to avoid image duplication we don't add the main image of gallery articles to the array
+                            if (article.type !== 'gallery' && article.image) {
+                                lbCreditedImages.unshift(article.image)
+                                if (parsed.isMainImage === 'false') {
+                                    index++
+                                }
                             }
+                            navigateToLightbox({
+                                navigation,
+                                navigationProps: {
+                                    images: lbCreditedImages,
+                                    index,
+                                    pillar,
+                                },
+                            })
                         }
-                        navigateToLightbox({
-                            navigation,
-                            navigationProps: {
-                                images: lbCreditedImages,
-                                index,
-                                pillar,
-                            },
-                        })
                     }
                 }}
             />

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -141,6 +141,8 @@ const Article = ({
 
     const [, { pillar }] = useArticle()
 
+    const lightboxEnabled = remoteConfig().getValue('lightbox_enabled').value
+
     return (
         <Fader>
             <WebviewWithArticle
@@ -186,30 +188,25 @@ const Article = ({
                     if (parsed.type === 'isAtTopChange') {
                         onIsAtTopChange(parsed.isAtTop)
                     }
-                    if (parsed.type === 'openLightbox') {
-                        const lightboxEnabled = remoteConfig().getValue(
-                            'lightbox_enabled',
-                        ).value
-                        if (lightboxEnabled) {
-                            const lbimages = getLightboxImages(article.elements)
-                            const lbCreditedImages = getCreditedImages(lbimages)
-                            let index = parsed.index
-                            // to avoid image duplication we don't add the main image of gallery articles to the array
-                            if (article.type !== 'gallery' && article.image) {
-                                lbCreditedImages.unshift(article.image)
-                                if (parsed.isMainImage === 'false') {
-                                    index++
-                                }
+                    if (lightboxEnabled && parsed.type === 'openLightbox') {
+                        const lbimages = getLightboxImages(article.elements)
+                        const lbCreditedImages = getCreditedImages(lbimages)
+                        let index = parsed.index
+                        // to avoid image duplication we don't add the main image of gallery articles to the array
+                        if (article.type !== 'gallery' && article.image) {
+                            lbCreditedImages.unshift(article.image)
+                            if (parsed.isMainImage === 'false') {
+                                index++
                             }
-                            navigateToLightbox({
-                                navigation,
-                                navigationProps: {
-                                    images: lbCreditedImages,
-                                    index,
-                                    pillar,
-                                },
-                            })
                         }
+                        navigateToLightbox({
+                            navigation,
+                            navigationProps: {
+                                images: lbCreditedImages,
+                                index,
+                                pillar,
+                            },
+                        })
                     }
                 }}
             />

--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -136,8 +136,6 @@ const Login = ({
     }
 
     const appleSignInEnabled = remoteConfig().getValue('apple_sign_in').value
-    console.log('apple enabled', appleSignInEnabled)
-    console.log('apple enabled', remoteConfig().getValue('apple_sign_in'))
 
     return (
         <LoginLayout

--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -15,6 +15,7 @@ import {
     AuthParams,
     AppleSignInTokenKey,
 } from 'src/authentication/authorizers/IdentityAuthorizer'
+import remoteConfig from '@react-native-firebase/remote-config'
 
 import { iosMajorVersion } from 'src/helpers/platform'
 
@@ -134,6 +135,10 @@ const Login = ({
         setShowAppleAuthWebView(true)
     }
 
+    const appleSignInEnabled = remoteConfig().getValue('apple_sign_in').value
+    console.log('apple enabled', appleSignInEnabled)
+    console.log('apple enabled', remoteConfig().getValue('apple_sign_in'))
+
     return (
         <LoginLayout
             title={title}
@@ -169,7 +174,7 @@ const Login = ({
                         >
                             Continue with Google
                         </SocialButton>
-                        {iosMajorVersion >= 13 && (
+                        {appleSignInEnabled && iosMajorVersion >= 13 && (
                             <SocialButton
                                 onPress={onApplePress}
                                 iconRequire={require('src/assets/images/apple.png')}
@@ -178,7 +183,7 @@ const Login = ({
                             </SocialButton>
                         )}
 
-                        {iosMajorVersion < 13 && (
+                        {appleSignInEnabled && iosMajorVersion < 13 && (
                             <SocialButton
                                 onPress={onAppleSignInPress}
                                 iconRequire={require('src/assets/images/apple.png')}

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -5,16 +5,19 @@ export const initialiseRemoteConfig = async () => {
     const activated = await remoteConfig()
         .setDefaults({
             apple_sign_in: false,
+            lightbox_enabled: false,
         })
-        // fetch config, cache for 15mins
+        // fetch config, cache for 5mins
         // NOTE: this cache persists when app is reloaded
-        .then(() => remoteConfig().fetch(900))
+        .then(() => remoteConfig().fetch(300))
         // activate() replaces the default config with what has been fetched
         .then(() => remoteConfig().activate())
 
     if (activated) {
         console.log('Remote config defaults set, fetched & activated!')
     } else {
-        console.warn('Failed to activate remote config - using default values.')
+        console.log(
+            'Remote config not activated - using default or cached values.',
+        )
     }
 }

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -1,0 +1,20 @@
+import remoteConfig from '@react-native-firebase/remote-config'
+
+// see https://rnfirebase.io/remote-config/usage for docs
+export const initialiseRemoteConfig = async () => {
+    const activated = await remoteConfig()
+        .setDefaults({
+            apple_sign_in: false,
+        })
+        // fetch config, cache for 15mins
+        // NOTE: this cache persists when app is reloaded
+        .then(() => remoteConfig().fetch(900))
+        // activate() replaces the default config with what has been fetched
+        .then(() => remoteConfig().activate())
+
+    if (activated) {
+        console.log('Remote config defaults set, fetched & activated!')
+    } else {
+        console.warn('Failed to activate remote config - using default values.')
+    }
+}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2148,6 +2148,25 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-2.0.1.tgz#892e2148c8bca4ff157280e4be81d88be3264efc"
   integrity sha512-fTTpO6xdVrTAAWbC1B2TQbxOkzDtvE9YfovDPYpi+S9oWmT06Eh8pv1Umd/7R/ewuLy9i2fzBnAu5WY+Di8OwA==
 
+"@react-native-firebase/app-types@6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/app-types/-/app-types-6.7.1.tgz#93497885e6c112203db310636616647c16478da9"
+  integrity sha512-jfP2wdBUaptGXO6BC0g3RYMgmGLGOkdWhkGxPhZZy1uxIxN4IXPfeUKEPL0as6ZJqfdx0IMvSvtcp7ywoFNxyg==
+
+"@react-native-firebase/app@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/app/-/app-6.7.1.tgz#0fe8bb9a82292d672da524763dc42e224dda4fde"
+  integrity sha512-MzRlcR+5+RCU3Za+QMV064oPpZhkXvLoZbB8CdYxI66Qd2XKAGUT0FoQlFaeXZxkrfisdhLbvRUYJo1TY/Iuxg==
+  dependencies:
+    "@react-native-firebase/app-types" "6.7.1"
+    opencollective-postinstall "^2.0.1"
+    superstruct "^0.6.2"
+
+"@react-native-firebase/remote-config@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/remote-config/-/remote-config-6.7.1.tgz#10d3ea0b19bb627e22c4a3fc72416926c24e1be7"
+  integrity sha512-VEgHloZ21bWs+C5QV+mOm7jBrym118wgANC88e7naXMcZ3OlKDrSOSmGFr8R+N9goyyj2AV0Zmrvdm/5QY4TeQ==
+
 "@react-navigation/core@~3.4.1":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.4.2.tgz#bec563e94fde40fbab3730cdc97f22afbb2a1498"
@@ -4828,6 +4847,16 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clone-deep@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-2.0.2.tgz#00db3a1e173656730d1188c3d6aced6d7ea97713"
+  integrity sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==
+  dependencies:
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.0"
+    shallow-clone "^1.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -6468,10 +6497,22 @@ focus-lock@^0.6.6:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
 
-for-in@^1.0.2:
+for-in@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+  integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
+
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
+  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
+  dependencies:
+    for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -8470,6 +8511,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+kind-of@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -9270,6 +9316,14 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mixin-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  integrity sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=
+  dependencies:
+    for-in "^0.1.3"
+    is-extendable "^0.1.1"
+
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -9837,6 +9891,11 @@ open@^7.0.0:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+opencollective-postinstall@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -11986,6 +12045,15 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallow-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
+  integrity sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^5.0.0"
+    mixin-object "^2.0.1"
+
 shallow-equal@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
@@ -12546,6 +12614,14 @@ sudo-prompt@^9.0.0:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.1.1.tgz#73853d729770392caec029e2470db9c221754db0"
   integrity sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==
+
+superstruct@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.6.2.tgz#c5eb034806a17ff98d036674169ef85e4c7f6a1c"
+  integrity sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==
+  dependencies:
+    clone-deep "^2.0.1"
+    kind-of "^6.0.1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
This attempts to implement [firebase remote config](https://rnfirebase.io/remote-config/usage) for apple sign in and lightbox. 

I've copied a lot of stuff from @mohammad-haque 's [crashlytics pr](https://github.com/guardian/editions/pull/1142) to get this working. This is currently pointed at our CODE firebase environment - you should be able to see and set the config values [here](https://console.firebase.google.com/u/0/project/guardian-daily-edition-code/config)

I'm not sure whether to modify this to point at our PROD firebase setup in this PR or to try and support both via the debug/release tags in xcode - any thoughts @mohammad-haque ?

Not sure the approach I've gone for the lightbox disable/enable is the best it could be but it does the job - happy to change it though. 

The default config cache time is 12 hours but I've set it to 5 minutes here for now, we should update it to something less frequent in future.

[**Trello Card ->**](https://trello.com/c/8vZuG1Uh/1337-apple-sign-in-behind-server-side-switch)

## Test Plan
We should be able to disable/enable these features in the firebase console and see them reflected on our devices after installing this build. 
