### PR TITLE
feat: getBylineText adds newline where appropriate

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -18,6 +18,7 @@ import { Line } from './line'
 import { renderMediaAtom } from './media-atoms'
 import { Rating } from './rating'
 import { SportScore } from './sport-score'
+import { getByLineText } from './helpers/getBylineText'
 
 export interface ArticleHeaderProps {
     headline: string
@@ -697,18 +698,6 @@ const getHeaderClassForType = (headerType: HeaderType): string => {
                 header-byline header-byline-italic
             `
     }
-}
-
-const getByLineText = (
-    headerType: HeaderType,
-    headerProps: ArticleHeaderProps,
-): string | undefined => {
-    const byLineText =
-        headerType === HeaderType.NoByline ||
-        headerType === HeaderType.LargeByline
-            ? headerProps.standfirst
-            : headerProps.bylineHtml
-    return byLineText
 }
 
 const hasByLine = (

--- a/projects/Mallard/src/components/article/html/components/helpers/__tests__/getBylineText.spec.ts
+++ b/projects/Mallard/src/components/article/html/components/helpers/__tests__/getBylineText.spec.ts
@@ -1,0 +1,37 @@
+import { getByLineText } from '../getBylineText'
+import { HeaderType } from 'src/common'
+
+describe('getBylineText', () => {
+    it('should return undefined if the header type is NoByline or LargeByline and there is no standfirst', () => {
+        const bylineText = getByLineText(HeaderType.NoByline, {
+            headline: 'Test Headline',
+        })
+        expect(bylineText).toEqual(undefined)
+    })
+    it('should return undefined if the header type is RegularByline and there is no byline html', () => {
+        const bylineText = getByLineText(HeaderType.RegularByline, {
+            headline: 'Test Headline',
+        })
+        expect(bylineText).toEqual(undefined)
+    })
+    it('should return uneditted html if the byline text ends in a link', () => {
+        const bylineHtml =
+            '<a href="path/to/bio">James Miller</a> and <a href="path/to/bio">Autumn Miller</a>'
+        const bylineText = getByLineText(HeaderType.RegularByline, {
+            headline: 'Test Headline',
+            bylineHtml,
+        })
+        expect(bylineText).toEqual(bylineHtml)
+    })
+    it('should add a new line if the byline text does not end in a link', () => {
+        const standfirst =
+            '<a href="path/to/bio">James Miller</a> and <a href="path/to/bio">Autumn Miller</a> at Kenilworth Road'
+        const bylineText = getByLineText(HeaderType.NoByline, {
+            headline: 'Test Headline',
+            standfirst,
+        })
+        expect(bylineText).toEqual(
+            '<a href="path/to/bio">James Miller</a> and <a href="path/to/bio">Autumn Miller</a><br /> at Kenilworth Road',
+        )
+    })
+})

--- a/projects/Mallard/src/components/article/html/components/helpers/getBylineText.ts
+++ b/projects/Mallard/src/components/article/html/components/helpers/getBylineText.ts
@@ -1,0 +1,28 @@
+import { ArticleHeaderProps } from '../header'
+import { HeaderType } from 'src/common'
+
+const getByLineText = (
+    headerType: HeaderType,
+    headerProps: ArticleHeaderProps,
+): string | undefined => {
+    const byLineText =
+        headerType === HeaderType.NoByline ||
+        headerType === HeaderType.LargeByline
+            ? headerProps.standfirst
+            : headerProps.bylineHtml
+    if (!byLineText) return undefined
+
+    const newLineCheck = byLineText.split('</a>')
+    // Link at the end? No new line needed
+    if (newLineCheck[newLineCheck.length - 1] === '') {
+        return byLineText
+    }
+
+    const bylineWithNewLine = byLineText.replace(
+        `</a>${newLineCheck[newLineCheck.length - 1]}`,
+        `</a><br />${newLineCheck[newLineCheck.length - 1]}`,
+    )
+    return bylineWithNewLine
+}
+
+export { getByLineText }


### PR DESCRIPTION
## Summary
The current templates are incorrect. There should be a newline at the end of the byline after the last author. This is shown in the Showcase designs and is a regression in the current design. This fixes this and writes tests to support this and its previous implementation.

Some screenshots:
<img width="335" alt="Screen Shot 2020-07-23 at 11 10 09" src="https://user-images.githubusercontent.com/935975/88275734-c7c68d00-ccd5-11ea-9806-75e47aca8346.png">

<img width="334" alt="Screen Shot 2020-07-23 at 11 10 17" src="https://user-images.githubusercontent.com/935975/88275748-cbf2aa80-ccd5-11ea-98a1-6a8664ff4b64.png">
