### PR TITLE
Feat: Separate Headline from Standfirst in HTML Articles

### DIFF
--- a/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
+++ b/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
@@ -4,15 +4,17 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
 "
             <section class=\\"header-top\\">
                 <div class=\\"\\">
-                    <h1>
-                        <Quotes />
-                        <span class=\\"header-top-headline\\"
-                            >Test Headline
-                        </span>
-                        <span class=\\"header-top-byline\\"
-                            ><p>Test Byline</p>
-                        </span>
-                    </h1>
+                    
+            <h1>
+                <Quotes />
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        
                     
                 </div>
             </section>
@@ -23,15 +25,17 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
 "
             <section class=\\"header-top\\">
                 <div class=\\"header-opinion-flex\\">
-                    <h1>
-                        <Quotes />
-                        <span class=\\"header-top-headline\\"
-                            >Test Headline
-                        </span>
-                        <span class=\\"header-top-byline\\"
-                            ><p>Test Byline</p>
-                        </span>
-                    </h1>
+                    
+            <h1>
+                <Quotes />
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        
                     
                             <div>
                                 
@@ -48,15 +52,17 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
 "
             <section class=\\"header-top\\">
                 <div class=\\"header-opinion-flex\\">
-                    <h1>
-                        <Quotes />
-                        <span class=\\"header-top-headline\\"
-                            >Test Headline
-                        </span>
-                        <span class=\\"header-top-byline\\"
-                            ><p>Test Byline</p>
-                        </span>
-                    </h1>
+                    
+            <h1>
+                <Quotes />
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        
                     
                 </div>
             </section>
@@ -67,15 +73,17 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
 "
             <section class=\\"header-top\\">
                 <div class=\\"\\">
-                    <h1>
-                        
-                        <span class=\\"header-top-headline\\"
-                            >Test Headline
-                        </span>
-                        <span class=\\"header-top-byline\\"
-                            ><p>Test Byline</p>
-                        </span>
-                    </h1>
+                    
+            <h1>
+                
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        
                     
                 </div>
             </section>
@@ -85,9 +93,11 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
 exports[`article html Header getStandFirst should display NoByline Header Type, show only the headline 1`] = `
 "
             <section class=\\"header-top\\">
-                <h1>
-                    Test Headline
-                </h1>
+                
+            <h1>
+                Test Headline
+            </h1>
+        
                 
             </section>
         "
@@ -96,9 +106,11 @@ exports[`article html Header getStandFirst should display NoByline Header Type, 
 exports[`article html Header getStandFirst should display RegularByline Header Type, show a standfirst with the headline 1`] = `
 "
             <section class=\\"header-top\\">
-                <h1>
-                    Test Headline
-                </h1>
+                
+            <h1>
+                Test Headline
+            </h1>
+        
                 <p>
                         Test Standfirst
                       </p>

--- a/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/headline.spec.ts.snap
+++ b/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/headline.spec.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getHeadline should display a headline on its own 1`] = `
+"
+            <h1>
+                Test Headline
+            </h1>
+        "
+`;
+
+exports[`getHeadline should display a headline with only the byline 1`] = `
+"
+            <h1>
+                
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        "
+`;
+
+exports[`getHeadline should display a headline with the byline and quotes 1`] = `
+"
+            <h1>
+                <Quotes />
+                <span class=\\"header-top-headline\\"
+                    >Test Headline
+                </span>
+                <span class=\\"header-top-byline\\"
+                    ><p>Test Byline</p>
+                </span>
+            </h1>
+        "
+`;

--- a/projects/Mallard/src/components/article/html/components/__tests__/headline.spec.ts
+++ b/projects/Mallard/src/components/article/html/components/__tests__/headline.spec.ts
@@ -1,0 +1,30 @@
+import { getHeadline } from '../headline'
+import { HeaderType, ArticleType } from 'src/common'
+
+jest.mock('src/components/article/html/components/icon/quotes', () => ({
+    Quotes: () => '<Quotes />',
+}))
+
+describe('getHeadline', () => {
+    it('should display a headline with the byline and quotes', () => {
+        const html = getHeadline(HeaderType.LargeByline, ArticleType.Opinion, {
+            headline: 'Test Headline',
+            bylineHtml: '<p>Test Byline</p>',
+        })
+        expect(html).toMatchSnapshot()
+    })
+    it('should display a headline with only the byline', () => {
+        const html = getHeadline(HeaderType.LargeByline, ArticleType.Article, {
+            headline: 'Test Headline',
+            bylineHtml: '<p>Test Byline</p>',
+        })
+        expect(html).toMatchSnapshot()
+    })
+    it('should display a headline on its own', () => {
+        const html = getHeadline(HeaderType.NoByline, ArticleType.Opinion, {
+            headline: 'Test Headline',
+            bylineHtml: '<p>Test Byline</p>',
+        })
+        expect(html).toMatchSnapshot()
+    })
+})

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { ArticleType, HeaderType, Image as ImageT, Issue } from 'src/common'
 import { css, html, px } from 'src/helpers/webview'
 import { GetImagePath } from 'src/hooks/use-image-paths'
@@ -6,18 +7,17 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { families } from 'src/theme/typography'
 import {
-    CreditedImage,
     Article,
+    CreditedImage,
     MediaAtomElement,
 } from '../../../../../../Apps/common/src'
 import { CssProps, themeColors } from '../helpers/css'
 import { breakSides } from '../helpers/layout'
-import { Quotes } from './icon/quotes'
+import { getHeadline } from './headline'
 import { Line } from './line'
+import { renderMediaAtom } from './media-atoms'
 import { Rating } from './rating'
 import { SportScore } from './sport-score'
-import { renderMediaAtom } from './media-atoms'
-import { Platform } from 'react-native'
 
 export interface ArticleHeaderProps {
     headline: string
@@ -654,15 +654,7 @@ const getStandFirst = (
         return html`
             <section class="header-top">
                 <div class="${cutout && `header-opinion-flex`}">
-                    <h1>
-                        ${type === ArticleType.Opinion && Quotes()}
-                        <span class="header-top-headline"
-                            >${headerProps.headline}
-                        </span>
-                        <span class="header-top-byline"
-                            >${headerProps.bylineHtml}
-                        </span>
-                    </h1>
+                    ${getHeadline(articleHeaderType, type, headerProps)}
                     ${publishedId &&
                         cutout &&
                         html`
@@ -679,9 +671,7 @@ const getStandFirst = (
     } else {
         return html`
             <section class="header-top">
-                <h1>
-                    ${headerProps.headline}
-                </h1>
+                ${getHeadline(articleHeaderType, type, headerProps)}
                 ${articleHeaderType === HeaderType.RegularByline &&
                     headerProps.standfirst &&
                     `<p>

--- a/projects/Mallard/src/components/article/html/components/headline.ts
+++ b/projects/Mallard/src/components/article/html/components/headline.ts
@@ -1,0 +1,32 @@
+import { html } from 'src/helpers/webview'
+import { HeaderType, ArticleType } from 'src/common'
+import { ArticleHeaderProps } from './header'
+import { Quotes } from './icon/quotes'
+
+const getHeadline = (
+    articleHeaderType: HeaderType,
+    articleType: ArticleType,
+    headerProps: ArticleHeaderProps,
+) => {
+    if (articleHeaderType === HeaderType.LargeByline) {
+        return html`
+            <h1>
+                ${articleType === ArticleType.Opinion && Quotes()}
+                <span class="header-top-headline"
+                    >${headerProps.headline}
+                </span>
+                <span class="header-top-byline"
+                    >${headerProps.bylineHtml}
+                </span>
+            </h1>
+        `
+    } else {
+        return html`
+            <h1>
+                ${headerProps.headline}
+            </h1>
+        `
+    }
+}
+
+export { getHeadline }


### PR DESCRIPTION
## Summary
In order to do the new template, the standfirst and headline need to not be tightly coupled. This does this work.

The header.spec.snap file is updated with only white space changes due to template strings maintaining spacing. This happens because of our implementation of the `html` function and Prettier.

[**Trello Card ->**](https://trello.com/c/toCtvPTB/1402-showcase-template-implementation)