### PR TITLE
feat: Support Title and Subtitle in Regional Editions

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -6,17 +6,28 @@ export const defaultRegionalEditions: RegionalEdition[] = [
         subTitle: `Published every morning
 by 6am (GMT)`,
         edition: editions.daily,
+        header: {
+            title: 'The Daily',
+        },
     },
     {
-        title: 'Australia Weekend',
+        title: 'Australia Weekender',
         subTitle: `Published every Saturday morning 
 by 6am (AEST)`,
         edition: editions.ausWeekly,
+        header: {
+            title: 'Australia',
+            subTitle: 'Weekender',
+        },
     },
     {
-        title: 'US Weekend',
+        title: 'US Weekender',
         subTitle: `Published every Saturday morning 
 by 6am (EST)`,
         edition: editions.usWeekly,
+        header: {
+            title: 'US',
+            subTitle: 'Weekender',
+        },
     },
 ]

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -569,6 +569,10 @@ export interface RegionalEdition {
     title: string
     subTitle: string
     edition: Edition
+    header: {
+        title: string
+        subTitle?: string
+    }
 }
 
 export interface SpecialEdition {

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -39,16 +39,27 @@ const regionalEditions = [
         title: 'The UK Daily Edition',
         subTitle: 'Published every day by 12am (GMT)',
         edition: editions.daily as Edition,
+        header: {
+            title: 'The Daily',
+        },
     },
     {
         title: 'Australia Daily',
         subTitle: 'Published every day by 9:30am (AEST)',
         edition: editions.ausWeekly as Edition,
+        header: {
+            title: 'Austraila',
+            subTitle: 'Weekender',
+        },
     },
     {
         title: 'US and Cananda Weekend',
         subTitle: 'Published every Saturday by 8am (EST)',
         edition: editions.usWeekly as Edition,
+        header: {
+            title: 'US',
+            subTitle: 'Weekender',
+        },
     },
 ]
 

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -54,16 +54,27 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
         Array [
           Object {
             "edition": "daily-edition",
+            "header": Object {
+              "title": "The Daily",
+            },
             "subTitle": "Published every day by 12am (GMT)",
             "title": "The UK Daily Edition",
           },
           Object {
             "edition": "australian-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "Austraila",
+            },
             "subTitle": "Published every day by 9:30am (AEST)",
             "title": "Australia Daily",
           },
           Object {
             "edition": "american-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "US",
+            },
             "subTitle": "Published every Saturday by 8am (EST)",
             "title": "US and Cananda Weekend",
           },
@@ -346,21 +357,32 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
         Array [
           Object {
             "edition": "daily-edition",
+            "header": Object {
+              "title": "The Daily",
+            },
             "subTitle": "Published every morning
 by 6am (GMT)",
             "title": "The Daily",
           },
           Object {
             "edition": "australian-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "Australia",
+            },
             "subTitle": "Published every Saturday morning 
 by 6am (AEST)",
-            "title": "Australia Weekend",
+            "title": "Australia Weekender",
           },
           Object {
             "edition": "american-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "US",
+            },
             "subTitle": "Published every Saturday morning 
 by 6am (EST)",
-            "title": "US Weekend",
+            "title": "US Weekender",
           },
         ]
       }
@@ -461,7 +483,7 @@ by 6am (GMT)
           style={null}
         >
           <View
-            accessibilityLabel="Australia Weekend - Regional Edition Button"
+            accessibilityLabel="Australia Weekender - Regional Edition Button"
             accessibilityRole="button"
             accessible={true}
             focusable={true}
@@ -499,7 +521,7 @@ by 6am (GMT)
                 ]
               }
             >
-              Australia Weekend
+              Australia Weekender
             </Text>
             <Text
               style={
@@ -529,7 +551,7 @@ by 6am (AEST)
           style={null}
         >
           <View
-            accessibilityLabel="US Weekend - Regional Edition Button"
+            accessibilityLabel="US Weekender - Regional Edition Button"
             accessibilityRole="button"
             accessible={true}
             focusable={true}
@@ -567,7 +589,7 @@ by 6am (AEST)
                 ]
               }
             >
-              US Weekend
+              US Weekender
             </Text>
             <Text
               style={
@@ -838,21 +860,32 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
         Array [
           Object {
             "edition": "daily-edition",
+            "header": Object {
+              "title": "The Daily",
+            },
             "subTitle": "Published every morning
 by 6am (GMT)",
             "title": "The Daily",
           },
           Object {
             "edition": "australian-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "Australia",
+            },
             "subTitle": "Published every Saturday morning 
 by 6am (AEST)",
-            "title": "Australia Weekend",
+            "title": "Australia Weekender",
           },
           Object {
             "edition": "american-edition",
+            "header": Object {
+              "subTitle": "Weekender",
+              "title": "US",
+            },
             "subTitle": "Published every Saturday morning 
 by 6am (EST)",
-            "title": "US Weekend",
+            "title": "US Weekender",
           },
         ]
       }
@@ -953,7 +986,7 @@ by 6am (GMT)
           style={null}
         >
           <View
-            accessibilityLabel="Australia Weekend - Regional Edition Button"
+            accessibilityLabel="Australia Weekender - Regional Edition Button"
             accessibilityRole="button"
             accessible={true}
             focusable={true}
@@ -991,7 +1024,7 @@ by 6am (GMT)
                 ]
               }
             >
-              Australia Weekend
+              Australia Weekender
             </Text>
             <Text
               style={
@@ -1021,7 +1054,7 @@ by 6am (AEST)
           style={null}
         >
           <View
-            accessibilityLabel="US Weekend - Regional Edition Button"
+            accessibilityLabel="US Weekender - Regional Edition Button"
             accessibilityRole="button"
             accessible={true}
             focusable={true}
@@ -1059,7 +1092,7 @@ by 6am (AEST)
                 ]
               }
             >
-              US Weekend
+              US Weekender
             </Text>
             <Text
               style={

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -72,6 +72,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
             Dimensions.removeEventListener('change', listener)
         }
     }, [])
+
     useEffect(() => {
         fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
             setEditionsMenuEnabled(editionsMenuToggle)


### PR DESCRIPTION
## Summary
For the header work we need the ability to add a subtitle and title for the issue picker header. It makes sense to keep it with the data for the edition.

[**Trello Card ->**](https://trello.com/c/CwmvTcT7/1397-changes-to-headers-on-fronts-and-issue-picker-screen)