### PR TITLE
Feat: ScreenHeader refactor and IssuePickerHeader implementation

### DIFF
--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
@@ -1,0 +1,28 @@
+import { color, withKnobs } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react-native'
+import React from 'react'
+import { IssueOrigin } from '../../../../../Apps/common/src'
+import { IssuePickerHeader } from './IssuePickerHeader'
+
+const issue = {
+    name: 'Daily Edition',
+    date: '2020-06-25',
+    key: 'daily-edition/2020-06-25',
+    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
+    localId: 'daily-edition/2020-06-25',
+    fronts: [],
+    origin: 'api' as IssueOrigin,
+}
+
+storiesOf('IssuePickerHeader', module)
+    .addDecorator(withKnobs)
+    .add('Default', () => <IssuePickerHeader />)
+    .add('With Header Styles', () => (
+        <IssuePickerHeader
+            headerStyles={{
+                backgroundColor: color('Background Colour', '#7D0068'),
+                textColorPrimary: color('Text Colour Primary', '#007ABC'),
+                textColorSecondary: color('Text Colour Secondary', '#F3C100'),
+            }}
+        />
+    ))

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
@@ -1,18 +1,7 @@
 import { color, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react-native'
 import React from 'react'
-import { IssueOrigin } from '../../../../../Apps/common/src'
 import { IssuePickerHeader } from './IssuePickerHeader'
-
-const issue = {
-    name: 'Daily Edition',
-    date: '2020-06-25',
-    key: 'daily-edition/2020-06-25',
-    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
-    localId: 'daily-edition/2020-06-25',
-    fronts: [],
-    origin: 'api' as IssueOrigin,
-}
 
 storiesOf('IssuePickerHeader', module)
     .addDecorator(withKnobs)

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { Button, ButtonAppearance } from 'src/components/Button/Button'
+import { navigateToSettings } from 'src/navigation/helpers/base'
+import { ScreenHeader } from '../ScreenHeader'
+
+const IssuePickerHeader = withNavigation(
+    ({ navigation }: NavigationInjectedProps) => {
+        const action = (
+            <Button
+                accessibilityLabel="Close button"
+                accessibilityHint="Returns to the edition"
+                accessibilityRole="button"
+                icon={'\uE04F'}
+                alt="Return to edition"
+                onPress={() => navigation.goBack()}
+            />
+        )
+        const settings = (
+            <Button
+                accessibilityLabel="Settings button"
+                accessibilityHint="Navigates to the settings screen"
+                accessibilityRole="button"
+                icon={'\uE040'}
+                alt="Settings"
+                onPress={() => {
+                    navigateToSettings(navigation)
+                }}
+                appearance={ButtonAppearance.skeleton}
+            />
+        )
+        return (
+            <ScreenHeader
+                leftAction={settings}
+                onPress={() => navigation.goBack()}
+                rightAction={action}
+                title="Recent"
+                subTitle="Editions"
+            />
+        )
+    },
+)
+
+export { IssuePickerHeader }

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { SpecialEditionHeaderStyles } from 'src/common'
 import { Button, ButtonAppearance } from 'src/components/Button/Button'
 import { navigateToSettings } from 'src/navigation/helpers/base'
 import { ScreenHeader } from '../ScreenHeader'
 
 const IssuePickerHeader = withNavigation(
-    ({ navigation }: NavigationInjectedProps) => {
+    ({
+        headerStyles,
+        navigation,
+    }: {
+        headerStyles?: SpecialEditionHeaderStyles
+    } & NavigationInjectedProps) => {
         const action = (
             <Button
                 accessibilityLabel="Close button"
@@ -36,6 +42,7 @@ const IssuePickerHeader = withNavigation(
                 rightAction={action}
                 title="Recent"
                 subTitle="Editions"
+                headerStyles={headerStyles}
             />
         )
     },

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { IssuePickerHeader } from '../IssuePickerHeader'
+
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
+
+jest.mock('react-navigation', () => ({
+    withNavigation: (child: any) => child,
+}))
+
+describe('IssuePickerHeader', () => {
+    it('should match the default style', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <IssuePickerHeader />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should match the altered style by the prop headerStyles', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <IssuePickerHeader
+                headerStyles={{
+                    backgroundColor: '#7D0068',
+                    textColorPrimary: '#007ABC',
+                    textColorSecondary: '#F3C100',
+                }}
+            />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
@@ -2,10 +2,6 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { IssuePickerHeader } from '../IssuePickerHeader'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('react-navigation', () => ({
     withNavigation: (child: any) => child,
 }))

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
@@ -1,0 +1,653 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IssuePickerHeader should match the altered style by the prop headerStyles 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      Object {
+        "backgroundColor": "#7D0068",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityHint="Navigates to the settings screen"
+          accessibilityLabel="Settings button"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 10,
+              "left": 10,
+              "right": 10,
+              "top": 10,
+            }
+          }
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderRadius": 999,
+                  "height": 42,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 21,
+                },
+                Object {
+                  "backgroundColor": undefined,
+                  "borderColor": "#ffffff",
+                  "borderWidth": 1,
+                },
+                Object {
+                  "alignItems": "center",
+                  "aspectRatio": 1,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 0,
+                  "width": 42,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "GuardianIcons-Regular",
+                    "fontSize": 20,
+                    "lineHeight": 20,
+                  },
+                  Array [
+                    Object {
+                      "color": "#ffffff",
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {
+                          "color": "#007ABC",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  Recent
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {
+                          "color": "#F3C100",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  Editions
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="Returns to the edition"
+            accessibilityLabel="Close button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`IssuePickerHeader should match the default style 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityHint="Navigates to the settings screen"
+          accessibilityLabel="Settings button"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 10,
+              "left": 10,
+              "right": 10,
+              "top": 10,
+            }
+          }
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderRadius": 999,
+                  "height": 42,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 21,
+                },
+                Object {
+                  "backgroundColor": undefined,
+                  "borderColor": "#ffffff",
+                  "borderWidth": 1,
+                },
+                Object {
+                  "alignItems": "center",
+                  "aspectRatio": 1,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 0,
+                  "width": 42,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "GuardianIcons-Regular",
+                    "fontSize": 20,
+                    "lineHeight": 20,
+                  },
+                  Array [
+                    Object {
+                      "color": "#ffffff",
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Recent
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Editions
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="Returns to the edition"
+            accessibilityLabel="Close button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories.tsx
@@ -1,0 +1,30 @@
+import { color, withKnobs } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react-native'
+import React from 'react'
+import { IssueOrigin } from '../../../../../Apps/common/src'
+import { IssueScreenHeader } from './IssueScreenHeader'
+
+const issue = {
+    name: 'Daily Edition',
+    date: '2020-06-25',
+    key: 'daily-edition/2020-06-25',
+    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
+    localId: 'daily-edition/2020-06-25',
+    fronts: [],
+    origin: 'api' as IssueOrigin,
+}
+
+storiesOf('IssueScreenHeader', module)
+    .addDecorator(withKnobs)
+    .add('Default', () => <IssueScreenHeader />)
+    .add('With Issue', () => <IssueScreenHeader issue={issue} />)
+    .add('With Issue and Header Styles', () => (
+        <IssueScreenHeader
+            issue={issue}
+            headerStyles={{
+                backgroundColor: color('Background Colour', '#7D0068'),
+                textColorPrimary: color('Text Colour Primary', '#007ABC'),
+                textColorSecondary: color('Text Colour Secondary', '#F3C100'),
+            }}
+        />
+    ))

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { IssueWithFronts, SpecialEditionHeaderStyles } from 'src/common'
 import { useIssueDate } from 'src/helpers/issues'
 import { useEditionsMenuEnabled } from 'src/hooks/use-config-provider'
 import {
     navigateToEditionMenu,
     navigateToIssueList,
 } from 'src/navigation/helpers/base'
-import {
-    IssueWithFronts,
-    SpecialEditionHeaderStyles,
-} from '../../../../../Apps/common/src'
 import { IssueMenuButton } from '../../Button/IssueMenuButton'
 import { EditionsMenuButton } from '../../EditionsMenu/EditionsMenuButton/EditionsMenuButton'
 import { ScreenHeader } from '../ScreenHeader'

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { useIssueDate } from 'src/helpers/issues'
+import { useEditionsMenuEnabled } from 'src/hooks/use-config-provider'
+import {
+    navigateToEditionMenu,
+    navigateToIssueList,
+} from 'src/navigation/helpers/base'
+import {
+    IssueWithFronts,
+    SpecialEditionHeaderStyles,
+} from '../../../../../Apps/common/src'
+import { IssueMenuButton } from '../../Button/IssueMenuButton'
+import { EditionsMenuButton } from '../../EditionsMenu/EditionsMenuButton/EditionsMenuButton'
+import { ScreenHeader } from '../ScreenHeader'
+
+const IssueScreenHeader = withNavigation(
+    ({
+        headerStyles,
+        issue,
+        navigation,
+    }: {
+        headerStyles?: SpecialEditionHeaderStyles
+        issue?: IssueWithFronts
+    } & NavigationInjectedProps) => {
+        const { date, weekday } = useIssueDate(issue)
+        const { editionsMenuEnabled } = useEditionsMenuEnabled()
+
+        const goToIssueList = () => {
+            navigateToIssueList(navigation)
+        }
+
+        const goToEditionsMenu = () => {
+            navigateToEditionMenu(navigation)
+        }
+        return (
+            <ScreenHeader
+                title={weekday}
+                subTitle={date}
+                onPress={goToIssueList}
+                rightAction={<IssueMenuButton onPress={goToIssueList} />}
+                leftAction={
+                    editionsMenuEnabled ? (
+                        <EditionsMenuButton onPress={goToEditionsMenu} />
+                    ) : null
+                }
+                headerStyles={headerStyles}
+            />
+        )
+    },
+)
+
+export { IssueScreenHeader }

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/IssueScreenHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/IssueScreenHeader.spec.tsx
@@ -3,10 +3,6 @@ import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { IssueScreenHeader } from '../IssueScreenHeader'
 import { IssueOrigin } from '../../../../../../Apps/common/src'
 
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
 jest.mock('react-navigation', () => ({
     withNavigation: (child: any) => child,
 }))

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/IssueScreenHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/IssueScreenHeader.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { IssueScreenHeader } from '../IssueScreenHeader'
+import { IssueOrigin } from '../../../../../../Apps/common/src'
+
+jest.mock('src/helpers/locale', () => ({
+    locale: 'en_GB',
+}))
+
+jest.mock('react-navigation', () => ({
+    withNavigation: (child: any) => child,
+}))
+
+const issue = {
+    name: 'Daily Edition',
+    date: '2020-06-25',
+    key: 'daily-edition/2020-06-25',
+    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
+    localId: 'daily-edition/2020-06-25',
+    fronts: [],
+    origin: 'api' as IssueOrigin,
+}
+
+describe('IssueScreenHeader', () => {
+    it('should match the default style', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <IssueScreenHeader issue={issue} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should match the altered style by the prop headerStyles', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <IssueScreenHeader
+                issue={issue}
+                headerStyles={{
+                    backgroundColor: '#7D0068',
+                    textColorPrimary: '#007ABC',
+                    textColorSecondary: '#F3C100',
+                }}
+            />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
@@ -1,0 +1,497 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IssueScreenHeader should match the altered style by the prop headerStyles 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      Object {
+        "backgroundColor": "#7D0068",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {
+                          "color": "#007ABC",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  Thursday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {
+                          "color": "#F3C100",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  25 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="More issues"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`IssueScreenHeader should match the default style 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Thursday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  25 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="More issues"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/components/ScreenHeader/ScreenHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/ScreenHeader.stories.tsx
@@ -1,29 +1,42 @@
-import { color, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react-native'
 import React from 'react'
-import { IssueOrigin } from '../../../../Apps/common/src'
 import { ScreenHeader } from './ScreenHeader'
-
-const issue = {
-    name: 'Daily Edition',
-    date: '2020-06-25',
-    key: 'daily-edition/2020-06-25',
-    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
-    localId: 'daily-edition/2020-06-25',
-    fronts: [],
-    origin: 'api' as IssueOrigin,
-}
+import { props } from './fixtures'
 
 storiesOf('ScreenHeader', module)
-    .addDecorator(withKnobs)
-    .add('Default', () => <ScreenHeader issue={issue} />)
-    .add('With Header Styles', () => (
+    .add('Default', () => <ScreenHeader />)
+    .add('with Title', () => <ScreenHeader title={props.title} />)
+    .add('with Title and Subtitle', () => (
+        <ScreenHeader title={props.title} subTitle={props.subTitle} />
+    ))
+    .add('with Title, Subtitle and Right Action', () => (
         <ScreenHeader
-            issue={issue}
-            headerStyles={{
-                backgroundColor: color('Background Colour', '#7D0068'),
-                textColorPrimary: color('Text Colour Primary', '#007ABC'),
-                textColorSecondary: color('Text Colour Secondary', '#F3C100'),
-            }}
+            title={props.title}
+            subTitle={props.subTitle}
+            rightAction={props.rightAction}
         />
     ))
+    .add('with Title, Subtitle, Right Action and Left Action', () => (
+        <ScreenHeader
+            title={props.title}
+            subTitle={props.subTitle}
+            rightAction={props.rightAction}
+            leftAction={props.leftAction}
+        />
+    ))
+    .add(
+        'with Title, Subtitle, Right Action, Left Action and Title is Pressable',
+        () => (
+            <ScreenHeader
+                title={props.title}
+                subTitle={props.subTitle}
+                rightAction={props.rightAction}
+                leftAction={props.leftAction}
+                onPress={props.onPress}
+            />
+        ),
+    )
+    .add(
+        'with Title, Subtitle, Right Action, Left Action, Title is Pressable and Custom Header Styles',
+        () => <ScreenHeader {...props} />,
+    )

--- a/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
@@ -24,12 +24,12 @@ export const ScreenHeader = ({
         leftAction={leftAction}
         headerStyles={headerStyles}
     >
-        {title && (
+        {title ? (
             <IssueTitle
                 title={title}
                 subtitle={subTitle}
                 overwriteStyles={headerStyles}
             />
-        )}
+        ) : null}
     </Header>
 )

--- a/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
@@ -1,62 +1,36 @@
 import React from 'react'
-import { View } from 'react-native'
-import { NavigationInjectedProps, withNavigation } from 'react-navigation'
+import { withNavigation } from 'react-navigation'
 import { Header } from 'src/components/layout/header/header'
-import { useIssueDate } from 'src/helpers/issues'
-import { useEditionsMenuEnabled } from 'src/hooks/use-config-provider'
-import {
-    navigateToEditionMenu,
-    navigateToIssueList,
-} from 'src/navigation/helpers/base'
-import {
-    IssueWithFronts,
-    SpecialEditionHeaderStyles,
-} from '../../../../Apps/common/src'
-import { IssueMenuButton } from '../Button/IssueMenuButton'
-import { EditionsMenuButton } from '../EditionsMenu/EditionsMenuButton/EditionsMenuButton'
+import { SpecialEditionHeaderStyles } from '../../../../Apps/common/src'
 import { IssueTitle } from '../issue/issue-title'
 
-export const ScreenHeader = withNavigation(
-    ({
-        issue,
-        navigation,
-        headerStyles,
-    }: {
-        issue?: IssueWithFronts
-        headerStyles?: SpecialEditionHeaderStyles
-    } & NavigationInjectedProps) => {
-        const { date, weekday } = useIssueDate(issue)
-        const { editionsMenuEnabled } = useEditionsMenuEnabled()
-
-        const goToIssueList = () => {
-            navigateToIssueList(navigation)
-        }
-
-        const goToEditionsMenu = () => {
-            navigateToEditionMenu(navigation)
-        }
-
-        return (
-            <Header
-                onPress={() => {
-                    goToIssueList()
-                }}
-                action={<IssueMenuButton onPress={goToIssueList} />}
-                leftAction={
-                    editionsMenuEnabled && (
-                        <EditionsMenuButton onPress={goToEditionsMenu} />
-                    )
-                }
-                headerStyles={headerStyles}
-            >
-                <View>
-                    <IssueTitle
-                        title={weekday}
-                        subtitle={date}
-                        overwriteStyles={headerStyles}
-                    />
-                </View>
-            </Header>
-        )
-    },
+export const ScreenHeader = ({
+    headerStyles,
+    leftAction,
+    onPress,
+    rightAction,
+    title,
+    subTitle,
+}: {
+    headerStyles?: SpecialEditionHeaderStyles
+    leftAction?: React.ReactElement | null
+    onPress?: () => void
+    rightAction?: React.ReactElement | null
+    subTitle?: string
+    title?: string
+}) => (
+    <Header
+        onPress={onPress}
+        action={rightAction}
+        leftAction={leftAction}
+        headerStyles={headerStyles}
+    >
+        {title && (
+            <IssueTitle
+                title={title}
+                subtitle={subTitle}
+                overwriteStyles={headerStyles}
+            />
+        )}
+    </Header>
 )

--- a/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/ScreenHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { withNavigation } from 'react-navigation'
+import { SpecialEditionHeaderStyles } from 'src/common'
 import { Header } from 'src/components/layout/header/header'
-import { SpecialEditionHeaderStyles } from '../../../../Apps/common/src'
 import { IssueTitle } from '../issue/issue-title'
 
 export const ScreenHeader = ({

--- a/projects/Mallard/src/components/ScreenHeader/__tests__/ScreenHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/__tests__/ScreenHeader.spec.tsx
@@ -1,43 +1,69 @@
 import React from 'react'
-import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { ScreenHeader } from '../ScreenHeader'
-import { IssueOrigin } from '../../../../../Apps/common/src'
-
-jest.mock('src/helpers/locale', () => ({
-    locale: 'en_GB',
-}))
-
-jest.mock('react-navigation', () => ({
-    withNavigation: (child: any) => child,
-}))
-
-const issue = {
-    name: 'Daily Edition',
-    date: '2020-06-25',
-    key: 'daily-edition/2020-06-25',
-    publishedId: 'daily-edition/2020-06-25/2020-06-25T00:58:19.4Z',
-    localId: 'daily-edition/2020-06-25',
-    fronts: [],
-    origin: 'api' as IssueOrigin,
-}
+import { props } from '../fixtures'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 
 describe('ScreenHeader', () => {
-    it('should match the default style', () => {
+    it('should show a default version', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <ScreenHeader issue={issue} />,
+            <ScreenHeader title={props.title} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
-    it('should match the altered style by the prop headerStyles', () => {
+    it('should show a version with title', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader title={props.title} subTitle={props.subTitle} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a version with title and subTitle', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
             <ScreenHeader
-                issue={issue}
-                headerStyles={{
-                    backgroundColor: '#7D0068',
-                    textColorPrimary: '#007ABC',
-                    textColorSecondary: '#F3C100',
-                }}
+                title={props.title}
+                subTitle={props.subTitle}
+                rightAction={props.rightAction}
             />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a version with title, subTitle and rightAction', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a version with title, subTitle, rightAction and leftAction', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader
+                title={props.title}
+                subTitle={props.subTitle}
+                rightAction={props.rightAction}
+                leftAction={props.leftAction}
+            />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a version with title, subTitle, rightAction, leftAction and pressable title', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader
+                title={props.title}
+                subTitle={props.subTitle}
+                rightAction={props.rightAction}
+                leftAction={props.leftAction}
+                onPress={props.onPress}
+            />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a version with title, subTitle, rightAction, leftAction, pressable title and header styles', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader {...props} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should show a default version when a subTitle is provided but no title', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <ScreenHeader subTitle={props.subTitle} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/ScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/ScreenHeader.spec.tsx.snap
@@ -1,259 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScreenHeader should match the altered style by the prop headerStyles 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#052962",
-        "flexDirection": "row",
-        "justifyContent": "flex-end",
-        "paddingVertical": 10,
-      },
-      Object {
-        "backgroundColor": "#7D0068",
-      },
-    ]
-  }
->
-  <View
-    style={
-      Array [
-        Object {
-          "alignSelf": "flex-end",
-          "flexDirection": "row",
-          "justifyContent": "flex-end",
-          "width": "100%",
-        },
-        Array [
-          Object {
-            "marginTop": 20,
-          },
-          Object {
-            "height": 49,
-          },
-        ],
-        undefined,
-      ]
-    }
-  >
-    <View
-      style={
-        Object {
-          "flexGrow": 1,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "paddingLeft": 14,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        Array [
-          Object {
-            "flex": 0,
-            "flexDirection": "row",
-          },
-          Object {
-            "width": 0,
-          },
-        ]
-      }
-    >
-      <View
-        style={
-          Array [
-            Object {
-              "alignItems": "flex-start",
-              "flexDirection": "row",
-              "flexGrow": 1,
-            },
-          ]
-        }
-      >
-        <View
-          style={
-            Object {
-              "flexGrow": 1,
-              "flexShrink": 0,
-              "paddingHorizontal": 14,
-            }
-          }
-        >
-          <RNGestureHandlerButton
-            collapsable={false}
-            onGestureEvent={[Function]}
-            onGestureHandlerEvent={[Function]}
-            onGestureHandlerStateChange={[Function]}
-            onHandlerStateChange={[Function]}
-            rippleColor={0}
-            style={
-              Array [
-                Object {
-                  "overflow": "hidden",
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              accessible={true}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-            >
-              <View>
-                <View>
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "flexShrink": 0,
-                          "fontFamily": "GTGuardianTitlepiece-Bold",
-                          "fontSize": 24,
-                          "lineHeight": 26,
-                        },
-                        Array [
-                          Object {
-                            "color": "#ffffff",
-                            "marginTop": -2,
-                          },
-                          undefined,
-                          Object {
-                            "color": "#007ABC",
-                          },
-                        ],
-                      ]
-                    }
-                  >
-                    Thursday
-                  </Text>
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "flexShrink": 0,
-                          "fontFamily": "GTGuardianTitlepiece-Bold",
-                          "fontSize": 24,
-                          "lineHeight": 26,
-                        },
-                        Array [
-                          Object {
-                            "color": "#ffffff",
-                            "marginTop": -2,
-                          },
-                          Object {
-                            "color": "#ffe500",
-                          },
-                          Object {
-                            "color": "#F3C100",
-                          },
-                        ],
-                      ]
-                    }
-                  >
-                    25 June
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </RNGestureHandlerButton>
-        </View>
-        <View
-          style={
-            Object {
-              "paddingRight": 14,
-            }
-          }
-        >
-          <View
-            accessibilityHint="More issues"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 10,
-                "left": 10,
-                "right": 10,
-                "top": 10,
-              }
-            }
-            isTVSelectable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={
-                Array [
-                  Object {
-                    "alignItems": "center",
-                    "borderRadius": 999,
-                    "height": 42,
-                    "justifyContent": "center",
-                    "paddingHorizontal": 21,
-                  },
-                  Object {
-                    "backgroundColor": "#ffe500",
-                  },
-                  Object {
-                    "alignItems": "center",
-                    "aspectRatio": 1,
-                    "justifyContent": "center",
-                    "paddingHorizontal": 0,
-                    "width": 42,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "fontFamily": "GuardianIcons-Regular",
-                      "fontSize": 20,
-                      "lineHeight": 20,
-                    },
-                    Array [
-                      Object {
-                        "color": "#121212",
-                      },
-                      undefined,
-                    ],
-                  ]
-                }
-              >
-                
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`ScreenHeader should match the default style 1`] = `
+exports[`ScreenHeader should show a default version 1`] = `
 <View
   style={
     Array [
@@ -361,54 +108,2361 @@ exports[`ScreenHeader should match the default style 1`] = `
               }
             >
               <View>
-                <View>
-                  <Text
-                    style={
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
                       Array [
                         Object {
-                          "flexShrink": 0,
-                          "fontFamily": "GTGuardianTitlepiece-Bold",
-                          "fontSize": 24,
-                          "lineHeight": 26,
+                          "color": "#ffffff",
+                          "marginTop": -2,
                         },
-                        Array [
-                          Object {
-                            "color": "#ffffff",
-                            "marginTop": -2,
-                          },
-                          undefined,
-                          Object {},
-                        ],
-                      ]
-                    }
-                  >
-                    Thursday
-                  </Text>
-                  <Text
-                    style={
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a default version when a subTitle is provided but no title 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View />
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
                       Array [
                         Object {
-                          "flexShrink": 0,
-                          "fontFamily": "GTGuardianTitlepiece-Bold",
-                          "fontSize": 24,
-                          "lineHeight": 26,
+                          "color": "#ffffff",
+                          "marginTop": -2,
                         },
-                        Array [
-                          Object {
-                            "color": "#ffffff",
-                            "marginTop": -2,
-                          },
-                          Object {
-                            "color": "#ffe500",
-                          },
-                          Object {},
-                        ],
-                      ]
-                    }
-                  >
-                    25 June
-                  </Text>
-                </View>
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  26 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title and subTitle 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  26 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="More issues"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title, subTitle and rightAction 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View />
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title, subTitle, rightAction and leftAction 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Regions and specials editions menu"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderRadius": 24,
+              "height": 42,
+              "justifyContent": "center",
+              "opacity": 1,
+              "width": 42,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight={42}
+            bbWidth={42}
+            fill="none"
+            focusable={false}
+            height={42}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 42,
+                  "width": 42,
+                },
+              ]
+            }
+            width={42}
+          >
+            <RNSVGGroup
+              fill={null}
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            >
+              <RNSVGRect
+                fill={
+                  Array [
+                    0,
+                    4278190080,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                height="41"
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "stroke",
+                  ]
+                }
+                rotation={0}
+                rx="20.5"
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                width="41"
+                x="0.5"
+                y="0.5"
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294949576,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4287683839,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4294934287,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  26 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="More issues"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title, subTitle, rightAction, leftAction and pressable title 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Regions and specials editions menu"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderRadius": 24,
+              "height": 42,
+              "justifyContent": "center",
+              "opacity": 1,
+              "width": 42,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight={42}
+            bbWidth={42}
+            fill="none"
+            focusable={false}
+            height={42}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 42,
+                  "width": 42,
+                },
+              ]
+            }
+            width={42}
+          >
+            <RNSVGGroup
+              fill={null}
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            >
+              <RNSVGRect
+                fill={
+                  Array [
+                    0,
+                    4278190080,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                height="41"
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "stroke",
+                  ]
+                }
+                rotation={0}
+                rx="20.5"
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                width="41"
+                x="0.5"
+                y="0.5"
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294949576,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4287683839,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4294934287,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  26 June
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="More issues"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ScreenHeader should show a version with title, subTitle, rightAction, leftAction, pressable title and header styles 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      Object {
+        "backgroundColor": "#7D0068",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="Regions and specials editions menu"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderRadius": 24,
+              "height": 42,
+              "justifyContent": "center",
+              "opacity": 1,
+              "width": 42,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight={42}
+            bbWidth={42}
+            fill="none"
+            focusable={false}
+            height={42}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+                Object {
+                  "flex": 0,
+                  "height": 42,
+                  "width": 42,
+                },
+              ]
+            }
+            width={42}
+          >
+            <RNSVGGroup
+              fill={null}
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            >
+              <RNSVGRect
+                fill={
+                  Array [
+                    0,
+                    4278190080,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                height="41"
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "stroke",
+                  ]
+                }
+                rotation={0}
+                rx="20.5"
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                width="41"
+                x="0.5"
+                y="0.5"
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294949576,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="14"
+                fill={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="29"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4287683839,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+              <RNSVGCircle
+                cx="14"
+                cy="29"
+                fill={
+                  Array [
+                    0,
+                    4294934287,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                r="7"
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {
+                          "color": "#007ABC",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  Friday
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {
+                          "color": "#F3C100",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  26 June
+                </Text>
               </View>
             </View>
           </RNGestureHandlerButton>

--- a/projects/Mallard/src/components/ScreenHeader/fixtures.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/fixtures.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Alert } from 'react-native'
+import { IssueMenuButton } from '../Button/IssueMenuButton'
+import { EditionsMenuButton } from '../EditionsMenu/EditionsMenuButton/EditionsMenuButton'
+
+const props = {
+    title: 'Friday',
+    subTitle: '26 June',
+    rightAction: (
+        <IssueMenuButton onPress={() => Alert.alert('Right Action')} />
+    ),
+    leftAction: (
+        <EditionsMenuButton onPress={() => Alert.alert('Left Action')} />
+    ),
+    onPress: () => Alert.alert('On Press'),
+    headerStyles: {
+        backgroundColor: '#7D0068',
+        textColorPrimary: '#007ABC',
+        textColorSecondary: '#F3C100',
+    },
+}
+
+export { props }

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -150,20 +150,6 @@ const Header = ({
     )
 }
 
-const IssuePickerHeader = (
-    headerProps: Omit<HeaderProps, 'children'> & TouchableHeaderProps,
-) => {
-    return (
-        <Header {...headerProps}>
-            <IssueTitle
-                {...headerProps}
-                title={`Recent`}
-                subtitle={`Editions`}
-            />
-        </Header>
-    )
-}
-
 const EditionsMenuScreenHeader = ({
     leftActionPress,
 }: {
@@ -177,4 +163,4 @@ const EditionsMenuScreenHeader = ({
     </Header>
 )
 
-export { Header, IssuePickerHeader, EditionsMenuScreenHeader }
+export { Header, EditionsMenuScreenHeader }

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -23,7 +23,6 @@ import {
 } from 'src/components/issue/issue-row'
 import { GridRowSplit } from 'src/components/issue/issue-title'
 import { FlexCenter } from 'src/components/layout/flex-center'
-import { IssuePickerHeader } from 'src/components/layout/header/header'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
 import { Spinner } from 'src/components/Spinner/Spinner'
 import {
@@ -48,6 +47,8 @@ import { useIssueResponse } from 'src/hooks/use-issue'
 import { IssueWithFronts } from '../../../Apps/common/src'
 import { PathToIssue } from 'src/paths'
 import { Loaded } from 'src/helpers/Loaded'
+import { ScreenHeader } from 'src/components/ScreenHeader/ScreenHeader'
+import { IssuePickerHeader } from 'src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader'
 
 const styles = StyleSheet.create({
     issueListFooter: {
@@ -67,47 +68,6 @@ const styles = StyleSheet.create({
         height: '100%',
     },
 })
-
-const HomeScreenHeader = withNavigation(
-    ({
-        navigation,
-        onReturn,
-    }: {
-        onReturn: () => void
-        onSettings: () => void
-    } & NavigationInjectedProps) => {
-        const action = (
-            <Button
-                accessibilityLabel="Close button"
-                accessibilityHint="Returns to the edition"
-                accessibilityRole="button"
-                icon={'\uE04F'}
-                alt="Return to edition"
-                onPress={onReturn}
-            />
-        )
-        const settings = (
-            <Button
-                accessibilityLabel="Settings button"
-                accessibilityHint="Navigates to the settings screen"
-                accessibilityRole="button"
-                icon={'\uE040'}
-                alt="Settings"
-                onPress={() => {
-                    navigateToSettings(navigation)
-                }}
-                appearance={ButtonAppearance.skeleton}
-            />
-        )
-        return (
-            <IssuePickerHeader
-                leftAction={settings}
-                onPress={onReturn}
-                action={action}
-            />
-        )
-    },
-)
 
 const IssueRowContainer = React.memo(
     ({
@@ -485,18 +445,7 @@ export const HomeScreen = ({
     const { issueSummary, error, setIssueId } = useIssueSummary()
     return (
         <WithAppAppearance value={'tertiary'}>
-            <HomeScreenHeader
-                onSettings={() => {
-                    navigation.navigate('Settings')
-                }}
-                onReturn={() => {
-                    navigateToIssue({
-                        navigation,
-                        navigationProps: {},
-                        setIssueId,
-                    })
-                }}
-            />
+            <IssuePickerHeader />
             {issueSummary ? (
                 <IssueListFetchContainer />
             ) : error ? (

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,54 +1,50 @@
 import React, {
-    useCallback,
-    useState,
-    useEffect,
-    useRef,
-    useMemo,
     Dispatch,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
 } from 'react'
-import { View, FlatList, StyleSheet, Platform } from 'react-native'
+import { FlatList, Platform, StyleSheet, View } from 'react-native'
 import {
     NavigationInjectedProps,
+    NavigationParams,
+    NavigationRoute,
     NavigationScreenProp,
     withNavigation,
-    NavigationRoute,
 } from 'react-navigation'
 import { IssueSummary } from 'src/common'
 import { Button, ButtonAppearance } from 'src/components/Button/Button'
 import {
     IssueRow,
-    ISSUE_ROW_HEADER_HEIGHT,
-    ISSUE_FRONT_ROW_HEIGHT,
     ISSUE_FRONT_ERROR_HEIGHT,
+    ISSUE_FRONT_ROW_HEIGHT,
+    ISSUE_ROW_HEADER_HEIGHT,
 } from 'src/components/issue/issue-row'
 import { GridRowSplit } from 'src/components/issue/issue-title'
 import { FlexCenter } from 'src/components/layout/flex-center'
 import { FlexErrorMessage } from 'src/components/layout/ui/errors/flex-error-message'
+import { Separator } from 'src/components/layout/ui/row'
+import { IssuePickerHeader } from 'src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader'
 import { Spinner } from 'src/components/Spinner/Spinner'
+import { Loaded } from 'src/helpers/Loaded'
 import {
     CONNECTION_FAILED_AUTO_RETRY,
     CONNECTION_FAILED_ERROR,
 } from 'src/helpers/words'
-import { useIssueSummary } from 'src/hooks/use-issue-summary'
-import {
-    navigateToIssue,
-    navigateToSettings,
-} from 'src/navigation/helpers/base'
-import { WithAppAppearance } from 'src/theme/appearance'
-import { metrics } from 'src/theme/spacing'
-import { ApiState } from './settings/api-screen'
-import { useIsUsingProdDevtools } from 'src/hooks/use-settings'
-import { routeNames } from 'src/navigation/routes'
-import { useSetNavPosition } from 'src/hooks/use-nav-position'
-import { NavigationParams } from 'react-navigation'
-import { Separator } from 'src/components/layout/ui/row'
-import { color } from 'src/theme/color'
 import { useIssueResponse } from 'src/hooks/use-issue'
-import { IssueWithFronts } from '../../../Apps/common/src'
+import { useIssueSummary } from 'src/hooks/use-issue-summary'
+import { useSetNavPosition } from 'src/hooks/use-nav-position'
+import { useIsUsingProdDevtools } from 'src/hooks/use-settings'
+import { navigateToIssue } from 'src/navigation/helpers/base'
+import { routeNames } from 'src/navigation/routes'
 import { PathToIssue } from 'src/paths'
-import { Loaded } from 'src/helpers/Loaded'
-import { ScreenHeader } from 'src/components/ScreenHeader/ScreenHeader'
-import { IssuePickerHeader } from 'src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader'
+import { WithAppAppearance } from 'src/theme/appearance'
+import { color } from 'src/theme/color'
+import { metrics } from 'src/theme/spacing'
+import { IssueWithFronts } from '../../../Apps/common/src'
+import { ApiState } from './settings/api-screen'
 
 const styles = StyleSheet.create({
     issueListFooter: {
@@ -437,12 +433,8 @@ const IssueListFetchContainer = () => {
     })
 }
 
-export const HomeScreen = ({
-    navigation,
-}: {
-    navigation: NavigationScreenProp<{}>
-}) => {
-    const { issueSummary, error, setIssueId } = useIssueSummary()
+export const HomeScreen = () => {
+    const { issueSummary, error } = useIssueSummary()
     return (
         <WithAppAppearance value={'tertiary'}>
             <IssuePickerHeader />

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -63,7 +63,7 @@ import { metrics } from 'src/theme/spacing'
 import { Front as TFront, IssueWithFronts } from '../../../Apps/common/src'
 import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
-import { ScreenHeader } from '../components/ScreenHeader/ScreenHeader'
+import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -293,7 +293,7 @@ const handleError = (
     { retry }: { retry: () => void },
 ) => (
     <>
-        <ScreenHeader />
+        <IssueScreenHeader />
 
         <FlexErrorMessage
             debugMessage={message}
@@ -306,7 +306,7 @@ const handleError = (
 
 const handlePending = () => (
     <>
-        <ScreenHeader />
+        <IssueScreenHeader />
         <FlexCenter>
             <Spinner />
         </FlexCenter>
@@ -315,7 +315,7 @@ const handlePending = () => (
 
 const handleIssueScreenError = (error: string) => (
     <>
-        <ScreenHeader />
+        <IssueScreenHeader />
         <FlexErrorMessage
             debugMessage={error}
             title={CONNECTION_FAILED_ERROR}
@@ -364,7 +364,7 @@ const IssueScreenWithPath = React.memo(
                                 retry()
                             }}
                         />
-                        <ScreenHeader issue={issue} />
+                        <IssueScreenHeader issue={issue} />
 
                         <WithBreakpoints>
                             {{

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -11,6 +11,7 @@ function loadStories() {
 	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
 	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
 	require('../src/components/Lightbox/LightboxCaption.stories');
+	require('../src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories');
 	require('../src/components/ScreenHeader/ScreenHeader.stories');
 	require('../src/components/SignInFailedModalCard.stories');
 	require('../src/components/Spinner/Spinner.stories');
@@ -27,6 +28,7 @@ const stories = [
 	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
 	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
 	'../src/components/Lightbox/LightboxCaption.stories',
+	'../src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories',
 	'../src/components/ScreenHeader/ScreenHeader.stories',
 	'../src/components/SignInFailedModalCard.stories',
 	'../src/components/Spinner/Spinner.stories',

--- a/projects/Mallard/storybook/storyLoader.js
+++ b/projects/Mallard/storybook/storyLoader.js
@@ -11,6 +11,7 @@ function loadStories() {
 	require('../src/components/EditionsMenu/RegionButton/RegionButton.stories');
 	require('../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories');
 	require('../src/components/Lightbox/LightboxCaption.stories');
+	require('../src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories');
 	require('../src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories');
 	require('../src/components/ScreenHeader/ScreenHeader.stories');
 	require('../src/components/SignInFailedModalCard.stories');
@@ -28,6 +29,7 @@ const stories = [
 	'../src/components/EditionsMenu/RegionButton/RegionButton.stories',
 	'../src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories',
 	'../src/components/Lightbox/LightboxCaption.stories',
+	'../src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories',
 	'../src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.stories',
 	'../src/components/ScreenHeader/ScreenHeader.stories',
 	'../src/components/SignInFailedModalCard.stories',


### PR DESCRIPTION
## Summary
- ScreenHeader has been split out so that its a base level component that can be used across the app
- Created a IssueScreenHeader component that uses ScreenHeader but manages all the navigation and inputs for the various different use cases
- Created a IssuePickerHeader components that again uses ScreenHeader for reusability and then repurposed back into the IssuePicker. This then has the `headerStyles` implementation required for the ticket
- Tests and stories

Please note: I would like to Refactor IssuePickerHeader further moving the buttons out into their own components, but this PR already feels to big so that will come next

![Simulator Screen Shot - iPhone 11 - 2020-06-26 at 16 31 55](https://user-images.githubusercontent.com/935975/85874979-67722780-b7cb-11ea-8972-506375ed19a1.png)

![Simulator Screen Shot - iPhone 11 - 2020-06-26 at 16 24 30](https://user-images.githubusercontent.com/935975/85874986-69d48180-b7cb-11ea-9019-dc396b32a9c5.png)


[**Trello Card ->**](https://trello.com/c/CwmvTcT7/1397-changes-to-headers-on-fronts-and-issue-picker-screen)
