### PR TITLE
fix: Issue Summary error in Sentry

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -225,10 +225,13 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
         // The above saves it locally, if successful we return it
         return issueSummary
     } catch (e) {
-        e.message = `Failed to fetch valid issue summary: ${e.message}`
-        errorService.captureException(e)
+        const issueSummary = await readIssueSummary()
+        if (!issueSummary) {
+            e.message = `Failed to fetch valid issue summary and empty cache: ${e.message}`
+            errorService.captureException(e)
+        }
         // Got a problem with the endpoint, return the last saved version
-        return readIssueSummary()
+        return issueSummary
     }
 }
 


### PR DESCRIPTION
## Summary
This relates to the following error: https://sentry.io/organizations/the-guardian/issues/1355238363/events/9dd45998f434468a8d0eba6d536eb9f9/?project=1519156&query=is%3Aunresolved+dist%3A763&statsPeriod=14d

This is actually sending too many events as its anytime we don't get what we want from the endpoint. What we care about is if someone actually receives an issue summary. So now we only log an error if there is nothing from the endpoint and nothing in the cache.

Also the cache was returning a promise rather than the result. It resolved fine but was wonky.