### PR TITLE
Accessibility: Tell users using screen readers that the buttons on the Settings are buttons pam_accessibility_buttons

### DIFF
--- a/projects/Mallard/src/components/lists/DualButton.tsx
+++ b/projects/Mallard/src/components/lists/DualButton.tsx
@@ -3,7 +3,6 @@ import { Text, View, AccessibilityRole } from 'react-native'
 import { Highlight } from '../highlight'
 import { UiBodyCopy } from '../styled-text'
 import { styles } from './styles'
-import { boolean } from '@storybook/addon-knobs'
 
 const DualButton = ({
     textPrimary,

--- a/projects/Mallard/src/components/lists/DualButton.tsx
+++ b/projects/Mallard/src/components/lists/DualButton.tsx
@@ -1,21 +1,30 @@
 import React from 'react'
-import { Text, View } from 'react-native'
+import { Text, View, AccessibilityRole } from 'react-native'
 import { Highlight } from '../highlight'
 import { UiBodyCopy } from '../styled-text'
 import { styles } from './styles'
+import { boolean } from '@storybook/addon-knobs'
 
 const DualButton = ({
     textPrimary,
     textSecondary,
     onPressPrimary,
     onPressSecondary,
+    accessible = true,
+    accessibilityRole = 'none',
 }: {
     textPrimary: string
     textSecondary: string
     onPressPrimary: () => void
     onPressSecondary: () => void
+    accessible: boolean
+    accessibilityRole: AccessibilityRole
 }) => (
-    <View style={styles.buttonContainer}>
+    <View
+        style={styles.buttonContainer}
+        accessible={accessible}
+        accessibilityRole={accessibilityRole}
+    >
         <Highlight
             style={[styles.button, styles.buttonPrimary]}
             onPress={onPressPrimary}

--- a/projects/Mallard/src/components/lists/FullButton.tsx
+++ b/projects/Mallard/src/components/lists/FullButton.tsx
@@ -3,15 +3,25 @@ import { Highlight } from '../highlight'
 import { RightChevron } from '../icons/RightChevron'
 import { UiBodyCopy } from '../styled-text'
 import { styles } from './styles'
+import { AccessibilityRole } from 'react-native'
 
 const FullButton = ({
     onPress,
     text,
+    accessible = true,
+    accessibilityRole = 'none',
 }: {
     onPress: () => void
     text: string
+    accessible: boolean
+    accessibilityRole: AccessibilityRole
 }) => (
-    <Highlight style={styles.button} onPress={onPress}>
+    <Highlight
+        style={styles.button}
+        onPress={onPress}
+        accessible={accessible}
+        accessibilityRole={accessibilityRole}
+    >
         <UiBodyCopy weight="bold">{text}</UiBodyCopy>
         <RightChevron />
     </Highlight>

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react'
-import { Alert, Text, Switch, Linking } from 'react-native'
+import { Alert, Text, Switch, Linking, AccessibilityRole } from 'react-native'
 import {
     NavigationInjectedProps,
     NavigationRoute,
@@ -82,15 +82,19 @@ const SignInButton = ({
     username,
     navigation,
     signOutIdentity,
+    accessible = true,
+    accessibilityRole = 'button',
 }: {
     username?: string
     navigation: NavigationScreenProp<NavigationRoute>
     signOutIdentity: () => void
+    accessible: boolean
+    accessibilityRole: AccessibilityRole
 }) =>
     username ? (
         <DualButton
-            accessible={true}
-            accessibilityRole="button"
+            accessible={accessible}
+            accessibilityRole={accessibilityRole}
             textPrimary={username}
             textSecondary="Sign out"
             onPressPrimary={() =>
@@ -103,7 +107,7 @@ const SignInButton = ({
     ) : (
         <FullButton
             accessible={true}
-            accessibilityRole="button"
+            accessibilityRole={accessibilityRole}
             text="Sign in"
             onPress={() => navigation.navigate(routeNames.SignIn)}
         />

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -89,6 +89,8 @@ const SignInButton = ({
 }) =>
     username ? (
         <DualButton
+            accessible={true}
+            accessibilityRole="button"
             textPrimary={username}
             textSecondary="Sign out"
             onPressPrimary={() =>
@@ -100,6 +102,8 @@ const SignInButton = ({
         />
     ) : (
         <FullButton
+            accessible={true}
+            accessibilityRole="button"
             text="Sign in"
             onPress={() => navigation.navigate(routeNames.SignIn)}
         />
@@ -177,6 +181,8 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
         <WithAppAppearance value={'settings'}>
             <ScrollContainer>
                 <SignInButton
+                    accessible={true}
+                    accessibilityRole="button"
                     navigation={navigation}
                     username={
                         identityData


### PR DESCRIPTION
## Summary
Why are we doing this?

_As a user using a screen reader, I want to know that the options on the settings are buttons so that I know that I can tap on it_

**Issues:**
The button options on the Settings do not read 'button', so users might not know that can tap on it to do something. It just reads the title.

[**Trello Card ->**](https://trello.com/c/Gf0d3gck/1380-accessibility-tell-users-using-screen-readers-that-the-buttons-on-the-setttings-are-buttons)

## Test Plan

Switch on VoiceOver on iOS and TalkBack on Android on the device settings. Tap the settings options and check if it's telling users that the options are buttons.

![Screenshot 2020-07-03 at 15 20 30](https://user-images.githubusercontent.com/10372380/86477640-c3472e00-bd40-11ea-8c42-d1aa210c9ea2.png)
