### PR TITLE
fix: Android Push Downloads

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -66,7 +66,6 @@ remoteConfigService.init()
 Platform.OS === 'ios' && enableScreens()
 pushNotifcationRegistration(apolloClient)
 prepFileSystem()
-Platform.OS === 'android' && prepareAndDownloadTodaysIssue(apolloClient)
 
 const styles = StyleSheet.create({
     appContainer: {

--- a/projects/Mallard/src/push-notifications/push-notifications.ts
+++ b/projects/Mallard/src/push-notifications/push-notifications.ts
@@ -81,8 +81,7 @@ const pushNotifcationRegistration = (apolloClient: ApolloClient<object>) => {
             }
         },
         onNotification: async (notification: any) => {
-            const key =
-                Platform.OS === 'ios' ? notification.data.key : notification.key
+            const key = notification.data.key
             const notificationId =
                 Platform.OS === 'ios'
                     ? notification.data.uniqueIdentifier


### PR DESCRIPTION
## Summary
After testing at the weekend, I confirmed that @mohammad-haque issue with his Android device. The device was receiving a notification but not downloading anything. It turns out the contract has changed and now the `key` sits inside a `data` object which is the same for iOS. This fixes that.

Additionally we are calling download twice on startup for Android which I believe is causing our promise rejection message in dev. 