### PR TITLE
Pass notification topic

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -272,6 +272,7 @@ export interface IssuePublicationIdentifier extends IssueIdentifier {
 export interface IssuePublicationActionIdentifier
     extends IssuePublicationIdentifier {
     action: string
+    topic: string
     notificationUTCOffset: number
 }
 

--- a/projects/archiver/src/invoke/parser.ts
+++ b/projects/archiver/src/invoke/parser.ts
@@ -33,6 +33,7 @@ export const parseIssueActionRecordInternal = (
         version,
         issueDate,
         notificationUTCOffset,
+        topic,
     } = JSON.parse(objContent) as IssuePublicationActionIdentifier
 
     if (
@@ -40,16 +41,17 @@ export const parseIssueActionRecordInternal = (
         edition === undefined ||
         version === undefined ||
         issueDate === undefined ||
-        notificationUTCOffset === undefined
+        notificationUTCOffset === undefined ||
+        topic === undefined
     ) {
         return failure({
             error: new Error(),
             messages: [
-                `⚠️ ${loc} json file with issue details did not contained required values: (action, edition, version, issueDate, notificationUTCOffset)`,
+                `⚠️ ${loc} json file with issue details did not contained required values: (action, edition, version, issueDate, notificationUTCOffset, topic)`,
             ],
         })
     }
-    return { action, edition, version, issueDate, notificationUTCOffset }
+    return { action, edition, version, issueDate, notificationUTCOffset, topic }
 }
 
 const parseEditionListActionRecordInternal = (

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications-helpers.ts
@@ -66,7 +66,7 @@ export const prepareScheduleDeviceNotificationRequest = (
 ): { reqEndpoint: RequestInfo; reqBody: RequestInit } => {
     const { domain, apiKey } = cfg
 
-    const { key, name, issueDate } = issueData
+    const { key, name, issueDate, topic } = issueData
 
     /**
      * TODO
@@ -76,7 +76,7 @@ export const prepareScheduleDeviceNotificationRequest = (
     const payload: ScheduleDeviceNotificationPayload = {
         id: uuid.fromString(key),
         type: 'editions',
-        topic: [{ type: 'editions', name: 'uk' }],
+        topic: [{ type: 'editions', name: topic }],
         key,
         name,
         date: issueDate,

--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -12,6 +12,7 @@ export interface IssueNotificationData {
     name: string
     issueDate: string
     edition: Edition
+    topic: string
     notificationUTCOffset: number
 }
 

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -24,7 +24,12 @@ export const handler: Handler<
     async ({ issuePublication, issue }) => {
         const stage: string = process.env.stage || 'code'
 
-        const { issueDate, edition, notificationUTCOffset, topic } = issuePublication
+        const {
+            issueDate,
+            edition,
+            notificationUTCOffset,
+            topic,
+        } = issuePublication
         const { key, name } = issue
 
         const guNotificationServiceDomain =

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -29,7 +29,7 @@ export const handler: Handler<
             edition,
             notificationUTCOffset,
             topic,
-        } = issuePublication
+        src/invoke/parser.ts} = issuePublication
         const { key, name } = issue
 
         const guNotificationServiceDomain =

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -29,7 +29,7 @@ export const handler: Handler<
             edition,
             notificationUTCOffset,
             topic,
-        src/invoke/parser.ts} = issuePublication
+        } = issuePublication
         const { key, name } = issue
 
         const guNotificationServiceDomain =

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -24,7 +24,7 @@ export const handler: Handler<
     async ({ issuePublication, issue }) => {
         const stage: string = process.env.stage || 'code'
 
-        const { issueDate, edition, notificationUTCOffset } = issuePublication
+        const { issueDate, edition, notificationUTCOffset, topic } = issuePublication
         const { key, name } = issue
 
         const guNotificationServiceDomain =
@@ -35,7 +35,7 @@ export const handler: Handler<
         const guNotificationServiceAPIKey =
             process.env.gu_notify_service_api_key || ''
         const notificationStatus = await scheduleDeviceNotificationIfEligible(
-            { key, name, issueDate, edition, notificationUTCOffset },
+            { key, name, issueDate, edition, notificationUTCOffset, topic },
             {
                 domain: guNotificationServiceDomain,
                 apiKey: guNotificationServiceAPIKey,

--- a/projects/archiver/test/invoke/index.spec.ts
+++ b/projects/archiver/test/invoke/index.spec.ts
@@ -8,7 +8,7 @@ import {
 
 describe('state machine invoker', () => {
     const objectsContentsInput =
-        '{"action":"proof","id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}], "notificationUTCOffset":1}'
+        '{"action":"proof","id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}], "notificationUTCOffset":1, "topic":"us"}'
 
     const recordsInput: Record[] = [
         {
@@ -48,6 +48,7 @@ describe('state machine invoker', () => {
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-10-09',
             notificationUTCOffset: 1,
+            topic: 'us',
         }
         const expected = [
             `✅ Invocation of ${JSON.stringify(issueExpected)} succeeded.`,

--- a/projects/archiver/test/invoke/parser.spec.ts
+++ b/projects/archiver/test/invoke/parser.spec.ts
@@ -4,7 +4,7 @@ import { hasFailed } from '../../common'
 describe('parseRecord', () => {
     it('should parse correct json', async () => {
         const obejctsContents =
-            '{"action":"proof","id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}], "notificationUTCOffset":1}'
+            '{"action":"proof","id":"ff8936b8-cc57-4572-9a50-bd779319f726","name":"american-edition","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z","fronts":[{"id":"cde7a75d-5fdc-4468-aefe-aac676f4090e","name":"National","collections":[{"id":"3e16f025-690f-4ea3-9e58-7aa779b20df4","name":"Front Page","items":[{"internalPageCode":6668324,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]},{"id":"47539d9a-bd1a-46d6-85d8-d6a69daada2e","name":"UK News","items":[{"internalPageCode":6668444,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}},{"internalPageCode":6668479,"furniture":{"showByline":false,"showQuotedHeadline":false,"mediaType":"useArticleTrail","overrideArticleMainMedia":false}}]}],"swatch":"news"}], "notificationUTCOffset":1, "topic": "us"}'
 
         const actual = parseIssueActionRecordInternal(obejctsContents)
 
@@ -14,12 +14,13 @@ describe('parseRecord', () => {
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-10-09',
             notificationUTCOffset: 1,
+            topic: 'us',
         })
     })
 
     it('should parse js smaller json with requiered fields', async () => {
         const obejctsContents =
-            '{"action":"proof","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z", "notificationUTCOffset":1}'
+            '{"action":"proof","edition":"american-edition","issueDate":"2019-10-09","version":"2019-10-04T16:08:35.951Z", "notificationUTCOffset":1, "topic":"us"}'
 
         const actual = parseIssueActionRecordInternal(obejctsContents)
 
@@ -29,6 +30,7 @@ describe('parseRecord', () => {
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-10-09',
             notificationUTCOffset: 1,
+            topic: 'us',
         })
     })
 

--- a/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/_tests_/device-notifications-helpers.spec.ts
@@ -14,6 +14,7 @@ describe('prepareScheduleDeviceNotificationRequest', () => {
             edition: 'daily-edition',
             issueDate: '2019-09-18',
             notificationUTCOffset: 1,
+            topic: 'uk',
         }
 
         const apiCfg = {

--- a/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
+++ b/projects/archiver/test/tasks/notification/helpers/device-notifications.spec.ts
@@ -25,6 +25,7 @@ describe('scheduleDeviceNotificationIfEligibleInternal', () => {
         edition: 'daily-edition',
         issueDate: '2019-09-18',
         notificationUTCOffset: 1,
+        topic: 'uk',
     }
 
     const dayBeforeIssue = new Date('2019-09-17')


### PR DESCRIPTION
## Summary

Currently the notification topic is hard coded as 'uk', which is not very helpful when publishing a US or AU issue of an edition.

This PR requires the topic to be specified as part of the publish notification, and uses it to construct the request to the notification service.

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
