### PR TITLE
Handle remote config promise rejection.

### DIFF
--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -12,6 +12,7 @@ export const initialiseRemoteConfig = async () => {
         .then(() => remoteConfig().fetch(300))
         // activate() replaces the default config with what has been fetched
         .then(() => remoteConfig().activate())
+        .catch(error => console.log('Failed to fetch remote config', error))
 
     if (activated) {
         console.log('Remote config defaults set, fetched & activated!')

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -1,4 +1,5 @@
 import remoteConfig from '@react-native-firebase/remote-config'
+import { errorService } from './errors'
 
 // see https://rnfirebase.io/remote-config/usage for docs
 export const initialiseRemoteConfig = async () => {
@@ -12,7 +13,7 @@ export const initialiseRemoteConfig = async () => {
         .then(() => remoteConfig().fetch(300))
         // activate() replaces the default config with what has been fetched
         .then(() => remoteConfig().activate())
-        .catch(error => console.log('Failed to fetch remote config', error))
+        .catch(error => errorService.captureException(error))
 
     if (activated) {
         console.log('Remote config defaults set, fetched & activated!')


### PR DESCRIPTION
## Summary

I noticed an 'unhandled promise rejection' in the android simulator for remote config initialisation. This might prevent that from happening.