### PR TITLE
Show preview controls when proof api selected.

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -14,7 +14,7 @@ export const backends = [
     {
         title: 'PROD proofed',
         value: 'https://editions-proof-prod.s3-eu-west-1.amazonaws.com/',
-        preview: false,
+        preview: true,
     },
     {
         title: 'PROD preview',
@@ -29,7 +29,7 @@ export const backends = [
     {
         title: 'CODE proofed',
         value: 'https://editions-proof-code.s3-eu-west-1.amazonaws.com/',
-        preview: false,
+        preview: true,
     },
     {
         title: 'CODE preview',


### PR DESCRIPTION
## Summary
Following from https://github.com/guardian/editions/pull/1309 we should show the preview controls - in particular the red 'reload' button for proofed issues so that the production team or anyone else using the app can re-fetch an issue after it has been re-proofed without restarting/reinstalling the app. 

[**Trello Card ->**](https://trello.com/c/PkjPqlFR/1336-production-edition-switching)

## Test Plan
Verify that when the proof API is selected from the duck menu that the red reload button is visible