### PR TITLE
Change on the modal 'Unable to download'

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -144,8 +144,8 @@ const IssueButton = ({
             }
             case DownloadBlockedStatus.WifiOnly: {
                 Alert.alert('Unable to download', WIFI_ONLY_DOWNLOAD, [
-                    { text: 'Manage editions', onPress: onGoToSettings },
-                    { text: 'Ok' },
+                    { text: 'Manage downloads', onPress: onGoToSettings },
+                    { text: 'OK' },
                 ])
                 return
             }


### PR DESCRIPTION
From:
'Manage editions' to 'Manage downloads'
'Ok' to 'OK'

## Summary
Why are we doing this?

Copy consistency.

[**Trello Card ->**](https://trello.com/c/oVra53YG/1430-download-blocked-toast)

## Test Plan
On Manage downloads screen, turn on 'wi-fi only' switch.
On the list of issues screen, tap on the download button to try to download it.
Can you see the modal? Are the copy changes applied?