### PR TITLE
Add script to generate github release tags for each build

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -31,6 +31,7 @@ jobs:
                   yarn validate
 
             - name: publish app
+              id: publish_app
               run: |
                   cd projects/Mallard
                   make beta-ios
@@ -62,3 +63,10 @@ jobs:
                   MATCH_S3_ACCESS_KEY: ${{ secrets.MATCH_S3_ACCESS_KEY }}
                   MATCH_S3_SECRET_ACCESS_KEY: ${{ secrets.MATCH_S3_SECRET_ACCESS_KEY }}
                   MATCH_S3_BUCKET: ${{ secrets.MATCH_S3_BUCKET }}
+
+            - name: publish release to github
+              run: |
+                  cd script
+                  node make-release.js ${{ github.sha }} ${{ github.ref }} ${{ steps.publish_app.outputs.buildnumber }} ios
+              env:
+                  REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/.github/workflows/upload-build.yml
+++ b/.github/workflows/upload-build.yml
@@ -26,6 +26,7 @@ jobs:
                   cd projects/Mallard
                   yarn validate
             - name: publish app
+              id: publish_app
               run: |
                   cd projects/Mallard
                   make beta-ios
@@ -57,3 +58,10 @@ jobs:
                   MATCH_S3_ACCESS_KEY: ${{ secrets.MATCH_S3_ACCESS_KEY }}
                   MATCH_S3_SECRET_ACCESS_KEY: ${{ secrets.MATCH_S3_SECRET_ACCESS_KEY }}
                   MATCH_S3_BUCKET: ${{ secrets.MATCH_S3_BUCKET }}
+
+            - name: publish release to github
+              run: |
+                  cd script
+                  node make-release.js ${{ github.sha }} ${{ github.ref }} ${{ steps.publish_app.outputs.buildnumber }} ios
+              env:
+                  REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
         "prettier": "^1.18.2",
         "typescript": "^3.5.3"
     },
-    "private": true
+    "private": true,
+    "dependencies": {
+        "node-fetch": "^2.6.0"
+    }
 }

--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -102,6 +102,8 @@ def enableProguardInReleaseBuilds = false
 //For legacy reason we are adding current build number (14001358) from Play Store
 def appVersionCode = 14001358 + buildNumber()
 
+println("##teamcity[setParameter name='VERSION_CODE' value='${appVersionCode}']")
+
 /**
  * The preferred build flavor of JavaScriptCore.
  *

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -50,6 +50,14 @@ platform :ios do
       xcodeproj: "ios/Mallard.xcodeproj",
       build_number: latest_testflight_build_number.to_i + 1
     )
+
+    ENV["FASTLANE_DISABLE_OUTPUT_FORMAT"] = "true"
+    ENV["FASTLANE_HIDE_TIMESTAMP"] = "true"
+    puts("::set-output name=buildnumber::#{latest_testflight_build_number.to_i + 1}")
+    ENV["FASTLANE_DISABLE_OUTPUT_FORMAT"] = "false"
+    ENV["FASTLANE_HIDE_TIMESTAMP"] = "false"
+
+
     build_app(
       scheme: "Mallard",
       workspace: "ios/Mallard.xcworkspace",
@@ -61,6 +69,7 @@ platform :ios do
     upload_to_testflight(
         distribute_external: true,
         notify_external_testers: true,
+        skip_waiting_for_build_processing: true,
         changelog: "Thanks for testing the app! We've made some improvements",
         groups: ["GNM"],
         demo_account_required: false,

--- a/script/make-release.js
+++ b/script/make-release.js
@@ -46,26 +46,33 @@ const findReleaseForCommit = (commit, releases) => {
 }
 
 const patchReleaseName = (name, os, appStoreId) =>
-    name.includes(`-${os}-`) ? name : `${name}--${os}-${appStoreId}`
+    `${name}--${os}-${appStoreId}`
 
 const updateRelease = async (commitSha, message, branch, appStoreId, os) => {
     const releases = await get('releases')
     const matchingRelease = findReleaseForCommit(commitSha, releases)
 
     if (matchingRelease) {
-        console.log('release exists, patching release name')
+        console.log(
+            `Release exists (${matchingRelease.html_url}), patching release name`,
+        )
+        const patchedName = patchReleaseName(
+            matchingRelease.name,
+            os,
+            appStoreId,
+        )
         const releaseUpdateResult = await patch(
             `releases/${matchingRelease.id}`,
-            { name: patchReleaseName(matchingRelease.name, os, appStoreId) },
+            { name: patchedName },
         )
         console.log(
-            `Updated release, view it here: ${releaseUpdateResult.html_url}`,
+            `Updated release, new name: ${patchedName}, view it here: ${releaseUpdateResult.html_url}`,
         )
     } else {
         console.log(
             `Creating release with tag name ${commitSha}, message ${message}, branch ${branch}`,
         )
-        const releaseName = `${branch}--${os}-${appStoreId}`
+        const releaseName = patchReleaseName(branch, os, appStoreId)
         const release = await post('releases', {
             tag_name: tagNameFromSha(commitSha),
             prerelease: true,

--- a/script/make-release.js
+++ b/script/make-release.js
@@ -1,0 +1,99 @@
+const fetch = require('node-fetch')
+
+const BASE_URL = 'https://api.github.com/repos/guardian/editions'
+
+const tagNameFromSha = sha => sha.slice(0, 8)
+
+const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `token ${process.env.GITHUB_TOKEN}`,
+}
+
+const doFetch = async (url, params) => {
+    const resp = await fetch(url, params)
+    if (resp.status >= 200 && resp.status < 300) {
+        return resp.json()
+    } else {
+        console.log(
+            `Request to ${url} failed with status ${resp.status}: ${resp.statusText}. Exiting.`,
+        )
+        process.exit()
+    }
+}
+
+const get = async path => {
+    return doFetch(`${BASE_URL}/${path}`, { headers: headers })
+}
+
+const post = async (path, body) => {
+    return doFetch(`${BASE_URL}/${path}`, {
+        headers: headers,
+        method: 'POST',
+        body: JSON.stringify(body),
+    })
+}
+
+const patch = async (path, body) => {
+    return doFetch(`${BASE_URL}/${path}`, {
+        headers: headers,
+        method: 'PATCH',
+        body: JSON.stringify(body),
+    })
+}
+
+const findReleaseForCommit = (commit, releases) => {
+    return releases.find(r => r.tag_name == tagNameFromSha(commit))
+}
+
+const patchReleaseName = (name, os, appStoreId) =>
+    name.includes(`-${os}-`) ? name : `${name}--${os}-${appStoreId}`
+
+const updateRelease = async (commitSha, message, branch, appStoreId, os) => {
+    const releases = await get('releases')
+    const matchingRelease = findReleaseForCommit(commitSha, releases)
+
+    if (matchingRelease) {
+        console.log('release exists, patching release name')
+        const releaseUpdateResult = await patch(
+            `releases/${matchingRelease.id}`,
+            { name: patchReleaseName(matchingRelease.name, os, appStoreId) },
+        )
+        console.log(
+            `Updated release, view it here: ${releaseUpdateResult.html_url}`,
+        )
+    } else {
+        console.log(
+            `Creating release with tag name ${commitSha}, message ${message}, branch ${branch}`,
+        )
+        const releaseName = `${branch}--${os}-${appStoreId}`
+        const release = await post('releases', {
+            tag_name: tagNameFromSha(commitSha),
+            prerelease: true,
+            target_commitish: branch,
+            name: releaseName,
+        })
+        console.log(`Created release, view it here: ${release.html_url}`)
+    }
+}
+const params = {
+    sha: 2,
+    message: 3,
+    branch: 4,
+    appStoreId: 5,
+    os: 6,
+}
+
+if (process.argv.length < Object.keys(params).length) {
+    console.log(
+        `Usage: node ${process.argv[1]} <${Object.keys(params).join('> <')}>`,
+    )
+    process.exit()
+} else {
+    updateRelease(
+        process.argv[params.sha],
+        process.argv[params.message],
+        process.argv[params.branch],
+        process.argv[params.appStoreId],
+        process.argv[params.os],
+    )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,6 +1100,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"


### PR DESCRIPTION
## Summary

This is following from the idea raised by @mohammad-haque to try and keep track of releases. I've added a script called make-release.js to be run after publishing to one of the app stores. It:

 - searches github for  a pre-existing release on the current commit
 - if one exists, it patches that release and adds the version number of whatever just built
 - if one doesn't exist, create a release with the name <branch_name>-<os>-<versionCode/build number>

So in the happy path we would expect:

 - 2pm: builds triggered for android in teamcity, ios in github actions for commit `abc123`
 - 2.10: android build finishes, creates a release for `abc123` called `master-android-<android version code>`
 - 2:45: ios build finishes, finds the release and updates the name to `master-android-<android version code>-ios-<ios build number>`

Here's an example release https://github.com/guardian/editions/releases/tag/9eeac3b4

Let me know what you think! 

[**Trello Card ->**](https://trello.com/c/rnF9my0t/1405-improve-release-process-automatically-generate-release-tags-in-github-with-version-code-ios-build-numbers)

## Test Plan
To test this really needs merging into master. Ii
