### PR TITLE
Fix/lightbox caption fixes

### DIFF
--- a/projects/Mallard/src/components/Lightbox/LightboxCaption.tsx
+++ b/projects/Mallard/src/components/Lightbox/LightboxCaption.tsx
@@ -85,7 +85,7 @@ const LightboxCaption = ({
                     <NativeArrow
                         fill={pillarColor}
                         direction={Direction.top}
-                        marginTop={Platform.OS === 'android' ? 8 : 4}
+                        marginTop={Platform.OS === 'android' ? 10 : 4}
                     />
                 )}
                 <View style={styles.captionText}>

--- a/projects/Mallard/src/components/Lightbox/LightboxCaption.tsx
+++ b/projects/Mallard/src/components/Lightbox/LightboxCaption.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet, View, Platform } from 'react-native'
 import { ArticleTheme } from 'src/components/article/html/article'
 import { NativeArrow } from 'src/components/article/html/components/icon/native-arrow'
 import { themeColors } from 'src/components/article/html/helpers/css'
@@ -10,7 +10,6 @@ import HTMLView from 'react-native-htmlview'
 const styles = StyleSheet.create({
     captionWrapper: {
         fontFamily: families.text.regular,
-        fontSize: 14,
         position: 'absolute',
         zIndex: 1,
         opacity: 0.8,
@@ -23,13 +22,13 @@ const styles = StyleSheet.create({
         color: themeColors(ArticleTheme.Dark).text,
         paddingLeft: 2,
         paddingRight: 13,
-        paddingBottom: 50,
     },
     caption: {
         display: 'flex',
+        flex: 1,
         flexDirection: 'row',
-        paddingTop: 5,
         paddingHorizontal: 10,
+        paddingBottom: 50,
     },
 })
 
@@ -38,6 +37,7 @@ const captionStyleSheet = (pillarColor: string) => {
         caption: {
             fontFamily: families.sans.regular,
             color: themeColors(ArticleTheme.Dark).text,
+            fontSize: Platform.OS === 'android' ? 16 : 14,
         },
         b: {
             fontFamily: families.sans.bold,
@@ -73,7 +73,7 @@ const LightboxCaption = ({
     const captionStyles = captionStyleSheet(pillarColor)
     const captionText = () => {
         if (displayCredit === true && credit) {
-            return caption + '&nbsp' + credit
+            return caption + ' ' + credit
         } else {
             return caption
         }
@@ -82,7 +82,11 @@ const LightboxCaption = ({
         <View style={styles.captionWrapper}>
             <View style={styles.caption}>
                 {caption.length > 1 && (
-                    <NativeArrow fill={pillarColor} direction={Direction.top} />
+                    <NativeArrow
+                        fill={pillarColor}
+                        direction={Direction.top}
+                        marginTop={Platform.OS === 'android' ? 8 : 4}
+                    />
                 )}
                 <View style={styles.captionText}>
                     <HTMLView

--- a/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
+++ b/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
       "backgroundColor": "#121212",
       "bottom": 0,
       "fontFamily": "GuardianTextEgyptian-Reg",
-      "fontSize": 14,
       "opacity": 0.8,
       "padding": 10,
       "position": "absolute",
@@ -20,9 +19,10 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
     style={
       Object {
         "display": "flex",
+        "flex": 1,
         "flexDirection": "row",
+        "paddingBottom": 50,
         "paddingHorizontal": 10,
-        "paddingTop": 5,
       }
     }
   >
@@ -193,7 +193,6 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
       style={
         Object {
           "color": "#ffffff",
-          "paddingBottom": 50,
           "paddingLeft": 2,
           "paddingRight": 13,
         }
@@ -207,6 +206,7 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
             Object {
               "color": "#ffffff",
               "fontFamily": "GuardianTextSans-Regular",
+              "fontSize": 14,
             }
           }
         >
@@ -217,6 +217,7 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
                 Object {
                   "color": "#ffffff",
                   "fontFamily": "GuardianTextSans-Regular",
+                  "fontSize": 14,
                 },
               ]
             }

--- a/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
+++ b/projects/Mallard/src/components/article/html/components/icon/native-arrow.tsx
@@ -5,16 +5,18 @@ import { Direction } from '../../../../../../../Apps/common/src'
 export const NativeArrow = ({
     fill,
     direction,
+    marginTop = 4,
 }: {
     fill: string
     direction: Direction
+    marginTop?: number
 }) => (
     <Svg
         width={11}
         height={9}
         viewBox="0 0 11 9"
         fill="none"
-        style={{ marginTop: 4 }}
+        style={{ marginTop: marginTop }}
         rotation={direction}
     >
         <G opacity="1.0">


### PR DESCRIPTION
## Summary
This PR removes the non-breaking space between caption and credit and instead just uses a normal space. 
It also increases the lightbox caption font size on android only and tries to fix the triangle alignment with the text (this isn't perfect) but an improvement. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/d6XXQPgW/1203-lightbox-bugs)

## Test Plan
Open lightbox on android on different device sizes. 
| Before | After |
| --- | --- |
![Screenshot_1594055692](https://user-images.githubusercontent.com/53755195/86620706-b3378480-bfb4-11ea-81fc-5d211822b533.png) | ![Screenshot_1594055702](https://user-images.githubusercontent.com/53755195/86620724-ba5e9280-bfb4-11ea-9233-0e5f5da8f36f.png)
![Screenshot_1594057830](https://user-images.githubusercontent.com/53755195/86623548-aec19a80-bfb9-11ea-9471-20ea60cb8f0f.png) | ![Screenshot_1594057856](https://user-images.githubusercontent.com/53755195/86623563-b719d580-bfb9-11ea-8e5b-e3904e4f3886.png)
![Screenshot_1594057835](https://user-images.githubusercontent.com/53755195/86623594-c26d0100-bfb9-11ea-85c8-bd4dcae281ff.png) | ![Screenshot_1594057851](https://user-images.githubusercontent.com/53755195/86623595-c26d0100-bfb9-11ea-81f0-1e79cc699fb4.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
