### PR TITLE
Revert "Set build number to 751 (#1242)"

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -48,7 +48,7 @@ platform :ios do
 
     increment_build_number(
       xcodeproj: "ios/Mallard.xcodeproj",
-      build_number: 751
+      build_number: latest_testflight_build_number.to_i + 1
     )
     build_app(
       scheme: "Mallard",


### PR DESCRIPTION
This reverts commit a55d0df8fe5d6d007452b396405ba1b1bbddd3e6.
The build number should be incremented from the latest testflight build. 
