### PR TITLE
Fix/lightbox-progress-indicator

### DIFF
--- a/projects/Mallard/src/components/article/progress-indicator.tsx
+++ b/projects/Mallard/src/components/article/progress-indicator.tsx
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
     },
 })
 
-type ProgressType = 'current' | 'small' | 'big' | 'hidden'
+type ProgressType = 'current' | 'small' | 'big'
 
 type ProgressIndicatorProps = {
     imageCount: number
@@ -22,7 +22,7 @@ type ProgressIndicatorProps = {
 }
 
 const progressStyle = (type: ProgressType) => {
-    const diameter = type === 'small' ? 5 : type === 'hidden' ? 3 : 10
+    const diameter = type === 'small' ? 5 : 10
     const colour =
         type === 'current' ? 'white' : themeColors(ArticleTheme.Dark).line
     return {

--- a/projects/Mallard/src/components/article/progress-indicator.tsx
+++ b/projects/Mallard/src/components/article/progress-indicator.tsx
@@ -89,9 +89,7 @@ export const ProgressIndicator = ({
     const circles = Array(windowSize)
         .fill('', 0)
         .map((e, index) =>
-            scrollInProgress && (showStarter && showEnd && index === 0)
-                ? 'hidden'
-                : scrollInProgress && (showEnd && index === windowSize - 1)
+            scrollInProgress && (showStarter && showEnd) && index === current
                 ? 'big'
                 : (showStarter && index === 0) ||
                   (showEnd && index === windowSize - 1)

--- a/projects/Mallard/src/components/article/progress-indicator.tsx
+++ b/projects/Mallard/src/components/article/progress-indicator.tsx
@@ -11,17 +11,18 @@ const styles = StyleSheet.create({
     },
 })
 
-type ProgressType = 'current' | 'small' | 'big'
+type ProgressType = 'current' | 'small' | 'big' | 'hidden'
 
 type ProgressIndicatorProps = {
     imageCount: number
     currentIndex: number
     windowStart: number
     windowSize: number
+    scrollInProgress: boolean
 }
 
 const progressStyle = (type: ProgressType) => {
-    const diameter = type === 'small' ? 5 : 10
+    const diameter = type === 'small' ? 5 : type === 'hidden' ? 3 : 10
     const colour =
         type === 'current' ? 'white' : themeColors(ArticleTheme.Dark).line
     return {
@@ -80,6 +81,7 @@ export const ProgressIndicator = ({
     currentIndex,
     windowStart,
     windowSize,
+    scrollInProgress,
 }: ProgressIndicatorProps) => {
     const current = currentIndex - windowStart
     const showStarter = windowStart > 0
@@ -87,8 +89,12 @@ export const ProgressIndicator = ({
     const circles = Array(windowSize)
         .fill('', 0)
         .map((e, index) =>
-            (showStarter && index === 0) ||
-            (showEnd && index === windowSize - 1)
+            scrollInProgress && (showStarter && showEnd && index === 0)
+                ? 'hidden'
+                : scrollInProgress && (showEnd && index === windowSize - 1)
+                ? 'big'
+                : (showStarter && index === 0) ||
+                  (showEnd && index === windowSize - 1)
                 ? 'small'
                 : index === current
                 ? 'current'

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -92,12 +92,19 @@ const LightboxScreen = ({
 
     const [closeButtonVisible, setCloseButtonVisible] = useState(false)
 
+    const [scrollInProgress, setScrollInProgress] = useState(false)
+
     const handleScrollEndEvent = (ev: any) => {
         const newIndex = Math.ceil(ev.nativeEvent.contentOffset.x / width)
         setCurrentIndex(newIndex)
+        setScrollInProgress(false)
         setWindowsStart(
             getNewWindowStart(newIndex, windowStart, images.length, numDots),
         )
+    }
+
+    const handleScrollStartEvent = () => {
+        setScrollInProgress(true)
     }
 
     const focusOnImageComponent = () => {
@@ -150,6 +157,7 @@ const LightboxScreen = ({
                             key={width}
                             data={images}
                             onMomentumScrollEnd={handleScrollEndEvent}
+                            onMomentumScrollBegin={handleScrollStartEvent}
                             getItemLayout={(_: never, index: number) => ({
                                 length: width,
                                 offset: width * index,
@@ -199,6 +207,7 @@ const LightboxScreen = ({
                                 imageCount={images.length}
                                 windowSize={numDots}
                                 windowStart={windowStart}
+                                scrollInProgress={scrollInProgress}
                             />
                         )}
                     </View>


### PR DESCRIPTION
## Summary
This PR adds a flash to indicate that the page has changed, this is needed when there a long list of images.
Bug was found on gallery with more than 14 images and the indicator didn't change between 6 and 12. 
(See video attached)
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/d6XXQPgW/1203-lightbox-bugs)

## Test Plan
You can test on Thursday 5th June National section on the latest article which has 14 images.  
[RPReplay-Final1591294448.MP4.zip](https://github.com/guardian/editions/files/4734634/RPReplay-Final1591294448.MP4.zip)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
