### PR TITLE
Remove short circuit for notifications

### DIFF
--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -73,13 +73,6 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
         issueData.notificationUTCOffset,
     )
 
-    if (edition != 'daily-edition') {
-        console.log(
-            `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the edition is not eligible for Device Notification`,
-        )
-        return 'skipped'
-    }
-
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(
             `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the schedule time is in the past`,

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -73,6 +73,15 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
         issueData.notificationUTCOffset,
     )
 
+    const stage: string = process.env.stage || 'code'
+
+    if (edition != 'daily-edition' && stage.toLowerCase() == 'prod') {
+        console.log(
+            `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the stage is prod and the edition is not eligible for Device Notification`,
+        )
+        return 'skipped'
+    }
+
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(
             `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the schedule time is in the past`,

--- a/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
@@ -41,7 +41,7 @@ describe('scheduleDeviceNotificationIfEligibleInternal', () => {
         expect(actual).toBe('scheduled')
     })
 
-    it('skip request if edition was not daily-edition', async () => {
+    it('do not skip request if edition was not daily-edition', async () => {
         const issueWithTrainingEdition = Object.assign(issueFromDailyEdition, {
             edition: 'training-edition',
         })
@@ -51,7 +51,7 @@ describe('scheduleDeviceNotificationIfEligibleInternal', () => {
             dayBeforeIssue,
             testDependencies,
         )
-        expect(actual).toBe('skipped')
+        expect(actual).not.toBe('skipped')
     })
 
     it('skip request if edition was daily-edition but in the past', async () => {


### PR DESCRIPTION
## Summary

Currently, we explicitly do not send notifications for non-Daily Editions.

When the app can support re-subscribing to appropriate topics (where topic and Edition have a one-to-one mapping), we can safely remove this.

## Test Plan

Test in CODE, confirm that notifications work correctly in the app for any Edition.