### PR TITLE
Fix small phone styling issues. Drop card height

### DIFF
--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -1,12 +1,11 @@
 import {
     css,
     generateAssetsFontCss,
-    getScaledFont,
     getScaledFontCss,
     px,
 } from 'src/helpers/webview'
 import { metrics } from 'src/theme/spacing'
-import { families } from 'src/theme/typography'
+import { families, getScaledFont } from 'src/theme/typography'
 import { headerStyles } from './components/header'
 import { imageStyles } from './components/images'
 import { lineStyles } from './components/line'
@@ -161,7 +160,7 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         .content-wrap {
             padding-left: ${px(metrics.article.sides)};
             padding-right: ${px(metrics.article.sides)};
-    
+
         }
     }
 

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -1,6 +1,6 @@
-import { Platform, PixelRatio } from 'react-native'
+import { Platform } from 'react-native'
 import { bundles } from 'src/html-bundle-info.json'
-import { getFont, FontSizes, FontFamily } from 'src/theme/typography'
+import { getScaledFont, FontSizes, FontFamily } from 'src/theme/typography'
 
 export type WebViewPing =
     | {
@@ -37,18 +37,6 @@ export const css = passthrough
 export const html = passthrough
 
 export const px = (value: string | number) => `${value}px`
-
-export const getScaledFont = <F extends FontFamily>(
-    family: F,
-    level: FontSizes<F>,
-) => {
-    const font = getFont(family, level)
-    return {
-        ...font,
-        lineHeight: font.lineHeight * PixelRatio.getFontScale(),
-        fontSize: font.fontSize * PixelRatio.getFontScale(),
-    }
-}
 
 export const getScaledFontCss = <F extends FontFamily>(
     family: F,

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -41,7 +41,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 530), // height should be 500 pending shorter headlines in production
+        cardSize: toSize(540, 500), // height should be 500 pending shorter headlines in production
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -41,7 +41,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 500),
+        cardSize: toSize(540, 520), // height should really be 500
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -41,7 +41,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 500), // height should be 500 pending shorter headlines in production
+        cardSize: toSize(540, 500),
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -1,5 +1,5 @@
 import { pickClosestBreakpoint, Breakpoints } from './breakpoints'
-import { Dimensions } from 'react-native'
+import { Dimensions, PixelRatio } from 'react-native'
 import { BreakpointList } from 'src/theme/breakpoints'
 
 export const families = {
@@ -83,8 +83,8 @@ const scale = {
     text: {
         0.9: {
             [Breakpoints.smallPhone]: {
-                fontSize: 15,
-                lineHeight: 17,
+                fontSize: 14,
+                lineHeight: 15,
             },
             [Breakpoints.phone]: {
                 fontSize: 15,
@@ -198,8 +198,8 @@ const scale = {
         },
         1.5: {
             [Breakpoints.smallPhone]: {
-                fontSize: 24,
-                lineHeight: 26,
+                fontSize: 20,
+                lineHeight: 22,
             },
             [Breakpoints.phone]: {
                 fontSize: 24,
@@ -371,5 +371,17 @@ export const getFont = <F extends FontFamily>(
     return {
         fontFamily: families[family][weight],
         ...applyScale(fontAtLevel),
+    }
+}
+
+export const getScaledFont = <F extends FontFamily>(
+    family: F,
+    level: FontSizes<F>,
+) => {
+    const font = getFont(family, level)
+    return {
+        ...font,
+        lineHeight: font.lineHeight * PixelRatio.getFontScale(),
+        fontSize: font.fontSize * PixelRatio.getFontScale(),
     }
 }


### PR DESCRIPTION

## Summary

This PR:
 - reduces headline font size on the smallPhone breakpoint to 20pt
 - reduces the trail text size to 14pt on smallPhones
 - implements a max card height of 520px, down from 530. In the designs this was originally 500px, baby steps... I have checked through one edition and I don't think this is a problem

The main motivation is to stop text overflow on small phones, and reduce the large space that sometimes appears below cover cards (to fix it completely we need taller cover cards)

I've also moved the `getScaledFont` function out of webview as it's not really got anything to do with webviews (though that's the main place it's used at the moment)

Before:
<img width="1405" alt="Screenshot 2020-07-02 at 13 42 59" src="https://user-images.githubusercontent.com/3606555/86360632-87da3000-bc6a-11ea-990d-4a14f01d9139.png">
<img width="1394" alt="Screenshot 2020-07-02 at 13 40 57" src="https://user-images.githubusercontent.com/3606555/86360713-a7715880-bc6a-11ea-8dab-60d1b2431b43.png">

After:
<img width="1400" alt="Screenshot 2020-07-02 at 13 26 04" src="https://user-images.githubusercontent.com/3606555/86360762-be17af80-bc6a-11ea-8741-450754dc69af.png">
<img width="1400" alt="Screenshot 2020-07-02 at 14 54 08" src="https://user-images.githubusercontent.com/3606555/86582524-a9dcf680-bf79-11ea-8b02-f20dd2360826.png">


[**Trello Card ->**](https://trello.com/c/z2kykKjb/1171-5s-cover-cards-draw-extra-padding)

## Test Plan
Lots of scrolling through fronts on as many devices as possible and checking for overflow text!