### PR TITLE
enable lightbox for cartoons

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -42,6 +42,7 @@ const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
             id: 'image',
             role: 'immersive',
         },
+        index: 0, // allows us to open lightbox
         path,
     })
 }

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -198,7 +198,8 @@ const ImageBase = ({
         <figure class="image" data-role="${role || 'inline'}">
             <img
                 src="${path}"
-                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
+                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index ||
+                    0}, isMainImage: 'false'}))"
                 alt="${alt}"
                 id="img-${index}"
             />

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -198,8 +198,7 @@ const ImageBase = ({
         <figure class="image" data-role="${role || 'inline'}">
             <img
                 src="${path}"
-                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index ||
-                    0}, isMainImage: 'false'}))"
+                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
                 alt="${alt}"
                 id="img-${index}"
             />

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -200,7 +200,10 @@ const Article = ({
                         // to avoid image duplication we don't add the main image of gallery articles to the array
                         if (article.type !== 'gallery' && article.image) {
                             lbCreditedImages.unshift(article.image)
-                            if (parsed.isMainImage === 'false') {
+                            if (
+                                parsed.isMainImage === 'false' &&
+                                lbCreditedImages.length > 1
+                            ) {
                                 index++
                             }
                         }


### PR DESCRIPTION
## Summary
After further testing of lightbox, I noticed that cartoon images were not opening. 
This is because the index was undefined and therefore the message was not being parsed correctly, this provides a default value if the index isn't defined.
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/d6XXQPgW/1203-lightbox-bugs)

## Test Plan
Find a cartoon article, usually found within the "Comment" section and ensure it opens in lightbox. 
<!-- 
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
