### PR TITLE
feat: Default Locale will set Edition

### DIFF
--- a/projects/Mallard/src/__mocks__/@react-native-firebase/remote-config.js
+++ b/projects/Mallard/src/__mocks__/@react-native-firebase/remote-config.js
@@ -1,0 +1,3 @@
+export default () => ({
+    getValue: () => jest.fn().mockReturnValue({ value: undefined }),
+})

--- a/projects/Mallard/src/__mocks__/helpers/locale.ts
+++ b/projects/Mallard/src/__mocks__/helpers/locale.ts
@@ -1,3 +1,0 @@
-export default () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-})

--- a/projects/Mallard/src/__mocks__/helpers/locale.ts
+++ b/projects/Mallard/src/__mocks__/helpers/locale.ts
@@ -1,0 +1,3 @@
+export default () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+})

--- a/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
+++ b/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
@@ -1,8 +1,6 @@
 import { getUserName, detectAuthType } from '../IdentityAuthorizer'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('IdentityAuthorizer', () => {
     describe('getUserName', () => {

--- a/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
+++ b/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
@@ -1,5 +1,9 @@
 import { getUserName, detectAuthType } from '../IdentityAuthorizer'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('IdentityAuthorizer', () => {
     describe('getUserName', () => {
         it('returns correct usernames for valid params', () => {

--- a/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
+++ b/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
@@ -1,10 +1,14 @@
 import { getUserName, detectAuthType } from '../IdentityAuthorizer'
+import { locale } from 'src/helpers/locale'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('IdentityAuthorizer', () => {
     describe('getUserName', () => {
         it('returns correct usernames for valid params', () => {
+            console.log(locale)
             expect(
                 getUserName('google', { 'google-access-token': 'blah' }),
             ).toBe('gu-editions::token::google')

--- a/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
+++ b/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
@@ -3,9 +3,7 @@ import { AccessController } from '../AccessController'
 import { AnyAttempt } from '../Attempt'
 import { AuthResult, ValidResult, InvalidResult } from '../Result'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 class AsyncStorage<T> {
     constructor(private data: T | null = null) {}

--- a/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
+++ b/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
@@ -3,6 +3,10 @@ import { AccessController } from '../AccessController'
 import { AnyAttempt } from '../Attempt'
 import { AuthResult, ValidResult, InvalidResult } from '../Result'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 class AsyncStorage<T> {
     constructor(private data: T | null = null) {}
     async get() {

--- a/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
+++ b/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
@@ -3,7 +3,9 @@ import { AccessController } from '../AccessController'
 import { AnyAttempt } from '../Attempt'
 import { AuthResult, ValidResult, InvalidResult } from '../Result'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 class AsyncStorage<T> {
     constructor(private data: T | null = null) {}

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -2,11 +2,6 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { LightboxCaption } from '../LightboxCaption'
 
-jest.mock('@react-native-firebase/remote-config', () => {
-    remoteConfig: jest.fn(() => ({
-        getValue: jest.fn(),
-    }))
-})
 jest.mock('src/helpers/locale', () => ({
     locale: () => jest.fn().mockReturnValue('en_GB'),
 }))

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { LightboxCaption } from '../LightboxCaption'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('LightboxCaption', () => {
     it('should show a LightboxCaption with a pillar colour', () => {

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { LightboxCaption } from '../LightboxCaption'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('LightboxCaption', () => {
     it('should show a LightboxCaption with a pillar colour', () => {

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -7,6 +7,9 @@ jest.mock('@react-native-firebase/remote-config', () => {
         getValue: jest.fn(),
     }))
 })
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
 
 describe('LightboxCaption', () => {
     it('should show a LightboxCaption with a pillar colour', () => {

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -1,6 +1,8 @@
 import { renderCaption } from '../components/images'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('html', () => {
     describe('renderCaption', () => {

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -5,6 +5,9 @@ jest.mock('@react-native-firebase/remote-config', () => {
         getValue: jest.fn(),
     }))
 })
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
 
 describe('html', () => {
     describe('renderCaption', () => {

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -1,8 +1,6 @@
 import { renderCaption } from '../components/images'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('html', () => {
     describe('renderCaption', () => {

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -1,10 +1,5 @@
 import { renderCaption } from '../components/images'
 
-jest.mock('@react-native-firebase/remote-config', () => {
-    remoteConfig: jest.fn(() => ({
-        getValue: jest.fn(),
-    }))
-})
 jest.mock('src/helpers/locale', () => ({
     locale: () => jest.fn().mockReturnValue('en_GB'),
 }))

--- a/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
@@ -1,9 +1,7 @@
 import MockDate from 'mockdate'
 import { issuesToDelete } from 'src/helpers/files'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('clear issues', () => {
     describe('issuesToDelete', () => {

--- a/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
@@ -1,7 +1,9 @@
 import MockDate from 'mockdate'
 import { issuesToDelete } from 'src/helpers/files'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('clear issues', () => {
     describe('issuesToDelete', () => {

--- a/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
@@ -1,6 +1,10 @@
 import MockDate from 'mockdate'
 import { issuesToDelete } from 'src/helpers/files'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('clear issues', () => {
     describe('issuesToDelete', () => {
         MockDate.set('2019-08-21')

--- a/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
@@ -2,9 +2,7 @@ import ApolloClient from 'apollo-client'
 import { DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import { downloadAndUnzipIssue } from '../download-and-unzip'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 const createIssueSummary = (localId: string) => ({
     key: 'de/1-1-1',

--- a/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
@@ -2,6 +2,10 @@ import ApolloClient from 'apollo-client'
 import { DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import { downloadAndUnzipIssue } from '../download-and-unzip'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 const createIssueSummary = (localId: string) => ({
     key: 'de/1-1-1',
     name: 'any',

--- a/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
@@ -2,7 +2,9 @@ import ApolloClient from 'apollo-client'
 import { DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import { downloadAndUnzipIssue } from '../download-and-unzip'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 const createIssueSummary = (localId: string) => ({
     key: 'de/1-1-1',

--- a/projects/Mallard/src/download-edition/download-todays-issue.ts
+++ b/projects/Mallard/src/download-edition/download-todays-issue.ts
@@ -7,7 +7,7 @@ import { errorService } from 'src/services/errors'
 import { downloadAndUnzipIssue } from './download-and-unzip'
 
 const downloadTodaysIssue = async (client: ApolloClient<object>) => {
-    const todaysKey = todayAsKey()
+    const todaysKey = await todayAsKey()
     try {
         const issueSummaries = await getIssueSummary()
 

--- a/projects/Mallard/src/helpers/__mocks__/locale.ts
+++ b/projects/Mallard/src/helpers/__mocks__/locale.ts
@@ -1,0 +1,3 @@
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))

--- a/projects/Mallard/src/helpers/__mocks__/locale.ts
+++ b/projects/Mallard/src/helpers/__mocks__/locale.ts
@@ -1,3 +1,0 @@
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))

--- a/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
@@ -3,6 +3,10 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { defaultSettings } from '../settings/defaults'
 import { fetchCacheClear } from '../fetch'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('helpers/fetch', () => {
     describe('fetchCacheClear', () => {
         it('should set the cache clear item if there is none and return true', async () => {

--- a/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
@@ -3,9 +3,7 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { defaultSettings } from '../settings/defaults'
 import { fetchCacheClear } from '../fetch'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('helpers/fetch', () => {
     describe('fetchCacheClear', () => {

--- a/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
@@ -3,7 +3,9 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { defaultSettings } from '../settings/defaults'
 import { fetchCacheClear } from '../fetch'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('helpers/fetch', () => {
     describe('fetchCacheClear', () => {

--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -2,9 +2,7 @@ import MockDate from 'mockdate'
 import { matchSummmaryToKey, issuesToDelete } from '../../helpers/files'
 import { issueSummaries } from '../../../../Apps/common/src/__tests__/fixtures/IssueSummary'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('helpers/files', () => {
     describe('matchSummmaryToKey', () => {

--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -2,7 +2,9 @@ import MockDate from 'mockdate'
 import { matchSummmaryToKey, issuesToDelete } from '../../helpers/files'
 import { issueSummaries } from '../../../../Apps/common/src/__tests__/fixtures/IssueSummary'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('helpers/files', () => {
     describe('matchSummmaryToKey', () => {

--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -2,6 +2,10 @@ import MockDate from 'mockdate'
 import { matchSummmaryToKey, issuesToDelete } from '../../helpers/files'
 import { issueSummaries } from '../../../../Apps/common/src/__tests__/fixtures/IssueSummary'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('helpers/files', () => {
     describe('matchSummmaryToKey', () => {
         it('should return a matched IssueSummary if the key matches', () => {

--- a/projects/Mallard/src/helpers/__tests__/issues.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/issues.spec.ts
@@ -1,6 +1,10 @@
 import MockDate from 'mockdate'
 import { todayAsFolder, lastNDays, todayAsKey } from '../issues'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('helpers/issues', () => {
     describe('todayAsFolder', () => {
         it('should return "today\'s" date in the correct format', () => {
@@ -25,9 +29,10 @@ describe('helpers/issues', () => {
     })
 
     describe('todayAsKey', () => {
-        it('should return a key in the correct format for "todays" date', () => {
+        it('should return a key in the correct format for "todays" date', async () => {
             MockDate.set('2019-08-21')
-            expect(todayAsKey()).toEqual('daily-edition/2019-08-21')
+            const funcToTest = await todayAsKey()
+            expect(funcToTest).toEqual('daily-edition/2019-08-21')
         })
     })
 })

--- a/projects/Mallard/src/helpers/__tests__/issues.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/issues.spec.ts
@@ -1,7 +1,9 @@
 import MockDate from 'mockdate'
 import { todayAsFolder, lastNDays, todayAsKey } from '../issues'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('helpers/issues', () => {
     describe('todayAsFolder', () => {

--- a/projects/Mallard/src/helpers/__tests__/issues.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/issues.spec.ts
@@ -1,9 +1,7 @@
 import MockDate from 'mockdate'
 import { todayAsFolder, lastNDays, todayAsKey } from '../issues'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('helpers/issues', () => {
     describe('todayAsFolder', () => {

--- a/projects/Mallard/src/helpers/__tests__/settings.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/settings.spec.ts
@@ -1,6 +1,8 @@
 import { withConsent } from '../settings'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('settings', () => {
     describe('withConsent', () => {

--- a/projects/Mallard/src/helpers/__tests__/settings.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/settings.spec.ts
@@ -1,8 +1,6 @@
 import { withConsent } from '../settings'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('settings', () => {
     describe('withConsent', () => {

--- a/projects/Mallard/src/helpers/__tests__/settings.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/settings.spec.ts
@@ -1,5 +1,9 @@
 import { withConsent } from '../settings'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('settings', () => {
     describe('withConsent', () => {
         it('runs deny when the relevant setting is not there', async () => {

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -6,7 +6,7 @@ import { IssueSummary } from '../../../Apps/common/src'
 import { lastNDays } from './issues'
 import { imageForScreenSize } from './screen'
 import { getSetting } from './settings'
-import { defaultSettings } from './settings/defaults'
+import { defaultSettings, editions } from './settings/defaults'
 import { errorService } from 'src/services/errors'
 import { londonTime } from './date'
 import { withCache } from './fetch/cache'
@@ -35,9 +35,13 @@ export const ensureDirExists = (dir: string): Promise<void> =>
 /*
 We always try to prep the file system before accessing issuesDir
 */
-export const prepFileSystem = (): Promise<void> =>
+export const prepFileSystem = (): Promise<void[]> =>
     ensureDirExists(FSPaths.issuesDir).then(() =>
-        ensureDirExists(`${FSPaths.issuesDir}/daily-edition`),
+        Promise.all(
+            Object.values(editions).map(edition =>
+                ensureDirExists(`${FSPaths.issuesDir}/${edition}`),
+            ),
+        ),
     )
 
 export const getJson = <T extends any>(path: string): Promise<T> =>
@@ -121,20 +125,22 @@ export type DLStatus =
 
 const withPathPrefix = (prefix: string) => (str: string) => `${prefix}/${str}`
 
-export const getLocalIssues = () =>
-    RNFetchBlob.fs
-        .ls(FSPaths.contentPrefixDir)
-        .then(files => files.map(withPathPrefix(defaultSettings.contentPrefix)))
+export const getLocalIssues = async () => {
+    const editionDirectory = await FSPaths.editionDir()
+    const edition = await getSetting('edition')
+    return RNFetchBlob.fs
+        .ls(editionDirectory)
+        .then(files => files.map(withPathPrefix(edition)))
+}
 
 export const issuesToDelete = async (files: string[]) => {
     const maxAvailableEditions = await getSetting('maxAvailableEditions')
+    const edition = await getSetting('edition')
     const lastNumberOfDays = lastNDays(maxAvailableEditions)
     return files.filter(
         issue =>
-            !lastNumberOfDays
-                .map(withPathPrefix(defaultSettings.contentPrefix))
-                .includes(issue) &&
-            issue !== `${defaultSettings.contentPrefix}/issues`,
+            !lastNumberOfDays.map(withPathPrefix(edition)).includes(issue) &&
+            issue !== `${edition}/issues`,
     )
 }
 
@@ -148,9 +154,10 @@ export const matchSummmaryToKey = (
     return summaryMatch || null
 }
 
-export const readIssueSummary = async (): Promise<IssueSummary[]> =>
-    RNFetchBlob.fs
-        .readFile(FSPaths.contentPrefixDir + defaultSettings.issuesPath, 'utf8')
+export const readIssueSummary = async (): Promise<IssueSummary[]> => {
+    const editionDirectory = await FSPaths.editionDir()
+    return RNFetchBlob.fs
+        .readFile(editionDirectory + defaultSettings.issuesPath, 'utf8')
         .then(data => {
             try {
                 return JSON.parse(data)
@@ -164,10 +171,12 @@ export const readIssueSummary = async (): Promise<IssueSummary[]> =>
         .catch(e => {
             throw e
         })
+}
 
 export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
     const apiUrl = await getSetting('apiUrl')
     const edition = await getSetting('edition')
+    const editionDirectory = await FSPaths.editionDir()
 
     const fetchIssueSummaryUrl = `${apiUrl}${edition}/issues`
 
@@ -180,7 +189,7 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
 
         const issueSummaryString = JSON.stringify(issueSummary)
         await RNFetchBlob.fs.writeFile(
-            FSPaths.contentPrefixDir + defaultSettings.issuesPath,
+            editionDirectory + defaultSettings.issuesPath,
             issueSummaryString,
             'utf8',
         )
@@ -207,9 +216,8 @@ const cleanFileDisplay = (stat: {
 
 export const getFileList = async () => {
     const imageFolders: RNFetchBlobStat[] = []
-    const files = await RNFetchBlob.fs.lstat(
-        FSPaths.issuesDir + '/daily-edition',
-    )
+    const editionDirectory = await FSPaths.editionDir()
+    const files = await RNFetchBlob.fs.lstat(editionDirectory)
 
     const subfolders = await Promise.all(
         files.map(file =>
@@ -252,9 +260,7 @@ export const getFileList = async () => {
         value => Object.keys(value).length !== 0,
     )
 
-    const issuesFile = await RNFetchBlob.fs.stat(
-        FSPaths.issuesDir + '/daily-edition/issues',
-    )
+    const issuesFile = await RNFetchBlob.fs.stat(editionDirectory + '/issues')
 
     const cleanIssuesFile = [
         {

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -1,7 +1,7 @@
 import { Issue } from 'src/common'
 import { useMemo } from 'react'
-import { defaultSettings } from 'src/helpers/settings/defaults'
 import { londonTime } from './date'
+import { getSetting } from './settings'
 
 const months = [
     'January',
@@ -62,8 +62,10 @@ const dateToFolderConvert = (date: Date): string => {
 export const todayAsFolder = (): string =>
     dateToFolderConvert(londonTime().toDate())
 
-export const todayAsKey = (): string =>
-    `${defaultSettings.contentPrefix}/${todayAsFolder()}`
+export const todayAsKey = async (): Promise<string> => {
+    const edition = await getSetting('edition')
+    return `${edition}/${todayAsFolder()}`
+}
 
 export const lastNDays = (n: number): string[] => {
     return Array.from({ length: n }, (_, i) => {

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -69,7 +69,6 @@ export interface DevSettings {
     notificationServiceRegister: string
     cacheClearUrl: string
     deprecationWarningUrl: string
-    contentPrefix: string
     storeDetails: {
         ios: string
         android: string

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
@@ -1,8 +1,6 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
@@ -1,5 +1,9 @@
 import { baseTests } from './defaults.base'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {
         beforeEach(() => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
@@ -1,6 +1,8 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
@@ -1,8 +1,6 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
@@ -1,5 +1,9 @@
 import { baseTests } from './defaults.base'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {
         baseTests({

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
@@ -1,6 +1,8 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -1,5 +1,6 @@
 import { Settings } from '../settings'
 import { Platform } from 'react-native'
+import { locale } from '../locale'
 
 /*
 Default settings.
@@ -55,6 +56,11 @@ export const editions = {
     training: 'training-edition',
 }
 
+const localeToEdition = new Map<string, string>()
+localeToEdition.set('en_AU', editions.ausWeekly)
+localeToEdition.set('en_US', editions.usWeekly)
+localeToEdition.set('en_GB', editions.daily)
+
 export const notificationServiceRegister = {
     prod: 'https://notifications.guardianapis.com/device/register',
     code: 'https://notifications.code.dev-guardianapis.com/device/register',
@@ -105,18 +111,19 @@ export const notificationTrackingUrl = (
 
 const apiUrl = backends[0].value
 
-const edition = editions.daily
+const edition = localeToEdition.has(locale)
+    ? localeToEdition.get(locale)
+    : editions.daily
+// const edition = editions.daily
 
 const storeDetails = {
     ios: 'itms-apps://itunes.apple.com/app/id452707806',
     android: 'market://details?id=com.guardian.editions',
 }
 
-const contentPrefix = 'daily-edition'
-
 export const defaultSettings: Settings = {
     apiUrl,
-    edition,
+    edition: edition || editions.daily,
     isUsingProdDevtools: false,
     gdprAllowEssential: true, // essential defaults to true and not switchable
     gdprAllowPerformance: null,
@@ -131,7 +138,6 @@ export const defaultSettings: Settings = {
         : notificationServiceRegister.prod,
     cacheClearUrl: apiUrl + 'cache-clear',
     deprecationWarningUrl: apiUrl + 'deprecation-warning',
-    contentPrefix,
     issuesPath: `/issues`,
     storeDetails,
     senderId: __DEV__ ? senderId.code : senderId.prod,

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -1,6 +1,7 @@
-import { Settings } from '../settings'
+import remoteConfig from '@react-native-firebase/remote-config'
 import { Platform } from 'react-native'
 import { locale } from '../locale'
+import { Settings } from '../settings'
 
 /*
 Default settings.
@@ -111,10 +112,11 @@ export const notificationTrackingUrl = (
 
 const apiUrl = backends[0].value
 
-const edition = localeToEdition.has(locale)
-    ? localeToEdition.get(locale)
-    : editions.daily
-// const edition = editions.daily
+const defaultLocaleEnabled = remoteConfig().getValue('default_locale').value
+const edition =
+    defaultLocaleEnabled && localeToEdition.has(locale)
+        ? localeToEdition.get(locale)
+        : editions.daily
 
 const storeDetails = {
     ios: 'itms-apps://itunes.apple.com/app/id452707806',

--- a/projects/Mallard/src/paths/__tests__/index.spec.ts
+++ b/projects/Mallard/src/paths/__tests__/index.spec.ts
@@ -8,7 +8,9 @@ jest.mock('rn-fetch-blob', () => ({
     },
 }))
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 describe('paths', () => {
     describe('FSPaths', () => {

--- a/projects/Mallard/src/paths/__tests__/index.spec.ts
+++ b/projects/Mallard/src/paths/__tests__/index.spec.ts
@@ -8,14 +8,12 @@ jest.mock('rn-fetch-blob', () => ({
     },
 }))
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 describe('paths', () => {
     describe('FSPaths', () => {
-        it('should give correct context prefixed directory', () => {
-            expect(FSPaths.contentPrefixDir).toEqual(
-                'path/to/base/directory/issues/daily-edition',
-            )
-        })
-
         it('should give correct issues directory', () => {
             expect(FSPaths.issuesDir).toEqual('path/to/base/directory/issues')
         })

--- a/projects/Mallard/src/paths/__tests__/index.spec.ts
+++ b/projects/Mallard/src/paths/__tests__/index.spec.ts
@@ -8,9 +8,7 @@ jest.mock('rn-fetch-blob', () => ({
     },
 }))
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 describe('paths', () => {
     describe('FSPaths', () => {

--- a/projects/Mallard/src/paths/index.ts
+++ b/projects/Mallard/src/paths/index.ts
@@ -12,6 +12,7 @@ import {
 import RNFetchBlob from 'rn-fetch-blob'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { imagePath } from '../../../Apps/common/src'
+import { getSetting } from 'src/helpers/settings'
 
 export interface PathToIssue {
     localIssueId: Issue['localId']
@@ -36,10 +37,16 @@ const issuesDir = `${RNFetchBlob.fs.dirs.DocumentDir}/issues`
 
 const issueRoot = (localIssueId: string) => `${issuesDir}/${localIssueId}`
 const mediaRoot = (localIssueId: string) => `${issueRoot(localIssueId)}/media`
+const editionDir = async () => {
+    const edition = await getSetting('edition')
+    return edition
+        ? `${issuesDir}/${edition}`
+        : `${issuesDir}/${defaultSettings.edition}`
+}
 
 export const FSPaths = {
     issuesDir,
-    contentPrefixDir: `${issuesDir}/${defaultSettings.contentPrefix}`,
+    editionDir,
     issueRoot,
     mediaRoot,
     image: (

--- a/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
@@ -5,9 +5,7 @@ import {
 } from 'src/test-helpers/test-helpers'
 import moment from 'moment'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 const _today = moment()
 const today = () => _today.clone()

--- a/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
@@ -5,7 +5,9 @@ import {
 } from 'src/test-helpers/test-helpers'
 import moment from 'moment'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 const _today = moment()
 const today = () => _today.clone()

--- a/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
@@ -5,6 +5,10 @@ import {
 } from 'src/test-helpers/test-helpers'
 import moment from 'moment'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 const _today = moment()
 const today = () => _today.clone()
 

--- a/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
@@ -2,9 +2,7 @@ import MockDate from 'mockdate'
 import { findLastXDaysPushTracking } from '../push-tracking'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 const fixtures = [
     {

--- a/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
@@ -2,7 +2,9 @@ import MockDate from 'mockdate'
 import { findLastXDaysPushTracking } from '../push-tracking'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 const fixtures = [
     {

--- a/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
@@ -2,6 +2,10 @@ import MockDate from 'mockdate'
 import { findLastXDaysPushTracking } from '../push-tracking'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 const fixtures = [
     {
         time: '2020-01-04T12:43:01Z',

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -11,6 +11,10 @@ jest.mock('@sentry/react-native', () => ({
     setTag: jest.fn(() => {}),
     setExtra: jest.fn(() => {}),
 }))
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 const QUERY = gql('{ gdprAllowPerformance @client }')
 
 describe('errorService', () => {

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -11,7 +11,9 @@ jest.mock('@sentry/react-native', () => ({
     setTag: jest.fn(() => {}),
     setExtra: jest.fn(() => {}),
 }))
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 const QUERY = gql('{ gdprAllowPerformance @client }')
 

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -11,9 +11,7 @@ jest.mock('@sentry/react-native', () => ({
     setTag: jest.fn(() => {}),
     setExtra: jest.fn(() => {}),
 }))
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 const QUERY = gql('{ gdprAllowPerformance @client }')
 

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -1,7 +1,9 @@
 import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve(false)),

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -1,9 +1,7 @@
 import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve(false)),

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -1,6 +1,10 @@
 import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve(false)),
     NetInfoStateType: {

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -3,9 +3,7 @@ import MockDate from 'mockdate'
 import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: () => jest.fn().mockReturnValue('en_GB'),
-}))
+jest.mock('src/helpers/locale')
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -3,6 +3,10 @@ import MockDate from 'mockdate'
 import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
+jest.mock('src/helpers/locale', () => ({
+    locale: () => jest.fn().mockReturnValue('en_GB'),
+}))
+
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
     NetInfoStateType: {

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -3,7 +3,9 @@ import MockDate from 'mockdate'
 import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
-jest.mock('src/helpers/locale')
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),


### PR DESCRIPTION
## Summary
On first startup, it detects the users locale and sets that to the default edition. Defaults to UK if locale is not compatible

Also looks to remove hard coded `daily-edition` and bring in universal use of `getSetting('edition')` to support the edition switch in the dev settings.

[**Trello Card ->**](https://trello.com/c/yBUPC5Bi/1361-detect-regional-edition-by-locale)

## Test Plan
- Set your locale to something different
- Clean install
- See region based edition
