### PR TITLE
Interviews now pull the article template

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -45,7 +45,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
             case 'news':
                 if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
-                else if (isInterview) return ArticleType.Immersive
+                else if (isInterview) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
@@ -57,7 +57,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
             case 'sport':
                 if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
-                else if (isInterview) return ArticleType.Immersive
+                else if (isInterview) return ArticleType.Article
                 else if (isMatchResult) return ArticleType.MatchResult
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isLetter) return ArticleType.Letter
@@ -84,7 +84,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isImmersive) return ArticleType.Immersive
                 else if (isReview) return ArticleType.Review
                 else if (isRecipe) return ArticleType.Recipe
-                else if (isInterview) return ArticleType.Immersive
+                else if (isInterview) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isGallery) return ArticleType.Gallery
                 else if (isLetter) return ArticleType.Letter
@@ -105,7 +105,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 if (isReview) return ArticleType.Review
                 else if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
-                else if (isInterview) return ArticleType.Immersive
+                else if (isInterview) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion


### PR DESCRIPTION
## Summary

<!--
Why are we doing this?

Interviews will have their own template in the future, but they don't right now. 
They've been using the immersive template, but that creates image crop issues because these are not checked by subs on composer. 
This fix makes interviews pull the article template, but their placing in the string has been kept where it was before.

Trello card here: https://trello.com/c/RVKbzPpW/1376-interviews-should-pick-standard-template-not-immersive

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com)

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
