### PR TITLE
fix: Disable Analytics Belt and Braces

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,8 @@
       android:appComponentFactory="androidx.core.app.CoreComponentFactory"
       >
 
+      <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
+
     <receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationPublisher" />
     <receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationBootEventReceiver">
         <intent-filter>

--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -45,6 +45,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -9,6 +9,8 @@ PODS:
     - React-Core (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/turbomodule/core (= 0.61.5)
+  - Firebase/Analytics (6.13.0):
+    - Firebase/Core
   - Firebase/Core (6.13.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (= 6.1.6)
@@ -333,6 +335,11 @@ PODS:
     - React
   - RNDeviceInfo (5.3.1):
     - React
+  - RNFBAnalytics (6.7.2):
+    - Firebase/Analytics (~> 6.13.0)
+    - Firebase/Core (~> 6.13.0)
+    - React
+    - RNFBApp
   - RNFBApp (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - React
@@ -416,6 +423,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - "RNFBAnalytics (from `../node_modules/@react-native-firebase/analytics`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -534,6 +542,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNFBAnalytics:
+    :path: "../node_modules/@react-native-firebase/analytics"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBRemoteConfig:
@@ -618,6 +628,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: b79e193409a90bf6b5170d421684f437ff4e2278
   RNCPushNotificationIOS: 0b8d06ff190d84627dd17501bfb96652375970e4
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
+  RNFBAnalytics: 29bc4baf70da8dc04238d2e1c050367264d2f440
   RNFBApp: 7b539bb25520fa73d6a240f5c6ea569e27683645
   RNFBRemoteConfig: 59818c5933149b5a6b7fe5159e3d4df09199e858
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -42,6 +42,7 @@
         "@react-native-community/netinfo": "^5.6.2",
         "@react-native-community/push-notification-ios": "^1.0.2",
         "@react-native-community/viewpager": "^2.0.1",
+        "@react-native-firebase/analytics": "^6.7.1",
         "@react-native-firebase/app": "^6.7.1",
         "@react-native-firebase/remote-config": "^6.7.1",
         "@sentry/react-native": "^1.3.9",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -41,6 +41,9 @@ import ApolloClient from 'apollo-client'
 import { pushDownloadFailsafe } from './helpers/push-download-failsafe'
 import { prepareAndDownloadTodaysIssue } from './download-edition/prepare-and-download-issue'
 import { initialiseRemoteConfig } from './services/remote-config'
+import analytics from '@react-native-firebase/analytics'
+
+analytics().setAnalyticsCollectionEnabled(false)
 
 /**
  * Only one global Apollo client. As such, any update done from any component

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2148,6 +2148,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-2.0.1.tgz#892e2148c8bca4ff157280e4be81d88be3264efc"
   integrity sha512-fTTpO6xdVrTAAWbC1B2TQbxOkzDtvE9YfovDPYpi+S9oWmT06Eh8pv1Umd/7R/ewuLy9i2fzBnAu5WY+Di8OwA==
 
+"@react-native-firebase/analytics@^6.7.1":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/analytics/-/analytics-6.7.2.tgz#5f5d6cdefbee09e2a45e33e8dbf55cbc3452c64b"
+  integrity sha512-PKNTvufrQ6ZTsjVzMyCzZncy14PsnSQqqGFXeoMK+Jwa3byJaz8rwVmgeGEwKUkcWQOmEQA0KxmIKjXHLeUskw==
+
 "@react-native-firebase/app-types@6.7.1":
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/@react-native-firebase/app-types/-/app-types-6.7.1.tgz#93497885e6c112203db310636616647c16478da9"


### PR DESCRIPTION
## Summary
The previous implementation as feared did not work.

This appears to have done the trick but we shall need to keep an eye on it. 

This "temporarily" disables analytics data collection which can then be turned on later using JS rather than the nuclear option. This gives us room in the future for collection via consent.

I have also added the JS library to ensure it is turned off when the app starts up.