### PR TITLE
Allow cover cards on the journal front.

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -200,9 +200,7 @@ export const getCardsForFront = (
 ): FrontCardsForArticleCount => {
     switch (frontName) {
         case 'National':
-            return denseLayout()
         case 'World':
-            return denseLayout()
         case 'Financial':
             return denseLayout()
         case 'Crosswords':
@@ -215,7 +213,6 @@ export const getCardsForFront = (
         case 'Culture':
             return thirdPageCoverLayout(FrontCardAppearance.splashPage)
         case 'Journal':
-            return defaultLayout(1)
         case 'Sport':
         default:
             return defaultLayout(FrontCardAppearance.splashPage)


### PR DESCRIPTION
## Summary
Following from https://github.com/guardian/editions/pull/1386 which I've checked with Katy, also allow cover cards on the journal front. 

## Test Plan
I've tested this briefly on code, Katy is on hand to test in PROD. This is a backend only change and will only affect issues that are republished after it is merged
