### PR TITLE
Fixed conflicting firebase version

### DIFF
--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         mediaCompatVersion = '1.0.1' // Do not specify if using old libraries, specify '1.0.1' or similar for androidx.media:media dependency
         supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
         firebaseVersion = "19.0.1"
+        firebaseMessagingVersion = "20.2.1"
         androidXAnnotation = "1.1.0"
         androidXBrowser = "1.0.0"
     }


### PR DESCRIPTION
## Summary
We had a conflicting firebase version that was causing android app to crash. It was due to pulling down a buggy version of the Firebase SDK. 

It would be better to have one source of truth for firebaes dependencies but that does require big refactoring.  

Details of the error can be found here:
https://stackoverflow.com/questions/62767041/firebase-messaging-on-android-suddenly-started-crashing-when-message-received


[**Trello Card ->**](https://trello.com/c/Atklc0nj/1434-fix-firebase-crash-on-android)

