### PR TITLE
Update manage editions copy

### DIFF
--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -84,7 +84,7 @@ const AvailableEditionsButtons = ({
                 selected={isSelected(number)}
                 onPress={() => onPress(number)}
             >
-                {`${number} editions`}
+                {`${number} issues`}
             </MultiButton>
         ))}
     </View>
@@ -162,7 +162,7 @@ const ManageEditionsScreen = () => {
                         key: 'Delete all downloads',
                         title: 'Delete all downloads',
                         explainer:
-                            'All downloaded editions will be deleted from your device but will still be available to download',
+                            'All downloaded issues will be deleted from your device but will still be available to download',
                         onPress: () => {
                             Alert.alert(
                                 'Are you sure you want to delete all downloads?',

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -109,7 +109,7 @@ const ManageEditionsScreen = () => {
                                   key: 'Wifi-only',
                                   title: 'Wifi-only',
                                   explainer:
-                                      'Editions will only be downloaded when wi-fi is available',
+                                      'Issues will only be downloaded when Wi-Fi is available',
                                   proxy: (
                                       <Switch
                                           accessible={true}


### PR DESCRIPTION
## Summary
To support multiple editions we're referring to an individual Issue as an Issue rather than an Edition. As a result we have some copy tweaks to make it easier to understand that you are downloading an 'issue' rather than an 'edition'. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/9PwOORmI/1442-update-the-copy-of-the-manage-download-screen)


## Test Plan
Open the settings -> Manage Downloads -> Check the content is as expected
![image](https://user-images.githubusercontent.com/5294853/87915028-7914bb00-ca69-11ea-97c4-18145bf7cd27.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
