### PR TITLE
Remove apple sign in switch

### DIFF
--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -121,8 +121,6 @@ const Login = ({
         fn(value)
     }
 
-    const appleSignInEnabled = remoteConfigService.getBoolean('apple_sign_in')
-
     return (
         <LoginLayout
             title={title}
@@ -145,7 +143,7 @@ const Login = ({
                         >
                             Continue with Google
                         </SocialButton>
-                        {appleSignInEnabled && iosMajorVersion >= 13 && (
+                        {iosMajorVersion >= 13 && (
                             <SocialButton
                                 onPress={onApplePress}
                                 iconRequire={require('src/assets/images/apple.png')}
@@ -154,7 +152,7 @@ const Login = ({
                             </SocialButton>
                         )}
 
-                        {appleSignInEnabled && iosMajorVersion < 13 && (
+                        {iosMajorVersion < 13 && (
                             <SocialButton
                                 onPress={onAppleOAuthPress}
                                 iconRequire={require('src/assets/images/apple.png')}

--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -12,7 +12,6 @@ import { EmailInput, PasswordInput } from 'src/components/login/login-input'
 import { LoginButton } from 'src/components/login/login-button'
 
 import { iosMajorVersion } from 'src/helpers/platform'
-import { remoteConfigService } from 'src/services/remote-config'
 
 const socialButtonStyles = StyleSheet.create({
     button: {

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -6,16 +6,21 @@ export type RemoteStringValue = string | undefined
 
 interface RemoteConfig {
     init(): void
-    getBoolean(key: string): boolean
-    getString(key: string): RemoteStringValue
+    getBoolean(key: RemoteConfigProperty): boolean
+    getString(key: RemoteConfigProperty): RemoteStringValue
 }
 
 const remoteConfigDefaults = {
-    apple_sign_in: false,
-    lightbox_enabled: false,
     logging_enabled: true,
     default_locale: true,
 }
+
+export const RemoteConfigProperties = [
+    'logging_enabled',
+    'default_locale',
+] as const
+
+export type RemoteConfigProperty = typeof RemoteConfigProperties[number]
 
 const configValues = {
     // fetch config, cache for 5mins. This cache persists when app is reloaded
@@ -52,7 +57,7 @@ class RemoteConfigService implements RemoteConfig {
             })
     }
 
-    getBoolean(key: string): boolean {
+    getBoolean(key: RemoteConfigProperty): boolean {
         if (this.initialized) {
             return remoteConfig().getValue(key).value as boolean
         }
@@ -60,7 +65,7 @@ class RemoteConfigService implements RemoteConfig {
         return false
     }
 
-    getString(key: string): RemoteStringValue {
+    getString(key: RemoteConfigProperty): RemoteStringValue {
         if (this.initialized) {
             return remoteConfig().getValue(key).value as string
         }


### PR DESCRIPTION
## Summary
This PR removes the switch for apple sign in now that has been permanently released. It also removes the lightbox_enabled default value as we never used that switch. 

It also introduces a 'RemoteConfigProperty' type to reduce the number of unchecked string types used with this service. 

[**Trello Card ->**](https://trello.com/c/m8XuTVvr/1410-remove-the-apple-sign-in-feature-flag)

## Test Plan

Release, check that the app still starts and apple sign in button is still there!