### PR TITLE
Feat: Special Edition button

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -530,3 +530,18 @@ export interface Palette {
 
 export const notNull = <T>(value: T | null | undefined): value is T =>
     value !== null && value !== undefined
+
+export type TextFormatting = {
+    color: string
+    font: string
+    lineHeight: number
+    size: number
+}
+
+export interface SpecialEditionButtonStyles {
+    backgroundColor: string
+    title: TextFormatting
+    subTitle: TextFormatting
+    expiry: TextFormatting
+    image: { width: number; height: number }
+}

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+import { withKnobs, text } from '@storybook/addon-knobs'
+import { SpecialEditionButton } from './SpecialEditionButton'
+
+const props = {
+    devUri:
+        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+    expiry: new Date(),
+    image: {
+        source: '',
+        path: '',
+    },
+    onPress: () => {},
+    title: text(
+        'Title',
+        `Food
+Monthly`,
+    ),
+    subTitle: text(
+        'SubTitle',
+        'Store cupboard special: 20 quick and easy lockdown suppers',
+    ),
+    style: {
+        backgroundColor: '#FEEEF7',
+        expiry: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Regular',
+            lineHeight: 16,
+            size: 15,
+        },
+
+        subTitle: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Bold',
+            lineHeight: 20,
+            size: 17,
+        },
+        title: {
+            color: '#121212',
+            font: 'GHGuardianHeadline-Regular',
+            lineHeight: 34,
+            size: 34,
+        },
+        image: {
+            height: 134,
+            width: 87,
+        },
+    },
+}
+
+storiesOf('SpecialEditionButton', module)
+    .addDecorator(withKnobs)
+    // This is useful to check the default style but breaks TS
+    // .add('SpecialEditionButton - default', () => (
+    //     <SpecialEditionButton {...props} style={null} />
+    // ))
+    .add('SpecialEditionButton - with styles', () => (
+        <SpecialEditionButton {...props} />
+    ))
+    .add('SpecialEditionButton - selected', () => (
+        <SpecialEditionButton selected {...props} />
+    ))

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -1,0 +1,61 @@
+import moment from 'moment'
+import React, { useState } from 'react'
+import { Text, TouchableWithoutFeedback, View } from 'react-native'
+import { ImageResource } from 'src/components/front/image-resource'
+import {
+    Image,
+    SpecialEditionButtonStyles,
+} from '../../../../../Apps/common/src'
+import { styles } from './styles'
+
+const SpecialEditionButton = ({
+    expiry,
+    devUri,
+    image,
+    onPress,
+    selected = false,
+    subTitle,
+    style,
+    title,
+}: {
+    expiry: Date
+    devUri?: string
+    image: Image
+    onPress: () => void
+    selected?: boolean
+    style: SpecialEditionButtonStyles
+    subTitle: string
+    title: string
+}) => {
+    const [pressed, setPressed] = useState(false)
+    const defaultStyles = styles({ style, selected: selected || pressed })
+
+    return (
+        <TouchableWithoutFeedback
+            onPressIn={() => setPressed(true)}
+            onPressOut={() => setPressed(false)}
+            onPress={onPress}
+        >
+            <View style={defaultStyles.container}>
+                <ImageResource
+                    devUri={devUri}
+                    image={image}
+                    use="full-size"
+                    style={defaultStyles.image}
+                />
+                <View style={defaultStyles.textBox}>
+                    <Text style={defaultStyles.title}>{title}</Text>
+                    <Text style={defaultStyles.subTitle}>{subTitle}</Text>
+                    <Text style={defaultStyles.expiry}>
+                        Available until{' '}
+                        {moment(expiry)
+                            .local()
+                            .format('l')}
+                    </Text>
+                </View>
+            </View>
+        </TouchableWithoutFeedback>
+    )
+}
+
+export { SpecialEditionButton }

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
-import TestRenderer, {
-    ReactTestRendererJSON,
-    ReactTestRenderer,
-} from 'react-test-renderer'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { SpecialEditionButton } from '../SpecialEditionButton'
 
 jest.mock('src/components/front/image-resource', () => ({

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import TestRenderer, {
+    ReactTestRendererJSON,
+    ReactTestRenderer,
+} from 'react-test-renderer'
+import { SpecialEditionButton } from '../SpecialEditionButton'
+
+jest.mock('src/components/front/image-resource', () => ({
+    ImageResource: () => 'ImageResource',
+}))
+
+const fixtures = {
+    expiry: new Date(98, 1),
+    image: {
+        source: 'media',
+        path: '/path/to/image',
+    },
+    onPress: () => {},
+    title: `Food
+Monthly`,
+    subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+    style: {
+        backgroundColor: '#FEEEF7',
+        expiry: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Regular',
+            lineHeight: 16,
+            size: 15,
+        },
+
+        subTitle: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Bold',
+            lineHeight: 20,
+            size: 17,
+        },
+        title: {
+            color: '#121212',
+            font: 'GHGuardianHeadline-Regular',
+            lineHeight: 34,
+            size: 34,
+        },
+        image: {
+            height: 134,
+            width: 87,
+        },
+    },
+}
+
+export { fixtures }
+
+describe('SpecialEditionButton', () => {
+    it('should display a default SpecialEditionButton with imported styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <SpecialEditionButton {...fixtures} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should display a selected SpecialEditionButton despite imported styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <SpecialEditionButton selected {...fixtures} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
@@ -6,7 +6,7 @@ jest.mock('src/components/front/image-resource', () => ({
     ImageResource: () => 'ImageResource',
 }))
 
-const fixtures = {
+const props = {
     expiry: new Date(98, 1),
     image: {
         source: 'media',
@@ -44,18 +44,16 @@ Monthly`,
     },
 }
 
-export { fixtures }
-
 describe('SpecialEditionButton', () => {
     it('should display a default SpecialEditionButton with imported styling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <SpecialEditionButton {...fixtures} />,
+            <SpecialEditionButton {...props} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should display a selected SpecialEditionButton despite imported styling', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <SpecialEditionButton selected {...fixtures} />,
+            <SpecialEditionButton selected {...props} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SpecialEditionButton should display a default SpecialEditionButton with imported styling 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#FEEEF7",
+      "flexDirection": "row",
+      "paddingTop": 12,
+    }
+  }
+>
+  ImageResource
+  <View
+    style={
+      Object {
+        "flexShrink": 1,
+        "paddingBottom": 15,
+        "paddingLeft": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#121212",
+          "flexWrap": "wrap",
+          "fontFamily": "GHGuardianHeadline-Regular",
+          "fontSize": 34,
+          "lineHeight": 34,
+        }
+      }
+    >
+      Food
+Monthly
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#7D0068",
+          "flexWrap": "wrap",
+          "fontFamily": "GuardianTextSans-Bold",
+          "fontSize": 17,
+          "lineHeight": 20,
+          "marginTop": 10,
+        }
+      }
+    >
+      Store cupboard special: 20 quick and easy lockdown suppers
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#7D0068",
+          "flexWrap": "wrap",
+          "fontFamily": "GuardianTextSans-Regular",
+          "fontSize": 15,
+          "lineHeight": 16,
+          "marginTop": 8,
+        }
+      }
+    >
+      Available until
+       
+      2/1/1998
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SpecialEditionButton should display a selected SpecialEditionButton despite imported styling 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#052962",
+      "flexDirection": "row",
+      "paddingTop": 12,
+    }
+  }
+>
+  ImageResource
+  <View
+    style={
+      Object {
+        "flexShrink": 1,
+        "paddingBottom": 15,
+        "paddingLeft": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "flexWrap": "wrap",
+          "fontFamily": "GHGuardianHeadline-Regular",
+          "fontSize": 34,
+          "lineHeight": 34,
+        }
+      }
+    >
+      Food
+Monthly
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "flexWrap": "wrap",
+          "fontFamily": "GuardianTextSans-Bold",
+          "fontSize": 17,
+          "lineHeight": 20,
+          "marginTop": 10,
+        }
+      }
+    >
+      Store cupboard special: 20 quick and easy lockdown suppers
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "flexWrap": "wrap",
+          "fontFamily": "GuardianTextSans-Regular",
+          "fontSize": 15,
+          "lineHeight": 16,
+          "marginTop": 8,
+        }
+      }
+    >
+      Available until
+       
+      2/1/1998
+    </Text>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
@@ -1,0 +1,85 @@
+import { color } from 'src/theme/color'
+import {
+    TextFormatting,
+    SpecialEditionButtonStyles,
+} from '../../../../../Apps/common/src'
+import { StyleSheet } from 'react-native'
+
+const expiryDefaults = {
+    color: color.text,
+    font: 'GuardianTextSans-Regular',
+    lineHeight: 16,
+    size: 15,
+}
+
+const titleDefaults = {
+    color: color.text,
+    font: 'GHGuardianHeadline-Regular',
+    lineHeight: 34,
+    size: 34,
+}
+
+const subTitleDefaults = {
+    color: color.text,
+    font: 'GuardianTextSans-Bold',
+    lineHeight: 20,
+    size: 17,
+}
+
+const textFormatting = (
+    selected: boolean,
+    style: TextFormatting,
+    defaults: TextFormatting,
+) => ({
+    color: selected ? 'white' : (style && style.color) || defaults.color,
+    fontFamily: (style && style.font) || defaults.font,
+    fontSize: (style && style.size) || defaults.size,
+    lineHeight: (style && style.lineHeight) || defaults.lineHeight,
+})
+
+const styles = ({
+    style,
+    selected,
+}: {
+    style: SpecialEditionButtonStyles
+    selected: boolean
+}) =>
+    StyleSheet.create({
+        container: {
+            backgroundColor:
+                (selected ? color.primary : style && style.backgroundColor) ||
+                color.palette.neutral[97],
+            flexDirection: 'row',
+            paddingTop: 12,
+        },
+        expiry: {
+            flexWrap: 'wrap',
+            marginTop: 8,
+            ...textFormatting(selected, style && style.expiry, expiryDefaults),
+        },
+        image: {
+            width: (style && style.image && style.image.width) || 87,
+            height: (style && style.image && style.image.height) || 134,
+        },
+        textBox: {
+            flexShrink: 1,
+            paddingLeft: 10,
+            paddingBottom: 15,
+        },
+        title: {
+            flexWrap: 'wrap',
+
+            ...textFormatting(selected, style && style.title, titleDefaults),
+        },
+        subTitle: {
+            flexWrap: 'wrap',
+            marginTop: 10,
+            ...textFormatting(
+                selected,
+                style && style.subTitle,
+                subTitleDefaults,
+            ),
+        },
+    })
+
+export { styles }

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -18,6 +18,7 @@ type ImageResourceProps = {
     use: ImageUse
     style?: StyleProp<ImageStyle>
     setAspectRatio?: boolean
+    devUri?: string
 } & Omit<ImageProps, 'source'>
 
 const ImageResource = ({
@@ -25,19 +26,20 @@ const ImageResource = ({
     style,
     setAspectRatio = false,
     use,
+    devUri,
     ...props
 }: ImageResourceProps) => {
     const imagePath = useImagePath(image, use)
     const aspectRatio = useAspectRatio(imagePath)
     const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
 
-    return imagePath ? (
+    return imagePath || devUri ? (
         <Image
             key={imagePath}
             resizeMethod={'resize'}
             {...props}
             style={[styles, style]}
-            source={{ uri: imagePath }}
+            source={{ uri: devUri || imagePath }}
         />
     ) : (
         <View style={styles}></View>

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -7,6 +7,7 @@ function loadStories() {
 	require('../src/components/Button/Button.stories');
 	require('../src/components/EditionsMenu/Header/Header.stories');
 	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
+	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
 	require('../src/components/Lightbox/LightboxCaption.stories');
 	require('../src/components/SignInFailedModalCard.stories');
 	require('../src/components/Spinner/Spinner.stories');
@@ -19,6 +20,7 @@ const stories = [
 	'../src/components/Button/Button.stories',
 	'../src/components/EditionsMenu/Header/Header.stories',
 	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
+	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
 	'../src/components/Lightbox/LightboxCaption.stories',
 	'../src/components/SignInFailedModalCard.stories',
 	'../src/components/Spinner/Spinner.stories',


### PR DESCRIPTION
## Summary
Component build of the Special Edition Button:
- Takes in a paired down style object which will be given to it by tools
- `devUri` in `ImageResource` is to help with showing images that are not on the device in Storybook
- Default styles for the button are provided in case for any reason we have an issue with the style object from the endpoint (belt and braces). This has been confirmed with Ana.
- Provides shared types in `common` to help put together a contract for the data required for this component
- Expiry takes a Date object and turns that into whatever the local date is for the device.

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)

### Default Style
![Simulator Screen Shot - iPhone 11 - 2020-06-16 at 10 52 08](https://user-images.githubusercontent.com/935975/84777691-d6849a80-afd9-11ea-81d1-115b85cbe25d.png)

### Example Style
![Simulator Screen Shot - iPhone 11 - 2020-06-16 at 10 30 24](https://user-images.githubusercontent.com/935975/84777745-e69c7a00-afd9-11ea-9e2f-93d3fd2bac9c.png)

### Selected Style
![Simulator Screen Shot - iPhone 11 - 2020-06-16 at 10 30 33](https://user-images.githubusercontent.com/935975/84777765-ed2af180-afd9-11ea-9d6a-3fa3ee852243.png)

