### PR TITLE
Added an option to copy diagnostic info to clipboard

### DIFF
--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -21,6 +21,7 @@ import {
     DIAGNOSTICS_TITLE,
     IOS_BETA_EMAIL,
 } from './words'
+import { OnCompletionToast } from 'src/screens/settings/help-screen'
 
 const getGDPREntries = () =>
     Promise.all(
@@ -173,10 +174,11 @@ const createMailtoHandler = (
 const copyDiagnosticInfoToClipboard = (
     client: ApolloClient<object>,
     authAttempt: AnyAttempt<string>,
+    callback: OnCompletionToast,
 ) => async () => {
     const diagnostics = await getDiagnosticInfo(client, authAttempt)
     Clipboard.setString(diagnostics)
-    console.log('Diagnostic info copied to clipboard')
+    callback('Diagnostic info copied to clipboard')
 }
 
 const createSupportMailto = (
@@ -195,11 +197,12 @@ const copyDiagnosticInfo = (
     client: ApolloClient<object>,
     text: string,
     authAttempt: AnyAttempt<string>,
+    callback: OnCompletionToast,
 ) => ({
     key: text,
     title: text,
     linkWeight: 'regular' as const,
-    onPress: copyDiagnosticInfoToClipboard(client, authAttempt),
+    onPress: copyDiagnosticInfoToClipboard(client, authAttempt, callback),
 })
 
 export { createSupportMailto, createMailtoHandler, copyDiagnosticInfo }

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -1,6 +1,6 @@
 import ApolloClient from 'apollo-client'
 import gql from 'graphql-tag'
-import { Linking, Platform } from 'react-native'
+import { Linking, Platform, Clipboard } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import RNFetchBlob from 'rn-fetch-blob'
 import { canViewEdition, getCASCode } from 'src/authentication/helpers'
@@ -170,6 +170,15 @@ const createMailtoHandler = (
         },
     ])
 
+const copyDiagnosticInfoToClipboard = (
+    client: ApolloClient<object>,
+    authAttempt: AnyAttempt<string>,
+) => async () => {
+    const diagnostics = await getDiagnosticInfo(client, authAttempt)
+    Clipboard.setString(diagnostics)
+    console.log('Diagnostic info copied to clipboard')
+}
+
 const createSupportMailto = (
     client: ApolloClient<object>,
     text: string,
@@ -182,4 +191,15 @@ const createSupportMailto = (
     onPress: createMailtoHandler(client, text, releaseURL, authAttempt),
 })
 
-export { createSupportMailto, createMailtoHandler }
+const copyDiagnosticInfo = (
+    client: ApolloClient<object>,
+    text: string,
+    authAttempt: AnyAttempt<string>,
+) => ({
+    key: text,
+    title: text,
+    linkWeight: 'regular' as const,
+    onPress: copyDiagnosticInfoToClipboard(client, authAttempt),
+})
+
+export { createSupportMailto, createMailtoHandler, copyDiagnosticInfo }

--- a/projects/Mallard/src/screens/settings/help-screen.tsx
+++ b/projects/Mallard/src/screens/settings/help-screen.tsx
@@ -18,10 +18,21 @@ import {
 } from 'src/helpers/words'
 import { AccessContext } from 'src/authentication/AccessContext'
 import { useApolloClient } from '@apollo/react-hooks'
+import { useToast } from 'src/hooks/use-toast'
+
+export interface OnCompletionToast {
+    (msg: string): void
+}
 
 const HelpScreen = ({ navigation }: NavigationInjectedProps) => {
+    const { showToast } = useToast()
     const { attempt } = useContext(AccessContext)
     const client = useApolloClient()
+
+    const showToastCallback: OnCompletionToast = (msg: string) => {
+        showToast(msg)
+    }
+
     return (
         <WithAppAppearance value={'settings'}>
             <ScrollContainer>
@@ -73,6 +84,7 @@ const HelpScreen = ({ navigation }: NavigationInjectedProps) => {
                             client,
                             'Copy diagnostic information',
                             attempt,
+                            showToastCallback,
                         ),
                     ]}
                 />

--- a/projects/Mallard/src/screens/settings/help-screen.tsx
+++ b/projects/Mallard/src/screens/settings/help-screen.tsx
@@ -6,7 +6,10 @@ import { routeNames } from 'src/navigation/routes'
 import { WithAppAppearance } from 'src/theme/appearance'
 import { RightChevron } from 'src/components/icons/RightChevron'
 import { Heading } from 'src/components/layout/ui/row'
-import { createSupportMailto } from 'src/helpers/diagnostics'
+import {
+    createSupportMailto,
+    copyDiagnosticInfo,
+} from 'src/helpers/diagnostics'
 import {
     ISSUE_EMAIL,
     SUBSCRIPTION_EMAIL,
@@ -59,6 +62,16 @@ const HelpScreen = ({ navigation }: NavigationInjectedProps) => {
                             client,
                             'Send feedback',
                             APPS_FEEDBACK_EMAIL,
+                            attempt,
+                        ),
+                    ]}
+                />
+                <Heading>Diagnostics</Heading>
+                <List
+                    data={[
+                        copyDiagnosticInfo(
+                            client,
+                            'Copy diagnostic information',
                             attempt,
                         ),
                     ]}


### PR DESCRIPTION
## Summary
To help users to provide us diagnostic info an option is added to the help section to copy diagnostic info into the clipboard.

@prisalcalde please see this screenshot let me know if you want to design/ux change.

![Screenshot_1591980147](https://user-images.githubusercontent.com/6583174/84526057-902af500-acd4-11ea-8d4f-c5d8b67a5234.png)
