### PR TITLE
fix: Downloads missing folders

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -41,7 +41,6 @@ import { pushDownloadFailsafe } from './helpers/push-download-failsafe'
 import { prepareAndDownloadTodaysIssue } from './download-edition/prepare-and-download-issue'
 import { remoteConfigService } from './services/remote-config'
 import analytics from '@react-native-firebase/analytics'
-import { clearDownloadsDirectory } from './download-edition/clear-issues'
 import { prepFileSystem } from './helpers/files'
 import { EditionProvider } from './hooks/use-edition-provider'
 
@@ -155,7 +154,6 @@ export default class App extends React.Component<{}, {}> {
     componentDidMount() {
         SplashScreen.hide()
         weatherHider(apolloClient)
-        clearDownloadsDirectory()
         prepareAndDownloadTodaysIssue(apolloClient)
         shouldHavePushFailsafe(apolloClient)
         loggingService.postLogs()

--- a/projects/Mallard/src/download-edition/clear-issues.ts
+++ b/projects/Mallard/src/download-edition/clear-issues.ts
@@ -38,8 +38,8 @@ const deleteIssue = (localId: string): Promise<void> => {
 const deleteIssueFiles = async (): Promise<void> => {
     await RNFS.unlink(FSPaths.issuesDir)
     localIssueListStore.reset()
-    await clearDownloadsDirectory()
     await prepFileSystem()
+    await clearDownloadsDirectory()
 }
 
 const clearOldIssues = async (): Promise<void> => {

--- a/projects/Mallard/src/download-edition/prepare-and-download-issue.ts
+++ b/projects/Mallard/src/download-edition/prepare-and-download-issue.ts
@@ -4,11 +4,12 @@ import { prepFileSystem } from '../helpers/files'
 import { cleanPushTrackingByDays } from '../push-notifications/push-tracking'
 import { largeDeviceMemory } from 'src/hooks/use-config-provider'
 import { downloadTodaysIssue } from 'src/download-edition/download-todays-issue'
-import { clearOldIssues } from './clear-issues'
+import { clearOldIssues, clearDownloadsDirectory } from './clear-issues'
 
 const prepareAndDownloadTodaysIssue = async (client: ApolloClient<object>) => {
     await prepFileSystem()
     await clearOldIssues()
+    await clearDownloadsDirectory()
     await cleanPushTrackingByDays()
     const weOk = await fetchCacheClear()
     if (weOk) {


### PR DESCRIPTION
## Summary
Fixes the following issue: https://sentry.io/organizations/the-guardian/issues/1731217197/?project=1519156&query=is%3Aunresolved+dist%3A770&statsPeriod=14d

This was due to a race condition between downloading and periodic cleaning of downloads. This now will only clean when the edition is downloaded and towards the end of deleting issues.