### PR TITLE
chore: Remove RN Screens

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -367,8 +367,6 @@ PODS:
     - React
   - RNPermissions (2.0.3):
     - React
-  - RNScreens (2.0.0-alpha.34):
-    - React
   - RNSentry (1.4.5):
     - React
     - Sentry (~> 5.1.4)
@@ -442,7 +440,6 @@ DEPENDENCIES:
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
-  - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNZipArchive (from `../node_modules/react-native-zip-archive`)
@@ -575,8 +572,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-localize"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
-  RNScreens:
-    :path: "../node_modules/react-native-screens"
   RNSentry:
     :path: "../node_modules/@sentry/react-native"
   RNSVG:
@@ -657,7 +652,6 @@ SPEC CHECKSUMS:
   RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
-  RNScreens: 9d8a2900cd4f967af70dbfed74b64f77fbb6600a
   RNSentry: 0a70359ddacbfb9b1cbbb0971e54065b9f70ac57
   RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
   RNZipArchive: 87111bb6130a38edd68c8d2059d46ac94d53ffe4

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -81,7 +81,6 @@
         "react-native-progress-circle": "^2.1.0",
         "react-native-push-notification": "^3.5.2",
         "react-native-safe-area-context": "^0.6.4",
-        "react-native-screens": "^2.0.0-alpha.34",
         "react-native-splash-screen": "^3.2.0",
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.12.0",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -5,8 +5,7 @@
 import { ApolloProvider } from '@apollo/react-hooks'
 import AsyncStorage from '@react-native-community/async-storage'
 import React from 'react'
-import { AppState, Platform, StatusBar, StyleSheet, View } from 'react-native'
-import { enableScreens } from 'react-native-screens'
+import { AppState, StatusBar, StyleSheet, View } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
 import { NavigationState } from 'react-navigation'
 import { NavPositionProvider } from 'src/hooks/use-nav-position'
@@ -61,9 +60,6 @@ loggingService.init(apolloClient)
 remoteConfigService.init()
 
 // --- SETUP OPERATIONS ---
-// useScreens is not a hook
-// eslint-disable-next-line react-hooks/rules-of-hooks
-Platform.OS === 'ios' && enableScreens()
 pushNotifcationRegistration(apolloClient)
 prepFileSystem()
 

--- a/projects/Mallard/src/navigation/navigators/sidebar.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar.tsx
@@ -13,8 +13,6 @@ import {
     NavigationRouteConfig,
     NavigationTransitionProps,
 } from 'react-navigation'
-const createNativeStackNavigator = require('react-native-screens/createNativeStackNavigator')
-    .default
 import { ariaHidden } from 'src/helpers/a11y'
 import { supportsAnimation } from 'src/helpers/features'
 import { safeInterpolation } from 'src/helpers/math'
@@ -135,18 +133,6 @@ export const createSidebarNavigator = (
                 () => animatedValue,
             )
         }
-    }
-
-    // -iOS12 only use Native navigator
-    if (!supportsAnimation()) {
-        return createNativeStackNavigator(navigation, {
-            initialRouteName: '_',
-            defaultNavigationOptions: {
-                gesturesEnabled: false,
-            },
-            headerMode: 'none',
-            mode: 'card',
-        })
     }
 
     const transitionConfig = (transitionProps: NavigationTransitionProps) => {

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11107,13 +11107,6 @@ react-native-safe-area-view@^0.14.1:
   dependencies:
     debounce "^1.2.0"
 
-react-native-screens@^2.0.0-alpha.34:
-  version "2.0.0-alpha.34"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.34.tgz#41c689f81a5272fd6fbd00155b6ec254dae60b52"
-  integrity sha512-O5h8S9rc25QCfWZ9NA6tBn7Wr6a3GsswI+MdtAbwpjXOkQ6ShN8mK/ROzN4Ls2HipWMVSi/1Mz6iuVhNlayJWw==
-  dependencies:
-    debounce "^1.2.0"
-
 react-native-splash-screen@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"


### PR DESCRIPTION
## Summary
Crashes in Sentry seem to be related to React Native Screens. This was only required for iOS9.

It was in before the iOS9 work which suggests its implementation was there for performance reasons. So we will need to keep an eye on if there are many crashes due to memory