### PR TITLE
Add validate-app github actions workflow

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -1,0 +1,27 @@
+name: scheduled-ios-beta
+
+on: push
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+    # This workflow contains a single job called "build"
+    build:
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
+
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: '10.15'
+
+            - name: install mallard
+              run: make install
+
+            - name: validate Mallard project
+              run: make PROJECT=Mallard validate
+
+            - name: test Mallard project
+              run: make PROJECT=Mallard test

--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -1,4 +1,4 @@
-name: scheduled-ios-beta
+name: validate-app
 
 on: push
 


### PR DESCRIPTION
## Summary
This adds a workflow to validate and text the Mallard project, with a view to potentially moving this check from teamcity into github actions permanently.

Pros: all viewable within github, no VPN blah blah
Cons: 2 minutes slower

## Test Plan
Try this out for a bit and see if the slowness is annoying 
