### PR TITLE
feat: Transparent Menu on Android

### DIFF
--- a/projects/Mallard/src/navigation/navigators/sidebar.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar.tsx
@@ -5,7 +5,6 @@ import {
     StyleSheet,
     TouchableWithoutFeedback,
     View,
-    Platform,
 } from 'react-native'
 import {
     createStackNavigator,
@@ -17,10 +16,7 @@ import {
 const createNativeStackNavigator = require('react-native-screens/createNativeStackNavigator')
     .default
 import { ariaHidden } from 'src/helpers/a11y'
-import {
-    supportsTransparentCards,
-    supportsAnimation,
-} from 'src/helpers/features'
+import { supportsAnimation } from 'src/helpers/features'
 import { safeInterpolation } from 'src/helpers/math'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
@@ -31,11 +27,6 @@ import {
 } from '../helpers/transition'
 import { sidebarWidth } from './sidebar/positions'
 import { screenInterpolator, mainLayerTransition } from './sidebar/transition'
-
-const USE_SIDEBAR_ANIMATION =
-    supportsTransparentCards() ||
-    /* Android API Level 29; would need to test further on lower versions */
-    (Platform.OS === 'android' && Platform.Version >= 29)
 
 const overlayStyles = StyleSheet.create({
     root: {
@@ -133,17 +124,16 @@ export const createSidebarNavigator = (
     let animatedValue = new Animated.Value(0)
 
     const navigation: { [key: string]: NavigationContainer } = {
-        _: USE_SIDEBAR_ANIMATION
-            ? addViewsForMainLayer(mainRoute, () => animatedValue)
-            : mainRoute,
+        _: addViewsForMainLayer(mainRoute, () => animatedValue),
     }
     for (const [key, value] of Object.entries(sidebarRoute)) {
         if (!supportsAnimation()) {
             navigation[key] = value
         } else {
-            navigation[key] = USE_SIDEBAR_ANIMATION
-                ? addViewsForSidebarLayer(value, () => animatedValue)
-                : value
+            navigation[key] = addViewsForSidebarLayer(
+                value,
+                () => animatedValue,
+            )
         }
     }
 
@@ -178,13 +168,9 @@ export const createSidebarNavigator = (
             gesturesEnabled: false,
         },
         headerMode: 'none',
-        ...(USE_SIDEBAR_ANIMATION
-            ? {
-                  mode: 'modal',
-                  transparentCard: isTablet,
-                  cardOverlayEnabled: isTablet,
-                  transitionConfig,
-              }
-            : {}),
+        mode: 'modal',
+        transparentCard: isTablet,
+        cardOverlayEnabled: isTablet,
+        transitionConfig,
     })
 }


### PR DESCRIPTION
## Summary
Attempted to remove the restrictions on Android menus and seems pretty good even on Android 5.0. And worked quite well in a simulator suggesting performance should be fine.

#### Phone
![animation-android-phone](https://user-images.githubusercontent.com/935975/85540142-8b3c3e80-b60e-11ea-8a2c-66440f649f4a.gif)

#### Tablet
![animation-android-tablet](https://user-images.githubusercontent.com/935975/85540167-92634c80-b60e-11ea-9f6a-a47e5e243c0a.gif)
