### PR TITLE
chore: Region Button Background Colour Change

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react-native'
-import { withKnobs, text } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 import { RegionButton } from './RegionButton'
 
 storiesOf('RegionButton', module)
@@ -8,15 +8,15 @@ storiesOf('RegionButton', module)
     .add('RegionButton - default', () => (
         <RegionButton
             onPress={() => {}}
-            title={text('Title', 'Daily Edition')}
-            subTitle={text('Subtitle', 'Published every day by 6am (GMT)')}
+            title="Daily Edition"
+            subTitle={'Published every day by 6am (GMT)'}
         />
     ))
     .add('RegionButton - selected', () => (
         <RegionButton
             selected
             onPress={() => {}}
-            title={text('Title', 'Daily Edition')}
-            subTitle={text('Subtitle', 'Published every day by 6am (GMT)')}
+            title={'Daily Edition'}
+            subTitle={'Published every day by 6am (GMT)'}
         />
     ))

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
@@ -7,7 +7,9 @@ import { families } from 'src/theme/typography'
 const styles = (selected: boolean) =>
     StyleSheet.create({
         container: {
-            backgroundColor: selected ? color.primary : '#E5E5E5',
+            backgroundColor: selected
+                ? color.primary
+                : color.palette.neutral[97],
             paddingBottom: 32,
             paddingLeft: 104,
             paddingTop: 4,

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`RegionButton should display a default RegionButton with correct styling
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "backgroundColor": "#E5E5E5",
+      "backgroundColor": "#f6f6f6",
       "paddingBottom": 32,
       "paddingLeft": 104,
       "paddingTop": 4,


### PR DESCRIPTION
## Summary
Background colour on the Region Button was too dark. After consultation with Ana, this fixes it.

Also noticed the `text` function from Storybook Knobs is causing a problem, so removed this.