### PR TITLE
Fix: correct temperature unit on android

### DIFF
--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -138,11 +138,7 @@ const getWeather = async (
     fallback: Weather | null,
 ): Promise<Weather | null> => {
     try {
-        console.log('LOCALE:', locale)
-        console.log('METRIC:', shouldUseMetric())
-        console.log('RNMetric:', RNLocalize.getTemperatureUnit())
         const { accuLoc, isPrecise } = await getCurrentLocation()
-        const usesMetricTemp = RNLocalize.getTemperatureUnit() === 'celsius'
         const forecasts = await fetchFromWeatherApi<Forecast[]>(
             `forecasts/v1/hourly/12hour/${
                 accuLoc.Key

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -1,5 +1,5 @@
 import { AccuWeatherLocation, Forecast } from 'src/common'
-import { AppState } from 'react-native'
+import { AppState, Platform } from 'react-native'
 import ApolloClient from 'apollo-client'
 import Geolocation, {
     GeolocationResponse,
@@ -8,6 +8,7 @@ import { resolveLocationPermissionStatus } from './location-permission'
 import { RESULTS } from 'react-native-permissions'
 import gql from 'graphql-tag'
 import * as RNLocalize from 'react-native-localize'
+import { locale } from './locale'
 
 class CannotFetchError extends Error {}
 
@@ -121,6 +122,13 @@ const makeWeatherObject = (
     lastUpdated: Date.now(),
 })
 
+const shouldUseMetric = (): boolean => {
+    return Platform.select({
+        ios: RNLocalize.getTemperatureUnit() === 'celsius',
+        android: locale === 'en_US' ? false : true,
+    })
+}
+
 /**
  * We augment the return object with `__typename` fields to that Apollo can
  * "reconcile" the value when we update the cache later. If the weather is
@@ -130,10 +138,15 @@ const getWeather = async (
     fallback: Weather | null,
 ): Promise<Weather | null> => {
     try {
+        console.log('LOCALE:', locale)
+        console.log('METRIC:', shouldUseMetric())
+        console.log('RNMetric:', RNLocalize.getTemperatureUnit())
         const { accuLoc, isPrecise } = await getCurrentLocation()
         const usesMetricTemp = RNLocalize.getTemperatureUnit() === 'celsius'
         const forecasts = await fetchFromWeatherApi<Forecast[]>(
-            `forecasts/v1/hourly/12hour/${accuLoc.Key}.json?metric=${usesMetricTemp}&language=en-gb`,
+            `forecasts/v1/hourly/12hour/${
+                accuLoc.Key
+            }.json?metric=${shouldUseMetric()}&language=en-gb`,
         )
         return makeWeatherObject(accuLoc, isPrecise, forecasts)
     } catch (error) {


### PR DESCRIPTION
## Summary
This PR changes how we decide the temperature unit on android. There is universal way to get user preference for temperature from an android device. This PR applies a simple logic to determine the unit:

1. User device local is the US: unit is F
2. Anything else: unit is C



[**Trello Card ->**](https://trello.com/c/S4pX3YIk/1404-locale-weather-unit-should-be-determined-by-os-settings-for-android)
