### PR TITLE
Add switch to disable logging service

### DIFF
--- a/projects/aws/lib/logging-stack.ts
+++ b/projects/aws/lib/logging-stack.ts
@@ -70,6 +70,7 @@ export class LoggingStack extends cdk.Stack {
                     STACK: stackParameter.valueAsString,
                     APP: 'editions-logging',
                     MAX_LOG_SIZE: maxLogSize.valueAsString,
+                    LOG_ENDPOINT_ENABLED: 'true',
                 },
             })
             Tag.add(fn, 'App', `editions-logging`)


### PR DESCRIPTION
## Summary
Until we get a release out errors thrown by the logging backend will result in client side errors in the app which can cause performance issues. This change allows us to sent an environment variable to set the logging service up to always return 200 messages so we can reduce the client side performance impact of this issue.

Hopefully the next release will solve this problem as we'll be reducing the amount of data we log, and not retrying failed requests to the log service.

## Testing
This is a backend only change - you can see the dashboard (frontend AWS account) for the logging service [here](https://eu-west-1.console.aws.amazon.com/apigateway/home?region=eu-west-1#/apis/2ryhgnliu1/dashboard)