### PR TITLE
Patch into release: Remove the logging from the Error service (#1270)

### DIFF
--- a/projects/Mallard/src/services/errors.ts
+++ b/projects/Mallard/src/services/errors.ts
@@ -4,8 +4,6 @@ import { isInBeta } from 'src/helpers/release-stream'
 import ApolloClient from 'apollo-client'
 import gql from 'graphql-tag'
 import { GdprSwitchSetting } from 'src/helpers/settings'
-import { loggingService } from './logging'
-import { Level } from '../../../Apps/common/src/logging'
 
 const { SENTRY_DSN_URL } = Config
 
@@ -75,12 +73,6 @@ class ErrorServiceImpl implements ErrorService {
         } else if (this.hasConsent === true) {
             Sentry.captureException(err)
         }
-        // Also send to the logging service (where it manages its own consent and queue)
-        loggingService.log({
-            level: Level.ERROR,
-            message: 'captureException',
-            optionalFields: { error: err },
-        })
     }
 }
 


### PR DESCRIPTION
This adds the work in https://github.com/guardian/editions/pull/1270 to the release/2.0.9 release branch for an urgent patch release