### PR TITLE
Allow cover cards on the sport front.

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -214,10 +214,9 @@ export const getCardsForFront = (
         case 'Life':
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage)
-        case 'Sport':
-            return defaultLayout(1)
         case 'Journal':
             return defaultLayout(1)
+        case 'Sport':
         default:
             return defaultLayout(FrontCardAppearance.splashPage)
     }


### PR DESCRIPTION
## Summary
This change allows for cover cards to be used on the sport front. 

Following from https://github.com/guardian/editions/pull/1029 many months later, this takes a more conservative approach of enabling cover cards on one extra front. Now that we have removed the sidekick card https://github.com/guardian/editions/pull/1340 the problems identified in https://github.com/guardian/editions/pull/1042 are now hopefully less of a concern

## Test Plan
Warn production before release! Tested on CODE.  For testing release, publish an edition and double check that the first card on the sport front hasn't suddenly become a cover card. 
