### PR TITLE
fix-crossword-controls

### DIFF
--- a/projects/Apps/crosswords/package.json
+++ b/projects/Apps/crosswords/package.json
@@ -22,7 +22,7 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
-        "@guardian/react-crossword": "^0.2.2",
+        "@guardian/react-crossword": "0.1.8",
         "chalk": "^3.0.0",
         "kill-port": "^1.6.0",
         "react": "16.0.0",

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -1022,10 +1022,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/react-crossword@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.2.tgz#d309662d4a2ac428b052d2b86b7fa7172df5026f"
-  integrity sha512-OC80Ee3ei844PC5wz4JcoK4QfTDn00FnpTWMwjaSlsLwz9iij/G4gLdQ2sh48yY6qDlIqY2v09MXEx3+R+Jqjw==
+"@guardian/react-crossword@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.1.8.tgz#cfdd469b83f9ac868d5d96e001901153ed17244b"
+  integrity sha512-QOsKa+s2shxd/m+U/OcwqfiT/akF9OuIWTo8Y/TYCsKtgEOLbdyxLe5SZ6vQalEiandaukUR25rAJ8/eSZGvGQ==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"


### PR DESCRIPTION
## Summary
This PR locks the crossword package version to v0.1.8 as changes made for special instructions in later versions have broken some of the controls. 

The breaking PR was https://github.com/guardian/editions/pull/1333 .
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

## Test Plan
Open crosswords and ensure that the Reveal all and Check all buttons are visible. 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-07-09 at 17 19 14](https://user-images.githubusercontent.com/53755195/87280290-e2d11a00-c4e9-11ea-85ab-ffc66752e88a.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 09 18 17](https://user-images.githubusercontent.com/53755195/87280300-e664a100-c4e9-11ea-9511-331d9ec2dd78.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
