### PR TITLE
Updated font size for android in article page

### DIFF
--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -55,9 +55,10 @@ export const getScaledFontCss = <F extends FontFamily>(
     level: FontSizes<F>,
 ) => {
     const font = getScaledFont(family, level)
+    const adjustment = Platform.OS == 'android' ? 0 : 0
     return css`
-        font-size: ${px(font.fontSize)};
-        line-height: ${px(font.lineHeight)};
+        font-size: ${px(font.fontSize + adjustment)};
+        line-height: ${px(font.lineHeight + adjustment)};
     `
 }
 

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -55,7 +55,7 @@ export const getScaledFontCss = <F extends FontFamily>(
     level: FontSizes<F>,
 ) => {
     const font = getScaledFont(family, level)
-    const adjustment = Platform.OS == 'android' ? 0 : 0
+    const adjustment = Platform.OS == 'android' ? 2 : 0
     return css`
         font-size: ${px(font.fontSize + adjustment)};
         line-height: ${px(font.lineHeight + adjustment)};


### PR DESCRIPTION
## Summary
The article's body font size is too small for android. This PR updated the size and line by a small amount for android only.

@prisalcalde are they looking good to you?

Trello card is [here](https://trello.com/c/ItKc90zA/1264-android-increase-font-size-and-line-height)

Screenshots:
| Phone - Before | Phone - After |
|  ---      | ---    |
| ![Screenshot_20200611_124850_com guardian editions](https://user-images.githubusercontent.com/6583174/84401979-cea0b100-abfb-11ea-925e-c40f453a24af.jpg)|![Screenshot_20200611_124813_com guardian editions](https://user-images.githubusercontent.com/6583174/84402219-16273d00-abfc-11ea-9d59-b27b54dad578.jpg)|
| Tab - Before | Tab - After |
|  ---      | ---    |
|![Screenshot_1591894891](https://user-images.githubusercontent.com/6583174/84417661-e1bc7c80-ac0d-11ea-80fd-1cd2313b8278.png)|![Screenshot_1591894900](https://user-images.githubusercontent.com/6583174/84417757-044e9580-ac0e-11ea-9106-be9d8ec1abe4.png)|




