### PR TITLE
test: getStandfirst in the header html build

### DIFF
--- a/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
+++ b/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`article html Header getStandFirst should display LargeByline Header Type with Opinion Article Type 1`] = `
+"
+            <section class=\\"header-top\\">
+                <div class=\\"\\">
+                    <h1>
+                        <Quotes />
+                        <span class=\\"header-top-headline\\"
+                            >Test Headline
+                        </span>
+                        <span class=\\"header-top-byline\\"
+                            ><p>Test Byline</p>
+                        </span>
+                    </h1>
+                    
+                </div>
+            </section>
+        "
+`;
+
+exports[`article html Header getStandFirst should display LargeByline Header Type with Opinion Article Type with a cutout image 1`] = `
+"
+            <section class=\\"header-top\\">
+                <div class=\\"header-opinion-flex\\">
+                    <h1>
+                        <Quotes />
+                        <span class=\\"header-top-headline\\"
+                            >Test Headline
+                        </span>
+                        <span class=\\"header-top-byline\\"
+                            ><p>Test Byline</p>
+                        </span>
+                    </h1>
+                    
+                            <div>
+                                
+        <img class=\\"\\" src=\\"\\" />
+    
+                            </div>
+                        
+                </div>
+            </section>
+        "
+`;
+
+exports[`article html Header getStandFirst should display LargeByline Header Type with Opinion Article Type with a cutout space 1`] = `
+"
+            <section class=\\"header-top\\">
+                <div class=\\"header-opinion-flex\\">
+                    <h1>
+                        <Quotes />
+                        <span class=\\"header-top-headline\\"
+                            >Test Headline
+                        </span>
+                        <span class=\\"header-top-byline\\"
+                            ><p>Test Byline</p>
+                        </span>
+                    </h1>
+                    
+                </div>
+            </section>
+        "
+`;
+
+exports[`article html Header getStandFirst should display LargeByline Header Type with alternative Article Type with a cutout image 1`] = `
+"
+            <section class=\\"header-top\\">
+                <div class=\\"\\">
+                    <h1>
+                        
+                        <span class=\\"header-top-headline\\"
+                            >Test Headline
+                        </span>
+                        <span class=\\"header-top-byline\\"
+                            ><p>Test Byline</p>
+                        </span>
+                    </h1>
+                    
+                </div>
+            </section>
+        "
+`;
+
+exports[`article html Header getStandFirst should display NoByline Header Type, show only the headline 1`] = `
+"
+            <section class=\\"header-top\\">
+                <h1>
+                    Test Headline
+                </h1>
+                
+            </section>
+        "
+`;
+
+exports[`article html Header getStandFirst should display RegularByline Header Type, show a standfirst with the headline 1`] = `
+"
+            <section class=\\"header-top\\">
+                <h1>
+                    Test Headline
+                </h1>
+                <p>
+                        Test Standfirst
+                      </p>
+            </section>
+        "
+`;

--- a/projects/Mallard/src/components/article/html/components/__tests__/header.spec.ts
+++ b/projects/Mallard/src/components/article/html/components/__tests__/header.spec.ts
@@ -1,0 +1,96 @@
+import { getStandFirst } from '../header'
+import { HeaderType, ArticleType } from '../../../../../../../Apps/common/src'
+
+jest.mock('src/components/article/html/components/icon/quotes', () => ({
+    Quotes: () => '<Quotes />',
+}))
+
+describe('article html Header', () => {
+    describe('getStandFirst', () => {
+        it('should display LargeByline Header Type with Opinion Article Type', () => {
+            const html = getStandFirst(
+                HeaderType.LargeByline,
+                ArticleType.Opinion,
+                { headline: 'Test Headline', bylineHtml: '<p>Test Byline</p>' },
+                null,
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+        it('should display LargeByline Header Type with Opinion Article Type with a cutout space', () => {
+            const html = getStandFirst(
+                HeaderType.LargeByline,
+                ArticleType.Opinion,
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                    bylineImages: {
+                        cutout: { source: 'media', path: 'path/to/image' },
+                    },
+                },
+                null,
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+        it('should display LargeByline Header Type with Opinion Article Type with a cutout image', () => {
+            const html = getStandFirst(
+                HeaderType.LargeByline,
+                ArticleType.Opinion,
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                    bylineImages: {
+                        cutout: { source: 'media', path: 'path/to/image' },
+                    },
+                },
+                '1234567880',
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+        it('should display LargeByline Header Type with alternative Article Type with a cutout image', () => {
+            const html = getStandFirst(
+                HeaderType.LargeByline,
+                ArticleType.Article,
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                    bylineImages: {
+                        cutout: { source: 'media', path: 'path/to/image' },
+                    },
+                },
+                null,
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+        it('should display RegularByline Header Type, show a standfirst with the headline', () => {
+            const html = getStandFirst(
+                HeaderType.RegularByline,
+                ArticleType.Article,
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                    standfirst: 'Test Standfirst',
+                },
+                null,
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+        it('should display NoByline Header Type, show only the headline', () => {
+            const html = getStandFirst(
+                HeaderType.NoByline,
+                ArticleType.Article,
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                },
+                null,
+                () => undefined,
+            )
+            expect(html).toMatchSnapshot()
+        })
+    })
+})

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -868,5 +868,4 @@ const Header = ({
         </div>
     `
 }
-
-export { Header }
+export { Header, getStandFirst }


### PR DESCRIPTION
## Summary
Editing this area of the code is required for the Showcase template work. Its a bit of a scary place and I feel more comfortable if it is tested beforehand to make sure i'm not affecting the look and feel on potentially obscure template/pillar combinations.

As a result I have written tests to cover the Standfirst area as this will need refactoring to pull the Headline out of it
