### PR TITLE
Fix: Transparent background on Settings menu for Android

### DIFF
--- a/projects/Mallard/src/navigation/navigators/modal.tsx
+++ b/projects/Mallard/src/navigation/navigators/modal.tsx
@@ -11,7 +11,6 @@ import React from 'react'
 import { Animated } from 'react-native'
 import { ModalForTablet } from 'src/components/layout/ui/modal-for-tablet'
 import { addStaticRouter } from '../helpers/base'
-import { supportsTransparentCards } from 'src/helpers/features'
 import { safeInterpolation } from 'src/helpers/math'
 
 const addStaticRouterWithModal = (
@@ -41,13 +40,6 @@ const createModalNavigator = (
         navigation[key] = addStaticRouterWithModal(value, () => animatedValue)
     }
 
-    if (!supportsTransparentCards()) {
-        return createStackNavigator(navigation, {
-            headerMode: 'none',
-            initialRouteName: '_',
-        })
-    }
-
     return createStackNavigator(navigation, {
         mode: 'modal',
         headerMode: 'none',
@@ -57,6 +49,7 @@ const createModalNavigator = (
         defaultNavigationOptions: {
             gesturesEnabled: false,
         },
+        cardStyle: { opacity: 1 },
         transitionConfig: (transitionProps, prevTransitionProps) => {
             const {
                 position,


### PR DESCRIPTION
## Summary

#### Before
<img width="494" alt="Screen Shot 2020-06-24 at 16 39 11" src="https://user-images.githubusercontent.com/935975/85586951-424daf80-b639-11ea-8860-75a18e8f9efd.png">

#### After
![settings-android-tablet](https://user-images.githubusercontent.com/935975/85586971-45e13680-b639-11ea-9d40-636150b5adea.gif)