### PR TITLE
Fix code signing

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -63,10 +63,7 @@ platform :ios do
       workspace: "ios/Mallard.xcworkspace",
       xcargs: "-allowProvisioningUpdates",
       export_options: {
-        exportOptionsPlist: "exports-plists/release.plist",
-        provisioningProfiles: {
-            "uk.co.guardian.gce" => "match AppStore uk.co.guardian.gce"
-        }
+        exportOptionsPlist: "exports-plists/release.plist"
       }
     )
     upload_to_testflight(

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -63,7 +63,10 @@ platform :ios do
       workspace: "ios/Mallard.xcworkspace",
       xcargs: "-allowProvisioningUpdates",
       export_options: {
-        exportOptionsPlist: "exports-plists/release.plist"
+        exportOptionsPlist: "exports-plists/release.plist",
+        provisioningProfiles: {
+            "uk.co.guardian.gce" => "match AppStore uk.co.guardian.gce"
+        }
       }
     )
     upload_to_testflight(

--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -954,7 +954,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = GuardianDaily;
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore uk.co.guardian.gce 1586248549";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore uk.co.guardian.gce";
 				SWIFT_OBJC_BRIDGING_HEADER = "Mallard-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary
As part of the changes in the [deep links feature]() we needed to add 'associated domains' to our provisioning profile. Regenerating the profile resulted in the name changing from `match AppStore uk.co.guardian.gce 1586248549` to just `match AppStore uk.co.guardian.gce`. I'm not certain why this is but it seems easier to not worry about what that number is on the end! This PR needs to be merged for github actions ios builds to start working again. 

[**Trello Card ->**](https://trello.com/c/iGkBQHm8/1448-fix-ios-builds)

## Test Plan
Check ios builds work
