### PR TITLE
When using preview api, always return to API when refreshing issue.

### DIFF
--- a/projects/Mallard/src/helpers/fetch.ts
+++ b/projects/Mallard/src/helpers/fetch.ts
@@ -60,6 +60,7 @@ const fetchIssueWithFrontsFromFS = async (
 const fetchIssue = (
     localIssueId: Issue['localId'],
     publishedIssueId: Issue['publishedId'],
+    forceApiFetch: boolean,
 ): CachedOrPromise<IssueWithFronts> => {
     /*
     retrieve any cached value if we have any
@@ -71,7 +72,7 @@ const fetchIssue = (
             retrieve(localIssueId),
             async () => {
                 const issueOnDevice = await isIssueOnDevice(localIssueId)
-                if (issueOnDevice) {
+                if (!forceApiFetch && issueOnDevice) {
                     return fetchIssueWithFrontsFromFS(localIssueId)
                 } else {
                     return fetchIssueWithFrontsFromAPI(publishedIssueId)

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -34,7 +34,7 @@ export const getArticleResponse = ({
     publishedIssueId,
     front,
 }: PathToArticle) =>
-    chain(fetchIssue(localIssueId, publishedIssueId), issue => {
+    chain(fetchIssue(localIssueId, publishedIssueId, false), issue => {
         const maybeFront = issue.fronts.find(f => f.key === front)
         if (!maybeFront) throw ERR_404_REMOTE
 

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -15,14 +15,20 @@ export const useIssueWithResponse = <T>(
     deps: unknown[] = [],
 ) => withResponse<T>(useCachedOrPromise<T>(getter, deps))
 
-export const useIssueResponse = (issue: {
-    localIssueId: Issue['localId']
-    publishedIssueId: Issue['publishedId']
-}) =>
-    useIssueWithResponse(
-        fetchIssue(issue.localIssueId, issue.publishedIssueId),
+export const useIssueResponse = (
+    issue: {
+        localIssueId: Issue['localId']
+        publishedIssueId: Issue['publishedId']
+    },
+    forceAPIFetch = false,
+) => {
+    console.log('responding')
+    console.log(issue.localIssueId, issue.publishedIssueId)
+    return useIssueWithResponse(
+        fetchIssue(issue.localIssueId, issue.publishedIssueId, forceAPIFetch),
         [issue],
     )
+}
 
 export const getArticleResponse = ({
     article,

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -22,8 +22,6 @@ export const useIssueResponse = (
     },
     forceAPIFetch = false,
 ) => {
-    console.log('responding')
-    console.log(issue.localIssueId, issue.publishedIssueId)
     return useIssueWithResponse(
         fetchIssue(issue.localIssueId, issue.publishedIssueId, forceAPIFetch),
         [issue],

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -52,6 +52,7 @@ import { useIssueResponse } from 'src/hooks/use-issue'
 import {
     issueSummaryToLatestPath,
     useIssueSummary,
+    getIssueSummary,
 } from 'src/hooks/use-issue-summary'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
 import { useIsPreview } from 'src/hooks/use-settings'
@@ -347,7 +348,8 @@ const IssueScreenWithPath = React.memo(
         path: PathToIssue
         initialFrontKey: string | null
     }) => {
-        const response = useIssueResponse(path)
+        const preview = useIsPreview()
+        const response = useIssueResponse(path, preview)
 
         return response({
             error: handleError,
@@ -359,8 +361,10 @@ const IssueScreenWithPath = React.memo(
                 return (
                     <>
                         <PreviewReloadButton
-                            onPress={() => {
+                            onPress={async () => {
                                 clearCache()
+                                const issueSummary = await getIssueSummary()
+                                path = issueSummaryToLatestPath(issueSummary)
                                 retry()
                             }}
                         />


### PR DESCRIPTION
## Summary

The 'refresh' button doesn't currently work for the proof backend. This is because for each new version of a proofed edition there is a new 'publishedId'. This change forces the app to refetch the /issues list to pick up the new ID. 

The 'local id' of an edition is just the date it was published (without time). This causes problems for the proof endpoint as once the issue is downloaded it will only re-download if the local id is different, so I've added a 'forceApiFetch' parameter to skip the fetch from file system step for thsi endpoint.

[**Trello Card ->**](https://trello.com/c/PkjPqlFR/1336-production-edition-switching)

## Test Plan
Release, check that the refresh button works, and that issue switching still works!

