### PR TITLE
Respect notification offset from input

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -267,6 +267,7 @@ export interface IssueIdentifier {
 
 export interface IssuePublicationIdentifier extends IssueIdentifier {
     version: string
+    notificationUTCOffset: number
 }
 
 export interface IssuePublicationActionIdentifier

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -267,12 +267,12 @@ export interface IssueIdentifier {
 
 export interface IssuePublicationIdentifier extends IssueIdentifier {
     version: string
-    notificationUTCOffset: number
 }
 
 export interface IssuePublicationActionIdentifier
     extends IssuePublicationIdentifier {
     action: string
+    notificationUTCOffset: number
 }
 
 export interface IssueSummary extends WithKey, IssueCompositeKey {

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -26,7 +26,7 @@ const sf = new StepFunctions({
 
 const getRuntimeInvokeStateMachineFunction = (stateMachineArn: string) => {
     return async (
-        issuePublication: IssuePublicationIdentifier,
+        issuePublication: IssuePublicationActionIdentifier,
     ): Promise<IssuePublicationIdentifier | Failure> => {
         const invoke: IssueParams = {
             issuePublication,
@@ -64,10 +64,10 @@ const getRuntimeInvokeStateMachineFunction = (stateMachineArn: string) => {
 
 export interface InvokerDependencies {
     proofStateMachineInvoke: (
-        issuePub: IssuePublicationIdentifier,
+        issuePub: IssuePublicationActionIdentifier,
     ) => Promise<IssuePublicationIdentifier | Failure>
     publishStateMachineInvoke: (
-        issuePub: IssuePublicationIdentifier,
+        issuePub: IssuePublicationActionIdentifier,
     ) => Promise<IssuePublicationIdentifier | Failure>
     s3fetch: (params: GetS3ObjParams) => Promise<string>
 }
@@ -93,14 +93,14 @@ export const internalHandler = async (
     console.log('Found following issues:', JSON.stringify(issues))
 
     const runs = await Promise.all(
-        issues.map(issuePublication => {
-            if (issuePublication.action === 'proof')
+        issues.map(issuePublicationAction => {
+            if (issuePublicationAction.action === 'proof')
                 return dependencies.proofStateMachineInvoke(
-                    issuePublication as IssuePublicationIdentifier,
+                    issuePublicationAction as IssuePublicationActionIdentifier,
                 )
             else
                 return dependencies.publishStateMachineInvoke(
-                    issuePublication as IssuePublicationIdentifier,
+                    issuePublicationAction as IssuePublicationActionIdentifier,
                 )
         }),
     )

--- a/projects/archiver/src/tasks/issue/index.ts
+++ b/projects/archiver/src/tasks/issue/index.ts
@@ -1,13 +1,13 @@
 import { Handler } from 'aws-lambda'
 import { attempt, hasFailed } from '../../../../backend/utils/try'
-import { Issue, IssuePublicationIdentifier } from '../../../common'
+import { Issue, IssuePublicationActionIdentifier } from '../../../common'
 import { getIssue } from '../../utils/backend-client'
 import { getBucket } from '../../utils/s3'
 import { getPublishedId } from '../../utils/path-builder'
 import { handleAndNotify } from '../../services/task-handler'
 
 export interface IssueParams {
-    issuePublication: IssuePublicationIdentifier
+    issuePublication: IssuePublicationActionIdentifier
 }
 export interface IssueTaskOutput extends IssueParams {
     issue: Issue

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
@@ -39,7 +39,9 @@ export const createScheduleTime = (issueDate: string, offset = 3): string => {
     const issueDateAsDate = moment.utc(issueDate, 'YYYY-MM-DD')
     issueDateAsDate.locale('utc')
     const notificationDate = issueDateAsDate.add(offset, 'hours')
-    return notificationDate.format('YYYY-MM-DDTHH:mm:ssZ')
+    const notificationDateAsString = notificationDate.format('YYYY-MM-DDTHH:mm:ssZ')
+    console.log(`Calculated notification time: ${issueDate} + ${offset} gives ${notificationDateAsString}`)
+    return notificationDateAsString;
 }
 
 export const shouldSchedule = (scheduleTime: string, now: Date): boolean => {

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
@@ -39,9 +39,13 @@ export const createScheduleTime = (issueDate: string, offset = 3): string => {
     const issueDateAsDate = moment.utc(issueDate, 'YYYY-MM-DD')
     issueDateAsDate.locale('utc')
     const notificationDate = issueDateAsDate.add(offset, 'hours')
-    const notificationDateAsString = notificationDate.format('YYYY-MM-DDTHH:mm:ssZ')
-    console.log(`Calculated notification time: ${issueDate} + ${offset} gives ${notificationDateAsString}`)
-    return notificationDateAsString;
+    const notificationDateAsString = notificationDate.format(
+        'YYYY-MM-DDTHH:mm:ssZ',
+    )
+    console.log(
+        `Calculated notification time: ${issueDate} + ${offset} gives ${notificationDateAsString}`,
+    )
+    return notificationDateAsString
 }
 
 export const shouldSchedule = (scheduleTime: string, now: Date): boolean => {

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -68,21 +68,21 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
 ): Promise<NotificationStatus> => {
     const { edition } = issueData
 
-    if (edition != 'daily-edition') {
-        console.log(
-            `skipping schedule Device Notification because the ${edition} edition is not eligible for Device Notification`,
-        )
-        return 'skipped'
-    }
-
     const scheduleTime = createScheduleTime(
         issueData.issueDate,
         issueData.notificationUTCOffset,
     )
 
+    if (edition != 'daily-edition') {
+        console.log(
+            `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the edition is not eligible for Device Notification`,
+        )
+        return 'skipped'
+    }
+
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(
-            `skipping schedule Device Notification because the (scheduleTime: ${scheduleTime}) is in the past`,
+            `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the schedule time is in the past`,
         )
         return 'skipped'
     }

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -12,6 +12,7 @@ export interface IssueNotificationData {
     name: string
     issueDate: string
     edition: Edition
+    notificationUTCOffset: number
 }
 
 export interface ScheduleDeviceNotificationAPIResponse {
@@ -74,7 +75,7 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
         return 'skipped'
     }
 
-    const scheduleTime = createScheduleTime(issueData.issueDate)
+    const scheduleTime = createScheduleTime(issueData.issueDate, issueData.notificationUTCOffset)
 
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -75,7 +75,10 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
         return 'skipped'
     }
 
-    const scheduleTime = createScheduleTime(issueData.issueDate, issueData.notificationUTCOffset)
+    const scheduleTime = createScheduleTime(
+        issueData.issueDate,
+        issueData.notificationUTCOffset,
+    )
 
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -24,7 +24,7 @@ export const handler: Handler<
     async ({ issuePublication, issue }) => {
         const stage: string = process.env.stage || 'code'
 
-        const { issueDate, edition } = issuePublication
+        const { issueDate, edition, notificationUTCOffset } = issuePublication
         const { key, name } = issue
 
         const guNotificationServiceDomain =
@@ -35,7 +35,7 @@ export const handler: Handler<
         const guNotificationServiceAPIKey =
             process.env.gu_notify_service_api_key || ''
         const notificationStatus = await scheduleDeviceNotificationIfEligible(
-            { key, name, issueDate, edition },
+            { key, name, issueDate, edition, notificationUTCOffset },
             {
                 domain: guNotificationServiceDomain,
                 apiKey: guNotificationServiceAPIKey,

--- a/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
@@ -13,6 +13,7 @@ describe('prepareScheduleDeviceNotificationRequest', () => {
             name: 'Daily Edition',
             edition: 'daily-edition',
             issueDate: '2019-09-18',
+            notificationUTCOffset: 1
         }
 
         const apiCfg = {

--- a/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
@@ -13,7 +13,7 @@ describe('prepareScheduleDeviceNotificationRequest', () => {
             name: 'Daily Edition',
             edition: 'daily-edition',
             issueDate: '2019-09-18',
-            notificationUTCOffset: 1
+            notificationUTCOffset: 1,
         }
 
         const apiCfg = {

--- a/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
@@ -24,6 +24,7 @@ describe('scheduleDeviceNotificationIfEligibleInternal', () => {
         name: 'Daily Edition',
         edition: 'daily-edition',
         issueDate: '2019-09-18',
+        notificationUTCOffset: 1
     }
 
     const dayBeforeIssue = new Date('2019-09-17')

--- a/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
@@ -24,7 +24,7 @@ describe('scheduleDeviceNotificationIfEligibleInternal', () => {
         name: 'Daily Edition',
         edition: 'daily-edition',
         issueDate: '2019-09-18',
-        notificationUTCOffset: 1
+        notificationUTCOffset: 1,
     }
 
     const dayBeforeIssue = new Date('2019-09-17')


### PR DESCRIPTION
## Summary

Pre-requisite: https://github.com/guardian/editions/pull/1355 which passes a Notification UTC Offset value in to each step of the step function.

This matching PR will respect that value when calculating the notification time.

## Test Plan

Run in code.  I have: it worked.

![image](https://user-images.githubusercontent.com/5476326/87532644-5d856b00-c68b-11ea-9119-2c7316915ddd.png)

And for the US edition, with a different offset:
![image](https://user-images.githubusercontent.com/5476326/87551259-03df6980-c6a8-11ea-9e69-955469ac588c.png)
