### PR TITLE
Add 'from London', 'from Sydney', 'from New York' to the description of the editions on the switch screen

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -3,8 +3,7 @@ import { RegionalEdition, editions } from './index'
 export const defaultRegionalEditions: RegionalEdition[] = [
     {
         title: 'The Daily',
-        subTitle: `Published every morning
-by 6am (GMT)`,
+        subTitle: `Published from London every morning by 6 am (GMT)`,
         edition: editions.daily,
         header: {
             title: 'The Daily',
@@ -12,22 +11,20 @@ by 6am (GMT)`,
     },
     {
         title: 'Australia Weekender',
-        subTitle: `Published every Saturday morning 
-by 6am (AEST)`,
+        subTitle: `Published from Sydney every Saturday by 6 am (AEST)`,
         edition: editions.ausWeekly,
         header: {
             title: 'Australia',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
     },
     {
         title: 'US Weekender',
-        subTitle: `Published every Saturday morning 
-by 6am (EST)`,
+        subTitle: `Published from New York every Saturday by 6 am (EST)`,
         edition: editions.usWeekly,
         header: {
             title: 'US',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
     },
 ]


### PR DESCRIPTION
Published from London every morning by 6 am (GMT)
Published from Sydney every Saturday by 6 am (AEST)
Published from New York every Saturday by 6 am (EST)

## Summary
Why are we doing this?

We want to provide clarity on where each edition is published.

[**Trello Card ->**](https://trello.com/c/JXgwlRaY/1439-add-from-london-from-sydney-from-new-york-to-the-description-of-the-editions-on-the-switch-screen)

## Test Plan
Open the switch icon on the left-hand side of the front
Check if the copy matches the description above