### PR TITLE
Bump android seed version code

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -99,8 +99,8 @@ def enableSeparateBuildPerCPUArchitecture = false
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
-//For legacy reason we are adding current build number (13587155) from Play Store
-def appVersionCode = 13587155 + buildNumber() 
+//For legacy reason we are adding current build number (14001358) from Play Store
+def appVersionCode = 14001358 + buildNumber()
 
 /**
  * The preferred build flavor of JavaScriptCore.
@@ -210,10 +210,10 @@ def appVersionName() {
 
 def minorAppVersion() {
     // Update the minor version after every 2nd build.
-    // Update seedNumber if major number changes that will be equal to the 
+    // Update seedNumber if major number changes that will be equal to the
     // TeamCity build number (currently it is 7)
     // The app version will increment like this:
-    // 2.0.7 
+    // 2.0.7
     // 2.0.8
     // 2.1.9
     def seedNumber = 7


### PR DESCRIPTION
## Summary
This change bumps the base version code to the current value of the android release APK. This will allow us to release beta/internal test versions to users.