### PR TITLE
fix: Editions Menu Alignment

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
@@ -11,7 +11,7 @@ const styles = (selected: boolean) =>
                 ? color.primary
                 : color.palette.neutral[97],
             paddingBottom: 32,
-            paddingLeft: 104,
+            paddingLeft: 96,
             paddingTop: 4,
         },
         title: {

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/__tests__/__snapshots__/RegionButton.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`RegionButton should display a default RegionButton with correct styling
     Object {
       "backgroundColor": "#f6f6f6",
       "paddingBottom": 32,
-      "paddingLeft": 104,
+      "paddingLeft": 96,
       "paddingTop": 4,
     }
   }
@@ -74,7 +74,7 @@ exports[`RegionButton should display a selected RegionButton with correct stylin
     Object {
       "backgroundColor": "#052962",
       "paddingBottom": 32,
-      "paddingLeft": 104,
+      "paddingLeft": 96,
       "paddingTop": 4,
     }
   }

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -113,7 +113,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -180,7 +180,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -247,7 +247,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -405,7 +405,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -472,7 +472,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -539,7 +539,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -891,7 +891,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -958,7 +958,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }
@@ -1025,7 +1025,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
               Object {
                 "backgroundColor": "#f6f6f6",
                 "paddingBottom": 32,
-                "paddingLeft": 104,
+                "paddingLeft": 96,
                 "paddingTop": 4,
               }
             }


### PR DESCRIPTION
## Summary
As per @pradasa request, this is to now align.

![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 15 02 10](https://user-images.githubusercontent.com/935975/85734408-ed6f6f00-b6f4-11ea-9390-5e45a739cb45.png)

[**Trello Card ->**](https://trello.com/c/K0FZ5eyF/1332-editions-switch)