### PR TITLE
feat: Title and Subtitle support for IssuePickerHeader

### DIFF
--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { color, withKnobs, text } from '@storybook/addon-knobs'
+import { color, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react-native'
 import React from 'react'
 import { IssuePickerHeader } from './IssuePickerHeader'

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
@@ -1,13 +1,20 @@
-import { color, withKnobs } from '@storybook/addon-knobs'
+import { color, withKnobs, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react-native'
 import React from 'react'
 import { IssuePickerHeader } from './IssuePickerHeader'
 
 storiesOf('IssuePickerHeader', module)
     .addDecorator(withKnobs)
-    .add('Default', () => <IssuePickerHeader />)
+    .add('Default', () => (
+        <IssuePickerHeader title="Recent" subTitle="Editions" />
+    ))
+    .add('With Different Title and SubTitle', () => (
+        <IssuePickerHeader title="Australia" subTitle="Weekender" />
+    ))
     .add('With Header Styles', () => (
         <IssuePickerHeader
+            title="Food"
+            subTitle="Monthly"
             headerStyles={{
                 backgroundColor: color('Background Colour', '#7D0068'),
                 textColorPrimary: color('Text Colour Primary', '#007ABC'),

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -9,8 +9,12 @@ const IssuePickerHeader = withNavigation(
     ({
         headerStyles,
         navigation,
+        subTitle,
+        title,
     }: {
         headerStyles?: SpecialEditionHeaderStyles
+        subTitle?: string
+        title: string
     } & NavigationInjectedProps) => {
         const action = (
             <Button
@@ -40,8 +44,8 @@ const IssuePickerHeader = withNavigation(
                 leftAction={settings}
                 onPress={() => navigation.goBack()}
                 rightAction={action}
-                title="Recent"
-                subTitle="Editions"
+                title={title}
+                subTitle={subTitle}
                 headerStyles={headerStyles}
             />
         )

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
@@ -9,13 +9,20 @@ jest.mock('react-navigation', () => ({
 describe('IssuePickerHeader', () => {
     it('should match the default style', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <IssuePickerHeader />,
+            <IssuePickerHeader title="The Daily" />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+    it('should match the default style with a subTitle', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <IssuePickerHeader title="Recent" subTitle="Editions" />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should match the altered style by the prop headerStyles', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
             <IssuePickerHeader
+                title="The Daily"
                 headerStyles={{
                     backgroundColor: '#7D0068',
                     textColorPrimary: '#007ABC',

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
@@ -209,33 +209,7 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                     ]
                   }
                 >
-                  Recent
-                </Text>
-                <Text
-                  style={
-                    Array [
-                      Object {
-                        "flexShrink": 0,
-                        "fontFamily": "GTGuardianTitlepiece-Bold",
-                        "fontSize": 24,
-                        "lineHeight": 26,
-                      },
-                      Array [
-                        Object {
-                          "color": "#ffffff",
-                          "marginTop": -2,
-                        },
-                        Object {
-                          "color": "#ffe500",
-                        },
-                        Object {
-                          "color": "#F3C100",
-                        },
-                      ],
-                    ]
-                  }
-                >
-                  Editions
+                  The Daily
                 </Text>
               </View>
             </View>
@@ -330,6 +304,305 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
 `;
 
 exports[`IssuePickerHeader should match the default style 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#052962",
+        "flexDirection": "row",
+        "justifyContent": "flex-end",
+        "paddingVertical": 10,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "flex-end",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "width": "100%",
+        },
+        Array [
+          Object {
+            "marginTop": 20,
+          },
+          Object {
+            "height": 49,
+          },
+        ],
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 14,
+          }
+        }
+      >
+        <View
+          accessibilityHint="Navigates to the settings screen"
+          accessibilityLabel="Settings button"
+          accessibilityRole="button"
+          accessible={true}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 10,
+              "left": 10,
+              "right": 10,
+              "top": 10,
+            }
+          }
+          isTVSelectable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderRadius": 999,
+                  "height": 42,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 21,
+                },
+                Object {
+                  "backgroundColor": undefined,
+                  "borderColor": "#ffffff",
+                  "borderWidth": 1,
+                },
+                Object {
+                  "alignItems": "center",
+                  "aspectRatio": 1,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 0,
+                  "width": 42,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "GuardianIcons-Regular",
+                    "fontSize": 20,
+                    "lineHeight": 20,
+                  },
+                  Array [
+                    Object {
+                      "color": "#ffffff",
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 0,
+            "flexDirection": "row",
+          },
+          Object {
+            "width": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "flex-start",
+              "flexDirection": "row",
+              "flexGrow": 1,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+              "flexShrink": 0,
+              "paddingHorizontal": 14,
+            }
+          }
+        >
+          <RNGestureHandlerButton
+            collapsable={false}
+            onGestureEvent={[Function]}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            onHandlerStateChange={[Function]}
+            rippleColor={0}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        undefined,
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  The Daily
+                </Text>
+              </View>
+            </View>
+          </RNGestureHandlerButton>
+        </View>
+        <View
+          style={
+            Object {
+              "paddingRight": 14,
+            }
+          }
+        >
+          <View
+            accessibilityHint="Returns to the edition"
+            accessibilityLabel="Close button"
+            accessibilityRole="button"
+            accessible={true}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 10,
+                "left": 10,
+                "right": 10,
+                "top": 10,
+              }
+            }
+            isTVSelectable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 999,
+                    "height": 42,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 21,
+                  },
+                  Object {
+                    "backgroundColor": "#ffe500",
+                  },
+                  Object {
+                    "alignItems": "center",
+                    "aspectRatio": 1,
+                    "justifyContent": "center",
+                    "paddingHorizontal": 0,
+                    "width": 42,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "GuardianIcons-Regular",
+                      "fontSize": 20,
+                      "lineHeight": 20,
+                    },
+                    Array [
+                      Object {
+                        "color": "#121212",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`IssuePickerHeader should match the default style with a subTitle 1`] = `
 <View
   style={
     Array [

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -437,7 +437,7 @@ export const HomeScreen = () => {
     const { issueSummary, error } = useIssueSummary()
     return (
         <WithAppAppearance value={'tertiary'}>
-            <IssuePickerHeader />
+            <IssuePickerHeader title="Recent" subTitle="Editions" />
             {issueSummary ? (
                 <IssueListFetchContainer />
             ) : error ? (


### PR DESCRIPTION
## Summary
This provides support for the `IssuePickerHeader` to have `title` and `subTitle` passed into it. This is required for the Editions work to customise the Issue Picker

[**Trello Card ->**](https://trello.com/c/CwmvTcT7/1397-changes-to-headers-on-fronts-and-issue-picker-screen)