### PR TITLE
Fix/lightbox rotation layout bug

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -93,7 +93,7 @@ const ArticleSlider = React.memo(
 
         const { panResponder } = useDismissArticle()
 
-        const currentArticle = flattenedArticles[Math.floor(current)]
+        const currentArticle = flattenedArticles[Math.round(current)]
 
         const sliderSections = articleNavigator.reduce(
             (sectionsWithStartIndex, frontSpec) => {
@@ -255,7 +255,7 @@ const ArticleSlider = React.memo(
                                 const newPos =
                                     ev.nativeEvent.contentOffset.x / width
                                 const newIndex = clamp(
-                                    Math.ceil(newPos),
+                                    Math.round(newPos),
                                     0,
                                     flattenedArticles.length - 1,
                                 )

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -89,7 +89,7 @@ const ArticleSlider = React.memo(
                     index: current,
                     animated: false,
                 })
-        }, [width]) // eslint-disable-line react-hooks/exhaustive-deps
+        }, [width, navigation.isFocused()]) // eslint-disable-line react-hooks/exhaustive-deps
 
         const { panResponder } = useDismissArticle()
 


### PR DESCRIPTION
## Summary
This fixes a layout issue after rotating within lightbox and then exiting the view. 
This now forces the article slider to re-render when it becomes in focus.
I've also updated how we calculate which index should be chosen so that it is closer to the raw position. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below. The articles should no 

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/oVRss3CA/1312-layout-bug-on-ipad-ios-13-after-rotation-in-lightbox)

## Test Plan
Open an article in portrait and open an image in lightbox, rotate lightbox to landscape and exit. 
Article should be mispositioned.  (See trello card for screenshot showing the layout bug). 


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
