### PR TITLE
Read and handle edition list

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -275,6 +275,11 @@ export interface IssuePublicationActionIdentifier
     notificationUTCOffset: number
 }
 
+export interface EditionListPublicationAction {
+    action: string
+    content: object
+}
+
 export interface IssueSummary extends WithKey, IssueCompositeKey {
     name: string
     date: string

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -145,12 +145,14 @@ export const internalHandler = async (
     Records: Record[],
     dependencies: InvokerDependencies,
 ) => {
-    const runs = await invokePublishProof(Records, dependencies)
+    const issueRuns = await invokePublishProof(Records, dependencies)
+    const editionsListRuns = await invokeEditionList(Records, dependencies)
 
-    const succesfulInvocations = runs
+    const invocations = issueRuns.concat(editionsListRuns)
+    const succesfulInvocations = invocations
         .filter(hasSucceeded)
         .map(issue => `✅ Invocation of ${JSON.stringify(issue)} succeeded.`)
-    const failedInvocations = runs.filter(hasFailed)
+    const failedInvocations = invocations.filter(hasFailed)
     console.error(JSON.stringify([...failedInvocations]))
     if (succesfulInvocations.length < 1)
         throw new Error('No invocations were made.')

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -95,11 +95,9 @@ const invokeEditionList = async (
     console.log('Found following edition lists:', JSON.stringify(editionLists))
 
     return await Promise.all(
-        editionLists.map(
-            () => {
-                fail(`No backend address to PUT edition list to yet - TODO`)
-            }
-        )
+        editionLists.map(() => {
+            fail(`No backend address to PUT edition list to yet - TODO`)
+        })
     )
 }
 
@@ -134,11 +132,9 @@ const invokePublishProof = async (
                 return dependencies.publishStateMachineInvoke(
                     issuePublicationAction as IssuePublicationActionIdentifier,
                 )
-            else
-                return fail(`Unknown action ${issuePublicationAction.action}`)
+            else return fail(`Unknown action ${issuePublicationAction.action}`)
         }),
     )
-
 }
 
 export const internalHandler = async (

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -15,7 +15,6 @@ import {
 import { IssueParams } from '../tasks/issue'
 import { fetchfromCMSFrontsS3, GetS3ObjParams } from '../utils/s3'
 import { parseIssueActionRecord, parseEditionListActionRecord } from './parser'
-import { failure } from '../../../backend/utils/try'
 
 export interface Record {
     s3: { bucket: { name: string }; object: { key: string } }
@@ -97,7 +96,7 @@ const invokeEditionList = async (
 
     return await Promise.all(
         editionLists.map(
-            editionList => {
+            () => {
                 fail(`No backend address to PUT edition list to yet - TODO`)
             }
         )

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -72,7 +72,37 @@ export interface InvokerDependencies {
     s3fetch: (params: GetS3ObjParams) => Promise<string>
 }
 
-export const internalHandler = async (
+const invokeEditionList = async (
+    Records: Record[],
+    dependencies: InvokerDependencies,
+) => {
+    const maybeEditionListPromises: Promise<
+        Attempt<EditionListPublicationAction>
+    >[] = Records.map(async r => {
+        return await parseEditionListActionRecord(r, dependencies.s3fetch)
+    })
+
+    const maybeEditionLists: Attempt<
+        EditionListPublicationAction
+    >[] = await Promise.all(maybeEditionListPromises)
+
+    // explicitly ignore all files that didn't parse,
+    const editionLists: EditionListPublicationAction[] = maybeEditionLists.filter(
+        hasSucceeded,
+    )
+
+    console.log('Found following edition lists:', JSON.stringify(editionLists))
+
+    return await Promise.all(
+        editionLists.map(
+            editionList => {
+                fail(`No backend address to PUT edition list to yet - TODO`)
+            }
+        )
+    )
+}
+
+const invokePublishProof = async (
     Records: Record[],
     dependencies: InvokerDependencies,
 ) => {

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -5,6 +5,7 @@ import {
 } from '../../common'
 import { GetS3ObjParams } from '../utils/s3'
 import { Record } from '.'
+import { EditionListPublicationAction } from '../../../Apps/common/src'
 
 const isValidJSON = (s: string): boolean => {
     try {
@@ -51,7 +52,46 @@ export const parseRecordInternal = (
     return { action, edition, version, issueDate, notificationUTCOffset }
 }
 
-export const parseRecord = async (
+export const parseEditionListActionRecordInternal = (
+    objContent: string,
+    loc = '',
+): Attempt<EditionListPublicationAction> => {
+    if (!isValidJSON(objContent)) {
+        return failure({
+            error: new Error(),
+            messages: [`⚠️ JSON malformed in ${loc} file`],
+        })
+    }
+
+    const {
+        action,
+        content,
+    } = JSON.parse(objContent) as EditionListPublicationAction
+
+    if (
+        action === undefined ||
+        content === undefined
+    ) {
+        return failure({
+            error: new Error(),
+            messages: [
+                `⚠️ ${loc} json file with edition list details did not contained required values: (action, content)`,
+            ],
+        })
+    }
+    return { action, content }
+}
+
+export const parseEditionListActionRecord = async (
+    record: Record,
+    s3fetch: (params: GetS3ObjParams) => Promise<string>,
+): Promise<Attempt<EditionListPublicationAction>> => {
+    const { objContent, loc } = await fetchFromS3(record, s3fetch)
+    return parseEditionListActionRecordInternal(objContent, loc)
+
+}
+
+export const parseIssueActionRecord = async (
     record: Record,
     s3fetch: (params: GetS3ObjParams) => Promise<string>,
 ): Promise<Attempt<IssuePublicationActionIdentifier>> => {

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -52,7 +52,7 @@ export const parseIssueActionRecordInternal = (
     return { action, edition, version, issueDate, notificationUTCOffset }
 }
 
-export const parseEditionListActionRecordInternal = (
+const parseEditionListActionRecordInternal = (
     objContent: string,
     loc = '',
 ): Attempt<EditionListPublicationAction> => {

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -16,7 +16,7 @@ const isValidJSON = (s: string): boolean => {
     return true
 }
 
-export const parseRecordInternal = (
+export const parseIssueActionRecordInternal = (
     objContent: string,
     loc = '',
 ): Attempt<IssuePublicationActionIdentifier> => {
@@ -95,6 +95,12 @@ export const parseIssueActionRecord = async (
     record: Record,
     s3fetch: (params: GetS3ObjParams) => Promise<string>,
 ): Promise<Attempt<IssuePublicationActionIdentifier>> => {
+    const { objContent, loc } = await fetchFromS3(record, s3fetch)
+
+    return parseIssueActionRecordInternal(objContent, loc)
+}
+
+async function fetchFromS3(record: Record, s3fetch: (params: GetS3ObjParams) => Promise<string>) {
     console.log('Starting to parse record')
     const bucket = record.s3.bucket.name
     const key = decodeURIComponent(record.s3.object.key)
@@ -104,6 +110,6 @@ export const parseIssueActionRecord = async (
     const loc = `s3://${bucket}/${key}`
 
     console.log(`got object content from ${loc} location:`, objContent)
-
-    return parseRecordInternal(objContent, loc)
+    return { objContent, loc }
 }
+

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -63,15 +63,11 @@ export const parseEditionListActionRecordInternal = (
         })
     }
 
-    const {
-        action,
-        content,
-    } = JSON.parse(objContent) as EditionListPublicationAction
+    const { action, content } = JSON.parse(
+        objContent,
+    ) as EditionListPublicationAction
 
-    if (
-        action === undefined ||
-        content === undefined
-    ) {
+    if (action === undefined || content === undefined) {
         return failure({
             error: new Error(),
             messages: [
@@ -80,6 +76,22 @@ export const parseEditionListActionRecordInternal = (
         })
     }
     return { action, content }
+}
+
+async function fetchFromS3(
+    record: Record, 
+    s3fetch: (params: GetS3ObjParams) => Promise<string>,
+) {
+    console.log('Starting to parse record')
+    const bucket = record.s3.bucket.name
+    const key = decodeURIComponent(record.s3.object.key)
+
+    const objContent = await s3fetch({ Bucket: bucket, Key: key })
+
+    const loc = `s3://${bucket}/${key}`
+
+    console.log(`got object content from ${loc} location:`, objContent)
+    return { objContent, loc }
 }
 
 export const parseEditionListActionRecord = async (
@@ -99,17 +111,3 @@ export const parseIssueActionRecord = async (
 
     return parseIssueActionRecordInternal(objContent, loc)
 }
-
-async function fetchFromS3(record: Record, s3fetch: (params: GetS3ObjParams) => Promise<string>) {
-    console.log('Starting to parse record')
-    const bucket = record.s3.bucket.name
-    const key = decodeURIComponent(record.s3.object.key)
-
-    const objContent = await s3fetch({ Bucket: bucket, Key: key })
-
-    const loc = `s3://${bucket}/${key}`
-
-    console.log(`got object content from ${loc} location:`, objContent)
-    return { objContent, loc }
-}
-

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -79,7 +79,7 @@ export const parseEditionListActionRecordInternal = (
 }
 
 async function fetchFromS3(
-    record: Record, 
+    record: Record,
     s3fetch: (params: GetS3ObjParams) => Promise<string>,
 ) {
     console.log('Starting to parse record')
@@ -100,7 +100,6 @@ export const parseEditionListActionRecord = async (
 ): Promise<Attempt<EditionListPublicationAction>> => {
     const { objContent, loc } = await fetchFromS3(record, s3fetch)
     return parseEditionListActionRecordInternal(objContent, loc)
-
 }
 
 export const parseIssueActionRecord = async (

--- a/projects/archiver/test/invoke/parser.spec.ts
+++ b/projects/archiver/test/invoke/parser.spec.ts
@@ -49,6 +49,8 @@ describe('parseRecord', () => {
 
     it('should fail if JSON was malformed', async () => {
         const obejctsContents = '{"'
-        expect(hasFailed(parseIssueActionRecordInternal(obejctsContents))).toBe(true)
+        expect(hasFailed(parseIssueActionRecordInternal(obejctsContents))).toBe(
+            true,
+        )
     })
 })

--- a/projects/archiver/test/invoke/parser.spec.ts
+++ b/projects/archiver/test/invoke/parser.spec.ts
@@ -1,4 +1,4 @@
-import { parseRecordInternal } from '../../src/invoke/parser'
+import { parseIssueActionRecordInternal } from '../../src/invoke/parser'
 import { hasFailed } from '../../common'
 
 describe('parseRecord', () => {
@@ -6,7 +6,7 @@ describe('parseRecord', () => {
         const obejctsContents =
             '{"action":"proof","id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}], "notificationUTCOffset":1}'
 
-        const actual = parseRecordInternal(obejctsContents)
+        const actual = parseIssueActionRecordInternal(obejctsContents)
 
         expect(actual).toStrictEqual({
             action: 'proof',
@@ -21,7 +21,7 @@ describe('parseRecord', () => {
         const obejctsContents =
             '{"action":"proof","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z", "notificationUTCOffset":1}'
 
-        const actual = parseRecordInternal(obejctsContents)
+        const actual = parseIssueActionRecordInternal(obejctsContents)
 
         expect(actual).toStrictEqual({
             action: 'proof',
@@ -43,12 +43,12 @@ describe('parseRecord', () => {
         ]
 
         invalids.forEach(s => {
-            expect(hasFailed(parseRecordInternal(s))).toBe(true)
+            expect(hasFailed(parseIssueActionRecordInternal(s))).toBe(true)
         })
     })
 
     it('should fail if JSON was malformed', async () => {
         const obejctsContents = '{"'
-        expect(hasFailed(parseRecordInternal(obejctsContents))).toBe(true)
+        expect(hasFailed(parseIssueActionRecordInternal(obejctsContents))).toBe(true)
     })
 })

--- a/projects/backend/utils/try.ts
+++ b/projects/backend/utils/try.ts
@@ -5,7 +5,7 @@ export interface Failure {
     messages?: string[]
 }
 
-export const fail = (message: string):Failure => {
+export const fail = (message: string): Failure => {
     return {
         __failure: true,
         error: {},

--- a/projects/backend/utils/try.ts
+++ b/projects/backend/utils/try.ts
@@ -5,7 +5,7 @@ export interface Failure {
     messages?: string[]
 }
 
-export const fail = (message: string): Failure => {
+export const failFast = (message: string): Failure => {
     return {
         __failure: true,
         error: {},

--- a/projects/backend/utils/try.ts
+++ b/projects/backend/utils/try.ts
@@ -5,6 +5,14 @@ export interface Failure {
     messages?: string[]
 }
 
+export const fail = (message: string):Failure => {
+    return {
+        __failure: true,
+        error: {},
+        messages: [message],
+    }
+}
+
 export const failure = (failure: Omit<Failure, '__failure'>): Failure => ({
     __failure: true,
     ...failure,


### PR DESCRIPTION
## Summary

When the fronts tool puts an editions list file into S3, this code ensures it is picked up, parsed and processed, up to a point.

The backend endpoint is not currently present, so it fails at the last second where it should execute a PUT.

## Test Plan

Use the fronts tool to push a new editions list file, then observe the eventual failure message in the logs.