### PR TITLE
Feat: Editions menu composed

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -545,3 +545,18 @@ export interface SpecialEditionButtonStyles {
     expiry: TextFormatting
     image: { width: number; height: number }
 }
+
+interface Edtion {
+    title: string
+    subTitle: string
+    edition: string // @TODO: should be an ENUM that is tracked throughout the app
+}
+
+export interface RegionalEdition extends Edtion {}
+
+export interface SpecialEdition extends Edtion {
+    expiry: Date
+    devUri?: string
+    image: Image
+    style: SpecialEditionButtonStyles
+}

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -546,17 +546,18 @@ export interface SpecialEditionButtonStyles {
     image: { width: number; height: number }
 }
 
-interface Edtion {
+export interface RegionalEdition {
     title: string
     subTitle: string
-    edition: string // @TODO: should be an ENUM that is tracked throughout the app
+    edition: Edition
 }
 
-export interface RegionalEdition extends Edtion {}
-
-export interface SpecialEdition extends Edtion {
+export interface SpecialEdition {
+    edition: string
     expiry: Date
     devUri?: string
     image: Image
     style: SpecialEditionButtonStyles
+    subTitle: string
+    title: string
 }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react-native'
-import { withKnobs, text } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 import { EditionsMenu } from './EditionsMenu'
 
 const props = {

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -3,6 +3,54 @@ import { storiesOf } from '@storybook/react-native'
 import { withKnobs, text } from '@storybook/addon-knobs'
 import { EditionsMenu } from './EditionsMenu'
 
+const props = {
+    specialEditions: [
+        {
+            edition: '',
+            expiry: new Date(98, 1),
+            devUri:
+                'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+            image: {
+                source: 'media',
+                path: '/path/to/image',
+            },
+            title: `Food
+Monthly`,
+            subTitle:
+                'Store cupboard special: 20 quick and easy lockdown suppers',
+            style: {
+                backgroundColor: '#FEEEF7',
+                expiry: {
+                    color: '#7D0068',
+                    font: 'GuardianTextSans-Regular',
+                    lineHeight: 16,
+                    size: 15,
+                },
+
+                subTitle: {
+                    color: '#7D0068',
+                    font: 'GuardianTextSans-Bold',
+                    lineHeight: 20,
+                    size: 17,
+                },
+                title: {
+                    color: '#121212',
+                    font: 'GHGuardianHeadline-Regular',
+                    lineHeight: 34,
+                    size: 34,
+                },
+                image: {
+                    height: 134,
+                    width: 87,
+                },
+            },
+        },
+    ],
+}
+
 storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
     .add('EditionsMenu - default', () => <EditionsMenu />)
+    .add('EditionsMenu - with Special Edition', () => (
+        <EditionsMenu {...props} />
+    ))

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+import { withKnobs, text } from '@storybook/addon-knobs'
+import { EditionsMenu } from './EditionsMenu'
+
+storiesOf('EditionsMenu', module)
+    .addDecorator(withKnobs)
+    .add('EditionsMenu - default', () => <EditionsMenu />)

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,69 +1,77 @@
 import React from 'react'
-import { ScrollView } from 'react-native'
+import { FlatList, ScrollView } from 'react-native'
 import { EditionsMenuHeader } from './Header/Header'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
+import { editions } from 'src/helpers/settings/defaults'
+import {} from 'react-native-gesture-handler'
+import { RegionalEdition, SpecialEdition } from '../../../../Apps/common/src'
 
-const props = {
-    expiry: new Date(98, 1),
-    devUri:
-        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
-    image: {
-        source: 'media',
-        path: '/path/to/image',
+const defaultRegionalEditions: RegionalEdition[] = [
+    {
+        title: 'The Daily',
+        subTitle: 'Published every day by 6am (GMT)',
+        edition: editions.daily,
     },
-    onPress: () => {},
-    title: `Food
-Monthly`,
-    subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
-    style: {
-        backgroundColor: '#FEEEF7',
-        expiry: {
-            color: '#7D0068',
-            font: 'GuardianTextSans-Regular',
-            lineHeight: 16,
-            size: 15,
-        },
-
-        subTitle: {
-            color: '#7D0068',
-            font: 'GuardianTextSans-Bold',
-            lineHeight: 20,
-            size: 17,
-        },
-        title: {
-            color: '#121212',
-            font: 'GHGuardianHeadline-Regular',
-            lineHeight: 34,
-            size: 34,
-        },
-        image: {
-            height: 134,
-            width: 87,
-        },
+    {
+        title: 'Australia Weekend',
+        subTitle: 'Published every Saturday by 6am (AEST)',
+        edition: editions.ausWeekly,
     },
-}
+    {
+        title: 'US Weekend',
+        subTitle: 'Published every Saturday by 6am (EST)',
+        edition: editions.usWeekly,
+    },
+]
 
-const EditionsMenu = () => (
+const EditionsMenu = ({
+    regionalEdtions,
+    specialEditions,
+}: {
+    regionalEdtions?: RegionalEdition[]
+    specialEditions?: SpecialEdition[]
+}) => (
     <ScrollView>
         <EditionsMenuHeader>Regions</EditionsMenuHeader>
-        <RegionButton
-            onPress={() => {}}
-            title="The Daily"
-            subTitle="Published every day by 6am (GMT)"
+        <FlatList
+            data={regionalEdtions || defaultRegionalEditions}
+            renderItem={({ item }: { item: RegionalEdition }) => {
+                return (
+                    <RegionButton
+                        onPress={() => {}}
+                        title={item.title}
+                        subTitle={item.subTitle}
+                    />
+                )
+            }}
         />
-        <RegionButton
-            onPress={() => {}}
-            title="Australia Weekend"
-            subTitle="Published every Saturday by 6am (AEST)"
-        />
-        <RegionButton
-            onPress={() => {}}
-            title="US Weekend"
-            subTitle="Published every Saturday by 6am (EST)"
-        />
-        <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
-        <SpecialEditionButton {...props} />
+
+        {specialEditions && (
+            <>
+                <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
+                <FlatList
+                    data={specialEditions}
+                    renderItem={({
+                        item: { devUri, expiry, image, title, style, subTitle },
+                    }: {
+                        item: SpecialEdition
+                    }) => {
+                        return (
+                            <SpecialEditionButton
+                                devUri={devUri}
+                                expiry={expiry}
+                                image={image}
+                                onPress={() => {}}
+                                title={title}
+                                style={style}
+                                subTitle={subTitle}
+                            />
+                        )
+                    }}
+                />
+            </>
+        )}
     </ScrollView>
 )
 

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -4,24 +4,28 @@ import { EditionsMenuHeader } from './Header/Header'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
 import { editions } from 'src/helpers/settings/defaults'
-import { RegionalEdition, SpecialEdition } from '../../../../Apps/common/src'
+import {
+    Edition,
+    RegionalEdition,
+    SpecialEdition,
+} from '../../../../Apps/common/src'
 import { ItemSeperator } from './ItemSeperator/ItemSeperator'
 
 const defaultRegionalEditions: RegionalEdition[] = [
     {
         title: 'The Daily',
         subTitle: 'Published every day by 6am (GMT)',
-        edition: editions.daily,
+        edition: editions.daily as Edition,
     },
     {
         title: 'Australia Weekend',
         subTitle: 'Published every Saturday by 6am (AEST)',
-        edition: editions.ausWeekly,
+        edition: editions.ausWeekly as Edition,
     },
     {
         title: 'US Weekend',
         subTitle: 'Published every Saturday by 6am (EST)',
-        edition: editions.usWeekly,
+        edition: editions.usWeekly as Edition,
     },
 ]
 

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
-import { FlatList, ScrollView, View } from 'react-native'
+import { FlatList, ScrollView } from 'react-native'
 import { EditionsMenuHeader } from './Header/Header'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
 import { editions } from 'src/helpers/settings/defaults'
-import {} from 'react-native-gesture-handler'
 import { RegionalEdition, SpecialEdition } from '../../../../Apps/common/src'
-import { color } from 'src/theme/color'
 import { ItemSeperator } from './ItemSeperator/ItemSeperator'
 
 const defaultRegionalEditions: RegionalEdition[] = [

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { FlatList, ScrollView } from 'react-native'
+import { FlatList, ScrollView, View } from 'react-native'
 import { EditionsMenuHeader } from './Header/Header'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
 import { editions } from 'src/helpers/settings/defaults'
 import {} from 'react-native-gesture-handler'
 import { RegionalEdition, SpecialEdition } from '../../../../Apps/common/src'
+import { color } from 'src/theme/color'
+import { ItemSeperator } from './ItemSeperator/ItemSeperator'
 
 const defaultRegionalEditions: RegionalEdition[] = [
     {
@@ -45,8 +47,8 @@ const EditionsMenu = ({
                     />
                 )
             }}
+            ItemSeparatorComponent={() => <ItemSeperator />}
         />
-
         {specialEditions && (
             <>
                 <EditionsMenuHeader>Special Editions</EditionsMenuHeader>

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { ScrollView } from 'react-native'
+import { EditionsMenuHeader } from './Header/Header'
+import { RegionButton } from './RegionButton/RegionButton'
+import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
+
+const props = {
+    expiry: new Date(98, 1),
+    devUri:
+        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+    image: {
+        source: 'media',
+        path: '/path/to/image',
+    },
+    onPress: () => {},
+    title: `Food
+Monthly`,
+    subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+    style: {
+        backgroundColor: '#FEEEF7',
+        expiry: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Regular',
+            lineHeight: 16,
+            size: 15,
+        },
+
+        subTitle: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Bold',
+            lineHeight: 20,
+            size: 17,
+        },
+        title: {
+            color: '#121212',
+            font: 'GHGuardianHeadline-Regular',
+            lineHeight: 34,
+            size: 34,
+        },
+        image: {
+            height: 134,
+            width: 87,
+        },
+    },
+}
+
+const EditionsMenu = () => (
+    <ScrollView>
+        <EditionsMenuHeader>Regions</EditionsMenuHeader>
+        <RegionButton
+            onPress={() => {}}
+            title="The Daily"
+            subTitle="Published every day by 6am (GMT)"
+        />
+        <RegionButton
+            onPress={() => {}}
+            title="Australia Weekend"
+            subTitle="Published every Saturday by 6am (AEST)"
+        />
+        <RegionButton
+            onPress={() => {}}
+            title="US Weekend"
+            subTitle="Published every Saturday by 6am (EST)"
+        />
+        <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
+        <SpecialEditionButton {...props} />
+    </ScrollView>
+)
+
+export { EditionsMenu }

--- a/projects/Mallard/src/components/EditionsMenu/Header/Header.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/Header/Header.tsx
@@ -1,20 +1,31 @@
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
 import { TitlepieceText } from 'src/components/styled-text'
+import { color } from 'src/theme/color'
 
 const styles = StyleSheet.create({
     container: {
-        paddingTop: 4,
-        paddingLeft: 96,
-        paddingBottom: 38,
         flex: 1,
+        marginBottom: 5,
+    },
+    shadowBox: {
+        backgroundColor: 'white',
+        paddingBottom: 38,
+        paddingLeft: 96,
+        paddingTop: 4,
+        shadowColor: color.palette.neutral[7],
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.1,
+        shadowRadius: 4,
     },
     text: { fontSize: 24, lineHeight: 30 },
 })
 
 const EditionsMenuHeader = ({ children }: { children: string }) => (
     <View style={styles.container}>
-        <TitlepieceText style={styles.text}>{children}</TitlepieceText>
+        <View style={styles.shadowBox}>
+            <TitlepieceText style={styles.text}>{children}</TitlepieceText>
+        </View>
     </View>
 )
 

--- a/projects/Mallard/src/components/EditionsMenu/Header/Header.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/Header/Header.tsx
@@ -6,7 +6,7 @@ import { color } from 'src/theme/color'
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        marginBottom: 5,
+        marginBottom: 4,
     },
     shadowBox: {
         backgroundColor: 'white',

--- a/projects/Mallard/src/components/EditionsMenu/Header/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/Header/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -5,29 +5,45 @@ exports[`EditionsMenuHeader should display a default EditionsMenuHeader with cor
   style={
     Object {
       "flex": 1,
-      "paddingBottom": 38,
-      "paddingLeft": 96,
-      "paddingTop": 4,
+      "marginBottom": 4,
     }
   }
 >
-  <Text
+  <View
     style={
-      Array [
-        Object {
-          "flexShrink": 0,
-          "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 38,
+        "paddingLeft": 96,
+        "paddingTop": 4,
+        "shadowColor": "#121212",
+        "shadowOffset": Object {
+          "height": 4,
+          "width": 0,
         },
-        Object {
-          "fontSize": 24,
-          "lineHeight": 30,
-        },
-      ]
+        "shadowOpacity": 0.1,
+        "shadowRadius": 4,
+      }
     }
   >
-    Special Editions
-  </Text>
+    <Text
+      style={
+        Array [
+          Object {
+            "flexShrink": 0,
+            "fontFamily": "GTGuardianTitlepiece-Bold",
+            "fontSize": 30,
+            "lineHeight": 33,
+          },
+          Object {
+            "fontSize": 24,
+            "lineHeight": 30,
+          },
+        ]
+      }
+    >
+      Special Editions
+    </Text>
+  </View>
 </View>
 `;

--- a/projects/Mallard/src/components/EditionsMenu/ItemSeperator/ItemSeperator.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/ItemSeperator/ItemSeperator.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { View } from 'react-native'
+import { color } from 'src/theme/color'
+
+const ItemSeperator = () => (
+    <View
+        style={{
+            backgroundColor: color.palette.neutral[7],
+            height: 1,
+        }}
+    ></View>
+)
+
+export { ItemSeperator }

--- a/projects/Mallard/src/components/EditionsMenu/ItemSeperator/__tests__/ItemSeperator.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/ItemSeperator/__tests__/ItemSeperator.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { ItemSeperator } from '../ItemSeperator'
+
+describe('ItemSeperator', () => {
+    it('should display a default ItemSeperator with correct styling used for RegionButton seperation', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ItemSeperator />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/EditionsMenu/ItemSeperator/__tests__/__snapshots__/ItemSeperator.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/ItemSeperator/__tests__/__snapshots__/ItemSeperator.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ItemSeperator should display a default ItemSeperator with correct styling used for RegionButton seperation 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#121212",
+      "height": 1,
+    }
+  }
+/>
+`;

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { EditionsMenu } from '../EditionsMenu'
+import { editions } from 'src/helpers/settings/defaults'
 
 jest.mock('src/components/front/image-resource', () => ({
     ImageResource: () => 'ImageResource',
@@ -10,6 +11,64 @@ jest.mock('src/helpers/locale', () => ({
     locale: 'en_GB',
 }))
 
+const regionalEditions = [
+    {
+        title: 'The UK Daily Edition',
+        subTitle: 'Published every day by 12am (GMT)',
+        edition: editions.daily,
+    },
+    {
+        title: 'Australia Daily',
+        subTitle: 'Published every day by 9:30am (AEST)',
+        edition: editions.ausWeekly,
+    },
+    {
+        title: 'US and Cananda Weekend',
+        subTitle: 'Published every Saturday by 8am (EST)',
+        edition: editions.usWeekly,
+    },
+]
+
+const specialEditions = [
+    {
+        edition: '',
+        expiry: new Date(98, 1),
+        image: {
+            source: 'media',
+            path: '/path/to/image',
+        },
+        title: `Food
+Monthly`,
+        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+        style: {
+            backgroundColor: '#FEEEF7',
+            expiry: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Regular',
+                lineHeight: 16,
+                size: 15,
+            },
+
+            subTitle: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Bold',
+                lineHeight: 20,
+                size: 17,
+            },
+            title: {
+                color: '#121212',
+                font: 'GHGuardianHeadline-Regular',
+                lineHeight: 34,
+                size: 34,
+            },
+            image: {
+                height: 134,
+                width: 87,
+            },
+        },
+    },
+]
+
 describe('EditionsMenu', () => {
     it('should display a default EditionsMenu with correct styling and default Regional Buttons', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
@@ -17,6 +76,16 @@ describe('EditionsMenu', () => {
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
-    // Needs Regional Editions with different titles
-    // Needs Special Editions
+    it('should display a EditionsMenu with correct styling and alternative Regional Buttons', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <EditionsMenu regionalEdtions={regionalEditions} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <EditionsMenu specialEditions={specialEditions} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
 })

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { EditionsMenu } from '../EditionsMenu'
+
+jest.mock('src/components/front/image-resource', () => ({
+    ImageResource: () => 'ImageResource',
+}))
+
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
+
+describe('EditionsMenu', () => {
+    it('should display a default EditionsMenu with correct styling and default Regional Buttons', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <EditionsMenu />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    // Needs Regional Editions with different titles
+    // Needs Special Editions
+})

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
-import { EditionsMenu } from '../EditionsMenu'
 import { editions } from 'src/helpers/settings/defaults'
+import { Edition } from '../../../../../Apps/common/src'
+import { EditionsMenu } from '../EditionsMenu'
 
 jest.mock('src/components/front/image-resource', () => ({
     ImageResource: () => 'ImageResource',
@@ -15,17 +16,17 @@ const regionalEditions = [
     {
         title: 'The UK Daily Edition',
         subTitle: 'Published every day by 12am (GMT)',
-        edition: editions.daily,
+        edition: editions.daily as Edition,
     },
     {
         title: 'Australia Daily',
         subTitle: 'Published every day by 9:30am (AEST)',
-        edition: editions.ausWeekly,
+        edition: editions.ausWeekly as Edition,
     },
     {
         title: 'US and Cananda Weekend',
         subTitle: 'Published every Saturday by 8am (EST)',
-        edition: editions.usWeekly,
+        edition: editions.usWeekly as Edition,
     },
 ]
 

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -1,0 +1,271 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditionsMenu should display a default EditionsMenu with correct styling and default Regional Buttons 1`] = `
+<RCTScrollView>
+  <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingBottom": 38,
+          "paddingLeft": 96,
+          "paddingTop": 4,
+        }
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "flexShrink": 0,
+              "fontFamily": "GTGuardianTitlepiece-Bold",
+              "fontSize": 30,
+              "lineHeight": 33,
+            },
+            Object {
+              "fontSize": 24,
+              "lineHeight": 30,
+            },
+          ]
+        }
+      >
+        Regions
+      </Text>
+    </View>
+    <RCTScrollView
+      ItemSeparatorComponent={[Function]}
+      data={
+        Array [
+          Object {
+            "edition": "daily-edition",
+            "subTitle": "Published every day by 6am (GMT)",
+            "title": "The Daily",
+          },
+          Object {
+            "edition": "australian-edition",
+            "subTitle": "Published every Saturday by 6am (AEST)",
+            "title": "Australia Weekend",
+          },
+          Object {
+            "edition": "american-edition",
+            "subTitle": "Published every Saturday by 6am (EST)",
+            "title": "US Weekend",
+          },
+        ]
+      }
+      disableVirtualization={false}
+      getItem={[Function]}
+      getItemCount={[Function]}
+      horizontal={false}
+      initialNumToRender={10}
+      keyExtractor={[Function]}
+      maxToRenderPerBatch={10}
+      numColumns={1}
+      onContentSizeChange={[Function]}
+      onEndReachedThreshold={2}
+      onLayout={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEventThrottle={50}
+      stickyHeaderIndices={Array []}
+      updateCellsBatchingPeriod={50}
+      viewabilityConfigCallbackPairs={Array []}
+      windowSize={21}
+    >
+      <View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#E5E5E5",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              The Daily
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every day by 6am (GMT)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#E5E5E5",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              Australia Weekend
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every Saturday by 6am (AEST)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#E5E5E5",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              US Weekend
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every Saturday by 6am (EST)
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</RCTScrollView>
+`;

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -1,36 +1,344 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EditionsMenu should display a default EditionsMenu with correct styling and default Regional Buttons 1`] = `
+exports[`EditionsMenu should display a EditionsMenu with correct styling and alternative Regional Buttons 1`] = `
 <RCTScrollView>
   <View>
     <View
       style={
         Object {
           "flex": 1,
-          "paddingBottom": 38,
-          "paddingLeft": 96,
-          "paddingTop": 4,
+          "marginBottom": 4,
         }
       }
     >
-      <Text
+      <View
         style={
-          Array [
-            Object {
-              "flexShrink": 0,
-              "fontFamily": "GTGuardianTitlepiece-Bold",
-              "fontSize": 30,
-              "lineHeight": 33,
+          Object {
+            "backgroundColor": "white",
+            "paddingBottom": 38,
+            "paddingLeft": 96,
+            "paddingTop": 4,
+            "shadowColor": "#121212",
+            "shadowOffset": Object {
+              "height": 4,
+              "width": 0,
             },
-            Object {
-              "fontSize": 24,
-              "lineHeight": 30,
-            },
-          ]
+            "shadowOpacity": 0.1,
+            "shadowRadius": 4,
+          }
         }
       >
-        Regions
-      </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "flexShrink": 0,
+                "fontFamily": "GTGuardianTitlepiece-Bold",
+                "fontSize": 30,
+                "lineHeight": 33,
+              },
+              Object {
+                "fontSize": 24,
+                "lineHeight": 30,
+              },
+            ]
+          }
+        >
+          Regions
+        </Text>
+      </View>
+    </View>
+    <RCTScrollView
+      ItemSeparatorComponent={[Function]}
+      data={
+        Array [
+          Object {
+            "edition": "daily-edition",
+            "subTitle": "Published every day by 12am (GMT)",
+            "title": "The UK Daily Edition",
+          },
+          Object {
+            "edition": "australian-edition",
+            "subTitle": "Published every day by 9:30am (AEST)",
+            "title": "Australia Daily",
+          },
+          Object {
+            "edition": "american-edition",
+            "subTitle": "Published every Saturday by 8am (EST)",
+            "title": "US and Cananda Weekend",
+          },
+        ]
+      }
+      disableVirtualization={false}
+      getItem={[Function]}
+      getItemCount={[Function]}
+      horizontal={false}
+      initialNumToRender={10}
+      keyExtractor={[Function]}
+      maxToRenderPerBatch={10}
+      numColumns={1}
+      onContentSizeChange={[Function]}
+      onEndReachedThreshold={2}
+      onLayout={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEventThrottle={50}
+      stickyHeaderIndices={Array []}
+      updateCellsBatchingPeriod={50}
+      viewabilityConfigCallbackPairs={Array []}
+      windowSize={21}
+    >
+      <View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="The UK Daily Edition - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              The UK Daily Edition
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every day by 12am (GMT)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="Australia Daily - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              Australia Daily
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every day by 9:30am (AEST)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="US and Cananda Weekend - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              US and Cananda Weekend
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every Saturday by 8am (EST)
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`EditionsMenu should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button 1`] = `
+<RCTScrollView>
+  <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "marginBottom": 4,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "white",
+            "paddingBottom": 38,
+            "paddingLeft": 96,
+            "paddingTop": 4,
+            "shadowColor": "#121212",
+            "shadowOffset": Object {
+              "height": 4,
+              "width": 0,
+            },
+            "shadowOpacity": 0.1,
+            "shadowRadius": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "flexShrink": 0,
+                "fontFamily": "GTGuardianTitlepiece-Bold",
+                "fontSize": 30,
+                "lineHeight": 33,
+              },
+              Object {
+                "fontSize": 24,
+                "lineHeight": 30,
+              },
+            ]
+          }
+        >
+          Regions
+        </Text>
+      </View>
     </View>
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
@@ -82,6 +390,8 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
           style={null}
         >
           <View
+            accessibilityLabel="The Daily - Regional Edition Button"
+            accessibilityRole="button"
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -93,7 +403,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "backgroundColor": "#E5E5E5",
+                "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
                 "paddingLeft": 104,
                 "paddingTop": 4,
@@ -147,6 +457,8 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
           style={null}
         >
           <View
+            accessibilityLabel="Australia Weekend - Regional Edition Button"
+            accessibilityRole="button"
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -158,7 +470,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "backgroundColor": "#E5E5E5",
+                "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
                 "paddingLeft": 104,
                 "paddingTop": 4,
@@ -212,6 +524,8 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
           style={null}
         >
           <View
+            accessibilityLabel="US Weekend - Regional Edition Button"
+            accessibilityRole="button"
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -223,7 +537,493 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "backgroundColor": "#E5E5E5",
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              US Weekend
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every Saturday by 6am (EST)
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "marginBottom": 4,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "white",
+            "paddingBottom": 38,
+            "paddingLeft": 96,
+            "paddingTop": 4,
+            "shadowColor": "#121212",
+            "shadowOffset": Object {
+              "height": 4,
+              "width": 0,
+            },
+            "shadowOpacity": 0.1,
+            "shadowRadius": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "flexShrink": 0,
+                "fontFamily": "GTGuardianTitlepiece-Bold",
+                "fontSize": 30,
+                "lineHeight": 33,
+              },
+              Object {
+                "fontSize": 24,
+                "lineHeight": 30,
+              },
+            ]
+          }
+        >
+          Special Editions
+        </Text>
+      </View>
+    </View>
+    <RCTScrollView
+      data={
+        Array [
+          Object {
+            "edition": "",
+            "expiry": 1998-02-01T00:00:00.000Z,
+            "image": Object {
+              "path": "/path/to/image",
+              "source": "media",
+            },
+            "style": Object {
+              "backgroundColor": "#FEEEF7",
+              "expiry": Object {
+                "color": "#7D0068",
+                "font": "GuardianTextSans-Regular",
+                "lineHeight": 16,
+                "size": 15,
+              },
+              "image": Object {
+                "height": 134,
+                "width": 87,
+              },
+              "subTitle": Object {
+                "color": "#7D0068",
+                "font": "GuardianTextSans-Bold",
+                "lineHeight": 20,
+                "size": 17,
+              },
+              "title": Object {
+                "color": "#121212",
+                "font": "GHGuardianHeadline-Regular",
+                "lineHeight": 34,
+                "size": 34,
+              },
+            },
+            "subTitle": "Store cupboard special: 20 quick and easy lockdown suppers",
+            "title": "Food
+Monthly",
+          },
+        ]
+      }
+      disableVirtualization={false}
+      getItem={[Function]}
+      getItemCount={[Function]}
+      horizontal={false}
+      initialNumToRender={10}
+      keyExtractor={[Function]}
+      maxToRenderPerBatch={10}
+      numColumns={1}
+      onContentSizeChange={[Function]}
+      onEndReachedThreshold={2}
+      onLayout={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEventThrottle={50}
+      stickyHeaderIndices={Array []}
+      updateCellsBatchingPeriod={50}
+      viewabilityConfigCallbackPairs={Array []}
+      windowSize={21}
+    >
+      <View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="Food
+Monthly - Special Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#FEEEF7",
+                "flexDirection": "row",
+                "paddingTop": 12,
+              }
+            }
+          >
+            ImageResource
+            <View
+              style={
+                Object {
+                  "flexShrink": 1,
+                  "paddingBottom": 15,
+                  "paddingLeft": 10,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#121212",
+                    "flexWrap": "wrap",
+                    "fontFamily": "GHGuardianHeadline-Regular",
+                    "fontSize": 34,
+                    "lineHeight": 34,
+                  }
+                }
+              >
+                Food
+Monthly
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#7D0068",
+                    "flexWrap": "wrap",
+                    "fontFamily": "GuardianTextSans-Bold",
+                    "fontSize": 17,
+                    "lineHeight": 20,
+                    "marginTop": 10,
+                  }
+                }
+              >
+                Store cupboard special: 20 quick and easy lockdown suppers
+              </Text>
+              <Text
+                style={
+                  Object {
+                    "color": "#7D0068",
+                    "flexWrap": "wrap",
+                    "fontFamily": "GuardianTextSans-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 16,
+                    "marginTop": 8,
+                  }
+                }
+              >
+                Available until
+                 
+                2/1/1998
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`EditionsMenu should display a default EditionsMenu with correct styling and default Regional Buttons 1`] = `
+<RCTScrollView>
+  <View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "marginBottom": 4,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "white",
+            "paddingBottom": 38,
+            "paddingLeft": 96,
+            "paddingTop": 4,
+            "shadowColor": "#121212",
+            "shadowOffset": Object {
+              "height": 4,
+              "width": 0,
+            },
+            "shadowOpacity": 0.1,
+            "shadowRadius": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "flexShrink": 0,
+                "fontFamily": "GTGuardianTitlepiece-Bold",
+                "fontSize": 30,
+                "lineHeight": 33,
+              },
+              Object {
+                "fontSize": 24,
+                "lineHeight": 30,
+              },
+            ]
+          }
+        >
+          Regions
+        </Text>
+      </View>
+    </View>
+    <RCTScrollView
+      ItemSeparatorComponent={[Function]}
+      data={
+        Array [
+          Object {
+            "edition": "daily-edition",
+            "subTitle": "Published every day by 6am (GMT)",
+            "title": "The Daily",
+          },
+          Object {
+            "edition": "australian-edition",
+            "subTitle": "Published every Saturday by 6am (AEST)",
+            "title": "Australia Weekend",
+          },
+          Object {
+            "edition": "american-edition",
+            "subTitle": "Published every Saturday by 6am (EST)",
+            "title": "US Weekend",
+          },
+        ]
+      }
+      disableVirtualization={false}
+      getItem={[Function]}
+      getItemCount={[Function]}
+      horizontal={false}
+      initialNumToRender={10}
+      keyExtractor={[Function]}
+      maxToRenderPerBatch={10}
+      numColumns={1}
+      onContentSizeChange={[Function]}
+      onEndReachedThreshold={2}
+      onLayout={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEventThrottle={50}
+      stickyHeaderIndices={Array []}
+      updateCellsBatchingPeriod={50}
+      viewabilityConfigCallbackPairs={Array []}
+      windowSize={21}
+    >
+      <View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="The Daily - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              The Daily
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every day by 6am (GMT)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="Australia Weekend - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
+                "paddingBottom": 32,
+                "paddingLeft": 104,
+                "paddingTop": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "flexShrink": 0,
+                    "fontFamily": "GTGuardianTitlepiece-Bold",
+                    "fontSize": 30,
+                    "lineHeight": 33,
+                  },
+                  Object {
+                    "color": "#052962",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                ]
+              }
+            >
+              Australia Weekend
+            </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#121212",
+                  "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 16,
+                }
+              }
+            >
+              Published every Saturday by 6am (AEST)
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#121212",
+                "height": 1,
+              }
+            }
+          />
+        </View>
+        <View
+          onLayout={[Function]}
+          style={null}
+        >
+          <View
+            accessibilityLabel="US Weekend - Regional Edition Button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
                 "paddingLeft": 104,
                 "paddingTop": 4,

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -4,34 +4,36 @@
 // https://github.com/elderfo/react-native-storybook-loader.git
 
 function loadStories() {
-	require('../src/components/Button/Button.stories');
-	require('../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories');
-	require('../src/components/EditionsMenu/Header/Header.stories');
-	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
-	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
-	require('../src/components/Lightbox/LightboxCaption.stories');
-	require('../src/components/SignInFailedModalCard.stories');
-	require('../src/components/Spinner/Spinner.stories');
-	require('../src/components/SportScore/SportScore.stories');
-	require('../src/components/Stars/Stars.stories');
-	require('../src/components/icons/Icons.stories');
+    require('../src/components/Button/Button.stories')
+    require('../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories')
+    require('../src/components/EditionsMenu/EditionsMenu.stories')
+    require('../src/components/EditionsMenu/Header/Header.stories')
+    require('../src/components/EditionsMenu/RegionButton/RegionButton.stories')
+    require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories')
+    require('../src/components/Lightbox/LightboxCaption.stories')
+    require('../src/components/SignInFailedModalCard.stories')
+    require('../src/components/Spinner/Spinner.stories')
+    require('../src/components/SportScore/SportScore.stories')
+    require('../src/components/Stars/Stars.stories')
+    require('../src/components/icons/Icons.stories')
 }
 
 const stories = [
-	'../src/components/Button/Button.stories',
-	'../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories',
-	'../src/components/EditionsMenu/Header/Header.stories',
-	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
-	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
-	'../src/components/Lightbox/LightboxCaption.stories',
-	'../src/components/SignInFailedModalCard.stories',
-	'../src/components/Spinner/Spinner.stories',
-	'../src/components/SportScore/SportScore.stories',
-	'../src/components/Stars/Stars.stories',
-	'../src/components/icons/Icons.stories'
-];
+    '../src/components/Button/Button.stories',
+    '../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories',
+    '../src/components/EditionsMenu/EditionsMenu.stories',
+    '../src/components/EditionsMenu/Header/Header.stories',
+    '../src/components/EditionsMenu/RegionButton/RegionButton.stories',
+    '../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
+    '../src/components/Lightbox/LightboxCaption.stories',
+    '../src/components/SignInFailedModalCard.stories',
+    '../src/components/Spinner/Spinner.stories',
+    '../src/components/SportScore/SportScore.stories',
+    '../src/components/Stars/Stars.stories',
+    '../src/components/icons/Icons.stories',
+]
 
 module.exports = {
-  loadStories,
-  stories,
-};
+    loadStories,
+    stories,
+}

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -4,36 +4,36 @@
 // https://github.com/elderfo/react-native-storybook-loader.git
 
 function loadStories() {
-    require('../src/components/Button/Button.stories')
-    require('../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories')
-    require('../src/components/EditionsMenu/EditionsMenu.stories')
-    require('../src/components/EditionsMenu/Header/Header.stories')
-    require('../src/components/EditionsMenu/RegionButton/RegionButton.stories')
-    require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories')
-    require('../src/components/Lightbox/LightboxCaption.stories')
-    require('../src/components/SignInFailedModalCard.stories')
-    require('../src/components/Spinner/Spinner.stories')
-    require('../src/components/SportScore/SportScore.stories')
-    require('../src/components/Stars/Stars.stories')
-    require('../src/components/icons/Icons.stories')
+	require('../src/components/Button/Button.stories');
+	require('../src/components/EditionsMenu/EditionsMenu.stories');
+	require('../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories');
+	require('../src/components/EditionsMenu/Header/Header.stories');
+	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
+	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
+	require('../src/components/Lightbox/LightboxCaption.stories');
+	require('../src/components/SignInFailedModalCard.stories');
+	require('../src/components/Spinner/Spinner.stories');
+	require('../src/components/SportScore/SportScore.stories');
+	require('../src/components/Stars/Stars.stories');
+	require('../src/components/icons/Icons.stories');
 }
 
 const stories = [
-    '../src/components/Button/Button.stories',
-    '../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories',
-    '../src/components/EditionsMenu/EditionsMenu.stories',
-    '../src/components/EditionsMenu/Header/Header.stories',
-    '../src/components/EditionsMenu/RegionButton/RegionButton.stories',
-    '../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
-    '../src/components/Lightbox/LightboxCaption.stories',
-    '../src/components/SignInFailedModalCard.stories',
-    '../src/components/Spinner/Spinner.stories',
-    '../src/components/SportScore/SportScore.stories',
-    '../src/components/Stars/Stars.stories',
-    '../src/components/icons/Icons.stories',
-]
+	'../src/components/Button/Button.stories',
+	'../src/components/EditionsMenu/EditionsMenu.stories',
+	'../src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.stories',
+	'../src/components/EditionsMenu/Header/Header.stories',
+	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
+	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
+	'../src/components/Lightbox/LightboxCaption.stories',
+	'../src/components/SignInFailedModalCard.stories',
+	'../src/components/Spinner/Spinner.stories',
+	'../src/components/SportScore/SportScore.stories',
+	'../src/components/Stars/Stars.stories',
+	'../src/components/icons/Icons.stories'
+];
 
 module.exports = {
-    loadStories,
-    stories,
-}
+  loadStories,
+  stories,
+};


### PR DESCRIPTION
## Summary
This combines the previous PRs components together to create the design. 

Please note that the `onPress` in these components hasn't been hooked up yet as this will probably require passing in a React Navigation which will be better to do at the screen implementation stage.

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)

#### Without Special Editions
![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 08 31 56](https://user-images.githubusercontent.com/935975/84992435-ca1a5200-b13f-11ea-84cf-cacb36791f75.png)

#### With Special Editions
![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 08 31 40](https://user-images.githubusercontent.com/935975/84992457-d1d9f680-b13f-11ea-93f0-7a7c653e7a55.png)
