### PR TITLE
Add workflow_dispatch as build trigger.

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -1,6 +1,7 @@
 name: scheduled-ios-beta
 
 on:
+    workflow_dispatch:
     schedule:
         # * is a special character in YAML so you have to quote this string
         - cron: '0 14 * * 1-5' # every day at 2pm

--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -1,6 +1,8 @@
 name: validate-app
 
-on: push
+on:
+    workflow_dispatch:
+    push:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Summary
There is a new feature for Github actions to support manually triggering builds. This enables that for our ios build and validate-app builds. If this works then we can remove the upload-build workflow and associated script https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/ 

## Test Plan

Check that we can trigger builds manually
