### PR TITLE
update crosswords for special instructions

### DIFF
--- a/projects/Apps/crosswords/package.json
+++ b/projects/Apps/crosswords/package.json
@@ -22,7 +22,7 @@
         "webpack-cli": "^3.3.11"
     },
     "dependencies": {
-        "@guardian/react-crossword": "0.1.8",
+        "@guardian/react-crossword": "^0.2.3",
         "chalk": "^3.0.0",
         "kill-port": "^1.6.0",
         "react": "16.0.0",

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -1022,10 +1022,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@guardian/react-crossword@0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.1.8.tgz#cfdd469b83f9ac868d5d96e001901153ed17244b"
-  integrity sha512-QOsKa+s2shxd/m+U/OcwqfiT/akF9OuIWTo8Y/TYCsKtgEOLbdyxLe5SZ6vQalEiandaukUR25rAJ8/eSZGvGQ==
+"@guardian/react-crossword@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-0.2.3.tgz#1e09872873a553814e6158f5c097ec59aa295cc1"
+  integrity sha512-3w1fohvGy7Nsa3spI8AL7bpHWlz8h9cJvZcHidoEB5NTAbOyfnmOIuAxr+vi6jj5DwxoXJk27Z6OwKXN+IE/qQ==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"


### PR DESCRIPTION
## Summary
We previously reverted an update to the crossword package as the `Reveal all` and `Check all` buttons were missing. 
A breaking [change](https://github.com/guardian/react-crossword/pull/7) was reverted on `react-crossword`and a new version of the package was  published, this PR updates to the latest package.
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/LRatVLul/1372-crossword-special-instructions)

## Test Plan
The crosswords should now have the `Reveal all` and `Check all` buttons as well as special instructions when necessary, to test please check the Prize crossword on Saturday 27th June. 
| Special instructions | Solution buttons |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 18 17 45](https://user-images.githubusercontent.com/53755195/87400063-39a12700-c5b0-11ea-82ca-80ce242afec7.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 09 18 17](https://user-images.githubusercontent.com/53755195/87400073-3c9c1780-c5b0-11ea-83d2-1d46d4427ea7.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
