### PR TITLE
Allow cover cards  in dense layout.

### DIFF
--- a/projects/Apps/common/src/collection/card-layouts.ts
+++ b/projects/Apps/common/src/collection/card-layouts.ts
@@ -150,15 +150,16 @@ const thirdPageCoverLayout = (
 const denseLayout = (): FrontCardsForArticleCount => {
     // Delete this once the client-side changes are running in the released
     // non-beta version of the app.
-    if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled') return defaultLayout(1)
+    if (process.env.EDITIONS_DENSE_LAYOUT !== 'enabled')
+        return defaultLayout(FrontCardAppearance.splashPage)
     return {
         0: [],
-        1: [1],
+        1: [FrontCardAppearance.splashPage],
 
         // We do not want to switch to 2 articles on front page right away. Prod
         // team can decide to add more articles if they need a denser layout.
-        2: [1, 1],
-        3: [1, 2],
+        2: [FrontCardAppearance.splashPage, FrontCardAppearance.splashPage],
+        3: [FrontCardAppearance.splashPage, 2],
         4: [2, 2],
         // Growing up to 2 articles on front page to distribute density.
         5: [3, 2],


### PR DESCRIPTION
## Summary
Following from https://github.com/guardian/editions/pull/1390, this is a final bit of work to allow cover cards wherever there is currently a 1 story card in  the dense layour

## Test Plan

Backend only change - check that cover cards can be added in world/national/financial
