### PR TITLE
Fix/increase-instructions-font-size

### DIFF
--- a/projects/Apps/crosswords/package.json
+++ b/projects/Apps/crosswords/package.json
@@ -22,7 +22,7 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
-        "@guardian/react-crossword": "^0.2.0",
+        "@guardian/react-crossword": "^0.2.1",
         "chalk": "^3.0.0",
         "kill-port": "^1.6.0",
         "react": "16.0.0",

--- a/projects/Apps/crosswords/package.json
+++ b/projects/Apps/crosswords/package.json
@@ -22,7 +22,7 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
-        "@guardian/react-crossword": "^0.2.1",
+        "@guardian/react-crossword": "^0.2.2",
         "chalk": "^3.0.0",
         "kill-port": "^1.6.0",
         "react": "16.0.0",

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -1022,10 +1022,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/react-crossword@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.1.tgz#1e04d0712f3ccecd970f93fed0e02baa61ef18c5"
-  integrity sha512-pxvSzAjmXq4JZic5fbn6foFO41dAAPeplwk72GLmTHEJ9DJkNeISQcEh7eVcS5eyiIpaPyzzdyrEbHNbxuHutQ==
+"@guardian/react-crossword@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.2.tgz#d309662d4a2ac428b052d2b86b7fa7172df5026f"
+  integrity sha512-OC80Ee3ei844PC5wz4JcoK4QfTDn00FnpTWMwjaSlsLwz9iij/G4gLdQ2sh48yY6qDlIqY2v09MXEx3+R+Jqjw==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -1022,10 +1022,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/react-crossword@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.0.tgz#d3d7ffbc173f7977ace09d72b69f8ec84c7056f2"
-  integrity sha512-mHZoF4bEaLczx6vjoAc2FQRhzDWU4rmb6CyzldzvxJcKsXmesyVrace+f3cpm+3jM3nycxE1xviT9eFhAobTXg==
+"@guardian/react-crossword@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.1.tgz#1e04d0712f3ccecd970f93fed0e02baa61ef18c5"
+  integrity sha512-pxvSzAjmXq4JZic5fbn6foFO41dAAPeplwk72GLmTHEJ9DJkNeISQcEh7eVcS5eyiIpaPyzzdyrEbHNbxuHutQ==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"


### PR DESCRIPTION
## Summary
This increases the font size of the special instructions in crosswords as requested from design/UX. 
See screenshots: 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-07-09 at 14 42 47](https://user-images.githubusercontent.com/53755195/87070311-8384b880-c210-11ea-827a-079bddd28254.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-09 at 17 19 14](https://user-images.githubusercontent.com/53755195/87070269-72d44280-c210-11ea-8e98-6389c98d63ad.png)

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/LRatVLul/1372-crossword-special-instructions)

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
