### PR TITLE
feat: Refactor Logging

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -161,10 +161,12 @@ export default class App extends React.Component<{}, {}> {
         clearDownloadsDirectory()
         prepareAndDownloadTodaysIssue(apolloClient)
         shouldHavePushFailsafe(apolloClient)
+        loggingService.postLogs()
 
         AppState.addEventListener('change', async appState => {
             if (appState === 'active') {
                 prepareAndDownloadTodaysIssue(apolloClient)
+                loggingService.postLogs()
             }
         })
     }

--- a/projects/Mallard/src/helpers/__tests__/async-queue-cache.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/async-queue-cache.spec.ts
@@ -1,0 +1,43 @@
+import { AsyncQueue } from '../async-queue-cache'
+
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
+
+jest.mock('src/services/errors', () => ({
+    captureException: jest.fn(),
+}))
+
+const mockCache = {
+    set: () => Promise.resolve(),
+    get: () => Promise.resolve(),
+    reset: () => Promise.resolve(),
+}
+
+const items = [{ test: 1 }, { test: 2 }, { test: 3 }, { test: 4 }, { test: 5 }]
+
+describe('AsyncQueue', () => {
+    describe('filterByMaxNumberAndSaveItems', () => {
+        it('should return items if the number of items are less than the max number', () => {
+            const queue = new AsyncQueue(mockCache)
+            expect(queue.filterByMaxNumberAndSaveItems(items, 6)).toEqual(items)
+        })
+        it('should return items if the number of items are equal to the max number', () => {
+            const queue = new AsyncQueue(mockCache)
+            expect(queue.filterByMaxNumberAndSaveItems(items, 5)).toEqual(items)
+        })
+        it('should return remove items from the front if items are more than the max number', () => {
+            const queue = new AsyncQueue(mockCache)
+            const expectedItems = [
+                { test: 2 },
+                { test: 3 },
+                { test: 4 },
+                { test: 5 },
+            ]
+            console.log(queue.filterByMaxNumberAndSaveItems(items, 4))
+            expect(queue.filterByMaxNumberAndSaveItems(items, 4)).toEqual(
+                expectedItems,
+            )
+        })
+    })
+})

--- a/projects/Mallard/src/helpers/async-queue-cache.ts
+++ b/projects/Mallard/src/helpers/async-queue-cache.ts
@@ -49,6 +49,16 @@ class AsyncQueue {
         }
     }
 
+    async upsertQueuedItems(item: object[]): Promise<void | Error> {
+        try {
+            const itemsToStore = await this.queueItems(item)
+            return this.saveQueuedItems(itemsToStore)
+        } catch (e) {
+            errorService.captureException(e)
+            throw new Error(e)
+        }
+    }
+
     async clearItems() {
         try {
             return await this.cache.reset()

--- a/projects/Mallard/src/helpers/async-queue-cache.ts
+++ b/projects/Mallard/src/helpers/async-queue-cache.ts
@@ -49,6 +49,14 @@ class AsyncQueue {
         }
     }
 
+    filterByMaxNumberAndSaveItems(itemsToStore: object[], maxNumber: number) {
+        if (itemsToStore.length > maxNumber) {
+            const startIndex = itemsToStore.length - maxNumber
+            return itemsToStore.slice(startIndex)
+        }
+        return itemsToStore
+    }
+
     async upsertQueuedItems(
         item: object[],
         maxNumber?: number,
@@ -56,9 +64,11 @@ class AsyncQueue {
         try {
             const itemsToStore = await this.queueItems(item)
 
-            if (maxNumber && itemsToStore.length > maxNumber) {
-                const startIndex = itemsToStore.length - maxNumber - 1
-                const reducedItemsToStore = itemsToStore.slice(startIndex)
+            if (maxNumber) {
+                const reducedItemsToStore = this.filterByMaxNumberAndSaveItems(
+                    itemsToStore,
+                    maxNumber,
+                )
                 return this.saveQueuedItems(reducedItemsToStore)
             }
 

--- a/projects/Mallard/src/helpers/async-queue-cache.ts
+++ b/projects/Mallard/src/helpers/async-queue-cache.ts
@@ -49,9 +49,19 @@ class AsyncQueue {
         }
     }
 
-    async upsertQueuedItems(item: object[]): Promise<void | Error> {
+    async upsertQueuedItems(
+        item: object[],
+        maxNumber?: number,
+    ): Promise<void | Error> {
         try {
             const itemsToStore = await this.queueItems(item)
+
+            if (maxNumber && itemsToStore.length > maxNumber) {
+                const startIndex = itemsToStore.length - maxNumber - 1
+                const reducedItemsToStore = itemsToStore.slice(startIndex)
+                return this.saveQueuedItems(reducedItemsToStore)
+            }
+
             return this.saveQueuedItems(itemsToStore)
         } catch (e) {
             errorService.captureException(e)

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -106,15 +106,34 @@ describe('logging service', () => {
                 expect(loggingService.numberOfAttempts).toEqual(1)
             }
         })
-        it('should reset the number of attempts on a successful post and clear the items in storage', async () => {
+        it('should reset the number of attempts on a successful post and clear the items in storage with more than 1 log', async () => {
             const loggingService = new Logging()
             loggingService.postLogToService = jest
                 .fn()
                 .mockReturnValue(Promise.resolve(true))
             loggingService.clearItems = jest.fn()
+            loggingService.getQueuedItems = jest
+                .fn()
+                .mockReturnValue([{ log: 'one' }, { log: 'two' }])
 
             await loggingService.postLogs()
+            expect(loggingService.postLogToService).toHaveBeenCalled()
             expect(loggingService.clearItems).toHaveBeenCalled()
+            expect(loggingService.numberOfAttempts).toEqual(0)
+        })
+        it('should not attempt to post if there is only 1 log in the queue', async () => {
+            const loggingService = new Logging()
+            loggingService.postLogToService = jest
+                .fn()
+                .mockReturnValue(Promise.resolve(true))
+            loggingService.clearItems = jest.fn()
+            loggingService.getQueuedItems = jest
+                .fn()
+                .mockReturnValue([{ log: 'one' }])
+
+            await loggingService.postLogs()
+            expect(loggingService.postLogToService).not.toHaveBeenCalled()
+            expect(loggingService.clearItems).not.toHaveBeenCalled()
             expect(loggingService.numberOfAttempts).toEqual(0)
         })
         it('should call clearLogs if the threshold is reached when there is an error', async () => {

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -80,35 +80,42 @@ describe('logging service', () => {
     })
 
     describe('log', () => {
-        it('should have a successful post log', async () => {
+        it('should have a successful stored a log', async () => {
             const loggingService = new Logging()
             loggingService.getExternalInfo = jest
                 .fn()
                 .mockReturnValue(externalInfoFixture)
-            loggingService.clearItems = jest.fn()
-            loggingService.postLog = jest.fn()
+            loggingService.upsertQueuedItems = jest.fn()
             loggingService.enabled = true
             loggingService.hasConsent = true
             await loggingService.log({ level: Level.INFO, message: 'test' })
-            expect(loggingService.postLog).toHaveBeenCalled()
-            expect(loggingService.clearItems).toHaveBeenCalled()
+            expect(loggingService.upsertQueuedItems).toHaveBeenCalled()
         })
-        it('should not post a log if there is no consent', async () => {
+        it('should not store a log if there is no consent', async () => {
             const loggingService = new Logging()
             loggingService.getExternalInfo = jest
                 .fn()
                 .mockReturnValue(externalInfoFixture)
-            loggingService.clearItems = jest.fn()
-            loggingService.postLog = jest.fn()
+            loggingService.upsertQueuedItems = jest.fn()
+            loggingService.enabled = false
 
             await loggingService.log({ level: Level.INFO, message: 'test' })
-            expect(loggingService.postLog).not.toHaveBeenCalled()
-            expect(loggingService.clearItems).not.toHaveBeenCalled()
+            expect(loggingService.upsertQueuedItems).not.toHaveBeenCalled()
+        })
+        it('should not store a log if logging is not enabled in remote config', async () => {
+            const loggingService = new Logging()
+            loggingService.getExternalInfo = jest
+                .fn()
+                .mockReturnValue(externalInfoFixture)
+            loggingService.upsertQueuedItems = jest.fn()
+
+            await loggingService.log({ level: Level.INFO, message: 'test' })
+            expect(loggingService.upsertQueuedItems).not.toHaveBeenCalled()
         })
     })
 
-    describe('postLog', () => {
-        it('should increase the number of attempts if postLog fails', async () => {
+    describe('postLogs', () => {
+        it('should increase the number of attempts if postLogs fails', async () => {
             const loggingService = new Logging()
             loggingService.postLogToService = jest
                 .fn()
@@ -117,17 +124,20 @@ describe('logging service', () => {
                 })
 
             try {
-                await loggingService.postLog(logFixture)
+                await loggingService.postLogs()
             } catch {
                 expect(loggingService.numberOfAttempts).toEqual(1)
             }
         })
-        it('should reset the number of attempts on a successful post', async () => {
+        it('should reset the number of attempts on a successful post and clear the items in storage', async () => {
             const loggingService = new Logging()
             loggingService.postLogToService = jest
                 .fn()
                 .mockReturnValue(Promise.resolve(true))
-            await loggingService.postLog(logFixture)
+            loggingService.clearItems = jest.fn()
+
+            await loggingService.postLogs()
+            expect(loggingService.clearItems).toHaveBeenCalled()
             expect(loggingService.numberOfAttempts).toEqual(0)
         })
         it('should call clearLogs if the threshold is reached when there is an error', async () => {
@@ -141,7 +151,7 @@ describe('logging service', () => {
             loggingService.clearItems = jest.fn()
 
             try {
-                await loggingService.postLog(logFixture)
+                await loggingService.postLogs()
             } catch {
                 expect(loggingService.numberOfAttempts).toEqual(0)
                 expect(loggingService.clearItems).toHaveBeenCalled()

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,7 +1,5 @@
 import { Logging, Level, cropMessage } from '../logging'
 import MockDate from 'mockdate'
-import { ReleaseChannel, OS } from '../../../../Apps/common/src/logging'
-import { NetInfoStateType } from '@react-native-community/netinfo'
 
 jest.mock('src/helpers/locale', () => ({
     locale: 'en_GB',
@@ -14,27 +12,6 @@ jest.mock('@react-native-community/netinfo', () => ({
     },
 }))
 MockDate.set('2019-08-21')
-
-const logFixture = [
-    {
-        timestamp: new Date(),
-        level: Level.INFO,
-        message: 'basic log',
-        app: 'com.guardian.gce',
-        version: '2.0',
-        buildNumber: '678',
-        release_channel: ReleaseChannel.BETA,
-        os: OS.IOS,
-        device: 'iPad4,1',
-        networkStatus: NetInfoStateType.wifi,
-        deviceId: '12345qwerty',
-        signedIn: true,
-        userId: null,
-        digitalSub: false,
-        casCode: null,
-        iAP: false,
-    },
-]
 
 const externalInfoFixture = {
     networkStatus: { type: 'wifi' },

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -160,8 +160,11 @@ class Logging extends AsyncQueue {
             // Only attempt if we are connected, otherwise wait till next time
             if (isConnected) {
                 const logsToPost = await this.getQueuedItems()
-                await this.postLogToService(logsToPost)
-                await this.clearItems()
+
+                if (logsToPost.length > 1) {
+                    await this.postLogToService(logsToPost)
+                    await this.clearItems()
+                }
                 this.numberOfAttempts = 0
             }
         } catch (e) {
@@ -178,7 +181,7 @@ class Logging extends AsyncQueue {
 
     async log({ level, message, ...optionalFields }: LogParams) {
         try {
-            if (!this.enabled || !this.hasConsent) {
+            if (!this.hasConsent) {
                 return
             }
 

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -164,8 +164,8 @@ class Logging extends AsyncQueue {
                 if (logsToPost.length > 1) {
                     await this.postLogToService(logsToPost)
                     await this.clearItems()
+                    this.numberOfAttempts = 0
                 }
-                this.numberOfAttempts = 0
             }
         } catch (e) {
             if (this.numberOfAttempts >= ATTEMPTS_THEN_CLEAR) {

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -156,10 +156,14 @@ class Logging extends AsyncQueue {
 
     async postLogs() {
         try {
-            const logsToPost = await this.getQueuedItems()
-            await this.postLogToService(logsToPost)
-            await this.clearItems()
-            this.numberOfAttempts = 0
+            const { isConnected } = await NetInfo.fetch()
+            // Only attempt if we are connected, otherwise wait till next time
+            if (isConnected) {
+                const logsToPost = await this.getQueuedItems()
+                await this.postLogToService(logsToPost)
+                await this.clearItems()
+                this.numberOfAttempts = 0
+            }
         } catch (e) {
             if (this.numberOfAttempts >= ATTEMPTS_THEN_CLEAR) {
                 await this.clearItems()

--- a/projects/Mallard/src/services/logging.ts
+++ b/projects/Mallard/src/services/logging.ts
@@ -27,6 +27,7 @@ import remoteConfig from '@react-native-firebase/remote-config'
 
 const { LOGGING_API_KEY } = Config
 const ATTEMPTS_THEN_CLEAR = 10
+const MAX_NUM_OF_LOGS = 30
 
 interface LogParams {
     level: Level
@@ -194,7 +195,7 @@ class Logging extends AsyncQueue {
                 ...optionalFields,
             })
 
-            return this.upsertQueuedItems([currentLog])
+            return this.upsertQueuedItems([currentLog], MAX_NUM_OF_LOGS)
         } catch (e) {
             errorService.captureException(e)
             return e


### PR DESCRIPTION
## Summary
Based on the discussion we had yesterday, we need to protect the logging endpoint a bit more.

This takes the previous logging approach and does the following:
- `log` purpose is to take in a log, check for consent and store it in the async storage queue
- `postLog` has become `postLogs` and is a function that attempts to post the async queue of logs. If there is no connection, don't try. If there is attempt. If successful clear the logs. If unsuccessful then the attempts logic kicks in and will stop attempting at the threshold (5) and clear the async queue.
- `postLogs` is now called on start up and when the user wakes up the app from the background vastly reducing the amount of times logs are sent.
- Tests on the new logic.
- This removes the need to make the Push Downloads 1 log as they effectively get queued like one. This feels a better solution as sometime the app might stop running in the background, not get to a catch block and we might lose logs at the crucial point where we want to know what is happening.

In Short, we post logs on start up and when the app wakes up. We post a queue of logs instead of individual ones. So much larger requests but small in the grand scheme of things.

[**Trello Card ->**](https://trello.com/c/i3UhnF8F/1383-logging-only-send-batch-requests)