### PR TITLE
feat: Editions Menu Button

### DIFF
--- a/projects/Mallard/src/components/Button/Button.stories.tsx
+++ b/projects/Mallard/src/components/Button/Button.stories.tsx
@@ -31,4 +31,4 @@ storiesOf('Buttons', module)
         <ModalButton onPress={() => {}}>
             {text('Button Text', 'Sign In')}
         </ModalButton>
-    )) // WASSIS?!
+    ))

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+import { withKnobs, text } from '@storybook/addon-knobs'
+import { EditionsMenuButton } from './EditionsMenuButton'
+
+storiesOf('EditionsMenu', module)
+    .addDecorator(withKnobs)
+    .add('EditionsMenuButton - default', () => (
+        <EditionsMenuButton onPress={() => {}} />
+    ))
+    .add('EditionsMenuButton - selected', () => (
+        <EditionsMenuButton onPress={() => {}} selected />
+    ))

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react-native'
-import { withKnobs, text } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 import { EditionsMenuButton } from './EditionsMenuButton'
 
 storiesOf('EditionsMenu', module)

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Newspaper } from 'src/components/icons/Newspaper'
+import { TouchableOpacity, StyleSheet, View } from 'react-native'
+import { color } from 'src/theme/color'
+import { LeftChevron } from 'src/components/icons/LeftChevron'
+
+const styles = StyleSheet.create({
+    button: {
+        alignItems: 'center',
+        backgroundColor: color.palette.sport.pastel,
+        borderRadius: 24,
+        justifyContent: 'center',
+        height: 42,
+        width: 42,
+    },
+})
+
+const EditionsMenuButton = ({
+    onPress,
+    selected = false,
+}: {
+    onPress: () => void
+    selected?: boolean
+}) => (
+    <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityHint="Editions Menu"
+        onPress={onPress}
+        style={styles.button}
+    >
+        {selected ? <LeftChevron /> : <Newspaper />}
+    </TouchableOpacity>
+)
+
+export { EditionsMenuButton }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Newspaper } from 'src/components/icons/Newspaper'
-import { TouchableOpacity, StyleSheet, View } from 'react-native'
+import { TouchableOpacity, StyleSheet } from 'react-native'
 import { color } from 'src/theme/color'
 import { LeftChevron } from 'src/components/icons/LeftChevron'
 

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
@@ -24,7 +24,7 @@ const EditionsMenuButton = ({
 }) => (
     <TouchableOpacity
         accessibilityRole="button"
-        accessibilityLabel="Editions Menu Button"
+        accessibilityLabel="Regions and specials editions menu"
         onPress={onPress}
         style={styles.button}
     >

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
@@ -24,7 +24,7 @@ const EditionsMenuButton = ({
 }) => (
     <TouchableOpacity
         accessibilityRole="button"
-        accessibilityHint="Editions Menu"
+        accessibilityLabel="Editions Menu Button"
         onPress={onPress}
         style={styles.button}
     >

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/EditionsMenuButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/EditionsMenuButton.spec.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { EditionsMenuButton } from '../EditionsMenuButton'
+
+describe('EditionsMenuButton', () => {
+    it('should display a default EditionsMenuButton with correct styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <EditionsMenuButton onPress={() => {}} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should display a selected EditionsMenuButton with correct styling', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <EditionsMenuButton selected onPress={() => {}} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
@@ -1,0 +1,396 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditionsMenuButton should display a default EditionsMenuButton with correct styling 1`] = `
+<View
+  accessibilityHint="Editions Menu"
+  accessibilityRole="button"
+  accessible={true}
+  focusable={true}
+  isTVSelectable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#90dcff",
+      "borderRadius": 24,
+      "height": 42,
+      "justifyContent": "center",
+      "opacity": 1,
+      "width": 42,
+    }
+  }
+>
+  <RNSVGSvgView
+    bbHeight={26}
+    bbWidth={18}
+    fill="none"
+    focusable={false}
+    height={26}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+          "borderWidth": 0,
+        },
+        undefined,
+        Object {
+          "opacity": 1,
+        },
+        Object {
+          "flex": 0,
+          "height": 26,
+          "width": 18,
+        },
+      ]
+    }
+    width={18}
+  >
+    <RNSVGGroup
+      fill={null}
+      fillOpacity={1}
+      fillRule={1}
+      font={Object {}}
+      matrix={
+        Array [
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+        ]
+      }
+      opacity={1}
+      originX={0}
+      originY={0}
+      propList={
+        Array [
+          "fill",
+        ]
+      }
+      rotation={0}
+      scaleX={1}
+      scaleY={1}
+      skewX={0}
+      skewY={0}
+      stroke={null}
+      strokeDasharray={null}
+      strokeDashoffset={null}
+      strokeLinecap={0}
+      strokeLinejoin={0}
+      strokeMiterlimit={4}
+      strokeOpacity={1}
+      strokeWidth={1}
+      vectorEffect={0}
+      x={0}
+      y={0}
+    >
+      <RNSVGGroup
+        fill={
+          Array [
+            0,
+            4280098075,
+          ]
+        }
+        fillOpacity={1}
+        fillRule={1}
+        font={Object {}}
+        matrix={
+          Array [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ]
+        }
+        opacity={1}
+        originX={0}
+        originY={0}
+        propList={
+          Array [
+            "fill",
+          ]
+        }
+        rotation={0}
+        scaleX={1}
+        scaleY={1}
+        skewX={0}
+        skewY={0}
+        stroke={null}
+        strokeDasharray={null}
+        strokeDashoffset={null}
+        strokeLinecap={0}
+        strokeLinejoin={0}
+        strokeMiterlimit={4}
+        strokeOpacity={1}
+        strokeWidth={1}
+        vectorEffect={0}
+        x={0}
+        y={0}
+      >
+        <RNSVGPath
+          d="M1.402 24.949a.377.377 0 01-.35-.35V2.312C.455 2.453 0 3.013 0 3.679V24.6C0 25.368.63 26 1.402 26h12.58c.665 0 1.19-.456 1.366-1.051H1.402z"
+          fill={
+            Array [
+              0,
+              4278190080,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={Array []}
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        />
+        <RNSVGPath
+          d="M16.259 1.051c.21 0 .35.14.35.35v20.92c0 .21-.14.35-.35.35H3.679c-.21 0-.35-.14-.35-.35V1.4c0-.21.14-.35.35-.35h12.58zm0-1.051H3.679c-.77 0-1.402.63-1.402 1.402V22.32c0 .77.631 1.401 1.402 1.401h12.58c.77 0 1.401-.63 1.401-1.401V1.4C17.66.632 17.03 0 16.26 0z"
+          fill={
+            Array [
+              0,
+              4278190080,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={Array []}
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        />
+        <RNSVGPath
+          d="M13.036 14.226H5.432a.539.539 0 01-.526-.525c0-.28.246-.526.526-.526h7.604c.28 0 .525.245.525.526 0 .28-.245.525-.525.525zM14.507 11.143h-9.11a.539.539 0 01-.526-.526c0-.28.245-.525.526-.525h9.11c.28 0 .526.245.526.525 0 .316-.21.526-.526.526zM14.507 8.76h-9.11a.539.539 0 01-.526-.525v-4.31c0-.28.245-.526.526-.526h9.11c.28 0 .526.245.526.526v4.31c0 .28-.21.525-.526.525zM14.507 17.275h-9.11a.539.539 0 01-.526-.526c0-.28.245-.525.526-.525h9.11c.28 0 .526.245.526.525s-.21.526-.526.526zM11.599 20.323H5.432a.539.539 0 01-.526-.525c0-.28.246-.526.526-.526h6.202c.28 0 .526.245.526.526-.035.28-.246.525-.561.525z"
+          fill={
+            Array [
+              0,
+              4278190080,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={Array []}
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        />
+      </RNSVGGroup>
+      <RNSVGDefs>
+        <RNSVGClipPath
+          fill={
+            Array [
+              0,
+              4278190080,
+            ]
+          }
+          fillOpacity={1}
+          fillRule={1}
+          matrix={
+            Array [
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+            ]
+          }
+          name="clip0"
+          opacity={1}
+          originX={0}
+          originY={0}
+          propList={Array []}
+          rotation={0}
+          scaleX={1}
+          scaleY={1}
+          skewX={0}
+          skewY={0}
+          stroke={null}
+          strokeDasharray={null}
+          strokeDashoffset={null}
+          strokeLinecap={0}
+          strokeLinejoin={0}
+          strokeMiterlimit={4}
+          strokeOpacity={1}
+          strokeWidth={1}
+          vectorEffect={0}
+          x={0}
+          y={0}
+        >
+          <RNSVGPath
+            d="M0 0h17.66v26H0z"
+            fill={
+              Array [
+                0,
+                4294967295,
+              ]
+            }
+            fillOpacity={1}
+            fillRule={1}
+            matrix={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+            opacity={1}
+            originX={0}
+            originY={0}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+            rotation={0}
+            scaleX={1}
+            scaleY={1}
+            skewX={0}
+            skewY={0}
+            stroke={null}
+            strokeDasharray={null}
+            strokeDashoffset={null}
+            strokeLinecap={0}
+            strokeLinejoin={0}
+            strokeMiterlimit={4}
+            strokeOpacity={1}
+            strokeWidth={1}
+            vectorEffect={0}
+            x={0}
+            y={0}
+          />
+        </RNSVGClipPath>
+      </RNSVGDefs>
+    </RNSVGGroup>
+  </RNSVGSvgView>
+</View>
+`;
+
+exports[`EditionsMenuButton should display a selected EditionsMenuButton with correct styling 1`] = `
+<View
+  accessibilityHint="Editions Menu"
+  accessibilityRole="button"
+  accessible={true}
+  focusable={true}
+  isTVSelectable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#90dcff",
+      "borderRadius": 24,
+      "height": 42,
+      "justifyContent": "center",
+      "opacity": 1,
+      "width": 42,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#121212",
+        "fontFamily": "GuardianIcons-Regular",
+        "fontSize": 20,
+        "lineHeight": 20,
+      }
+    }
+  >
+    
+  </Text>
+</View>
+`;

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EditionsMenuButton should display a default EditionsMenuButton with correct styling 1`] = `
 <View
-  accessibilityHint="Editions Menu"
+  accessibilityLabel="Regions and specials editions menu"
   accessibilityRole="button"
   accessible={true}
   focusable={true}
@@ -356,7 +356,7 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
 
 exports[`EditionsMenuButton should display a selected EditionsMenuButton with correct styling 1`] = `
 <View
-  accessibilityHint="Editions Menu"
+  accessibilityLabel="Regions and specials editions menu"
   accessibilityRole="button"
   accessible={true}
   focusable={true}

--- a/projects/Mallard/src/components/EditionsMenu/Header/Header.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/Header/Header.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react-native'
 import { withKnobs, text } from '@storybook/addon-knobs'
 import { EditionsMenuHeader } from './Header'
 
-storiesOf('EditionsMenuHeader', module)
+storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
     .add('EditionsMenuHeader - default', () => (
         <EditionsMenuHeader>

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react-native'
 import { withKnobs, text } from '@storybook/addon-knobs'
 import { RegionButton } from './RegionButton'
 
-storiesOf('RegionButton', module)
+storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
     .add('RegionButton - default', () => (
         <RegionButton

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
@@ -49,7 +49,7 @@ Monthly`,
     },
 }
 
-storiesOf('SpecialEditionButton', module)
+storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
     // This is useful to check the default style but breaks TS
     // .add('SpecialEditionButton - default', () => (

--- a/projects/Mallard/src/components/icons/Icons.stories.tsx
+++ b/projects/Mallard/src/components/icons/Icons.stories.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-import { Text, View } from 'react-native'
+import { color, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react-native'
-import { withKnobs, color } from '@storybook/addon-knobs'
+import React from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { LeftChevron } from './LeftChevron'
+import { Newspaper } from './Newspaper'
 import { Quote } from './Quote'
 import { RightChevron } from './RightChevron'
-import { Newspaper } from './Newspaper'
-
-import { StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({
     icon: {
@@ -27,6 +26,10 @@ storiesOf('Icons', module)
             <View style={styles.icon}>
                 <Quote fill={color('Colour', '#000000')} />
                 <Text style={styles.label}>Quote</Text>
+            </View>
+            <View style={styles.icon}>
+                <LeftChevron />
+                <Text style={styles.label}>LeftChevron</Text>
             </View>
             <View style={styles.icon}>
                 <RightChevron />

--- a/projects/Mallard/src/components/icons/LeftChevron.tsx
+++ b/projects/Mallard/src/components/icons/LeftChevron.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text, StyleSheet } from 'react-native'
+import { useAppAppearance } from 'src/theme/appearance'
+import { getFont } from 'src/theme/typography'
+
+const LeftChevron = () => {
+    const styles = StyleSheet.create({
+        icon: {
+            ...getFont('icon', 1),
+            color: useAppAppearance().color,
+        },
+    })
+
+    return <Text style={styles.icon}>{'\uE00A'}</Text>
+}
+
+export { LeftChevron }

--- a/projects/Mallard/src/components/icons/__tests__/LeftChevron.spec.tsx
+++ b/projects/Mallard/src/components/icons/__tests__/LeftChevron.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { LeftChevron } from '../LeftChevron'
+
+describe('LeftChevron', () => {
+    it('should display a LeftChevron icon using the icon font', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <LeftChevron />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/icons/__tests__/RightChevron.spec.tsx
+++ b/projects/Mallard/src/components/icons/__tests__/RightChevron.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { RightChevron } from '../RightChevron'
+
+describe('RightChevron', () => {
+    it('should display a RightChevron icon using the icon font', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <RightChevron />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/LeftChevron.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/LeftChevron.spec.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LeftChevron should display a LeftChevron icon using the icon font 1`] = `
+<Text
+  style={
+    Object {
+      "color": "#121212",
+      "fontFamily": "GuardianIcons-Regular",
+      "fontSize": 20,
+      "lineHeight": 20,
+    }
+  }
+>
+  
+</Text>
+`;

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/RightChevron.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/RightChevron.spec.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RightChevron should display a RightChevron icon using the icon font 1`] = `
+<Text
+  style={
+    Object {
+      "color": "#121212",
+      "fontFamily": "GuardianIcons-Regular",
+      "fontSize": 20,
+      "lineHeight": 20,
+    }
+  }
+>
+  
+</Text>
+`;

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -5,6 +5,7 @@
 
 function loadStories() {
 	require('../src/components/Button/Button.stories');
+	require('../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories');
 	require('../src/components/EditionsMenu/Header/Header.stories');
 	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
 	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
@@ -18,6 +19,7 @@ function loadStories() {
 
 const stories = [
 	'../src/components/Button/Button.stories',
+	'../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories',
 	'../src/components/EditionsMenu/Header/Header.stories',
 	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
 	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',


### PR DESCRIPTION
## Summary

Editions menu button with storybook stories and tests.
This has a selected state rather than a separate button but this might change when it's all hooked up.
I also did a little housekeeping to get all the Editions menu stories together.

#### Default
![Simulator Screen Shot - iPhone 11 - 2020-06-17 at 09 03 32](https://user-images.githubusercontent.com/935975/84872411-c8865680-b079-11ea-9556-b2619c363b6d.png)

#### Selected state
![Simulator Screen Shot - iPhone 11 - 2020-06-17 at 09 03 36](https://user-images.githubusercontent.com/935975/84872440-d2a85500-b079-11ea-95a3-591d5a9d3326.png)

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)
