### PR TITLE
fix: Correct the Star background colour

### DIFF
--- a/projects/Mallard/src/components/Stars/Stars.tsx
+++ b/projects/Mallard/src/components/Stars/Stars.tsx
@@ -15,13 +15,12 @@ const styles = StyleSheet.create({
         letterSpacing: 0.25,
         ...getFont('icon', 1),
     },
-    trailImage: {
+    bottomLeft: {
         position: 'absolute',
-        backgroundColor: 'white',
         left: 0,
         bottom: 0,
     },
-    smallItems: {
+    inline: {
         flex: 0,
     },
 })
@@ -38,17 +37,17 @@ export const getRatingAsText = (rating: number) =>
     })
 
 const Stars = ({
-    type,
+    position,
     rating,
 }: {
-    type?: 'trailImage' | 'smallItems'
+    position?: 'bottomLeft' | 'inline'
     rating: number
 }) => {
     const ratingAsText = useMemo(() => getRatingAsText(rating), [rating])
     return (
         <View
             accessibilityLabel={`${rating.toString()} stars`}
-            style={[styles.background, type && styles[type]]}
+            style={[styles.background, position && styles[position]]}
         >
             <Text style={styles.text} accessible={false}>
                 {ratingAsText.join('')}

--- a/projects/Mallard/src/components/Stars/__tests__/Stars.spec.tsx
+++ b/projects/Mallard/src/components/Stars/__tests__/Stars.spec.tsx
@@ -14,14 +14,14 @@ describe('Stars', () => {
 
     it('should show a Stars with trailImage styling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <Stars rating={rating} type="trailImage" />,
+            <Stars rating={rating} position="bottomLeft" />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
 
     it('should show a Stars with smallItems styling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <Stars rating={rating} type="smallItems" />,
+            <Stars rating={rating} position="inline" />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/Stars/__tests__/__snapshots__/Stars.spec.tsx.snap
+++ b/projects/Mallard/src/components/Stars/__tests__/__snapshots__/Stars.spec.tsx.snap
@@ -76,7 +76,6 @@ exports[`Stars should show a Stars with trailImage styling 1`] = `
         "paddingHorizontal": 4.666666666666667,
       },
       Object {
-        "backgroundColor": "white",
         "bottom": 0,
         "left": 0,
         "position": "absolute",

--- a/projects/Mallard/src/components/front/items/small-items.tsx
+++ b/projects/Mallard/src/components/front/items/small-items.tsx
@@ -22,7 +22,7 @@ const StarsWrapper = ({ article }: { article: CAPIArticle }) => {
     if (article.type != 'article' || article.starRating == null) return null
     return (
         <View style={styles.starsAndSportScoreWrapper}>
-            <Stars type="smallItems" rating={article.starRating} />
+            <Stars position="inline" rating={article.starRating} />
         </View>
     )
 }

--- a/projects/Mallard/src/components/front/items/trail-image-view.tsx
+++ b/projects/Mallard/src/components/front/items/trail-image-view.tsx
@@ -62,7 +62,7 @@ export const TrailImageView = ({
                     image={image}
                     use={use}
                 />
-                <Stars type="trailImage" rating={starRating} />
+                <Stars position="bottomLeft" rating={starRating} />
             </View>
         )
     } else if (sportScore) {

--- a/projects/Mallard/src/components/stars/Stars.stories.tsx
+++ b/projects/Mallard/src/components/stars/Stars.stories.tsx
@@ -9,8 +9,8 @@ storiesOf('Stars', module)
     .addDecorator(withKnobs)
     .add('Stars - default', () => <Stars rating={rating} />)
     .add('Stars - smallItems', () => (
-        <Stars rating={rating} type="smallItems" />
+        <Stars rating={rating} position="inline" />
     ))
     .add('Stars - trailImage', () => (
-        <Stars rating={rating} type="trailImage" />
+        <Stars rating={rating} position="bottomLeft" />
     ))


### PR DESCRIPTION
## Summary
This was white when it should have been yellow.

Also after discussion with Ana, I have changed the API a bit so that it is based on positioning rather than type. This is a bit literal for my liking but will help with understanding in the future.

![Simulator Screen Shot - iPhone 11 - 2020-06-03 at 09 22 48](https://user-images.githubusercontent.com/935975/83614988-de762080-a57d-11ea-9970-1dc8d080c3d0.png)

