### PR TITLE
Fixed broken edition button on small screen

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -94,6 +94,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.6.2",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/runtime": "^7.6.2",
         "@storybook/addon-knobs": "^5.3.18",
         "@storybook/addon-ondevice-knobs": "^5.3.18",

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -20,7 +20,10 @@ const buttonStyles = StyleSheet.create({
         borderRadius: 3,
         flex: 1,
         marginHorizontal: 5,
-        padding: 8,
+        paddingLeft: 8,
+        paddingRight: 8,
+        paddingTop: 10,
+        paddingBottom: 10,
         alignItems: 'center',
     },
 })

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -20,7 +20,7 @@ const buttonStyles = StyleSheet.create({
         borderRadius: 3,
         flex: 1,
         marginHorizontal: 5,
-        padding: 10,
+        padding: 8,
         alignItems: 'center',
     },
 })

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -509,6 +509,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"


### PR DESCRIPTION
## Summary
This PR fixes broken editions buttons. See screenshots.

### iPhone SE
![Simulator Screen Shot - iPhone SE 13 3 - 2020-07-14 at 13 19 23](https://user-images.githubusercontent.com/6583174/87425223-25bbec00-c5d5-11ea-99aa-519f1db4b0f4.png)

### Android pixel 3
![device-2020-07-14-131819](https://user-images.githubusercontent.com/6583174/87425193-1a68c080-c5d5-11ea-8cff-25a490283135.png)

### iPad 13 inch
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2020-07-14 at 13 18 48](https://user-images.githubusercontent.com/6583174/87425197-1b99ed80-c5d5-11ea-919c-07382005af28.png)

@prisalcalde please let me know if they need further adjustments
