### PR TITLE
Updated webview version

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -287,7 +287,7 @@ PODS:
     - React
   - react-native-viewpager (2.0.1):
     - React
-  - react-native-webview (6.9.0):
+  - react-native-webview (10.3.2):
     - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -624,7 +624,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-viewpager: f41b42bba71407e916654d64e87ff2680edecc92
-  react-native-webview: 2d8de2be422f0f8b9ba38db3f013f9ebfdb9b78f
+  react-native-webview: 679b6f400176e2ea8a785acf7ae16cf282e7d1eb
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -86,7 +86,7 @@
         "react-native-splash-screen": "^3.2.0",
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.12.0",
-        "react-native-webview": "^6.9.0",
+        "react-native-webview": "10.3.2",
         "react-native-zip-archive": "5.0.1",
         "react-navigation": "3.11.1",
         "react-navigation-fluid-transitions": "^0.3.2",

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -187,7 +187,6 @@ const Article = ({
                 article={article}
                 path={path}
                 scrollEnabled={true}
-                useWebKit={false}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r

--- a/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
+++ b/projects/Mallard/src/screens/settings/default-info-text-webview.tsx
@@ -43,7 +43,6 @@ const DefaultInfoTextWebview = ({ html }: { html: string }) => {
                 originWhitelist={['*']}
                 source={{ html: makeHtml({ styles, body: html }), baseUrl: '' }}
                 style={{ flex: 1 }}
-                useWebKit={false}
                 onShouldStartLoadWithRequest={(event: WebViewNavigation) => {
                     /**
                      * Open any non-local documents in the external browser

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6119,6 +6119,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
@@ -11311,12 +11316,12 @@ react-native-tab-view@^1.2.0, react-native-tab-view@^1.4.1:
   dependencies:
     prop-types "^15.6.1"
 
-react-native-webview@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-6.9.0.tgz#d637618fe65ddc9972a55a1d181fd6879a2fcebd"
-  integrity sha512-pipcyQNhSjSfMyle+JugLwYXJBJ0rQCnJOgkz7EcsZbrAvGjFbQOAjDRYi86y9Ibw+h+sjdhPWcLi/kSHScc+w==
+react-native-webview@10.3.2:
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.3.2.tgz#c634946152099c95d521a3abc71065d1d642e192"
+  integrity sha512-4A8FKL/puonkqQ1FOKd+iPulqRXCG4inmIK4pQ60zv9Ua+YkBKLxxofQiCvRwIXSSgAXYT+AE3rOHr3bx4A/cw==
   dependencies:
-    escape-string-regexp "1.0.5"
+    escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
 react-native-zip-archive@5.0.1:


### PR DESCRIPTION
@jimhunty please discard the previous PR

## Summary
This PR updates the webview dependency and makes relevant changes. Local testing looks fine and now we need to release this to internal beta for further testing.

This is a big jump in terms of library version and there are lots of minor and major changes between 6.9.0 and 10.3.2. We may need some adjustments after we get feedback from beta users.

This is the release where `react-native-webview` switched to WKWebview:
https://github.com/react-native-community/react-native-webview/releases/tag/v7.0.1

