### PR TITLE
Correct trigger name in github workflow

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -2,7 +2,7 @@ name: scheduled-ios-beta
 
 on:
     workflow_dispatch:
-    deploy:
+    deployment:
     schedule:
         # * is a special character in YAML so you have to quote this string
         - cron: '0 14 * * 1-5' # every day at 2pm


### PR DESCRIPTION
I broke this in https://github.com/guardian/editions/pull/1378/files - this fixes the ios build!