### PR TITLE
Feat/main media image template changes

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -130,26 +130,46 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         position: absolute;
         z-index: -1;
     }
-    .header-image {
-        height: 10%;
-        width: 100%;
-        object-fit: cover;
-        display: block;
-        z-index: 99;
-        position: relative;
+    .header-image--wide {
+        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
+        margin: auto;
     }
+
+    .header-image--standard { 
+        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
+        margin: auto;
+
+    }
+
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .header-image--standard {
+            margin-right: ${px(
+                metrics.article.rightRail + metrics.article.sides,
+            )};
+            max-width: ${metrics.article.maxWidth -
+                (metrics.article.rightRail + metrics.article.sides)}px;
+
+        }
+    }
+
     .header-image > .rating, .sport-score {
         position: absolute;
         bottom:0;
         left:0;
     }
-    .header-image.header-image--immersive {
+    .header-image--immersive {
+        height: 70%;
+        width: 100%;
+        object-fit: cover;
+        display: block;
+        z-index: 99;
+        position: relative;
         margin: 0 ${px(metrics.article.sides * -1)};
         width: calc(100% + ${px(metrics.article.sides * 2)});
         padding-top: 100%;
     }
     @media (max-width: ${px(Breakpoints.tabletVertical)}) {
-        .header-image.header-image--immersive {
+        header-image--immersive {
             padding-top: 140%;
         }
     }
@@ -291,6 +311,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         overflow: visible;
         height: auto;
     }
+
     .image-as-bg__img {
         width: 100%;
         z-index: 0;
@@ -374,6 +395,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     .header-container[data-type='review'] .header-bg {
         background-color: ${colors.faded};
     }
+    .header-image[data-type='review'] .header-bg {
+        background-color: ${colors.faded};
+    }
     .header-container[data-type='review'] h1 {
         color: ${colors.dark};
         font-family: ${families.headline.bold};
@@ -393,6 +417,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         border-bottom: 1px solid ${color.dimLine};
     }
     .header-container[data-type='opinion'] .header-bg {
+        background-color: ${color.palette.opinion.faded};
+    }
+    .header-image[data-type='opinion'] .header-bg {
         background-color: ${color.palette.opinion.faded};
     }
     .header-container[data-type='opinion'] .header-kicker {
@@ -416,6 +443,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         border-bottom: 1px solid ${color.dimLine};
     }
     .header-container[data-type='analysis'] .header-bg {
+        background-color: ${color.palette.neutral[93]};
+    }
+    .header-image[data-type='analysis'] .header-bg {
         background-color: ${color.palette.neutral[93]};
     }
     .header-container[data-type='analysis'] .header-kicker {
@@ -458,6 +488,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     .header-container[data-type='immersive'] .header-bg {
         background-color: ${color.palette.neutral[100]};
     }
+    .header-image[data-type='immersive'] .header-bg {
+        background-color: ${color.palette.neutral[100]};
+    }
     .header-container[data-type='immersive'] .header {
         background-color: ${color.palette.neutral[100]};
     }
@@ -479,6 +512,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         color: ${color.textOverDarkBackground};
     }
     .header-container[data-type='${ArticleType.Longread}'] .header-bg {
+        background-color: ${color.palette.neutral[7]};
+    }
+    .header-image[data-type='${ArticleType.Longread}'] .header-bg {
         background-color: ${color.palette.neutral[7]};
     }
     .header-container[data-type='${ArticleType.Longread}'] .header {
@@ -504,6 +540,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         color: ${color.textOverDarkBackground};
     }
     .header-container[data-type='${ArticleType.Obituary}'] .header-bg {
+        background-color: ${color.palette.neutral[20]};
+    }
+    .header-image[data-type='${ArticleType.Obituary}'] .header-bg {
         background-color: ${color.palette.neutral[20]};
     }
     .header-container[data-type='${ArticleType.Obituary}'] .header {
@@ -547,6 +586,7 @@ const Image = ({
 
 const MainMediaImage = ({
     image,
+    articleType,
     isGallery,
     className,
     children,
@@ -555,6 +595,7 @@ const MainMediaImage = ({
 }: {
     image: CreditedImage
     className?: string
+    articleType?: ArticleType
     isGallery?: boolean
     children?: string
     preserveRatio?: boolean
@@ -562,28 +603,35 @@ const MainMediaImage = ({
 }) => {
     const path = getImagePath(image)
     return html`
-        <div
-            class="image-as-bg ${className}"
-            data-preserve-ratio="${preserveRatio || 'false'}"
-            style="background-image: url(${path}); "
-            ${!isGallery &&
-                `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
-            data-open="false"
-        >
-            ${preserveRatio &&
-                html`
-                    <img class="image-as-bg__img" src="${path}" aria-hidden />
-                `}
-            <button
-                aria-hidden
-                onclick="event.stopPropagation(); this.parentNode.dataset.open = !JSON.parse(this.parentNode.dataset.open)"
+        <div class="header-image" data-type="${articleType}">
+            <div
+                class="image-as-bg ${className}"
+                data-preserve-ratio="${preserveRatio || 'false'}"
+                style="background-image: url(${path}); "
+                ${!isGallery &&
+                    `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
+                data-open="false"
             >
-                
-            </button>
-            <div class="image-as-bg-info">
-                ${image.caption} ${!image.displayCredit ? '' : image.credit}
+                ${preserveRatio &&
+                    html`
+                        <img
+                            class="image-as-bg__img"
+                            src="${path}"
+                            aria-hidden
+                        />
+                    `}
+                <button
+                    aria-hidden
+                    onclick="event.stopPropagation(); this.parentNode.dataset.open = !JSON.parse(this.parentNode.dataset.open)"
+                >
+                    
+                </button>
+                <div class="image-as-bg-info">
+                    ${image.caption} ${!image.displayCredit ? '' : image.credit}
+                </div>
+                ${children}
+                <div class="header-bg"></div>
             </div>
-            ${children}
         </div>
     `
 }
@@ -734,6 +782,8 @@ const Header = ({
     const immersive = isImmersive(type)
     const isGallery = type === ArticleType.Gallery
     const byLineText = getByLineText(headerType, headerProps)
+    const displayWideImage =
+        type === ArticleType.Article || type === ArticleType.Review
     return html`
         ${immersive &&
             headerProps.image &&
@@ -741,14 +791,19 @@ const Header = ({
             MainMediaImage({
                 image: headerProps.image,
                 isGallery: isGallery,
-                className: 'header-image header-image--immersive',
+                className: 'header-image--immersive',
                 getImagePath,
             })}
         ${!immersive &&
             headerProps.image &&
             publishedId &&
             MainMediaImage({
-                className: 'header-image',
+                articleType: type,
+                className: `${
+                    displayWideImage
+                        ? 'header-image--wide'
+                        : 'header-image--standard'
+                }`,
                 image: headerProps.image,
                 isGallery: isGallery,
                 preserveRatio: true,

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -113,11 +113,18 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         -webkit-user-drag: none;
     }
     .header-container-line-wrap {
-        ${breakSides}
         z-index: 100;
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
     }
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .header-container-line-wrap {
+            padding-left: ${px(metrics.article.sides)};
+            padding-right: ${px(metrics.article.sides)};
+        }
+    }
+            
+
     .header-bg {
         left: -50em;
         right: -50em;

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -113,12 +113,10 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         -webkit-user-drag: none;
     }
     .header-container-line-wrap {
+        ${breakSides}
         z-index: 100;
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
-    }
-    .header-container-line-wrap .line { 
-            margin-right: ${px(metrics.article.sides * -1)};
     }
     .header-bg {
         left: -50em;
@@ -129,7 +127,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         z-index: -1;
     }
     .header-image--wide {
-        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
+        max-width: ${px(metrics.article.maxWidth)};
         margin: auto;
     }
 
@@ -139,7 +137,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         left:0;
     }
     .header-image--immersive {
-        height: 70%;
+        height: 65%;
         width: 100%;
         object-fit: cover;
         display: block;

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -117,6 +117,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
     }
+    .header-container-line-wrap .line { 
+            margin-right: ${px(metrics.article.sides * -1)};
+    }
     .header-bg {
         left: -50em;
         right: -50em;

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -154,8 +154,13 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         width: calc(100% + ${px(metrics.article.sides * 2)});
         padding-top: 100%;
     }
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .header-image--immersive {
+            height: 80%;
+        }
+    }
     @media (max-width: ${px(Breakpoints.tabletVertical)}) {
-        header-image--immersive {
+        .header-image--immersive {
             padding-top: 140%;
         }
     }

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -114,7 +114,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
     .header-container-line-wrap {
         z-index: 100;
-        ${breakSides}
+        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
+        margin: auto;
     }
     .header-bg {
         left: -50em;
@@ -738,6 +739,23 @@ const Header = ({
                 className: 'header-image header-image--immersive',
                 getImagePath,
             })}
+        ${!immersive &&
+            headerProps.image &&
+            publishedId &&
+            MainMediaImage({
+                className: 'header-image',
+                image: headerProps.image,
+                isGallery: isGallery,
+                preserveRatio: true,
+                children: headerProps.starRating
+                    ? Rating(headerProps)
+                    : headerProps.sportScore
+                    ? SportScore({
+                          sportScore: headerProps.sportScore,
+                      })
+                    : undefined,
+                getImagePath,
+            })}
         <div class="header-container-line-wrap">
             ${Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
@@ -748,23 +766,6 @@ const Header = ({
                         ? 'header-immersive-video'
                         : 'header'}
                 >
-                    ${!immersive &&
-                        headerProps.image &&
-                        publishedId &&
-                        MainMediaImage({
-                            className: 'header-image',
-                            image: headerProps.image,
-                            isGallery: isGallery,
-                            preserveRatio: true,
-                            children: headerProps.starRating
-                                ? Rating(headerProps)
-                                : headerProps.sportScore
-                                ? SportScore({
-                                      sportScore: headerProps.sportScore,
-                                  })
-                                : undefined,
-                            getImagePath,
-                        })}
                     ${headerProps.mainMedia &&
                         (headerProps.showMedia
                             ? renderMediaAtom(headerProps.mainMedia)

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -116,8 +116,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         z-index: 100;
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
-        padding-left:  ${px(metrics.vertical)};
-        padding-right:  ${px(metrics.vertical)};
     }
     .header-container-line-wrap .line { 
             margin-right: ${px(metrics.article.sides * -1)};

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -135,23 +135,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin: auto;
     }
 
-    .header-image--standard { 
-        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
-        margin: auto;
-
-    }
-
-    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-        .header-image--standard {
-            margin-right: ${px(
-                metrics.article.rightRail + metrics.article.sides,
-            )};
-            max-width: ${metrics.article.maxWidth -
-                (metrics.article.rightRail + metrics.article.sides)}px;
-
-        }
-    }
-
     .header-image > .rating, .sport-score {
         position: absolute;
         bottom:0;
@@ -795,15 +778,12 @@ const Header = ({
                 getImagePath,
             })}
         ${!immersive &&
+            displayWideImage &&
             headerProps.image &&
             publishedId &&
             MainMediaImage({
                 articleType: type,
-                className: `${
-                    displayWideImage
-                        ? 'header-image--wide'
-                        : 'header-image--standard'
-                }`,
+                className: 'header-image--wide',
                 image: headerProps.image,
                 isGallery: isGallery,
                 preserveRatio: true,
@@ -819,6 +799,25 @@ const Header = ({
         <div class="header-container-line-wrap">
             ${Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
+                ${!immersive &&
+                    !displayWideImage &&
+                    headerProps.image &&
+                    publishedId &&
+                    MainMediaImage({
+                        articleType: type,
+                        className: 'header-image--standard',
+                        image: headerProps.image,
+                        isGallery: isGallery,
+                        preserveRatio: true,
+                        children: headerProps.starRating
+                            ? Rating(headerProps)
+                            : headerProps.sportScore
+                            ? SportScore({
+                                  sportScore: headerProps.sportScore,
+                              })
+                            : undefined,
+                        getImagePath,
+                    })}
                 <header
                     class=${immersive &&
                     headerProps.mainMedia &&

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -116,6 +116,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         z-index: 100;
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
+        padding-left:  ${px(metrics.vertical)};
+        padding-right:  ${px(metrics.vertical)};
     }
     .header-container-line-wrap .line { 
             margin-right: ${px(metrics.article.sides * -1)};

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -156,6 +156,8 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         margin: auto;
         position: relative;
         padding-top: ${px(metrics.vertical)};
+        padding-left:  ${px(metrics.vertical)};
+        padding-right:  ${px(metrics.vertical)};
     }
     .content-wrap .line {
         margin-right: ${px(metrics.article.sides * -1)};

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -155,10 +155,16 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
         position: relative;
-        padding-left: ${px(metrics.article.sides)};
-        padding-right: ${px(metrics.article.sides)};
         padding-top: ${px(metrics.vertical)};
     }
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .content-wrap {
+            padding-left: ${px(metrics.article.sides)};
+            padding-right: ${px(metrics.article.sides)};
+    
+        }
+    }
+
     ${quoteStyles({
         colors,
         theme,

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -155,10 +155,9 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
         margin: auto;
         position: relative;
+        padding-left: ${px(metrics.article.sides)};
+        padding-right: ${px(metrics.article.sides)};
         padding-top: ${px(metrics.vertical)};
-    }
-    .content-wrap .line {
-        margin-right: ${px(metrics.article.sides * -1)};
     }
     ${quoteStyles({
         colors,

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -115,8 +115,6 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
 
     .app {
         padding: 0 ${metrics.article.sides} ${px(metrics.vertical)};
-        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
-        margin: auto;
         position: relative;
         animation-duration: .5s;
         animation-name: fade;
@@ -154,6 +152,8 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
       margin-top: ${px(metrics.vertical * 2.5)};
     }
     .content-wrap {
+        max-width: ${px(metrics.article.maxWidth + metrics.article.sides * 2)};
+        margin: auto;
         position: relative;
         padding-top: ${px(metrics.vertical)};
     }

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -156,8 +156,6 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         margin: auto;
         position: relative;
         padding-top: ${px(metrics.vertical)};
-        padding-left:  ${px(metrics.vertical)};
-        padding-right:  ${px(metrics.vertical)};
     }
     .content-wrap .line {
         margin-right: ${px(metrics.article.sides * -1)};


### PR DESCRIPTION
## Summary
This PR is to update the cropping of main media images on **tablet**:
- **Standard/Review** templates to be the width of the wrapper 
- **Immersive** templates use the full width of the screen

We are doing this to mimic the behaviour of platforms that editorial are already checking for, so that we should get more acceptable image use, since someone has already previewed similar renditions.

**Mobile should not be affected by these changes**

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/AhP0tx3T/1219-main-media-images)

## Test Plan
Here are some screenshots to show what changes have been introduced. 
It is worth checking that these changes only affect the mentioned templates and all others should remain the same. 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 40 52](https://user-images.githubusercontent.com/53755195/84665114-644b8180-af17-11ea-8ac5-d105a03d87a0.png)| ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 38 34](https://user-images.githubusercontent.com/53755195/84665157-6f061680-af17-11ea-9d61-afd3524599d7.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 41 03](https://user-images.githubusercontent.com/53755195/84665187-76c5bb00-af17-11ea-81f9-1073c1f288ab.png)| ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 38 29](https://user-images.githubusercontent.com/53755195/84665201-79c0ab80-af17-11ea-9494-16fb7c6d7756.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 40 45](https://user-images.githubusercontent.com/53755195/84665389-b2608500-af17-11ea-84eb-5350617973f4.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 40 01](https://user-images.githubusercontent.com/53755195/84665427-bd1b1a00-af17-11ea-9349-90a86e16ef23.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 45 09](https://user-images.githubusercontent.com/53755195/84664706-d7a0c380-af16-11ea-9253-7b155fc23cc7.png)| ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 09 57 06](https://user-images.githubusercontent.com/53755195/84663774-83e1aa80-af15-11ea-8aca-fb9350900830.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 44 56](https://user-images.githubusercontent.com/53755195/84664796-f4d59200-af16-11ea-9dca-e0549fb9cc52.png)| ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 09 56 54](https://user-images.githubusercontent.com/53755195/84663791-88a65e80-af15-11ea-9413-3152b3a89145.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 47 30](https://user-images.githubusercontent.com/53755195/84664970-323a1f80-af17-11ea-8ca9-aafb9bbbbdd9.png)| ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 10 17 34](https://user-images.githubusercontent.com/53755195/84663837-9a880180-af15-11ea-9d39-7051a03eb585.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 14 47 40](https://user-images.githubusercontent.com/53755195/84665040-48e07680-af17-11ea-9875-ac06641775eb.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-06-15 at 10 17 40](https://user-images.githubusercontent.com/53755195/84663853-a07de280-af15-11ea-94ed-e2eeb9a3d9e4.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
