### PR TITLE
Show error message when login fails.

### DIFF
--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -99,6 +99,7 @@ const AuthSwitcherScreen = ({
                             }
                             navigation.goBack()
                         } else {
+                            attempt.reason && setError(attempt.reason)
                             // push this into the catch logic below
                             throw attempt.reason
                         }


### PR DESCRIPTION
## Summary
When a user types in invalid login credentials we ought to show an error message. For some reason we're not doing that at the moment. This change fixes that.

[**Trello Card ->**](https://trello.com/c/15kppWd2/1347-incorrect-password-error-no-longer-shown-on-the-sign-in-screen-for-email)

## Test Plan
Try signing in using identity with invalid credentials. You should see something like this:

<img width="354" alt="Screenshot 2020-06-03 at 16 29 39" src="https://user-images.githubusercontent.com/3606555/83656804-ece12e00-a5b7-11ea-951a-356e67bb6e5d.png">

