### PR TITLE
Registered push tokens are now visible in Duck Menu and diagnostic info

### DIFF
--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -14,7 +14,7 @@ import { locale } from './locale'
 import { getDiagnosticPushTracking } from '../push-notifications/push-tracking'
 import { isInBeta } from './release-stream'
 import { imageForScreenSize } from './screen'
-import { iapReceiptCache, userDataCache } from './storage'
+import { iapReceiptCache, userDataCache, pushRegisteredTokens } from './storage'
 import {
     ANDROID_BETA_EMAIL,
     DIAGNOSTICS_REQUEST,
@@ -79,6 +79,7 @@ const getDiagnosticInfo = async (
         imageSize,
         pushTracking,
         edition,
+        registeredPushTokens,
     ] = await Promise.all([
         DeviceInfo.getFirstInstallTime(),
         DeviceInfo.getLastUpdateTime(),
@@ -88,6 +89,7 @@ const getDiagnosticInfo = async (
         imageForScreenSize(),
         getDiagnosticPushTracking(),
         getSelectedEditionSlug(),
+        pushRegisteredTokens.get(),
     ])
 
     return `
@@ -122,6 +124,9 @@ Digital Pack subscription: ${idData && canViewEdition(idData)}
 Apple IAP Transaction Details: ${receiptData &&
         `\n${JSON.stringify(receiptData, null, 2)}`}
 Subscriber ID: ${casCode}
+
+-Registered Push Tokens-
+${JSON.stringify(registeredPushTokens)}
 
 -Push Downloads-
 ${pushTracking && JSON.stringify(pushTracking, null, 2)}

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -10,6 +10,7 @@ import {
 } from 'src/constants'
 import { PushNotificationRegistration } from 'src/push-notifications/push-notifications'
 import { CASExpiry } from '../../../Apps/common/src/cas-expiry'
+import { PushToken } from 'src/push-notifications/notification-service'
 
 /**
  * this is ostensibly used to get the legacy data from the old GCE app
@@ -89,6 +90,10 @@ const editionsListCache = createAsyncCache<{
     specialEditions: SpecialEdition[]
 }>('editionsList')
 
+const pushRegisteredTokens = createAsyncCache<PushToken[]>(
+    'push-registered-tokens',
+)
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -155,4 +160,5 @@ export {
     selectedEditionCache,
     defaultEditionCache,
     editionsListCache,
+    pushRegisteredTokens,
 }

--- a/projects/Mallard/src/push-notifications/notification-service.ts
+++ b/projects/Mallard/src/push-notifications/notification-service.ts
@@ -2,6 +2,11 @@ import { Platform } from 'react-native'
 import { notificationEdition } from 'src/helpers/settings/defaults'
 import { getSetting } from 'src/helpers/settings'
 
+export interface PushToken {
+    name: string
+    type: string
+}
+
 const registerWithNotificationService = async (deviceToken: {
     token: string
 }) => {

--- a/projects/Mallard/src/push-notifications/push-notifications.ts
+++ b/projects/Mallard/src/push-notifications/push-notifications.ts
@@ -1,7 +1,10 @@
 import moment, { MomentInput } from 'moment'
 import { Platform } from 'react-native'
 import PushNotification from 'react-native-push-notification'
-import { pushNotificationRegistrationCache } from '../helpers/storage'
+import {
+    pushNotificationRegistrationCache,
+    pushRegisteredTokens,
+} from '../helpers/storage'
 import PushNotificationIOS from '@react-native-community/push-notification-ios'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { errorService } from 'src/services/errors'
@@ -49,7 +52,9 @@ const maybeRegister = async (
 
     if (should) {
         // this will throw on non-200 so that we won't add registration info to the cache
-        await registerWithNotificationServiceImpl({ token })
+        const response = await registerWithNotificationServiceImpl({ token })
+        pushRegisteredTokens.set(response['topics'])
+
         await pushNotificationRegistrationCacheImpl.set({
             registrationDate: now,
             token,

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -86,7 +86,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
         pushRegisteredTokens.get().then(tokens => {
             setPushTokens(JSON.stringify(tokens, null, 2))
         })
-    })
+    }, [])
 
     useEffect(() => {
         getFileList().then(fileList => {

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -36,6 +36,7 @@ import {
 } from 'src/push-notifications/push-tracking'
 import { metrics } from 'src/theme/spacing'
 import { useEditions } from 'src/hooks/use-edition-provider'
+import { pushRegisteredTokens } from 'src/helpers/storage'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -79,6 +80,13 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [imageSize, setImageSize] = useState('fetching...')
     const [lightboxEnabled, setLightboxEnabled] = useState(false)
     const buildNumber = DeviceInfo.getBuildNumber()
+    const [pushTokens, setPushTokens] = useState('fetching...')
+
+    useEffect(() => {
+        pushRegisteredTokens.get().then(tokens => {
+            setPushTokens(JSON.stringify(tokens, null, 2))
+        })
+    })
 
     useEffect(() => {
         getFileList().then(fileList => {
@@ -300,6 +308,11 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         key: 'Image Size used for Editions',
                         title: 'Image Size used for Editions',
                         explainer: imageSize,
+                    },
+                    {
+                        key: 'Push Tokens',
+                        title: 'Registered push tokens',
+                        explainer: pushTokens,
                     },
                     {
                         key: 'Files in Issues',


### PR DESCRIPTION
## Summary
To help investigate issues we may need to see that topics a user is registered to. This PR makes that information available in Duck Menu and in Diagnostic info.


[**Trello Card ->**](https://trello.com/c/qGL4Izsq/1373-push-downloads-display-registered-topics-in-dev-menu-and-diagnostics)

Duck Menu:
![Screenshot_20200707-181933](https://user-images.githubusercontent.com/6583174/86910619-e17ea680-c111-11ea-843b-c463d8b202b4.png)
