### PR TITLE
Add remote config switch around logging.

### DIFF
--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -30,6 +30,7 @@ describe('logging service - Offline', () => {
             })
             loggingService.saveQueuedItems = jest.fn()
             loggingService.hasConsent = true
+            loggingService.enabled = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.saveQueuedItems).toHaveBeenCalled()
         })

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -87,6 +87,7 @@ describe('logging service', () => {
                 .mockReturnValue(externalInfoFixture)
             loggingService.clearItems = jest.fn()
             loggingService.postLog = jest.fn()
+            loggingService.enabled = true
             loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
             expect(loggingService.postLog).toHaveBeenCalled()

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../Apps/common/src/logging'
 import { AsyncQueue } from '../helpers/async-queue-cache'
 import { errorService } from './errors'
+import remoteConfig from '@react-native-firebase/remote-config'
 
 const { LOGGING_API_KEY } = Config
 const ATTEMPTS_THEN_CLEAR = 10
@@ -167,12 +168,15 @@ class Logging extends AsyncQueue {
     }
 
     async log({ level, message, ...optionalFields }: LogParams) {
-        // limit max length of message we post to logging service
-        const croppedMessage = cropMessage(message, 300)
+        const loggingEnabled = remoteConfig().getValue('remote_logging_enabled')
+            .value
         try {
-            if (!this.hasConsent) {
+            if (!this.hasConsent || !loggingEnabled) {
                 return
             }
+
+            // limit max length of message we post to logging service
+            const croppedMessage = cropMessage(message, 300)
 
             const currentLog = await this.baseLog({
                 level,

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -46,11 +46,14 @@ const cropMessage = (message: string, maxLength: number): string => {
 class Logging extends AsyncQueue {
     hasConsent: GdprSwitchSetting
     numberOfAttempts: number
+    enabled: boolean
 
     constructor() {
         super(loggingQueueCache)
         this.hasConsent = false
         this.numberOfAttempts = 0
+        this.enabled =
+            remoteConfig().getValue('remote_logging_enabled').value === true
     }
 
     init(apolloClient: ApolloClient<object>) {
@@ -168,10 +171,8 @@ class Logging extends AsyncQueue {
     }
 
     async log({ level, message, ...optionalFields }: LogParams) {
-        const loggingEnabled = remoteConfig().getValue('remote_logging_enabled')
-            .value
         try {
-            if (!this.hasConsent || !loggingEnabled) {
+            if (!this.enabled || !this.hasConsent) {
                 return
             }
 

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -6,10 +6,11 @@ export const initialiseRemoteConfig = async () => {
         .setDefaults({
             apple_sign_in: false,
             lightbox_enabled: false,
+            remote_logging_enabled: true,
         })
         // fetch config, cache for 5mins
         // NOTE: this cache persists when app is reloaded
-        .then(() => remoteConfig().fetch(300))
+        .then(() => remoteConfig().fetch(0))
         // activate() replaces the default config with what has been fetched
         .then(() => remoteConfig().activate())
 

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -10,7 +10,7 @@ export const initialiseRemoteConfig = async () => {
         })
         // fetch config, cache for 5mins
         // NOTE: this cache persists when app is reloaded
-        .then(() => remoteConfig().fetch(0))
+        .then(() => remoteConfig().fetch(300))
         // activate() replaces the default config with what has been fetched
         .then(() => remoteConfig().activate())
 


### PR DESCRIPTION
## Summary
This adds a switch to enable/disable the client side logging to editions-logging.guardianapis.com. 

I think this could be useful as a temporary thing for when the backend service is messed up (hopefully rare but more likely at the moment till it stabilises), but also more permanently even when the backend is reliable as it might allow us (if we switch firebase analytics back on) to e.g. switch off logging on ios9 devices, since we're never going to fix any issues we see in the logs. 

## Test Plan
Release, verify that logs are still getting posted according to firebase switch
