### PR TITLE
feat: Settings button

### DIFF
--- a/projects/Mallard/src/components/Button/Button.stories.tsx
+++ b/projects/Mallard/src/components/Button/Button.stories.tsx
@@ -7,6 +7,7 @@ import { ReloadButton } from './ReloadButton'
 import { ModalButton } from './ModalButton'
 import { ButtonAppearance } from './Button'
 import { CloseButton } from './CloseButton'
+import { SettingsButton } from './SettingsButton'
 
 storiesOf('Buttons', module)
     .addDecorator(withKnobs)
@@ -39,4 +40,7 @@ storiesOf('Buttons', module)
         <ModalButton onPress={() => {}}>
             {text('Button Text', 'Sign In')}
         </ModalButton>
+    ))
+    .add('SettingsButton - default', () => (
+        <SettingsButton onPress={() => {}} />
     ))

--- a/projects/Mallard/src/components/Button/SettingsButton.tsx
+++ b/projects/Mallard/src/components/Button/SettingsButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Button, ButtonAppearance } from './Button'
+
+const SettingsButton = ({ onPress }: { onPress: () => void }) => (
+    <Button
+        accessibilityLabel="Settings button"
+        accessibilityHint="Navigates to the settings screen"
+        accessibilityRole="button"
+        icon={'\uE040'}
+        alt="Settings"
+        onPress={onPress}
+        appearance={ButtonAppearance.skeleton}
+    />
+)
+
+export { SettingsButton }

--- a/projects/Mallard/src/components/Button/__tests__/SettingsButton.spec.tsx
+++ b/projects/Mallard/src/components/Button/__tests__/SettingsButton.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
+import { SettingsButton } from '../SettingsButton'
+
+describe('SettingsButton', () => {
+    it('should display a SettingsButton', () => {
+        const component: ReactTestRendererJSON | null = TestRenderer.create(
+            <SettingsButton onPress={() => {}} />,
+        ).toJSON()
+        expect(component).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/Button/__tests__/__snapshots__/SettingsButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/Button/__tests__/__snapshots__/SettingsButton.spec.tsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SettingsButton should display a SettingsButton 1`] = `
+<View
+  accessibilityHint="Navigates to the settings screen"
+  accessibilityLabel="Settings button"
+  accessibilityRole="button"
+  accessible={true}
+  focusable={true}
+  hitSlop={
+    Object {
+      "bottom": 10,
+      "left": 10,
+      "right": 10,
+      "top": 10,
+    }
+  }
+  isTVSelectable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 999,
+          "height": 42,
+          "justifyContent": "center",
+          "paddingHorizontal": 21,
+        },
+        Object {
+          "backgroundColor": undefined,
+          "borderColor": "#121212",
+          "borderWidth": 1,
+        },
+        Object {
+          "alignItems": "center",
+          "aspectRatio": 1,
+          "justifyContent": "center",
+          "paddingHorizontal": 0,
+          "width": 42,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "fontFamily": "GuardianIcons-Regular",
+            "fontSize": 20,
+            "lineHeight": 20,
+          },
+          Array [
+            Object {
+              "color": "#121212",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { NavigationInjectedProps, withNavigation } from 'react-navigation'
 import { SpecialEditionHeaderStyles } from 'src/common'
-import { Button, ButtonAppearance } from 'src/components/Button/Button'
 import { navigateToSettings } from 'src/navigation/helpers/base'
 import { ScreenHeader } from '../ScreenHeader'
 import { CloseButton } from 'src/components/Button/CloseButton'
+import { SettingsButton } from 'src/components/Button/SettingsButton'
 
 const IssuePickerHeader = withNavigation(
     ({
@@ -16,38 +16,28 @@ const IssuePickerHeader = withNavigation(
         headerStyles?: SpecialEditionHeaderStyles
         subTitle?: string
         title: string
-    } & NavigationInjectedProps) => {
-        const action = (
-            <CloseButton
-                accessibilityLabel="Close button"
-                accessibilityHint="Returns to the edition"
-                onPress={() => navigation.goBack()}
-            />
-        )
-        const settings = (
-            <Button
-                accessibilityLabel="Settings button"
-                accessibilityHint="Navigates to the settings screen"
-                accessibilityRole="button"
-                icon={'\uE040'}
-                alt="Settings"
-                onPress={() => {
-                    navigateToSettings(navigation)
-                }}
-                appearance={ButtonAppearance.skeleton}
-            />
-        )
-        return (
-            <ScreenHeader
-                leftAction={settings}
-                onPress={() => navigation.goBack()}
-                rightAction={action}
-                title={title}
-                subTitle={subTitle}
-                headerStyles={headerStyles}
-            />
-        )
-    },
+    } & NavigationInjectedProps) => (
+        <ScreenHeader
+            leftAction={
+                <SettingsButton
+                    onPress={() => {
+                        navigateToSettings(navigation)
+                    }}
+                />
+            }
+            onPress={() => navigation.goBack()}
+            rightAction={
+                <CloseButton
+                    accessibilityLabel="Close button"
+                    accessibilityHint="Returns to the edition"
+                    onPress={() => navigation.goBack()}
+                />
+            }
+            title={title}
+            subTitle={subTitle}
+            headerStyles={headerStyles}
+        />
+    ),
 )
 
 export { IssuePickerHeader }


### PR DESCRIPTION
## Summary
Adds a settings button to Storybook, a test and reimplements this back into the `IssuePickerHeader`

![Simulator Screen Shot - iPhone 11 - 2020-07-08 at 11 50 13](https://user-images.githubusercontent.com/935975/86910243-484f9000-c111-11ea-8ac6-603ce0c70acb.png)
