### PR TITLE
Fix login screen when iPad 'floating keyboard' enabled

### DIFF
--- a/projects/Mallard/src/components/login/login-layout.tsx
+++ b/projects/Mallard/src/components/login/login-layout.tsx
@@ -103,8 +103,6 @@ const LoginLayout = ({
     const [avoidKeyboard, setAvoidKeyboard] = useState(true)
 
     const toggleAvoidKeyboard = (e: any) => {
-        console.log(Dimensions.get('window').width, e.endCoordinates.width)
-        // e.endCoordinates.width > 0 &&
         e.endCoordinates.width !== Dimensions.get('window').width
             ? setAvoidKeyboard(false)
             : setAvoidKeyboard(true)


### PR DESCRIPTION
## Summary
iOS 13 introduced a new feature - [floating keyboard](https://support.apple.com/en-gb/HT210758) where users can 'undock' their keyboard and type with one hand. Unfortunately this doesn't play nicely with react native [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) - I found [this](https://stackoverflow.com/questions/59871352/is-is-possible-on-ipad-os-to-detect-if-the-keyboard-is-in-floating-mode) stackoverflow post  complaining about the issue.

This currently results in a login screen that looks like this: 
<img width="200" alt="Screenshot 2020-07-06 at 16 51 20" src="https://user-images.githubusercontent.com/3606555/86613038-f0961500-bfa8-11ea-80e4-9f0c9369e7a3.png">

The only solution for detecting whether the keyboard is floating or not at the moment seems to be to detect the width of the keyboard. This PR does that, and disables the KeyboardAvoidingView if a floating keyboard is detected (only for ios tablets)

[**Trello Card ->**](https://trello.com/c/H4LVXG3Y/1415-unable-to-enter-password-when-trying-to-sign-in-case-01383470)

## Test Plan
Open login screen on ios13 device, type in email, press next and check that screen looks normal and not like that ^^
