### PR TITLE
feat: Simplified Locale Mocking

### DIFF
--- a/projects/Mallard/jest-setup.js
+++ b/projects/Mallard/jest-setup.js
@@ -1,0 +1,3 @@
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))

--- a/projects/Mallard/jest.config.js
+++ b/projects/Mallard/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
     preset: 'react-native',
     transformIgnorePatterns: ['/node_modules/(?!(@guardian|react-native))/'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-    setupFiles: ['./node_modules/react-native-gesture-handler/jestSetup.js'],
+    setupFiles: [
+        './node_modules/react-native-gesture-handler/jestSetup.js',
+        './jest-setup.js',
+    ],
     testMatch: ['**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
 }

--- a/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
+++ b/projects/Mallard/src/authentication/authorizers/__tests__/identity-authorizer.spec.ts
@@ -1,10 +1,6 @@
 import { getUserName, detectAuthType } from '../IdentityAuthorizer'
 import { locale } from 'src/helpers/locale'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('IdentityAuthorizer', () => {
     describe('getUserName', () => {
         it('returns correct usernames for valid params', () => {

--- a/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
+++ b/projects/Mallard/src/authentication/lib/__tests__/AccessController.spec.ts
@@ -3,10 +3,6 @@ import { AccessController } from '../AccessController'
 import { AnyAttempt } from '../Attempt'
 import { AuthResult, ValidResult, InvalidResult } from '../Result'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 class AsyncStorage<T> {
     constructor(private data: T | null = null) {}
     async get() {

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -7,10 +7,6 @@ jest.mock('src/components/front/image-resource', () => ({
     ImageResource: () => 'ImageResource',
 }))
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('@apollo/react-hooks', () => ({
     useApolloClient: () => jest.fn(),
     useQuery: () => ({ data: 'something' }),

--- a/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
+++ b/projects/Mallard/src/components/Lightbox/__tests__/LightboxCaption.spec.tsx
@@ -2,10 +2,6 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { LightboxCaption } from '../LightboxCaption'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('LightboxCaption', () => {
     it('should show a LightboxCaption with a pillar colour', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(

--- a/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
+++ b/projects/Mallard/src/components/article/html/__tests__/images.spec.ts
@@ -1,9 +1,5 @@
 import { renderCaption } from '../components/images'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('html', () => {
     describe('renderCaption', () => {
         it('renders just the caption when the credit is undefined', () => {

--- a/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/clear-issues.spec.ts
@@ -1,10 +1,6 @@
 import MockDate from 'mockdate'
 import { issuesToDelete } from 'src/helpers/files'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('clear issues', () => {
     describe('issuesToDelete', () => {
         MockDate.set('2019-08-21')

--- a/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
@@ -2,10 +2,6 @@ import ApolloClient from 'apollo-client'
 import { DownloadBlockedStatus } from 'src/hooks/use-net-info'
 import { downloadAndUnzipIssue } from '../download-and-unzip'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 const createIssueSummary = (localId: string) => ({
     key: 'de/1-1-1',
     name: 'any',

--- a/projects/Mallard/src/helpers/__tests__/async-queue-cache.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/async-queue-cache.spec.ts
@@ -1,9 +1,5 @@
 import { AsyncQueue } from '../async-queue-cache'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('src/services/errors', () => ({
     captureException: jest.fn(),
 }))

--- a/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/fetch.spec.ts
@@ -3,10 +3,6 @@ import AsyncStorage from '@react-native-community/async-storage'
 import { defaultSettings } from '../settings/defaults'
 import { fetchCacheClear } from '../fetch'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('helpers/fetch', () => {
     describe('fetchCacheClear', () => {
         it('should set the cache clear item if there is none and return true', async () => {

--- a/projects/Mallard/src/helpers/__tests__/files.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/files.spec.ts
@@ -2,10 +2,6 @@ import MockDate from 'mockdate'
 import { matchSummmaryToKey, issuesToDelete } from '../../helpers/files'
 import { issueSummaries } from '../../../../Apps/common/src/__tests__/fixtures/IssueSummary'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('helpers/files', () => {
     describe('matchSummmaryToKey', () => {
         it('should return a matched IssueSummary if the key matches', () => {

--- a/projects/Mallard/src/helpers/__tests__/issues.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/issues.spec.ts
@@ -1,10 +1,6 @@
 import MockDate from 'mockdate'
 import { todayAsFolder, lastNDays, todayAsKey } from '../issues'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('helpers/issues', () => {
     describe('todayAsFolder', () => {
         it('should return "today\'s" date in the correct format', () => {

--- a/projects/Mallard/src/helpers/__tests__/settings.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/settings.spec.ts
@@ -1,9 +1,5 @@
 import { withConsent } from '../settings'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('settings', () => {
     describe('withConsent', () => {
         it('runs deny when the relevant setting is not there', async () => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.android.spec.ts
@@ -1,9 +1,5 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {
         beforeEach(() => {

--- a/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/defaults.ios.spec.ts
@@ -1,9 +1,5 @@
 import { baseTests } from './defaults.base'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('defaults', () => {
     describe('notificationTrackingUrl', () => {
         baseTests({

--- a/projects/Mallard/src/paths/__tests__/index.spec.ts
+++ b/projects/Mallard/src/paths/__tests__/index.spec.ts
@@ -4,10 +4,6 @@ jest.mock('react-native-fs', () => ({
     DocumentDirectoryPath: 'path/to/base/directory',
 }))
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('paths', () => {
     describe('FSPaths', () => {
         it('should give correct issues directory', () => {

--- a/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-notifications.spec.ts
@@ -5,10 +5,6 @@ import {
 } from 'src/test-helpers/test-helpers'
 import moment from 'moment'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 const _today = moment()
 const today = () => _today.clone()
 

--- a/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
+++ b/projects/Mallard/src/push-notifications/__tests__/push-tracking.spec.ts
@@ -2,10 +2,6 @@ import MockDate from 'mockdate'
 import { findLastXDaysPushTracking } from '../push-tracking'
 import { NetInfoStateType } from '@react-native-community/netinfo'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 const fixtures = [
     {
         time: '2020-01-04T12:43:01Z',

--- a/projects/Mallard/src/screens/settings/__tests__/gdpr-consent.spec.ts
+++ b/projects/Mallard/src/screens/settings/__tests__/gdpr-consent.spec.ts
@@ -12,10 +12,6 @@ const getperf = async () =>
 const getfunc = async () =>
     await AsyncStorage.getItem(SETTINGS_KEY_PREFIX + gdprAllowFunctionalityKey)
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 describe('gdpr-consent', () => {
     describe('setConsent', () => {
         it('should set consent values in AsyncStorage', async () => {

--- a/projects/Mallard/src/services/__tests__/errors.spec.ts
+++ b/projects/Mallard/src/services/__tests__/errors.spec.ts
@@ -11,9 +11,6 @@ jest.mock('@sentry/react-native', () => ({
     setTag: jest.fn(() => {}),
     setExtra: jest.fn(() => {}),
 }))
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
 
 const QUERY = gql('{ gdprAllowPerformance @client }')
 

--- a/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.offline.spec.ts
@@ -1,10 +1,6 @@
 import { Level, Logging } from '../logging'
 import MockDate from 'mockdate'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve(false)),
     NetInfoStateType: {

--- a/projects/Mallard/src/services/__tests__/logging.spec.ts
+++ b/projects/Mallard/src/services/__tests__/logging.spec.ts
@@ -1,10 +1,6 @@
 import { Logging, Level, cropMessage } from '../logging'
 import MockDate from 'mockdate'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
     NetInfoStateType: {


### PR DESCRIPTION
## Summary
Had a little brainwave the other day to avoid mocking `locale` everywhere. We just do the mocking in a test setup file and off we go.

As it is essentially all native functions we cant really test `locale` itself so it all works out