### PR TITLE
chore: Make Sport Score Trail Image Yellow

### DIFF
--- a/projects/Mallard/src/components/SportScore/SportScore.tsx
+++ b/projects/Mallard/src/components/SportScore/SportScore.tsx
@@ -20,7 +20,6 @@ const styles = StyleSheet.create({
     },
     trailImage: {
         position: 'absolute',
-        backgroundColor: 'white',
         left: 0,
         bottom: 0,
     },

--- a/projects/Mallard/src/components/sportscore/__tests__/__snapshots__/SportScore.spec.tsx.snap
+++ b/projects/Mallard/src/components/sportscore/__tests__/__snapshots__/SportScore.spec.tsx.snap
@@ -74,7 +74,6 @@ exports[`SportScore should show a SportScore with trailImage styling 1`] = `
         "paddingHorizontal": 4.666666666666667,
       },
       Object {
-        "backgroundColor": "white",
         "bottom": 0,
         "left": 0,
         "position": "absolute",


### PR DESCRIPTION
## Summary
As requested by Production

![Simulator Screen Shot - iPhone 11 - 2020-06-19 at 09 51 22](https://user-images.githubusercontent.com/935975/85114808-88a6a700-b212-11ea-91d7-af600fec01a8.png)