### PR TITLE
chore: Remove the logging from the Error service

### DIFF
--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -75,12 +75,6 @@ class ErrorServiceImpl implements ErrorService {
         } else if (this.hasConsent === true) {
             Sentry.captureException(err)
         }
-        // Also send to the logging service (where it manages its own consent and queue)
-        loggingService.log({
-            level: Level.ERROR,
-            message: 'captureException',
-            optionalFields: { error: err },
-        })
     }
 }
 

--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -4,8 +4,6 @@ import { isInBeta } from 'src/helpers/release-stream'
 import ApolloClient from 'apollo-client'
 import gql from 'graphql-tag'
 import { GdprSwitchSetting } from 'src/helpers/settings'
-import { loggingService } from './logging'
-import { Level } from '../../../Apps/common/src/logging'
 
 const { SENTRY_DSN_URL } = Config
 


### PR DESCRIPTION
## Summary
When there is an error with posting a log, we send it to the error service. Which then trys to log the error in the logging service, which then sends an error to the error service..... and so on!

No need to log errors in the logging service.