### PR TITLE
chore: Remove capturing Download Blocked event in Sentry

### DIFF
--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -180,9 +180,6 @@ export const downloadAndUnzipIssue = async (
             DownloadBlockedStatus[downloadBlocked],
             Feature.DOWNLOAD,
         )
-        errorService.captureException(
-            new Error('Download Blocked: Required signal not available'),
-        )
         return
     }
 


### PR DESCRIPTION
## Summary
We are logging "Download Blocked" in Sentry. Downloads are blocked when a user doesn't have enough signal. This is not a bug, this is intentional.

I have raised a UX/Design ticket so that we can communicate this blocking to a user as they are the ones that should be aware.

This event is already being stored in logging.

https://sentry.io/organizations/the-guardian/issues/1728310969/?project=1519156&query=is%3Aunresolved