### PR TITLE
feat: Editions Menu ready for wiring up

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -578,7 +578,7 @@ export interface RegionalEdition {
 export interface SpecialEdition {
     buttonStyle: SpecialEditionButtonStyles
     devUri?: string
-    edition: string
+    edition: Edition
     expiry: Date
     headerStyle?: SpecialEditionHeaderStyles
     image: Image

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -2,39 +2,22 @@ import React from 'react'
 import { storiesOf } from '@storybook/react-native'
 import { withKnobs } from '@storybook/addon-knobs'
 import { EditionsMenu } from './EditionsMenu'
-
-const mockNavigation = {
-    state: { params: {} },
-    dispatch: () => true,
-    goBack: () => true,
-    dismiss: () => true,
-    navigate: () => true,
-    openDrawer: () => true,
-    closeDrawer: () => true,
-    toggleDrawer: () => true,
-    getParam: () => true,
-    setParams: () => true,
-    addListener: () => ({ remove: () => {} }),
-    push: () => true,
-    replace: () => true,
-    pop: () => true,
-    popToTop: () => true,
-    isFocused: () => true,
-    reset: () => true,
-    isFirstRouteInParent: () => true,
-    dangerouslyGetParent: () => undefined,
-}
+import { editions, Edition } from 'src/common'
 
 const props = {
     specialEditions: [
         {
-            edition: '',
+            edition: 'daily-edition' as Edition,
             expiry: new Date(98, 1),
             devUri:
                 'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
             image: {
                 source: 'media',
                 path: '/path/to/image',
+            },
+            header: {
+                title: `Food
+Monthly`,
             },
             title: `Food
 Monthly`,
@@ -73,8 +56,17 @@ Monthly`,
 storiesOf('EditionsMenu', module)
     .addDecorator(withKnobs)
     .add('EditionsMenu - default', () => (
-        <EditionsMenu navigation={mockNavigation} />
+        <EditionsMenu
+            navigationPress={() => {}}
+            selectedEdition={editions.daily}
+            storeSelectedEdition={() => {}}
+        />
     ))
     .add('EditionsMenu - with Special Edition', () => (
-        <EditionsMenu navigation={mockNavigation} {...props} />
+        <EditionsMenu
+            navigationPress={() => {}}
+            selectedEdition={editions.daily}
+            storeSelectedEdition={() => {}}
+            {...props}
+        />
     ))

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,34 +1,34 @@
 import React from 'react'
 import { FlatList, ScrollView } from 'react-native'
+import {
+    RegionalEdition,
+    SpecialEdition,
+    Edition,
+} from '../../../../Apps/common/src'
+import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults'
 import { EditionsMenuHeader } from './Header/Header'
+import { ItemSeperator } from './ItemSeperator/ItemSeperator'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
-import { RegionalEdition, SpecialEdition } from '../../../../Apps/common/src'
-import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults'
-import { ItemSeperator } from './ItemSeperator/ItemSeperator'
-import { NavigationScreenProp } from 'react-navigation'
-import { useApolloClient } from '@apollo/react-hooks'
-import { setEdition } from 'src/helpers/settings/setters'
-import { routeNames } from 'src/navigation/routes'
-import { useEdition } from 'src/hooks/use-settings'
 
 const EditionsMenu = ({
-    navigation,
-    regionalEdtions,
+    navigationPress,
+    regionalEditions,
+    selectedEdition,
     specialEditions,
+    storeSelectedEdition,
 }: {
-    navigation: NavigationScreenProp<{}>
-    regionalEdtions?: RegionalEdition[]
+    navigationPress: () => void
+    regionalEditions?: RegionalEdition[]
+    selectedEdition: Edition
     specialEditions?: SpecialEdition[]
+    storeSelectedEdition: (edition: Edition) => void
 }) => {
-    const client = useApolloClient()
-    const selectedEdition = useEdition()
-
     return (
         <ScrollView>
             <EditionsMenuHeader>Regions</EditionsMenuHeader>
             <FlatList
-                data={regionalEdtions || defaultRegionalEditions}
+                data={regionalEditions || defaultRegionalEditions}
                 renderItem={({ item }: { item: RegionalEdition }) => {
                     return (
                         <RegionButton
@@ -36,8 +36,8 @@ const EditionsMenu = ({
                                 selectedEdition === item.edition ? true : false
                             }
                             onPress={() => {
-                                setEdition(client, item.edition)
-                                navigation.navigate(routeNames.Issue)
+                                storeSelectedEdition(item.edition)
+                                navigationPress()
                             }}
                             title={item.title}
                             subTitle={item.subTitle}
@@ -46,13 +46,13 @@ const EditionsMenu = ({
                 }}
                 ItemSeparatorComponent={() => <ItemSeperator />}
             />
-            {specialEditions && (
+            {specialEditions && specialEditions.length > 0 && (
                 <>
                     <EditionsMenuHeader>Special Editions</EditionsMenuHeader>
                     <FlatList
                         data={specialEditions}
-                        renderItem={({
-                            item: {
+                        renderItem={({ item }: { item: SpecialEdition }) => {
+                            const {
                                 buttonStyle,
                                 devUri,
                                 edition,
@@ -60,20 +60,22 @@ const EditionsMenu = ({
                                 image,
                                 title,
                                 subTitle,
-                            },
-                        }: {
-                            item: SpecialEdition
-                        }) => {
+                            } = item
                             return (
                                 <SpecialEditionButton
                                     devUri={devUri}
                                     expiry={expiry}
                                     image={image}
                                     onPress={() => {
-                                        setEdition(client, edition)
-                                        navigation.navigate(routeNames.Issue)
+                                        storeSelectedEdition(edition)
+                                        navigationPress()
                                     }}
                                     title={title}
+                                    selected={
+                                        selectedEdition === edition
+                                            ? true
+                                            : false
+                                    }
                                     style={buttonStyle}
                                     subTitle={subTitle}
                                 />

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
 import { FlatList, ScrollView } from 'react-native'
-import {
-    RegionalEdition,
-    SpecialEdition,
-    Edition,
-} from '../../../../Apps/common/src'
+import { RegionalEdition, SpecialEdition, Edition } from 'src/common'
 import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults'
 import { EditionsMenuHeader } from './Header/Header'
 import { ItemSeperator } from './ItemSeperator/ItemSeperator'

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -1,38 +1,22 @@
 import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
-import { Edition, editions } from '../../../../../Apps/common/src'
+import { Edition, editions } from 'src/common'
 import { EditionsMenu } from '../EditionsMenu'
 
-jest.mock('src/components/front/image-resource', () => ({
-    ImageResource: () => 'ImageResource',
+jest.mock('src/components/EditionsMenu/RegionButton/RegionButton', () => ({
+    RegionButton: () => 'RegionButton',
 }))
 
-jest.mock('@apollo/react-hooks', () => ({
-    useApolloClient: () => jest.fn(),
-    useQuery: () => ({ data: 'something' }),
-}))
+jest.mock(
+    'src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton',
+    () => ({
+        SpecialEditionButton: () => 'SpecialEditionButton',
+    }),
+)
 
-const mockNavigation = {
-    state: { params: {} },
-    dispatch: jest.fn(),
-    goBack: jest.fn(),
-    dismiss: jest.fn(),
-    navigate: jest.fn(),
-    openDrawer: jest.fn(),
-    closeDrawer: jest.fn(),
-    toggleDrawer: jest.fn(),
-    getParam: jest.fn(),
-    setParams: jest.fn(),
-    addListener: jest.fn(),
-    push: jest.fn(),
-    replace: jest.fn(),
-    pop: jest.fn(),
-    popToTop: jest.fn(),
-    isFocused: jest.fn(),
-    reset: jest.fn(),
-    isFirstRouteInParent: jest.fn(),
-    dangerouslyGetParent: jest.fn(),
-}
+jest.mock('src/components/EditionsMenu/Header/Header', () => ({
+    EditionsMenuHeader: () => 'EditionsMenuHeader',
+}))
 
 const regionalEditions = [
     {
@@ -65,7 +49,7 @@ const regionalEditions = [
 
 const specialEditions = [
     {
-        edition: '',
+        edition: 'daily-edition' as Edition,
         expiry: new Date(98, 1),
         image: {
             source: 'media',
@@ -74,6 +58,10 @@ const specialEditions = [
         title: `Food
 Monthly`,
         subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+        header: {
+            title: 'Food',
+            subTitle: 'Monthly',
+        },
         buttonStyle: {
             backgroundColor: '#FEEEF7',
             expiry: {
@@ -103,28 +91,28 @@ Monthly`,
     },
 ]
 
+const props = {
+    navigationPress: () => {},
+    selectedEdition: editions.daily,
+    storeSelectedEdition: () => {},
+}
+
 describe('EditionsMenu', () => {
     it('should display a default EditionsMenu with correct styling and default Regional Buttons', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu navigation={mockNavigation} />,
+            <EditionsMenu {...props} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should display a EditionsMenu with correct styling and alternative Regional Buttons', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu
-                navigation={mockNavigation}
-                regionalEdtions={regionalEditions}
-            />,
+            <EditionsMenu {...props} regionalEditions={regionalEditions} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
     it('should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <EditionsMenu
-                navigation={mockNavigation}
-                specialEditions={specialEditions}
-            />,
+            <EditionsMenu {...props} specialEditions={specialEditions} />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -3,51 +3,7 @@
 exports[`EditionsMenu should display a EditionsMenu with correct styling and alternative Regional Buttons 1`] = `
 <RCTScrollView>
   <View>
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "marginBottom": 4,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "backgroundColor": "white",
-            "paddingBottom": 38,
-            "paddingLeft": 96,
-            "paddingTop": 4,
-            "shadowColor": "#121212",
-            "shadowOffset": Object {
-              "height": 4,
-              "width": 0,
-            },
-            "shadowOpacity": 0.1,
-            "shadowRadius": 4,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "flexShrink": 0,
-                "fontFamily": "GTGuardianTitlepiece-Bold",
-                "fontSize": 30,
-                "lineHeight": 33,
-              },
-              Object {
-                "fontSize": 24,
-                "lineHeight": 30,
-              },
-            ]
-          }
-        >
-          Regions
-        </Text>
-      </View>
-    </View>
+    EditionsMenuHeader
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
       data={
@@ -108,60 +64,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="The UK Daily Edition - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              The UK Daily Edition
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every day by 12am (GMT)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -175,60 +78,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="Australia Daily - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              Australia Daily
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every day by 9:30am (AEST)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -242,60 +92,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="US and Cananda Weekend - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              US and Cananda Weekend
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every Saturday by 8am (EST)
-            </Text>
-          </View>
+          RegionButton
         </View>
       </View>
     </RCTScrollView>
@@ -306,51 +103,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
 exports[`EditionsMenu should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button 1`] = `
 <RCTScrollView>
   <View>
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "marginBottom": 4,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "backgroundColor": "white",
-            "paddingBottom": 38,
-            "paddingLeft": 96,
-            "paddingTop": 4,
-            "shadowColor": "#121212",
-            "shadowOffset": Object {
-              "height": 4,
-              "width": 0,
-            },
-            "shadowOpacity": 0.1,
-            "shadowRadius": 4,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "flexShrink": 0,
-                "fontFamily": "GTGuardianTitlepiece-Bold",
-                "fontSize": 30,
-                "lineHeight": 33,
-              },
-              Object {
-                "fontSize": 24,
-                "lineHeight": 30,
-              },
-            ]
-          }
-        >
-          Regions
-        </Text>
-      </View>
-    </View>
+    EditionsMenuHeader
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
       data={
@@ -414,61 +167,7 @@ by 6am (EST)",
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="The Daily - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              The Daily
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every morning
-by 6am (GMT)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -482,61 +181,7 @@ by 6am (GMT)
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="Australia Weekender - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              Australia Weekender
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every Saturday morning 
-by 6am (AEST)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -550,109 +195,11 @@ by 6am (AEST)
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="US Weekender - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              US Weekender
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every Saturday morning 
-by 6am (EST)
-            </Text>
-          </View>
+          RegionButton
         </View>
       </View>
     </RCTScrollView>
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "marginBottom": 4,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "backgroundColor": "white",
-            "paddingBottom": 38,
-            "paddingLeft": 96,
-            "paddingTop": 4,
-            "shadowColor": "#121212",
-            "shadowOffset": Object {
-              "height": 4,
-              "width": 0,
-            },
-            "shadowOpacity": 0.1,
-            "shadowRadius": 4,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "flexShrink": 0,
-                "fontFamily": "GTGuardianTitlepiece-Bold",
-                "fontSize": 30,
-                "lineHeight": 33,
-              },
-              Object {
-                "fontSize": 24,
-                "lineHeight": 30,
-              },
-            ]
-          }
-        >
-          Special Editions
-        </Text>
-      </View>
-    </View>
+    EditionsMenuHeader
     <RCTScrollView
       data={
         Array [
@@ -682,8 +229,12 @@ by 6am (EST)
                 "size": 34,
               },
             },
-            "edition": "",
+            "edition": "daily-edition",
             "expiry": 1998-02-01T00:00:00.000Z,
+            "header": Object {
+              "subTitle": "Monthly",
+              "title": "Food",
+            },
             "image": Object {
               "path": "/path/to/image",
               "source": "media",
@@ -722,83 +273,7 @@ Monthly",
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="Food
-Monthly - Special Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#FEEEF7",
-                "flexDirection": "row",
-                "paddingTop": 12,
-              }
-            }
-          >
-            ImageResource
-            <View
-              style={
-                Object {
-                  "flexShrink": 1,
-                  "paddingBottom": 15,
-                  "paddingLeft": 10,
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "color": "#121212",
-                    "flexWrap": "wrap",
-                    "fontFamily": "GHGuardianHeadline-Regular",
-                    "fontSize": 34,
-                    "lineHeight": 34,
-                  }
-                }
-              >
-                Food
-Monthly
-              </Text>
-              <Text
-                style={
-                  Object {
-                    "color": "#7D0068",
-                    "flexWrap": "wrap",
-                    "fontFamily": "GuardianTextSans-Bold",
-                    "fontSize": 17,
-                    "lineHeight": 20,
-                    "marginTop": 10,
-                  }
-                }
-              >
-                Store cupboard special: 20 quick and easy lockdown suppers
-              </Text>
-              <Text
-                style={
-                  Object {
-                    "color": "#7D0068",
-                    "flexWrap": "wrap",
-                    "fontFamily": "GuardianTextSans-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 16,
-                    "marginTop": 8,
-                  }
-                }
-              >
-                Available until
-                 
-                2/1/1998
-              </Text>
-            </View>
-          </View>
+          SpecialEditionButton
         </View>
       </View>
     </RCTScrollView>
@@ -809,51 +284,7 @@ Monthly
 exports[`EditionsMenu should display a default EditionsMenu with correct styling and default Regional Buttons 1`] = `
 <RCTScrollView>
   <View>
-    <View
-      style={
-        Object {
-          "flex": 1,
-          "marginBottom": 4,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "backgroundColor": "white",
-            "paddingBottom": 38,
-            "paddingLeft": 96,
-            "paddingTop": 4,
-            "shadowColor": "#121212",
-            "shadowOffset": Object {
-              "height": 4,
-              "width": 0,
-            },
-            "shadowOpacity": 0.1,
-            "shadowRadius": 4,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "flexShrink": 0,
-                "fontFamily": "GTGuardianTitlepiece-Bold",
-                "fontSize": 30,
-                "lineHeight": 33,
-              },
-              Object {
-                "fontSize": 24,
-                "lineHeight": 30,
-              },
-            ]
-          }
-        >
-          Regions
-        </Text>
-      </View>
-    </View>
+    EditionsMenuHeader
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
       data={
@@ -917,61 +348,7 @@ by 6am (EST)",
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="The Daily - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              The Daily
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every morning
-by 6am (GMT)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -985,61 +362,7 @@ by 6am (GMT)
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="Australia Weekender - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              Australia Weekender
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every Saturday morning 
-by 6am (AEST)
-            </Text>
-          </View>
+          RegionButton
           <View
             style={
               Object {
@@ -1053,61 +376,7 @@ by 6am (AEST)
           onLayout={[Function]}
           style={null}
         >
-          <View
-            accessibilityLabel="US Weekender - Regional Edition Button"
-            accessibilityRole="button"
-            accessible={true}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "backgroundColor": "#f6f6f6",
-                "paddingBottom": 32,
-                "paddingLeft": 96,
-                "paddingTop": 4,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "flexShrink": 0,
-                    "fontFamily": "GTGuardianTitlepiece-Bold",
-                    "fontSize": 30,
-                    "lineHeight": 33,
-                  },
-                  Object {
-                    "color": "#052962",
-                    "fontSize": 20,
-                    "lineHeight": 24,
-                    "marginBottom": 5,
-                  },
-                ]
-              }
-            >
-              US Weekender
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#121212",
-                  "fontFamily": "GuardianTextSans-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 18,
-                }
-              }
-            >
-              Published every Saturday morning 
-by 6am (EST)
-            </Text>
-          </View>
+          RegionButton
         </View>
       </View>
     </RCTScrollView>

--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -1,11 +1,15 @@
+import { useApolloClient } from '@apollo/react-hooks'
 import React, { ReactElement } from 'react'
+import { StyleSheet, View } from 'react-native'
 import { NavigationScreenProp } from 'react-navigation'
+import { Edition, editions } from 'src/common'
 import { EditionsMenu } from 'src/components/EditionsMenu/EditionsMenu'
 import { EditionsMenuScreenHeader } from 'src/components/layout/header/header'
+import { setEdition } from 'src/helpers/settings/setters'
+import { useEdition } from 'src/hooks/use-settings'
 import { routeNames } from 'src/navigation/routes'
 import { WithAppAppearance } from 'src/theme/appearance'
 import { ApiState } from './settings/api-screen'
-import { View, StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({
     screenFiller: {
@@ -23,6 +27,9 @@ export const EditionsMenuScreen = ({
 }: {
     navigation: NavigationScreenProp<{}>
 }) => {
+    const edition = useEdition()
+    const client = useApolloClient()
+
     return (
         <WithAppAppearance value="default">
             <ScreenFiller>
@@ -33,7 +40,15 @@ export const EditionsMenuScreen = ({
                         }
                     />
 
-                    <EditionsMenu navigation={navigation} />
+                    <EditionsMenu
+                        navigationPress={() =>
+                            navigation.navigate(routeNames.Issue)
+                        }
+                        selectedEdition={(edition as Edition) || editions.daily}
+                        storeSelectedEdition={(edition: Edition) =>
+                            setEdition(client, edition)
+                        }
+                    />
                     <ApiState />
                 </>
             </ScreenFiller>


### PR DESCRIPTION
## Summary
Again in the spirit of breaking up my mega PR into smaller bits, this does the work to move `EditionsMenu` to a presentational component and move the hooks up to the parent.

I have also mocked out child components in the tests to make the snapshots smaller. When `RegionButton` changes, we don't need to see a snapshot change in a parent component like this, we just ensure the API is maintained through TS giving better hierarchical snapshot tests.