### PR TITLE
Fix for crash on first launch - Crashlytics

### DIFF
--- a/projects/Mallard/firebase.json
+++ b/projects/Mallard/firebase.json
@@ -1,6 +1,6 @@
 {
     "react-native": {
         "analytics_auto_collection_enabled": false,
-        "crashlytics_auto_collection_enabled": false
+        "crashlytics_auto_collection_enabled": true
     }
 }


### PR DESCRIPTION
## Summary
It seems like if we turn off the Crashlytics Auto Collection feature in `firebase.json` file then on the first launch it crashes the app when sending any event through `crashlytics` interface (see screenshot)

This might be a bug in crashlytics RN package (not sure) and a possible workaround that I can see for now is keeping the auto collection feature `on` and then turn it `off` in runtime. A side effect of this change might be (which I'm not sure about) that Crashlytics may collect some data on App launch before we turn it off. I don't see any easier solution to this right now.

App crash error:

![Screenshot_20200619_174943_com guardian editions](https://user-images.githubusercontent.com/6583174/85162242-ed84f000-b258-11ea-8e3b-34b85132373d.jpg)