### PR TITLE
Stop using twoStoryPageWithSidekick (backend)

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -71,39 +71,33 @@ const defaultLayout = (
     cover: FrontCardAppearanceShort = 1,
     visual = false,
 ): FrontCardsForArticleCount => {
-    const [twoStories, threeStories]: [
-        FrontCardAppearanceShort,
-        FrontCardAppearanceShort,
-    ] = visual
-        ? [
-              FrontCardAppearance.twoStoryPageWithSidekick,
-              FrontCardAppearance.threeStoryPageWithSidekick,
-          ]
-        : [2, 3]
+    const threeStories: FrontCardAppearanceShort = visual
+        ? FrontCardAppearance.threeStoryPageWithSidekick
+        : 3
 
     return {
         0: [],
         1: [cover],
         2: [cover, 1],
-        3: [cover, twoStories],
+        3: [cover, 2],
         4: [cover, threeStories],
         5: [cover, 4],
         6: [cover, 5],
-        7: [cover, twoStories, 4],
+        7: [cover, 2, 4],
         8: [cover, threeStories, 4],
         9: [cover, threeStories, 5],
         10: [cover, 4, 5],
-        11: [cover, twoStories, 3, 5],
-        12: [cover, twoStories, 4, 5],
+        11: [cover, 2, 3, 5],
+        12: [cover, 2, 4, 5],
         13: [cover, threeStories, 4, 5],
         14: [cover, threeStories, 4, 6],
-        15: [cover, twoStories, 3, 4, 5],
-        16: [cover, twoStories, 3, 4, 6],
-        17: [cover, twoStories, 3, 5, 6],
-        18: [cover, twoStories, 4, 5, 6],
-        19: [cover, twoStories, 4, 5, 6],
-        20: [cover, twoStories, 4, 1, 5, 6],
-        21: [cover, twoStories, 3, 4, 5, 6],
+        15: [cover, 2, 3, 4, 5],
+        16: [cover, 2, 3, 4, 6],
+        17: [cover, 2, 3, 5, 6],
+        18: [cover, 2, 4, 5, 6],
+        19: [cover, 2, 4, 5, 6],
+        20: [cover, 2, 4, 1, 5, 6],
+        21: [cover, 2, 3, 4, 5, 6],
         22: [cover, threeStories, 4, 3, 5, 6],
         23: [cover, threeStories, 4, 5, 4, 6],
         24: [cover, threeStories, 5, 4, 5, 6],
@@ -115,39 +109,33 @@ const thirdPageCoverLayout = (
     cover: FrontCardAppearanceShort = 1,
     visual = false,
 ): FrontCardsForArticleCount => {
-    const [twoStories, threeStories]: [
-        FrontCardAppearanceShort,
-        FrontCardAppearanceShort,
-    ] = visual
-        ? [
-              FrontCardAppearance.twoStoryPageWithSidekick,
-              FrontCardAppearance.threeStoryPageWithSidekick,
-          ]
-        : [2, 3]
+    const threeStories: FrontCardAppearanceShort = visual
+        ? FrontCardAppearance.threeStoryPageWithSidekick
+        : 3
 
     return {
         0: [],
         1: [cover],
         2: [cover, 1],
-        3: [cover, twoStories],
+        3: [cover, 2],
         4: [cover, threeStories],
         5: [cover, 4],
         6: [cover, 5],
-        7: [cover, twoStories, cover, 3],
+        7: [cover, 2, cover, 3],
         8: [cover, threeStories, cover, 3],
         9: [cover, threeStories, cover, 4],
         10: [cover, 4, cover, 4],
-        11: [cover, twoStories, cover, 2, 5],
-        12: [cover, twoStories, cover, 3, 5],
+        11: [cover, 2, cover, 2, 5],
+        12: [cover, 2, cover, 3, 5],
         13: [cover, 3, cover, 3, 5],
         14: [cover, 3, cover, 3, 6],
-        15: [cover, twoStories, cover, 2, 4, 5],
-        16: [cover, twoStories, cover, 2, 4, 6],
-        17: [cover, twoStories, cover, 2, 5, 6],
-        18: [cover, twoStories, cover, 3, 5, 6],
+        15: [cover, 2, cover, 2, 4, 5],
+        16: [cover, 2, cover, 2, 4, 6],
+        17: [cover, 2, cover, 2, 5, 6],
+        18: [cover, 2, cover, 3, 5, 6],
         19: [cover, threeStories, cover, 3, 5, 6],
         20: [cover, threeStories, cover, 3, 1, 5, 6],
-        21: [cover, twoStories, cover, 2, 4, 5, 6],
+        21: [cover, 2, cover, 2, 4, 5, 6],
         22: [cover, threeStories, cover, 3, 3, 5, 6],
         23: [cover, threeStories, cover, 3, 5, 4, 6],
         24: [cover, threeStories, cover, 4, 4, 5, 6],


### PR DESCRIPTION
## Summary

This kind of card:

<img width="333" alt="Screenshot 2020-07-02 at 17 29 52" src="https://user-images.githubusercontent.com/3606555/86386548-cf23e900-bc89-11ea-88a8-4c9d688905d1.png">

Is no longer required. This change modifies the backend so that future issues will no longer contain this card type. In a month we can then remove the associated code to render them client side (probably not that much code as we still have `threeStoryPageWithSidekick`)

These cards now look like this:
<img width="404" alt="Screenshot 2020-07-02 at 17 30 43" src="https://user-images.githubusercontent.com/3606555/86386528-c92e0800-bc89-11ea-9982-6694326ef122.png">

[**Trello Card ->**](https://trello.com/c/PSX1xC1X/1286-easy-win-get-rid-of-front-card-with-hed-on-square)

## Test Plan
Release, check out 2 story cards in top stories/news containers. The above card is in the coronavirus front of issue sunday 28 June 2020
