### PR TITLE
Removed old firebase analytics lib(core)

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -226,7 +226,6 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     // These should be auto linked. TODO: TEST THIS
-    implementation "com.google.firebase:firebase-core:17.0.1"
     implementation "com.google.firebase:firebase-messaging:19.0.1"
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'


### PR DESCRIPTION
## Summary

This PR removes the old firebase analytics (core) library declared in build.gradle. We now have a new analytics library declared in package.json