### PR TITLE
Copy update on subscription activation modal

### DIFF
--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -61,7 +61,7 @@ const SignInModalCard = ({
         explainerTitle="Not subscribed yet?"
         explainerSubtitle={
             Platform.OS === 'ios'
-                ? 'Get the Daily with a digital subscription from The Guardian website.'
+                ? 'Get access with a digital subscription from The Guardian website.'
                 : 'Read the Daily with a digital subscription from The Guardian.'
         }
         bottomExplainerContent={


### PR DESCRIPTION
Changing copy from:
'Get the Daily with a digital subscription from The Guardian website'
to:
'Get access with a digital subscription from The Guardian website.'

## Summary

Why are we doing this?
To accommodate multiple editions.

[**Trello Card ->**](https://trello.com/c/sax1LXXf/1432-review-copy-of-subscription-activation-screen-to-accomodate-multiple-editions)

## Test Plan
Sign out if you are signed in. Open an article. Check if the copy matches:
'Get access with a digital subscription from The Guardian website.'

