### PR TITLE
feat: Working Editions Menu with Feature Switch

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -3,6 +3,28 @@ import { storiesOf } from '@storybook/react-native'
 import { withKnobs } from '@storybook/addon-knobs'
 import { EditionsMenu } from './EditionsMenu'
 
+const mockNavigation = {
+    state: { params: {} },
+    dispatch: () => true,
+    goBack: () => true,
+    dismiss: () => true,
+    navigate: () => true,
+    openDrawer: () => true,
+    closeDrawer: () => true,
+    toggleDrawer: () => true,
+    getParam: () => true,
+    setParams: () => true,
+    addListener: () => ({ remove: () => {} }),
+    push: () => true,
+    replace: () => true,
+    pop: () => true,
+    popToTop: () => true,
+    isFocused: () => true,
+    reset: () => true,
+    isFirstRouteInParent: () => true,
+    dangerouslyGetParent: () => undefined,
+}
+
 const props = {
     specialEditions: [
         {
@@ -50,7 +72,9 @@ Monthly`,
 
 storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
-    .add('EditionsMenu - default', () => <EditionsMenu />)
+    .add('EditionsMenu - default', () => (
+        <EditionsMenu navigation={mockNavigation} />
+    ))
     .add('EditionsMenu - with Special Edition', () => (
-        <EditionsMenu {...props} />
+        <EditionsMenu navigation={mockNavigation} {...props} />
     ))

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -10,6 +10,11 @@ import {
     SpecialEdition,
 } from '../../../../Apps/common/src'
 import { ItemSeperator } from './ItemSeperator/ItemSeperator'
+import { NavigationScreenProp } from 'react-navigation'
+import { useApolloClient } from '@apollo/react-hooks'
+import { setEdition } from 'src/helpers/settings/setters'
+import { routeNames } from 'src/navigation/routes'
+import { useEdition } from 'src/hooks/use-settings'
 
 const defaultRegionalEditions: RegionalEdition[] = [
     {
@@ -30,53 +35,77 @@ const defaultRegionalEditions: RegionalEdition[] = [
 ]
 
 const EditionsMenu = ({
+    navigation,
     regionalEdtions,
     specialEditions,
 }: {
+    navigation: NavigationScreenProp<{}>
     regionalEdtions?: RegionalEdition[]
     specialEditions?: SpecialEdition[]
-}) => (
-    <ScrollView>
-        <EditionsMenuHeader>Regions</EditionsMenuHeader>
-        <FlatList
-            data={regionalEdtions || defaultRegionalEditions}
-            renderItem={({ item }: { item: RegionalEdition }) => {
-                return (
-                    <RegionButton
-                        onPress={() => {}}
-                        title={item.title}
-                        subTitle={item.subTitle}
+}) => {
+    const client = useApolloClient()
+    const selectedEdition = useEdition()
+
+    return (
+        <ScrollView>
+            <EditionsMenuHeader>Regions</EditionsMenuHeader>
+            <FlatList
+                data={regionalEdtions || defaultRegionalEditions}
+                renderItem={({ item }: { item: RegionalEdition }) => {
+                    return (
+                        <RegionButton
+                            selected={
+                                selectedEdition === item.edition ? true : false
+                            }
+                            onPress={() => {
+                                setEdition(client, item.edition)
+                                navigation.navigate(routeNames.Issue)
+                            }}
+                            title={item.title}
+                            subTitle={item.subTitle}
+                        />
+                    )
+                }}
+                ItemSeparatorComponent={() => <ItemSeperator />}
+            />
+            {specialEditions && (
+                <>
+                    <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
+                    <FlatList
+                        data={specialEditions}
+                        renderItem={({
+                            item: {
+                                devUri,
+                                edition,
+                                expiry,
+                                image,
+                                title,
+                                style,
+                                subTitle,
+                            },
+                        }: {
+                            item: SpecialEdition
+                        }) => {
+                            return (
+                                <SpecialEditionButton
+                                    devUri={devUri}
+                                    expiry={expiry}
+                                    image={image}
+                                    onPress={() => {
+                                        setEdition(client, edition)
+                                        navigation.navigate(routeNames.Issue)
+                                    }}
+                                    title={title}
+                                    style={style}
+                                    subTitle={subTitle}
+                                />
+                            )
+                        }}
                     />
-                )
-            }}
-            ItemSeparatorComponent={() => <ItemSeperator />}
-        />
-        {specialEditions && (
-            <>
-                <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
-                <FlatList
-                    data={specialEditions}
-                    renderItem={({
-                        item: { devUri, expiry, image, title, style, subTitle },
-                    }: {
-                        item: SpecialEdition
-                    }) => {
-                        return (
-                            <SpecialEditionButton
-                                devUri={devUri}
-                                expiry={expiry}
-                                image={image}
-                                onPress={() => {}}
-                                title={title}
-                                style={style}
-                                subTitle={subTitle}
-                            />
-                        )
-                    }}
-                />
-            </>
-        )}
-    </ScrollView>
-)
+                </>
+            )}
+        </ScrollView>
+    )
+}
 
 export { EditionsMenu }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
@@ -383,7 +383,7 @@ exports[`EditionsMenuButton should display a selected EditionsMenuButton with co
   <Text
     style={
       Object {
-        "color": "#121212",
+        "color": "#333333",
         "fontFamily": "GuardianIcons-Regular",
         "fontSize": 20,
         "lineHeight": 20,

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -12,6 +12,33 @@ jest.mock('src/helpers/locale', () => ({
     locale: 'en_GB',
 }))
 
+jest.mock('@apollo/react-hooks', () => ({
+    useApolloClient: () => jest.fn(),
+    useQuery: () => ({ data: 'something' }),
+}))
+
+const mockNavigation = {
+    state: { params: {} },
+    dispatch: jest.fn(),
+    goBack: jest.fn(),
+    dismiss: jest.fn(),
+    navigate: jest.fn(),
+    openDrawer: jest.fn(),
+    closeDrawer: jest.fn(),
+    toggleDrawer: jest.fn(),
+    getParam: jest.fn(),
+    setParams: jest.fn(),
+    addListener: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    pop: jest.fn(),
+    popToTop: jest.fn(),
+    isFocused: jest.fn(),
+    reset: jest.fn(),
+    isFirstRouteInParent: jest.fn(),
+    dangerouslyGetParent: jest.fn(),
+}
+
 const regionalEditions = [
     {
         title: 'The UK Daily Edition',
@@ -73,19 +100,25 @@ Monthly`,
 describe('EditionsMenu', () => {
     it('should display a default EditionsMenu with correct styling and default Regional Buttons', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu />,
+            <EditionsMenu navigation={mockNavigation} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should display a EditionsMenu with correct styling and alternative Regional Buttons', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu regionalEdtions={regionalEditions} />,
+            <EditionsMenu
+                navigation={mockNavigation}
+                regionalEdtions={regionalEditions}
+            />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu specialEditions={specialEditions} />,
+            <EditionsMenu
+                navigation={mockNavigation}
+                specialEditions={specialEditions}
+            />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/icons/LeftChevron.tsx
+++ b/projects/Mallard/src/components/icons/LeftChevron.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import { Text, StyleSheet } from 'react-native'
-import { useAppAppearance } from 'src/theme/appearance'
 import { getFont } from 'src/theme/typography'
+import { color } from 'src/theme/color'
 
-const LeftChevron = () => {
+const LeftChevron = ({
+    fill = color.palette.neutral[20],
+}: {
+    fill?: string
+}) => {
     const styles = StyleSheet.create({
         icon: {
             ...getFont('icon', 1),
-            color: useAppAppearance().color,
+            color: fill,
         },
     })
 

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/LeftChevron.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/LeftChevron.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`LeftChevron should display a LeftChevron icon using the icon font 1`] =
 <Text
   style={
     Object {
-      "color": "#121212",
+      "color": "#333333",
       "fontFamily": "GuardianIcons-Regular",
       "fontSize": 20,
       "lineHeight": 20,

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
-import { StyleSheet, View, StatusBar } from 'react-native'
+import { StatusBar, StyleSheet, View } from 'react-native'
+import { EditionsMenuButton } from 'src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton'
 import { Highlight } from 'src/components/highlight'
 import { GridRowSplit, IssueTitle } from 'src/components/issue/issue-title'
 import { useInsets } from 'src/hooks/use-screen'
@@ -153,4 +154,17 @@ const IssuePickerHeader = (
     )
 }
 
-export { Header, IssuePickerHeader }
+const EditionsMenuScreenHeader = ({
+    leftActionPress,
+}: {
+    leftActionPress: () => void
+}) => (
+    <Header
+        leftAction={<EditionsMenuButton selected onPress={leftActionPress} />}
+        layout={'center'}
+    >
+        <IssueTitle title={`Editions`} />
+    </Header>
+)
+
+export { Header, IssuePickerHeader, EditionsMenuScreenHeader }

--- a/projects/Mallard/src/helpers/settings/debug.ts
+++ b/projects/Mallard/src/helpers/settings/debug.ts
@@ -1,21 +1,41 @@
-import { lightboxSettingCache } from 'src/helpers/storage'
+import {
+    lightboxSettingCache,
+    enableEditionMenuCache,
+} from 'src/helpers/storage'
+import { AsyncCache } from 'src/authentication/lib/Authorizer'
 
-const setlightboxSetting = async (lightboxEnabled: boolean) => {
-    await lightboxSettingCache.set(lightboxEnabled)
+const setDebugSetting = async (toggle: boolean, cache: AsyncCache<boolean>) => {
+    await cache.set(toggle)
 }
 
-const fetchLightboxSetting = async (): Promise<boolean> => {
+const fetchDebugSetting = async (
+    cache: AsyncCache<boolean>,
+): Promise<boolean> => {
     try {
-        const lightboxEnabledStorage = await lightboxSettingCache.get()
+        const debugStorage = await cache.get()
 
-        if (lightboxEnabledStorage === null) {
-            setlightboxSetting(false)
+        if (debugStorage === null) {
+            setDebugSetting(false, cache)
             return false
         }
-        return lightboxEnabledStorage
+        return debugStorage
     } catch (e) {
         return false
     }
 }
 
-export { fetchLightboxSetting, setlightboxSetting }
+const fetchLightboxSetting = () => fetchDebugSetting(lightboxSettingCache)
+const setlightboxSetting = (toggle: boolean) =>
+    setDebugSetting(toggle, lightboxSettingCache)
+
+const fetchEditionMenuEnabledSetting = () =>
+    fetchDebugSetting(enableEditionMenuCache)
+const setEditionMenuEnabledSetting = (toggle: boolean) =>
+    setDebugSetting(toggle, enableEditionMenuCache)
+
+export {
+    fetchLightboxSetting,
+    setlightboxSetting,
+    fetchEditionMenuEnabledSetting,
+    setEditionMenuEnabledSetting,
+}

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -74,6 +74,8 @@ const loggingQueueCache = createAsyncCache<string>('loggingQueue')
 
 const lightboxSettingCache = createAsyncCache<boolean>('lightbox-enabled')
 
+const enableEditionMenuCache = createAsyncCache<boolean>('edition-menu-enabled')
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -136,4 +138,5 @@ export {
     validAttemptCache,
     loggingQueueCache,
     lightboxSettingCache,
+    enableEditionMenuCache,
 }

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -2,6 +2,10 @@ import React, { createContext, useState, useEffect, useContext } from 'react'
 import { Dimensions } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { Breakpoints } from 'src/theme/breakpoints'
+import {
+    fetchEditionMenuEnabledSetting,
+    setEditionMenuEnabledSetting,
+} from 'src/helpers/settings/debug'
 
 const oneGB = 1073741824
 
@@ -13,6 +17,8 @@ const ConfigContext = createContext({
         scale: 0,
         fontScale: 0,
     },
+    editionsMenuEnabled: false,
+    toggleEditionsMenuEnabled: () => {},
 })
 
 export const largeDeviceMemory = () => {
@@ -23,7 +29,13 @@ export const largeDeviceMemory = () => {
 
 export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     const [largeDeviceMemeory, setLargeDeviceMemory] = useState(false)
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     const [dimensions, setDimensions] = useState(Dimensions.get('window'))
+
+    const toggleEditionsMenuEnabled = () => {
+        setEditionsMenuEnabled(!editionsMenuEnabled)
+        setEditionMenuEnabledSetting(!editionsMenuEnabled)
+    }
 
     useEffect(() => {
         largeDeviceMemory().then(deviceMemory =>
@@ -60,9 +72,21 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
             Dimensions.removeEventListener('change', listener)
         }
     }, [])
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
 
     return (
-        <ConfigContext.Provider value={{ largeDeviceMemeory, dimensions }}>
+        <ConfigContext.Provider
+            value={{
+                largeDeviceMemeory,
+                dimensions,
+                editionsMenuEnabled,
+                toggleEditionsMenuEnabled,
+            }}
+        >
             {children}
         </ConfigContext.Provider>
     )
@@ -72,3 +96,9 @@ export const useLargeDeviceMemory = () =>
     useContext(ConfigContext).largeDeviceMemeory
 
 export const useDimensions = () => useContext(ConfigContext).dimensions
+
+export const useEditionsMenuEnabled = () => ({
+    editionsMenuEnabled: useContext(ConfigContext).editionsMenuEnabled,
+    toggleEditionsMenuEnabled: useContext(ConfigContext)
+        .toggleEditionsMenuEnabled,
+})

--- a/projects/Mallard/src/navigation/helpers/base.tsx
+++ b/projects/Mallard/src/navigation/helpers/base.tsx
@@ -90,6 +90,12 @@ const navigateToIssueList = (navigation: NavigationScreenProp<{}>): void => {
     navigation.navigate(routeNames.IssueList, { from: navigation.state.params })
 }
 
+const navigateToEditionMenu = (navigation: NavigationScreenProp<{}>): void => {
+    navigation.navigate(routeNames.EditionsMenu, {
+        from: navigation.state.params,
+    })
+}
+
 export interface IssueNavigationProps {
     path?: PathToIssue
     issue?: Issue
@@ -149,4 +155,5 @@ export {
     navigateToIssue,
     navigateToSettings,
     navigateToLightbox,
+    navigateToEditionMenu,
 }

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -1,32 +1,42 @@
+import gql from 'graphql-tag'
 import { useEffect } from 'react'
 import {
     createAppContainer,
     createStackNavigator,
     createSwitchNavigator,
     NavigationScreenProp,
-    StackViewTransitionConfigs,
     NavigationTransitionProps,
+    StackViewTransitionConfigs,
 } from 'react-navigation'
+import { CURRENT_CONSENT_VERSION } from 'src/helpers/settings'
+import { useQuery } from 'src/hooks/apollo'
+import { EditionsMenuScreen } from 'src/screens/editions-menu-screen'
 import { AuthSwitcherScreen } from 'src/screens/identity-login-screen'
+import { LightboxScreen } from 'src/screens/lightbox'
 import { OnboardingConsentScreen } from 'src/screens/onboarding-screen'
 import { AlreadySubscribedScreen } from 'src/screens/settings/already-subscribed-screen'
-import { SubscriptionDetailsScreen } from 'src/screens/settings/subscription-details-screen'
 import { ApiScreen } from 'src/screens/settings/api-screen'
-import { EditionsScreen } from 'src/screens/settings/editions-screen'
 import { CasSignInScreen } from 'src/screens/settings/cas-sign-in-screen'
 import { CreditsScreen } from 'src/screens/settings/credits-screen'
+import { EditionsScreen } from 'src/screens/settings/editions-screen'
 import { FAQScreen } from 'src/screens/settings/faq-screen'
-import { LightboxScreen } from 'src/screens/lightbox'
 import {
     GdprConsentScreen,
     GdprConsentScreenForOnboarding,
 } from 'src/screens/settings/gdpr-consent-screen'
 import { HelpScreen } from 'src/screens/settings/help-screen'
 import {
+    ManageEditionScreenFromIssuePicker,
+    ManageEditionsScreen,
+} from 'src/screens/settings/manage-editions-screen'
+import {
     PrivacyPolicyScreen,
     PrivacyPolicyScreenForOnboarding,
 } from 'src/screens/settings/privacy-policy-screen'
+import { SubscriptionDetailsScreen } from 'src/screens/settings/subscription-details-screen'
 import { TermsAndConditionsScreen } from 'src/screens/settings/terms-and-conditions-screen'
+import StorybookScreen from 'src/screens/storybook-screen'
+import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 import { color } from 'src/theme/color'
 import { ArticleScreen } from '../screens/article-screen'
 import { HomeScreen } from '../screens/home-screen'
@@ -38,15 +48,6 @@ import { createHeaderStackNavigator } from './navigators/header'
 import { createModalNavigator } from './navigators/modal'
 import { createSidebarNavigator } from './navigators/sidebar'
 import { routeNames } from './routes'
-import { useQuery } from 'src/hooks/apollo'
-import gql from 'graphql-tag'
-import {
-    ManageEditionsScreen,
-    ManageEditionScreenFromIssuePicker,
-} from 'src/screens/settings/manage-editions-screen'
-import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
-import StorybookScreen from 'src/screens/storybook-screen'
-import { CURRENT_CONSENT_VERSION } from 'src/helpers/settings'
 
 const navOptionsWithGraunHeader = {
     headerStyle: {
@@ -83,6 +84,7 @@ const dynamicModalTransition = (
 const AppStack = createModalNavigator(
     createSidebarNavigator(createArticleNavigator(IssueScreen, ArticleScreen), {
         [routeNames.IssueList]: HomeScreen,
+        [routeNames.EditionsMenu]: EditionsMenuScreen,
     }),
     {
         [routeNames.ManageEditions]: createHeaderStackNavigator({

--- a/projects/Mallard/src/navigation/navigators/sidebar/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar/transition.tsx
@@ -3,6 +3,7 @@ import { NavigationTransitionProps } from 'react-navigation'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { safeInterpolation } from 'src/helpers/math'
 import { sidebarWidth } from './positions'
+import { routeNames } from 'src/navigation/routes'
 
 export const mainLayerTransition = () => {
     return {
@@ -16,13 +17,17 @@ export const mainLayerTransition = () => {
 export const sidebarLayerTransition = (
     position: NavigationTransitionProps['position'],
     sceneIndex: number,
+    reverse?: boolean,
 ) => {
     const { width } = Dimensions.get('window')
     const isTablet = width >= Breakpoints.tabletVertical
 
+    const outputRange = isTablet ? sidebarWidth : width
+    const outputRangeCheckReverse = reverse ? -outputRange : outputRange
+
     const translateX = position.interpolate({
         inputRange: safeInterpolation([sceneIndex - 1, sceneIndex]),
-        outputRange: safeInterpolation([isTablet ? sidebarWidth : width, 0]),
+        outputRange: safeInterpolation([outputRangeCheckReverse, 0]),
     })
 
     return {
@@ -38,7 +43,13 @@ const screenInterpolator = (sceneProps: NavigationTransitionProps) => {
     if (scene.route.routeName === '_') {
         return mainLayerTransition()
     }
-    return sidebarLayerTransition(sceneProps.position, sceneProps.scene.index)
+    const reverse =
+        scene.route.routeName === routeNames.EditionsMenu ? true : false
+    return sidebarLayerTransition(
+        sceneProps.position,
+        sceneProps.scene.index,
+        reverse,
+    )
 }
 
 export { screenInterpolator }

--- a/projects/Mallard/src/navigation/routes.ts
+++ b/projects/Mallard/src/navigation/routes.ts
@@ -26,4 +26,5 @@ export const routeNames = {
         PrivacyPolicyInline: 'PrivacyPolicyInline',
     },
     Storybook: 'Storybook',
+    EditionsMenu: 'EditionsMenu',
 }

--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { NavigationScreenProp } from 'react-navigation'
+import { EditionsMenu } from 'src/components/EditionsMenu/EditionsMenu'
+import { EditionsMenuScreenHeader } from 'src/components/layout/header/header'
+import { routeNames } from 'src/navigation/routes'
+import { WithAppAppearance } from 'src/theme/appearance'
+import { ApiState } from './settings/api-screen'
+
+export const EditionsMenuScreen = ({
+    navigation,
+}: {
+    navigation: NavigationScreenProp<{}>
+}) => {
+    return (
+        <WithAppAppearance value="default">
+            <EditionsMenuScreenHeader
+                leftActionPress={() => navigation.navigate(routeNames.Issue)}
+            />
+
+            <EditionsMenu navigation={navigation} />
+            <ApiState />
+        </WithAppAppearance>
+    )
+}

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -1,39 +1,40 @@
 import AsyncStorage from '@react-native-community/async-storage'
-import React, { useContext, ReactNode, useState, useEffect } from 'react'
+import gql from 'graphql-tag'
+import React, { ReactNode, useContext, useEffect, useState } from 'react'
 import { Alert, Clipboard, View } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
+import { Switch } from 'react-native-gesture-handler'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { AccessContext } from 'src/authentication/AccessContext'
+import { isValid } from 'src/authentication/lib/Attempt'
+import { DEV_getLegacyIAPReceipt } from 'src/authentication/services/iap'
+import { Button } from 'src/components/Button/Button'
 import { Footer, Heading } from 'src/components/layout/ui/row'
 import { List } from 'src/components/lists/list'
 import { UiBodyCopy } from 'src/components/styled-text'
-import { clearCache } from 'src/helpers/fetch/cache'
-import { routeNames } from 'src/navigation/routes'
-import { Button } from 'src/components/Button/Button'
-import { metrics } from 'src/theme/spacing'
-import { useToast } from 'src/hooks/use-toast'
-import { isInTestFlight, isInBeta } from 'src/helpers/release-stream'
-import { FSPaths } from 'src/paths'
-import { AccessContext } from 'src/authentication/AccessContext'
-import { isValid } from 'src/authentication/lib/Attempt'
-import DeviceInfo from 'react-native-device-info'
-import { ALL_SETTINGS_FRAGMENT } from 'src/helpers/settings/resolvers'
-import { setIsUsingProdDevtools } from 'src/helpers/settings/setters'
-import { useQuery } from 'src/hooks/apollo'
-import gql from 'graphql-tag'
-import {
-    getPushTracking,
-    clearPushTracking,
-} from 'src/push-notifications/push-tracking'
-import { getFileList } from 'src/helpers/files'
-import { DEV_getLegacyIAPReceipt } from 'src/authentication/services/iap'
-import { Switch } from 'react-native-gesture-handler'
-import { useNetInfo } from 'src/hooks/use-net-info'
-import { locale } from 'src/helpers/locale'
-import { imageForScreenSize } from 'src/helpers/screen'
 import { deleteIssueFiles } from 'src/download-edition/clear-issues'
+import { clearCache } from 'src/helpers/fetch/cache'
+import { getFileList } from 'src/helpers/files'
+import { locale } from 'src/helpers/locale'
+import { isInBeta, isInTestFlight } from 'src/helpers/release-stream'
+import { imageForScreenSize } from 'src/helpers/screen'
 import {
     fetchLightboxSetting,
     setlightboxSetting,
 } from 'src/helpers/settings/debug'
+import { ALL_SETTINGS_FRAGMENT } from 'src/helpers/settings/resolvers'
+import { setIsUsingProdDevtools } from 'src/helpers/settings/setters'
+import { useQuery } from 'src/hooks/apollo'
+import { useEditionsMenuEnabled } from 'src/hooks/use-config-provider'
+import { useNetInfo } from 'src/hooks/use-net-info'
+import { useToast } from 'src/hooks/use-toast'
+import { routeNames } from 'src/navigation/routes'
+import { FSPaths } from 'src/paths'
+import {
+    clearPushTracking,
+    getPushTracking,
+} from 'src/push-notifications/push-tracking'
+import { metrics } from 'src/theme/spacing'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -60,6 +61,10 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
         isDevButtonShown: showNetInfoButton,
         setIsDevButtonShown: setShowNetInfoButton,
     } = useNetInfo()
+    const {
+        editionsMenuEnabled,
+        toggleEditionsMenuEnabled,
+    } = useEditionsMenuEnabled()
     const onToggleNetInfoButton = () => setShowNetInfoButton(!showNetInfoButton)
 
     const { attempt, signOutCAS } = useContext(AccessContext)
@@ -258,11 +263,22 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                     {
                         key: 'Enable lightbox',
                         title: 'Enable lightbox',
-                        onPress: onToggleNetInfoButton,
+                        onPress: () => {},
                         proxy: (
                             <Switch
                                 value={lightboxEnabled}
                                 onValueChange={onToggleLightbox}
+                            />
+                        ),
+                    },
+                    {
+                        key: 'Enable edition menu',
+                        title: 'Enable edition menu',
+                        onPress: () => {},
+                        proxy: (
+                            <Switch
+                                value={editionsMenuEnabled}
+                                onValueChange={toggleEditionsMenuEnabled}
                             />
                         ),
                     },


### PR DESCRIPTION
## Summary
This hooks up the components 
- Uses the config context to enable a toggle switch in the dev menu to turn this on.
- Refactored `debug.ts` to be more generic for more switch use in the dev menu
- Wired up `EditionsMenu` and made the buttons clickable and have a selected state
- Updated the SideBar Navigator to accept the new menu, detect it and offer a reverse animation making it come out from the left.
- Updated tests and stories

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)

## Test Plan
As seen below:

![editions-menu-switch](https://user-images.githubusercontent.com/935975/85287869-ca428680-b48c-11ea-80a5-4c9ede71490c.gif)

