### PR TITLE
feat: Edition Menu Region Button

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+import { withKnobs, text } from '@storybook/addon-knobs'
+import { RegionButton } from './RegionButton'
+
+storiesOf('RegionButton', module)
+    .addDecorator(withKnobs)
+    .add('RegionButton - default', () => (
+        <RegionButton
+            onPress={() => {}}
+            title={text('Title', 'Daily Edition')}
+            subTitle={text('Subtitle', 'Published every day by 6am (GMT)')}
+        />
+    ))
+    .add('RegionButton - selected', () => (
+        <RegionButton
+            selected
+            onPress={() => {}}
+            title={text('Title', 'Daily Edition')}
+            subTitle={text('Subtitle', 'Published every day by 6am (GMT)')}
+        />
+    ))

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native'
+import { TitlepieceText } from 'src/components/styled-text'
+import { color } from 'src/theme/color'
+import { families } from 'src/theme/typography'
+
+const styles = (selected: boolean) =>
+    StyleSheet.create({
+        container: {
+            backgroundColor: selected ? color.primary : '#E5E5E5',
+            paddingBottom: 32,
+            paddingLeft: 104,
+            paddingTop: 4,
+        },
+        title: {
+            fontSize: 20,
+            lineHeight: 24,
+            marginBottom: 5,
+            color: selected ? 'white' : color.primary,
+        },
+        subTitle: {
+            fontFamily: families.sans.regular,
+            fontSize: 15,
+            lineHeight: 16,
+            color: selected ? 'white' : color.text,
+        },
+    })
+
+const RegionButton = ({
+    onPress,
+    selected = false,
+    subTitle,
+    title,
+}: {
+    onPress: () => void
+    selected?: boolean
+    subTitle: string
+    title: string
+}) => {
+    const [pressed, setPressed] = useState(false)
+    const defaultStyles = styles(selected || pressed)
+
+    return (
+        <TouchableWithoutFeedback
+            onPressIn={() => setPressed(true)}
+            onPressOut={() => setPressed(false)}
+            onPress={onPress}
+        >
+            <View style={defaultStyles.container}>
+                <TitlepieceText style={defaultStyles.title}>
+                    {title}
+                </TitlepieceText>
+                <Text style={defaultStyles.subTitle}>{subTitle}</Text>
+            </View>
+        </TouchableWithoutFeedback>
+    )
+}
+
+export { RegionButton }

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/RegionButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/RegionButton.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { RegionButton } from '../RegionButton'
+
+const props = {
+    onPress: () => {},
+    title: 'Australia Weekend',
+    subTitle: 'Published every Saturday by 6am (AEST)',
+}
+
+describe('RegionButton', () => {
+    it('should display a default RegionButton with correct styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <RegionButton {...props} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should display a selected RegionButton with correct styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <RegionButton selected={true} {...props} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RegionButton should display a default RegionButton with correct styling 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#E5E5E5",
+      "paddingBottom": 32,
+      "paddingLeft": 104,
+      "paddingTop": 4,
+    }
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "flexShrink": 0,
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+          "lineHeight": 33,
+        },
+        Object {
+          "color": "#052962",
+          "fontSize": 20,
+          "lineHeight": 24,
+          "marginBottom": 5,
+        },
+      ]
+    }
+  >
+    Australia Weekend
+  </Text>
+  <Text
+    style={
+      Object {
+        "color": "#121212",
+        "fontFamily": "GuardianTextSans-Regular",
+        "fontSize": 15,
+        "lineHeight": 16,
+      }
+    }
+  >
+    Published every Saturday by 6am (AEST)
+  </Text>
+</View>
+`;
+
+exports[`RegionButton should display a selected RegionButton with correct styling 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#052962",
+      "paddingBottom": 32,
+      "paddingLeft": 104,
+      "paddingTop": 4,
+    }
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "flexShrink": 0,
+          "fontFamily": "GTGuardianTitlepiece-Bold",
+          "fontSize": 30,
+          "lineHeight": 33,
+        },
+        Object {
+          "color": "white",
+          "fontSize": 20,
+          "lineHeight": 24,
+          "marginBottom": 5,
+        },
+      ]
+    }
+  >
+    Australia Weekend
+  </Text>
+  <Text
+    style={
+      Object {
+        "color": "white",
+        "fontFamily": "GuardianTextSans-Regular",
+        "fontSize": 15,
+        "lineHeight": 16,
+      }
+    }
+  >
+    Published every Saturday by 6am (AEST)
+  </Text>
+</View>
+`;

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -5,6 +5,7 @@
 
 function loadStories() {
 	require('../src/components/Button/Button.stories');
+	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
 	require('../src/components/Lightbox/LightboxCaption.stories');
 	require('../src/components/SignInFailedModalCard.stories');
 	require('../src/components/Spinner/Spinner.stories');
@@ -15,6 +16,7 @@ function loadStories() {
 
 const stories = [
 	'../src/components/Button/Button.stories',
+	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
 	'../src/components/Lightbox/LightboxCaption.stories',
 	'../src/components/SignInFailedModalCard.stories',
 	'../src/components/Spinner/Spinner.stories',


### PR DESCRIPTION
## Summary
In the spirit of breaking things down, this delivers the Region button for the Editions Menu. It has a selected state and also uses local state to manage to pressed style.

![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 10 16 09](https://user-images.githubusercontent.com/935975/84640454-98ac4700-aef1-11ea-8d84-e8b9913b3dd7.png)

![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 10 16 17](https://user-images.githubusercontent.com/935975/84640445-96e28380-aef1-11ea-9a65-858e3cf26984.png)

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)
