### PR TITLE
Fix https issue for weather api

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -1,9 +1,9 @@
 const CITIES_URL =
-    'http://mobile-weather.guardianapis.com/locations/v1/cities/ipAddress?q=127.0.0.1&details=false'
+    'https://mobile-weather.guardianapis.com/locations/v1/cities/ipAddress?q=127.0.0.1&details=false'
 const FORECASTS_URL =
-    'http://mobile-weather.guardianapis.com/forecasts/v1/hourly/12hour/london.json?metric=true&language=en-gb'
+    'https://mobile-weather.guardianapis.com/forecasts/v1/hourly/12hour/london.json?metric=true&language=en-gb'
 const GEOLOC_URL =
-    'http://mobile-weather.guardianapis.com/locations/v1/cities/geoposition/search?q=12,34&details=false'
+    'https://mobile-weather.guardianapis.com/locations/v1/cities/geoposition/search?q=12,34&details=false'
 
 let forecasts = [{ DateTime: '0000' }]
 ;(global as any).fetch = jest.fn().mockImplementation(async (url: string) => {

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -49,7 +49,9 @@ export const getGeolocation = async (): Promise<GeolocationResponse> => {
 }
 
 const fetchFromWeatherApi = async <T>(path: string): Promise<T> => {
-    const res = await tryFetch(`http://mobile-weather.guardianapis.com/${path}`)
+    const res = await tryFetch(
+        `https://mobile-weather.guardianapis.com/${path}`,
+    )
     if (res.status >= 500) {
         throw new CannotFetchError('Server returned 500') // 500s don't return json
     }


### PR DESCRIPTION
## Summary
The weather was failing to load on android (prod) because the API was using an insecure protocol. This PR fixes that issue.

[**Trello Card ->**](https://trello.com/c/41q5wmzc/908-android-launched-app-no-weather-showing)
