### PR TITLE
Feat/add image zoom library

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -70,7 +70,7 @@
         "react-native-gesture-handler": "^1.5.3",
         "react-native-htmlview": "^0.15.0",
         "react-native-iap": "^3.3.9",
-        "react-native-image-zoom-viewer": "^3.0.1",
+        "react-native-image-pan-zoom": "^2.1.12",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",
         "react-native-keychain": "^3.1.3",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -70,6 +70,7 @@
         "react-native-gesture-handler": "^1.5.3",
         "react-native-htmlview": "^0.15.0",
         "react-native-iap": "^3.3.9",
+        "react-native-image-zoom-viewer": "^3.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",
         "react-native-keychain": "^3.1.3",

--- a/projects/Mallard/src/components/Lightbox/LightboxImage.tsx
+++ b/projects/Mallard/src/components/Lightbox/LightboxImage.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Image, StyleSheet } from 'react-native'
+import { Image, StyleSheet, Dimensions } from 'react-native'
 import { Image as IImage } from '../../../../Apps/common/src'
 import { useImagePath } from 'src/hooks/use-image-paths'
+import ImageZoom from 'react-native-image-pan-zoom'
 
 const styles = StyleSheet.create({
     image: {

--- a/projects/Mallard/src/components/Lightbox/LightboxImage.tsx
+++ b/projects/Mallard/src/components/Lightbox/LightboxImage.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { Image, StyleSheet, Dimensions } from 'react-native'
+import { Image, StyleSheet } from 'react-native'
 import { Image as IImage } from '../../../../Apps/common/src'
 import { useImagePath } from 'src/hooks/use-image-paths'
-import ImageZoom from 'react-native-image-pan-zoom'
 
 const styles = StyleSheet.create({
     image: {

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -13,11 +13,11 @@ import {
 } from 'src/components/article/progress-indicator'
 import { LightboxCaption } from 'src/components/Lightbox/LightboxCaption'
 import { LightboxImage } from 'src/components/Lightbox/LightboxImage'
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 import { palette } from '@guardian/pasteup/palette'
 import { NavigationScreenProp } from 'react-navigation'
 import { StatusBar } from 'react-native'
 import { LightboxNavigationProps } from 'src/navigation/helpers/base'
+import ImageZoom from 'react-native-image-pan-zoom'
 
 const styles = StyleSheet.create({
     lightboxPage: {
@@ -78,7 +78,7 @@ const LightboxScreen = ({
     const index = navigation.getParam('index', 0)
     const pillar = navigation.getParam('pillar', 'news')
     const pillarColors = getPillarColors(pillar)
-    const { width } = useDimensions()
+    const { width, height } = useDimensions()
     const [windowStart, setWindowsStart] = useState(0)
     const [currentIndex, setCurrentIndex] = useState(index)
 
@@ -165,13 +165,16 @@ const LightboxScreen = ({
                                     <View
                                         style={[{ width }, styles.imageWrapper]}
                                     >
-                                        <TouchableWithoutFeedback
-                                            onPress={() =>
-                                                focusOnImageComponent()
-                                            }
+                                        <ImageZoom
+                                            cropWidth={width}
+                                            cropHeight={height}
+                                            imageWidth={width}
+                                            imageHeight={height}
+                                            onClick={focusOnImageComponent}
+                                            minScale={1.0}
                                         >
                                             <LightboxImage image={item} />
-                                        </TouchableWithoutFeedback>
+                                        </ImageZoom>
                                         {captionVisible && item.caption && (
                                             <LightboxCaption
                                                 caption={item.caption}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11002,6 +11002,18 @@ react-native-iap@^3.3.9:
   dependencies:
     dooboolab-welcome "^1.1.0"
 
+react-native-image-pan-zoom@^2.1.12:
+  version "2.1.12"
+  resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
+  integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
+
+react-native-image-zoom-viewer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-3.0.1.tgz#a2bd5fb3bda15e0686ce88fcde8576726495d7fb"
+  integrity sha512-la6s5DNSuq4GCRLsi5CZ29FPjgTpdCuGIRdO5T9rUrAtxrlpBPhhSnHrbmPVxsdtOUvxHacTh2Gfa9+RraMZQA==
+  dependencies:
+    react-native-image-pan-zoom "^2.1.12"
+
 react-native-in-app-utils@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.2.tgz#b44498c7cce772fe1cebb00af082ff7bf4000a55"

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11007,13 +11007,6 @@ react-native-image-pan-zoom@^2.1.12:
   resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
   integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
 
-react-native-image-zoom-viewer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-3.0.1.tgz#a2bd5fb3bda15e0686ce88fcde8576726495d7fb"
-  integrity sha512-la6s5DNSuq4GCRLsi5CZ29FPjgTpdCuGIRdO5T9rUrAtxrlpBPhhSnHrbmPVxsdtOUvxHacTh2Gfa9+RraMZQA==
-  dependencies:
-    react-native-image-pan-zoom "^2.1.12"
-
 react-native-in-app-utils@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.0.2.tgz#b44498c7cce772fe1cebb00af082ff7bf4000a55"


### PR DESCRIPTION
## Summary
This PR enables zoom and pan on lightbox images. 
I have opted to add a library for this case since adding pinch and pan gesture recognizer handlers to an item in a FlatList was causing issues. 
This library has nice of the box functionality for zooming and setting min zoom scale etc. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/d6XXQPgW/1203-lightbox-bugs)

## Test Plan
In order to test this you will need to override `lightboxEnabled` to true on this line https://github.com/guardian/editions/blob/87ab4213e65ef8e4d548d47c8725a97b9c6da525/projects/Mallard/src/components/article/types/article.tsx#L144
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
