### PR TITLE
Reduce log lambda timeout to 1 second.

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -59,7 +59,7 @@ export class LoggingStack extends cdk.Stack {
                 functionName: `editions-logging-${stageParameter.valueAsString}`,
                 runtime: lambda.Runtime.NODEJS_10_X,
                 memorySize: 128,
-                timeout: Duration.seconds(5),
+                timeout: Duration.seconds(1),
                 code: Code.bucket(
                     deployBucket,
                     `${stackParameter.valueAsString}/${stageParameter.valueAsString}/logging/logging.zip`,

--- a/projects/logging/application.ts
+++ b/projects/logging/application.ts
@@ -36,7 +36,7 @@ export const createApp = (): express.Application => {
 
     app.post(
         '/log/mallard',
-        express.json({ limit: '1mb  ' }),
+        express.json({ limit: '1mb' }),
         (req: Request, res: Response) => {
             if (req.body) {
                 const data = Array.isArray(req.body) ? req.body : [req.body]


### PR DESCRIPTION
## Summary

The average execution time of this lambda is 30ms. 1s timeout allows for invocations that take 30 times longer than the average, which seems reasonable breathing room.
