### PR TITLE
Feat/weather-visibility-multiple-editions

### DIFF
--- a/projects/Mallard/jest-setup.js
+++ b/projects/Mallard/jest-setup.js
@@ -5,3 +5,24 @@ jest.mock('src/helpers/locale', () => ({
 jest.mock('src/push-notifications/push-notifications', () => ({
     pushNotifcationRegistration: () => jest.fn(),
 }))
+
+jest.mock('@react-native-community/geolocation', () => ({
+    setRNConfiguration: () => {},
+    getCurrentPosition: resolve =>
+        Promise.resolve().then(() => {
+            resolve({
+                coords: { latitude: 12, longitude: 34 },
+            })
+        }),
+}))
+
+jest.mock('react-native-permissions', () => {
+    return {
+        RESULTS: { GRANTED: 1, DENIED: 2 },
+        PERMISSIONS: {
+            IOS: { LOCATION_WHEN_IN_USE: 1 },
+            ANDROID: { ACCESS_FINE_LOCATION: 1 },
+        },
+        check: jest.fn().mockResolvedValue(2),
+    }
+})

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -33,7 +33,6 @@ import {
     ConfigProvider,
     largeDeviceMemory,
 } from 'src/hooks/use-config-provider'
-import { weatherHider } from './helpers/weather-hider'
 import { loggingService } from './services/logging'
 import ApolloClient from 'apollo-client'
 import { pushDownloadFailsafe } from './helpers/push-download-failsafe'

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -147,7 +147,6 @@ const shouldHavePushFailsafe = async (client: ApolloClient<object>) => {
 export default class App extends React.Component<{}, {}> {
     componentDidMount() {
         SplashScreen.hide()
-        weatherHider(apolloClient)
         prepareAndDownloadTodaysIssue(apolloClient)
         shouldHavePushFailsafe(apolloClient)
         loggingService.postLogs()

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -42,6 +42,8 @@ import analytics from '@react-native-firebase/analytics'
 import { prepFileSystem } from './helpers/files'
 import { EditionProvider } from './hooks/use-edition-provider'
 import { apolloClient } from './services/apollo-singleton'
+import { eventEmitter } from 'src/helpers/event-emitter'
+import { weatherHider } from 'src/helpers/weather-hider'
 
 analytics().setAnalyticsCollectionEnabled(false)
 
@@ -156,6 +158,12 @@ export default class App extends React.Component<{}, {}> {
                 loggingService.postLogs()
             }
         })
+
+        {
+            eventEmitter.on('editionCachesSet', () => {
+                weatherHider(apolloClient)
+            })
+        }
     }
 
     async componentDidCatch(e: Error) {

--- a/projects/Mallard/src/helpers/__tests__/weather.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/weather.spec.ts
@@ -27,27 +27,6 @@ let forecasts = [{ DateTime: '0000' }]
     throw new Error(`unknown url`)
 })
 
-jest.mock('react-native-permissions', () => {
-    return {
-        RESULTS: { GRANTED: 1, DENIED: 2 },
-        PERMISSIONS: {
-            IOS: { LOCATION_WHEN_IN_USE: 1 },
-            ANDROID: { ACCESS_FINE_LOCATION: 1 },
-        },
-        check: jest.fn().mockResolvedValue(2),
-    }
-})
-
-jest.mock('@react-native-community/geolocation', () => ({
-    setRNConfiguration: () => {},
-    getCurrentPosition: (resolve: any) =>
-        Promise.resolve().then(() => {
-            resolve({
-                coords: { latitude: 12, longitude: 34 },
-            })
-        }),
-}))
-
 jest.mock('react-native-localize', () => ({
     getTemperatureUnit: () => 'celsius',
 }))

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -6,7 +6,7 @@ import { errorService } from 'src/services/errors'
 import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider'
 
 // Purpose: To hide the weahter on the first load unless the user turns it on
-// Intended for use on lower powered devices
+// Intended for use on lower powered devices and for users who do not use the daily edition as their default edition
 
 const KEY = '@weatherLowRAMCheck'
 const EDITIONCHECKKEY = '@weatherEditionCheck'
@@ -20,7 +20,8 @@ const weatherHider = async (client: ApolloClient<object>) => {
             const largeRAM = await largeDeviceMemory()
             await AsyncStorage.setItem(KEY, 'true')
             !largeRAM && setIsWeatherShown(client, false)
-        } else if (
+        }
+        if (
             !editionWeatherCheck &&
             defaultEdition &&
             defaultEdition !== 'daily-edition'

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -3,19 +3,30 @@ import { largeDeviceMemory } from 'src/hooks/use-config-provider'
 import { setIsWeatherShown } from './settings/setters'
 import AsyncStorage from '@react-native-community/async-storage'
 import { errorService } from 'src/services/errors'
+import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider'
 
 // Purpose: To hide the weahter on the first load unless the user turns it on
 // Intended for use on lower powered devices
 
 const KEY = '@weatherLowRAMCheck'
+const EDITIONCHECKKEY = '@weatherEditionCheck'
 
 const weatherHider = async (client: ApolloClient<object>) => {
     try {
         const weatherLowRamCheck = await AsyncStorage.getItem(KEY)
+        const editionWeatherCheck = await AsyncStorage.getItem(EDITIONCHECKKEY)
+        const defaultEdition = await getDefaultEditionSlug()
         if (!weatherLowRamCheck) {
             const largeRAM = await largeDeviceMemory()
             await AsyncStorage.setItem(KEY, 'true')
             !largeRAM && setIsWeatherShown(client, false)
+        } else if (
+            !editionWeatherCheck &&
+            defaultEdition &&
+            defaultEdition !== 'daily-edition'
+        ) {
+            await AsyncStorage.setItem(EDITIONCHECKKEY, 'true')
+            setIsWeatherShown(client, false)
         }
     } catch (e) {
         errorService.captureException(e)

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -20,6 +20,8 @@ import { AppState, AppStateStatus } from 'react-native'
 import { remoteConfigService } from 'src/services/remote-config'
 import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/push-notifications/push-notifications'
+import { weatherHider } from 'src/helpers/weather-hider'
+import { apolloClient } from 'src/services/apollo-singleton'
 
 interface EditionsEndpoint {
     regionalEditions: RegionalEdition[]
@@ -141,6 +143,7 @@ const setEdition = async (
     setSelectedEdition(edition)
     await selectedEditionCache.set(edition)
     await defaultEditionCache.set(edition)
+    weatherHider(apolloClient)
     pushNotifcationRegistration()
 }
 

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -141,6 +141,7 @@ const setEdition = async (
     setSelectedEdition(edition)
     await selectedEditionCache.set(edition)
     await defaultEditionCache.set(edition)
+    eventEmitter.emit('editionCachesSet')
     pushNotifcationRegistration()
 }
 

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -20,8 +20,6 @@ import { AppState, AppStateStatus } from 'react-native'
 import { remoteConfigService } from 'src/services/remote-config'
 import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/push-notifications/push-notifications'
-import { weatherHider } from 'src/helpers/weather-hider'
-import { apolloClient } from 'src/services/apollo-singleton'
 
 interface EditionsEndpoint {
     regionalEditions: RegionalEdition[]
@@ -143,7 +141,6 @@ const setEdition = async (
     setSelectedEdition(edition)
     await selectedEditionCache.set(edition)
     await defaultEditionCache.set(edition)
-    weatherHider(apolloClient)
     pushNotifcationRegistration()
 }
 

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -64,6 +64,8 @@ import { Front as TFront, IssueWithFronts } from '../../../Apps/common/src'
 import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
+import { weatherHider } from 'src/helpers/weather-hider'
+import { apolloClient } from 'src/services/apollo-singleton'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -348,6 +350,7 @@ const IssueScreenWithPath = React.memo(
         initialFrontKey: string | null
     }) => {
         const response = useIssueResponse(path)
+        weatherHider(apolloClient)
 
         return response({
             error: handleError,

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -64,8 +64,6 @@ import { Front as TFront, IssueWithFronts } from '../../../Apps/common/src'
 import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
-import { weatherHider } from 'src/helpers/weather-hider'
-import { apolloClient } from 'src/services/apollo-singleton'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -350,7 +348,6 @@ const IssueScreenWithPath = React.memo(
         initialFrontKey: string | null
     }) => {
         const response = useIssueResponse(path)
-        weatherHider(apolloClient)
 
         return response({
             error: handleError,


### PR DESCRIPTION
## Summary
This PR adds a check to hide the weather when the user's default edition is not the daily edition, this check is only run once.
This will ensure all previous daily edition users will continue seeing the weather across all editions unless they have disabled it from the settings menu. 
New users using other regional editions will not see the weather by default but can still switch it on globally in the settings menu.
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/lJuuo3Sz/1319-control-weather-visibility-by-edition)

## Test Plan
To test this you can either enable default locale in firebase remote config or enable it locally here https://github.com/guardian/editions/blob/c203614327c6d0d9f92f9b575ec4a06d555291d5/projects/Mallard/src/hooks/use-edition-provider.tsx#L161-L163
Then you can launch the app both inside and outside the UK and ensure that the weather visibility is as expected. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
