### PR TITLE
Update crosswords to include special instructions

### DIFF
--- a/projects/Apps/crosswords/package.json
+++ b/projects/Apps/crosswords/package.json
@@ -22,7 +22,7 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
-        "@guardian/react-crossword": "^0.1.8",
+        "@guardian/react-crossword": "^0.2.0",
         "chalk": "^3.0.0",
         "kill-port": "^1.6.0",
         "react": "16.0.0",

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -1022,10 +1022,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/react-crossword@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.1.8.tgz#cfdd469b83f9ac868d5d96e001901153ed17244b"
-  integrity sha512-QOsKa+s2shxd/m+U/OcwqfiT/akF9OuIWTo8Y/TYCsKtgEOLbdyxLe5SZ6vQalEiandaukUR25rAJ8/eSZGvGQ==
+"@guardian/react-crossword@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.0.tgz#d3d7ffbc173f7977ace09d72b69f8ec84c7056f2"
+  integrity sha512-mHZoF4bEaLczx6vjoAc2FQRhzDWU4rmb6CyzldzvxJcKsXmesyVrace+f3cpm+3jM3nycxE1xviT9eFhAobTXg==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"


### PR DESCRIPTION
## Summary
This updates the project to use the `v0.2.0` of the crossword package which accommodates special instructions. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/LRatVLul/1372-crossword-special-instructions)

## Test Plan
Open Prize crossword on 27th June and you should see special instructions. 

| phone | tablet |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-07-07 at 17 34 25](https://user-images.githubusercontent.com/53755195/86815306-6ae29a00-c07a-11ea-9696-269c63cc72dc.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2020-07-07 at 17 37 29](https://user-images.githubusercontent.com/53755195/86815315-6f0eb780-c07a-11ea-8601-0f0858a4c357.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
