### PR TITLE
Feat/add lightbox debug setting

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -146,7 +146,7 @@ const Article = ({
         fetchLightboxSetting().then(lightboxEnabled =>
             setLightboxEnabled(lightboxEnabled),
         )
-    })
+    }, [])
 
     return (
         <Fader>

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import { StyleSheet, Share, Platform } from 'react-native'
 import WebView from 'react-native-webview'
 import { parsePing } from 'src/helpers/webview'
@@ -17,7 +17,7 @@ import {
     CreditedImage,
 } from '../../../../../Apps/common/src'
 import { navigateToLightbox } from 'src/navigation/helpers/base'
-import remoteConfig from '@react-native-firebase/remote-config'
+import { fetchLightboxSetting } from 'src/helpers/settings/debug'
 
 const styles = StyleSheet.create({
     block: {
@@ -132,6 +132,7 @@ const Article = ({
 } & HeaderControlProps) => {
     const [, { type }] = useArticle()
     const ref = useRef<WebView | null>(null)
+    const [lightboxEnabled, setLightboxEnabled] = useState(false)
 
     const wasShowingHeader = useUpdateWebviewVariable(
         ref,
@@ -141,7 +142,11 @@ const Article = ({
 
     const [, { pillar }] = useArticle()
 
-    const lightboxEnabled = remoteConfig().getValue('lightbox_enabled').value
+    useEffect(() => {
+        fetchLightboxSetting().then(lightboxEnabled =>
+            setLightboxEnabled(lightboxEnabled),
+        )
+    })
 
     return (
         <Fader>

--- a/projects/Mallard/src/helpers/settings/debug.ts
+++ b/projects/Mallard/src/helpers/settings/debug.ts
@@ -1,0 +1,21 @@
+import { lightboxSettingCache } from 'src/helpers/storage'
+
+const setlightboxSetting = async (lightboxEnabled: boolean) => {
+    await lightboxSettingCache.set(lightboxEnabled)
+}
+
+const fetchLightboxSetting = async (): Promise<boolean> => {
+    try {
+        const lightboxEnabledStorage = await lightboxSettingCache.get()
+
+        if (lightboxEnabledStorage === null) {
+            setlightboxSetting(false)
+            return false
+        }
+        return lightboxEnabledStorage
+    } catch (e) {
+        return false
+    }
+}
+
+export { fetchLightboxSetting, setlightboxSetting }

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -47,7 +47,9 @@ const legacyCASPasswordCache = createSettingsCacheIOS<string>(
  * A wrapper around AsyncStorage, with json handling and standardizing the interface
  * between AsyncStorage and the keychain helper below
  */
-const createAsyncCache = <T extends object | string | number>(key: string) => ({
+const createAsyncCache = <T extends object | string | boolean | number>(
+    key: string,
+) => ({
     set: (value: T) => AsyncStorage.setItem(key, JSON.stringify(value)),
     get: (): Promise<T | null> =>
         AsyncStorage.getItem(key).then(value => value && JSON.parse(value)),
@@ -69,6 +71,8 @@ const cacheClearCache = createAsyncCache<string>('cacheClear')
 const validAttemptCache = createAsyncCache<number>('validAttempt-cache')
 
 const loggingQueueCache = createAsyncCache<string>('loggingQueue')
+
+const lightboxSettingCache = createAsyncCache<boolean>('lightbox-enabled')
 
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
@@ -131,4 +135,5 @@ export {
     cacheClearCache,
     validAttemptCache,
     loggingQueueCache,
+    lightboxSettingCache,
 }

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -30,6 +30,10 @@ import { useNetInfo } from 'src/hooks/use-net-info'
 import { locale } from 'src/helpers/locale'
 import { imageForScreenSize } from 'src/helpers/screen'
 import { deleteIssueFiles } from 'src/download-edition/clear-issues'
+import {
+    fetchLightboxSetting,
+    setlightboxSetting,
+} from 'src/helpers/settings/debug'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -64,6 +68,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [files, setFiles] = useState('fetching...')
     const [pushTrackingInfo, setPushTrackingInfo] = useState('fetching...')
     const [imageSize, setImageSize] = useState('fetching...')
+    const [lightboxEnabled, setLightboxEnabled] = useState(false)
     const buildNumber = DeviceInfo.getBuildNumber()
 
     useEffect(() => {
@@ -83,6 +88,17 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
             imageSize => imageSize && setImageSize(imageSize),
         )
     }, [])
+
+    useEffect(() => {
+        fetchLightboxSetting().then(lightboxEnabled =>
+            setLightboxEnabled(lightboxEnabled),
+        )
+    })
+
+    const onToggleLightbox = () => {
+        setLightboxEnabled(!lightboxEnabled)
+        setlightboxSetting(!lightboxEnabled)
+    }
 
     const query = useQuery<{ [key: string]: unknown }>(
         gql(`{ ${ALL_SETTINGS_FRAGMENT} }`),
@@ -229,6 +245,17 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                             Clipboard.setString(FSPaths.issuesDir)
                             Alert.alert(FSPaths.issuesDir)
                         },
+                    },
+                    {
+                        key: 'Enable lightbox',
+                        title: 'Enable lightbox',
+                        onPress: onToggleNetInfoButton,
+                        proxy: (
+                            <Switch
+                                value={lightboxEnabled}
+                                onValueChange={onToggleLightbox}
+                            />
+                        ),
                     },
                     {
                         key: 'Display NetInfo Button',

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -93,7 +93,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
         fetchLightboxSetting().then(lightboxEnabled =>
             setLightboxEnabled(lightboxEnabled),
         )
-    })
+    }, [])
 
     const onToggleLightbox = () => {
         setLightboxEnabled(!lightboxEnabled)


### PR DESCRIPTION
## Summary
This PR replaces a remote config setting for lightbox with a setting in the secret duck menu, to allow us to test lightbox internally but not release to the public. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

https://trello.com/c/zjHRmXHh/1329-disable-lightbox-before-production-releases
## Test Plan
Ensure that  lightbox is disabled by default and that the switch allows it to be enabled and persists between launches. 
You will find the new switch in the secret duck menu. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
