### PR TITLE
fix: Editions Menu iPad

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -305,6 +305,7 @@ const IssueRowHeader = React.memo(
                         onGoToSettings={onGoToSettings}
                     />
                 }
+                restrictWidth
             >
                 <View style={styles.issueTitleWrap}>
                     <Highlight onPress={onPress}>

--- a/projects/Mallard/src/components/issue/issue-title.tsx
+++ b/projects/Mallard/src/components/issue/issue-title.tsx
@@ -24,6 +24,7 @@ const GridRowSplit = ({
     children,
     proxy,
     style,
+    restrictWidth,
 }: {
     children: ReactNode
     proxy?: ReactNode
@@ -39,6 +40,7 @@ const GridRowSplit = ({
             | 'height'
         >
     >
+    restrictWidth?: boolean
 }) => {
     const Inner = ({
         width,
@@ -63,7 +65,7 @@ const GridRowSplit = ({
                     <Inner
                         width={metrics.gridRowSplit.wide}
                         // -iOS12 and Android style to make the menu look palatable
-                        innerStyle={{ maxWidth: 360 }}
+                        innerStyle={restrictWidth ? { maxWidth: 360 } : {}}
                     />
                 ),
             }}

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -90,7 +90,7 @@ const Header = ({
             {white && (
                 <StatusBar barStyle="dark-content" backgroundColor="#fff" />
             )}
-            <View style={[bg]}>
+            <View style={bg}>
                 {layout === 'issue' ? (
                     <GridRowSplit
                         proxy={

--- a/projects/Mallard/src/navigation/navigators/sidebar/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar/transition.tsx
@@ -22,12 +22,20 @@ export const sidebarLayerTransition = (
     const { width } = Dimensions.get('window')
     const isTablet = width >= Breakpoints.tabletVertical
 
-    const outputRange = isTablet ? sidebarWidth : width
-    const outputRangeCheckReverse = reverse ? -outputRange : outputRange
+    const outputRangeStart =
+        isTablet && reverse ? width : isTablet ? sidebarWidth : width
+    const outputRangeStartCheckReverse = reverse
+        ? -outputRangeStart
+        : outputRangeStart
+
+    const outputRangeEnd = isTablet && reverse ? -(width - sidebarWidth) : 0
 
     const translateX = position.interpolate({
         inputRange: safeInterpolation([sceneIndex - 1, sceneIndex]),
-        outputRange: safeInterpolation([outputRangeCheckReverse, 0]),
+        outputRange: safeInterpolation([
+            outputRangeStartCheckReverse,
+            outputRangeEnd,
+        ]),
     })
 
     return {

--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -1,10 +1,22 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import { NavigationScreenProp } from 'react-navigation'
 import { EditionsMenu } from 'src/components/EditionsMenu/EditionsMenu'
 import { EditionsMenuScreenHeader } from 'src/components/layout/header/header'
 import { routeNames } from 'src/navigation/routes'
 import { WithAppAppearance } from 'src/theme/appearance'
 import { ApiState } from './settings/api-screen'
+import { View, StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+    screenFiller: {
+        flex: 1,
+        backgroundColor: 'white',
+    },
+})
+
+const ScreenFiller = ({ children }: { children: ReactElement }) => (
+    <View style={styles.screenFiller}>{children}</View>
+)
 
 export const EditionsMenuScreen = ({
     navigation,
@@ -13,12 +25,18 @@ export const EditionsMenuScreen = ({
 }) => {
     return (
         <WithAppAppearance value="default">
-            <EditionsMenuScreenHeader
-                leftActionPress={() => navigation.navigate(routeNames.Issue)}
-            />
+            <ScreenFiller>
+                <>
+                    <EditionsMenuScreenHeader
+                        leftActionPress={() =>
+                            navigation.navigate(routeNames.Issue)
+                        }
+                    />
 
-            <EditionsMenu navigation={navigation} />
-            <ApiState />
+                    <EditionsMenu navigation={navigation} />
+                    <ApiState />
+                </>
+            </ScreenFiller>
         </WithAppAppearance>
     )
 }


### PR DESCRIPTION
## Summary
Fixes the following:
- Moves the editions menu button to the far left
- Update the transition to come from the left rather than the middle
- Fills the menu so it fills the whole vertical rather than just where the menu sits

Please note: Tested on iPhone and Android as well.

![editions-menu-ipad](https://user-images.githubusercontent.com/935975/85394709-df7beb80-b546-11ea-9bee-cf5f9919b7d1.gif)
