### PR TITLE
Deeplink to open Edition app or Play/App Store

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -87,6 +87,17 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="com.googleusercontent.apps.774465807556-cjat38acttpl7md4nfc4pfediouh7v97" />
         </intent-filter>
+        <!-- Content deep link -->
+        <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <!-- Accepts URIs that begin with "https://editions.theguardian.com” -->
+            <data android:scheme="https"
+                android:host="editions.theguardian.com"
+                android:pathPrefix="/edition" />
+        </intent-filter>
+        
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 

--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -94,8 +94,7 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <!-- Accepts URIs that begin with "https://editions.theguardian.com” -->
             <data android:scheme="https"
-                android:host="editions.theguardian.com"
-                android:pathPrefix="/edition" />
+                android:host="editions.theguardian.com" />
         </intent-filter>
         
       </activity>

--- a/projects/Mallard/ios/Mallard/Mallard.entitlements
+++ b/projects/Mallard/ios/Mallard/Mallard.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:editions.theguardian.com</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
We want to provide a way to open the app from an email link if the app is installed or open the Play/App store if not. This PR implements client-side change.

We have added corresponding files in the edition subdomain:
iOS: https://editions.theguardian.com/.well-known/apple-app-site-association
Android: https://editions.theguardian.com/.well-known/assetlinks.json

The way I tested it as follows:
Send an email to myself that contains a link `https://editions.theguardian.com`

Android: link open the Edition app when it is installed, or, open the Play Store when not installed
iOS: link open the Edition app when it is installed, or, open the App Store when not installed

Just adding @davidfurey
 