### PR TITLE
centralise-copy-from-onboarding

### DIFF
--- a/projects/Mallard/src/components/SignInFailedModalCard.tsx
+++ b/projects/Mallard/src/components/SignInFailedModalCard.tsx
@@ -9,7 +9,6 @@ import {
     APPLE_RELAY_BODY,
     APPLE_RELAY_RETRY,
     SIGN_IN_FAILED_TITLE,
-    CUSTOMER_HELP_EMAIL,
     SIGN_IN_FAILED_BODY,
     SIGN_IN_FAILED_RETRY,
 } from 'src/helpers/words'
@@ -42,7 +41,7 @@ const failureModalText = (
           }
         : {
               title: SIGN_IN_FAILED_TITLE,
-              bodyCopy: `We were unable to find a subscription associated with ${email}. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`,
+              bodyCopy: SIGN_IN_FAILED_BODY.replace('%email%', email),
               tryAgainText: SIGN_IN_FAILED_RETRY,
           }
 }

--- a/projects/Mallard/src/components/SignInFailedModalCard.tsx
+++ b/projects/Mallard/src/components/SignInFailedModalCard.tsx
@@ -4,14 +4,7 @@ import { View, StyleSheet } from 'react-native'
 import { ModalButton } from './Button/ModalButton'
 import { UiBodyCopy } from './styled-text'
 import { metrics } from 'src/theme/spacing'
-import {
-    APPLE_RELAY_TITLE,
-    APPLE_RELAY_BODY,
-    APPLE_RELAY_RETRY,
-    SIGN_IN_FAILED_TITLE,
-    SIGN_IN_FAILED_BODY,
-    SIGN_IN_FAILED_RETRY,
-} from 'src/helpers/words'
+import { Copy } from 'src/helpers/words'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -35,14 +28,14 @@ const failureModalText = (
 ): FailureModalText => {
     return isAppleRelayEmail
         ? {
-              title: APPLE_RELAY_TITLE,
-              bodyCopy: APPLE_RELAY_BODY,
-              tryAgainText: APPLE_RELAY_RETRY,
+              title: Copy.failedSignIn.appleRelayTitle,
+              bodyCopy: Copy.failedSignIn.appleRelayBody,
+              tryAgainText: Copy.failedSignIn.appleRelayRetry,
           }
         : {
-              title: SIGN_IN_FAILED_TITLE,
-              bodyCopy: SIGN_IN_FAILED_BODY.replace('%email%', email),
-              tryAgainText: SIGN_IN_FAILED_RETRY,
+              title: Copy.failedSignIn.title,
+              bodyCopy: Copy.failedSignIn.body.replace('%email%', email),
+              tryAgainText: Copy.failedSignIn.retryButtonTitle,
           }
 }
 

--- a/projects/Mallard/src/components/SignInFailedModalCard.tsx
+++ b/projects/Mallard/src/components/SignInFailedModalCard.tsx
@@ -4,6 +4,15 @@ import { View, StyleSheet } from 'react-native'
 import { ModalButton } from './Button/ModalButton'
 import { UiBodyCopy } from './styled-text'
 import { metrics } from 'src/theme/spacing'
+import {
+    APPLE_RELAY_TITLE,
+    APPLE_RELAY_BODY,
+    APPLE_RELAY_RETRY,
+    SIGN_IN_FAILED_TITLE,
+    CUSTOMER_HELP_EMAIL,
+    SIGN_IN_FAILED_BODY,
+    SIGN_IN_FAILED_RETRY,
+} from 'src/helpers/words'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -14,8 +23,6 @@ const styles = StyleSheet.create({
         marginTop: metrics.vertical * 2,
     },
 })
-
-const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
 
 interface FailureModalText {
     title: string
@@ -29,14 +36,14 @@ const failureModalText = (
 ): FailureModalText => {
     return isAppleRelayEmail
         ? {
-              title: 'We are unable to verify your subscription',
-              bodyCopy: `We are unable to detect your subscription as it seems you chose not to share your email address with us. \n \nPlease try a different sign in method. You will need to use the same email address as your Digital subscription. Alternatively, use your subscriber ID.`,
-              tryAgainText: 'Try alternative sign in method',
+              title: APPLE_RELAY_TITLE,
+              bodyCopy: APPLE_RELAY_BODY,
+              tryAgainText: APPLE_RELAY_RETRY,
           }
         : {
-              title: 'Subscription not found',
+              title: SIGN_IN_FAILED_TITLE,
               bodyCopy: `We were unable to find a subscription associated with ${email}. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`,
-              tryAgainText: 'Try a different email',
+              tryAgainText: SIGN_IN_FAILED_RETRY,
           }
 }
 

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -11,7 +11,7 @@ import {
     ONBOARDING_SUBTITLE,
     EXPLAINER_TITLE,
     EXPLAINER_SUBTITLE,
-    FREE_TRIAL
+    FREE_TRIAL,
 } from 'src/helpers/words'
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -6,13 +6,7 @@ import { Link } from './link'
 import { ButtonAppearance } from './Button/Button'
 import { getFont } from 'src/theme/typography'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
-import {
-    ONBOARDING_TITLE,
-    ONBOARDING_SUBTITLE,
-    EXPLAINER_TITLE,
-    EXPLAINER_SUBTITLE,
-    FREE_TRIAL,
-} from 'src/helpers/words'
+import { Copy } from 'src/helpers/words'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -36,8 +30,8 @@ const SignInModalCard = ({
 }) => (
     <OnboardingCard
         onDismissThisCard={onDismiss}
-        title={ONBOARDING_TITLE}
-        subtitle={ONBOARDING_SUBTITLE}
+        title={Copy.signIn.title}
+        subtitle={Copy.signIn.subtitle}
         appearance={CardAppearance.blue}
         size="medium"
         bottomContent={
@@ -65,8 +59,8 @@ const SignInModalCard = ({
                 </View>
             </>
         }
-        explainerTitle={EXPLAINER_TITLE}
-        explainerSubtitle={EXPLAINER_SUBTITLE}
+        explainerTitle={Copy.signIn.explainerTitle}
+        explainerSubtitle={Copy.signIn.explainerSubtitle}
         bottomExplainerContent={
             <>
                 {/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
@@ -79,7 +73,7 @@ const SignInModalCard = ({
                         }}
                         buttonAppearance={ButtonAppearance.dark}
                     >
-                        {FREE_TRIAL}
+                        {Copy.signIn.freeTrial}
                     </ModalButton>
                 ) : null}
                 {/* Being hidden temporarily - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -6,6 +6,13 @@ import { Link } from './link'
 import { ButtonAppearance } from './Button/Button'
 import { getFont } from 'src/theme/typography'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
+import {
+    ONBOARDING_TITLE,
+    ONBOARDING_SUBTITLE,
+    EXPLAINER_TITLE,
+    EXPLAINER_SUBTITLE,
+    FREE_TRIAL
+} from 'src/helpers/words'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -29,8 +36,8 @@ const SignInModalCard = ({
 }) => (
     <OnboardingCard
         onDismissThisCard={onDismiss}
-        title="Already a subscriber?"
-        subtitle="Sign in with your subscriber details to continue"
+        title={ONBOARDING_TITLE}
+        subtitle={ONBOARDING_SUBTITLE}
         appearance={CardAppearance.blue}
         size="medium"
         bottomContent={
@@ -58,12 +65,8 @@ const SignInModalCard = ({
                 </View>
             </>
         }
-        explainerTitle="Not subscribed yet?"
-        explainerSubtitle={
-            Platform.OS === 'ios'
-                ? 'Get the Daily with a digital subscription from The Guardian website.'
-                : 'Read the Daily with a digital subscription from The Guardian.'
-        }
+        explainerTitle={EXPLAINER_TITLE}
+        explainerSubtitle={EXPLAINER_SUBTITLE}
         bottomExplainerContent={
             <>
                 {/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
@@ -76,7 +79,7 @@ const SignInModalCard = ({
                         }}
                         buttonAppearance={ButtonAppearance.dark}
                     >
-                        {'Start your free 14 day trial'}
+                        {FREE_TRIAL}
                     </ModalButton>
                 ) : null}
                 {/* Being hidden temporarily - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}

--- a/projects/Mallard/src/components/sub-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-found-modal-card.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
+import { SUB_FOUND_TITLE, SUB_FOUND_SUBTITLE } from 'src/helpers/words'
 
 const SubFoundModalCard = ({ close }: { close: () => void }) => (
     <OnboardingCard
-        title="Subscription found"
+        title={SUB_FOUND_TITLE}
         onDismissThisCard={() => {
             close()
         }}
-        subtitle="Enjoy the Guardian and thank you for your support"
+        subtitle={SUB_FOUND_SUBTITLE}
         appearance={CardAppearance.blue}
         size="small"
         bottomContent={<></>}

--- a/projects/Mallard/src/components/sub-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-found-modal-card.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
-import { SUB_FOUND_TITLE, SUB_FOUND_SUBTITLE } from 'src/helpers/words'
+import { Copy } from 'src/helpers/words'
 
 const SubFoundModalCard = ({ close }: { close: () => void }) => (
     <OnboardingCard
-        title={SUB_FOUND_TITLE}
+        title={Copy.subFound.title}
         onDismissThisCard={() => {
             close()
         }}
-        subtitle={SUB_FOUND_SUBTITLE}
+        subtitle={Copy.subFound.subtitle}
         appearance={CardAppearance.blue}
         size="small"
         bottomContent={<></>}

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Platform } from 'react-native'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { ModalButton } from './Button/ModalButton'
 import {

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -2,6 +2,13 @@ import React from 'react'
 import { Platform } from 'react-native'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { ModalButton } from './Button/ModalButton'
+import {
+    SUB_NOT_FOUND_EXPLAINER_SUBTITLE,
+    SUB_NOT_FOUND_TITLE,
+    SUB_NOT_FOUND_EXPLAINER,
+    SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON,
+    SUB_NOT_FOUND_SIGN_IN,
+} from 'src/helpers/words'
 
 const SubNotFoundModalCard = ({
     close,
@@ -15,19 +22,15 @@ const SubNotFoundModalCard = ({
     onDismiss: () => void
 }) => (
     <OnboardingCard
-        title="Already a subscriber?"
+        title={SUB_NOT_FOUND_TITLE}
         appearance={CardAppearance.blue}
         size="small"
-        explainerTitle="Not subscribed yet?"
+        explainerTitle={SUB_NOT_FOUND_EXPLAINER}
         onDismissThisCard={() => {
             close()
             onDismiss()
         }}
-        explainerSubtitle={
-            Platform.OS === 'ios'
-                ? 'To get a free trial with our digital subscription, visit our website'
-                : 'Get a free trial with our digital subscription'
-        }
+        explainerSubtitle={SUB_NOT_FOUND_EXPLAINER_SUBTITLE}
         bottomContent={
             <>
                 <ModalButton
@@ -36,7 +39,7 @@ const SubNotFoundModalCard = ({
                         onLoginPress()
                     }}
                 >
-                    Sign in to activate
+                    {SUB_NOT_FOUND_SIGN_IN}
                 </ModalButton>
                 <ModalButton
                     onPress={() => {
@@ -44,7 +47,7 @@ const SubNotFoundModalCard = ({
                         onOpenCASLogin()
                     }}
                 >
-                    Activate with subscriber ID
+                    {SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON}
                 </ModalButton>
             </>
         }

--- a/projects/Mallard/src/components/sub-not-found-modal-card.tsx
+++ b/projects/Mallard/src/components/sub-not-found-modal-card.tsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { ModalButton } from './Button/ModalButton'
-import {
-    SUB_NOT_FOUND_EXPLAINER_SUBTITLE,
-    SUB_NOT_FOUND_TITLE,
-    SUB_NOT_FOUND_EXPLAINER,
-    SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON,
-    SUB_NOT_FOUND_SIGN_IN,
-} from 'src/helpers/words'
+import { Copy } from 'src/helpers/words'
 
 const SubNotFoundModalCard = ({
     close,
@@ -21,15 +15,15 @@ const SubNotFoundModalCard = ({
     onDismiss: () => void
 }) => (
     <OnboardingCard
-        title={SUB_NOT_FOUND_TITLE}
+        title={Copy.subNotFound.title}
         appearance={CardAppearance.blue}
         size="small"
-        explainerTitle={SUB_NOT_FOUND_EXPLAINER}
+        explainerTitle={Copy.subNotFound.explainer}
         onDismissThisCard={() => {
             close()
             onDismiss()
         }}
-        explainerSubtitle={SUB_NOT_FOUND_EXPLAINER_SUBTITLE}
+        explainerSubtitle={Copy.subNotFound.explainerSubtitle}
         bottomContent={
             <>
                 <ModalButton
@@ -38,7 +32,7 @@ const SubNotFoundModalCard = ({
                         onLoginPress()
                     }}
                 >
-                    {SUB_NOT_FOUND_SIGN_IN}
+                    {Copy.subNotFound.signIn}
                 </ModalButton>
                 <ModalButton
                     onPress={() => {
@@ -46,7 +40,7 @@ const SubNotFoundModalCard = ({
                         onOpenCASLogin()
                     }}
                 >
-                    {SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON}
+                    {Copy.subNotFound.subscriberButton}
                 </ModalButton>
             </>
         }

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -111,10 +111,19 @@ const AlreadySubscribed = {
         'We were unable to find a subscription associated with your Apple ID',
 }
 
+// Consent Onboarding
+export const ConsentOnboarding = {
+    title: 'We care about your privacy',
+    explainerTitle: 'This app is free of ads',
+    optionsButton: 'My options',
+    okayButton: "I'm okay with that",
+}
+
 export const Copy = {
     signIn: SignIn,
     failedSignIn: FailedSignIn,
     subFound: SubFound,
     subNotFound: SubNotFound,
     alreadySubscribed: AlreadySubscribed,
+    consentOnboarding: ConsentOnboarding,
 }

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -51,3 +51,40 @@ export const PRIVACY_SETTINGS_HEADER_TITLE = 'Privacy Settings'
 export const PRIVACY_POLICY_HEADER_TITLE = 'Privacy Policy'
 export const REFRESH_BUTTON_TEXT = 'Refresh'
 export const DOWNLOAD_ISSUE_MESSAGE_OFFLINE = `You're currently offline. You can download it when you go online`
+
+// Sign in modal
+export const ONBOARDING_TITLE = 'Already a subscriber?'
+export const ONBOARDING_SUBTITLE =
+    'Sign in with your subscriber details to continue'
+export const EXPLAINER_TITLE = 'Not subscribed yet?'
+export const EXPLAINER_SUBTITLE = `${Platform.select({
+    ios: 'Get the Daily with a digital subscription from The Guardian website.',
+
+    android: 'Read the Daily with a digital subscription from The Guardian.',
+})}`
+export const FREE_TRIAL = 'Start your free 14 day trial'
+
+// Failed sign in modal
+export const APPLE_RELAY_TITLE = 'We are unable to verify your subscription'
+export const APPLE_RELAY_BODY = `We are unable to detect your subscription as it seems you chose not to share your email address with us. \n \nPlease try a different sign in method. You will need to use the same email address as your Digital subscription. Alternatively, use your subscriber ID.`
+export const APPLE_RELAY_RETRY = 'Try alternative sign in method'
+
+export const SIGN_IN_FAILED_TITLE = 'Subscription not found'
+export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
+export const SIGN_IN_FAILED_RETRY = 'Try a different email'
+
+//Sub found modal
+export const SUB_FOUND_TITLE = 'Subscription found'
+export const SUB_FOUND_SUBTITLE =
+    'Enjoy the Guardian and thank you for your support'
+
+//Sub not found modal
+export const SUB_NOT_FOUND_TITLE = 'Already a subscriber?'
+export const SUB_NOT_FOUND_EXPLAINER = 'Not subscribed yet?'
+export const SUB_NOT_FOUND_EXPLAINER_SUBTITLE = `${Platform.select({
+    ios: 'To get a free trial with our digital subscription, visit our website',
+
+    android: 'Get a free trial with our digital subscription',
+})}`
+export const SUB_NOT_FOUND_SIGN_IN = 'Sign in to activate'
+export const SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON = 'Activate with subscriber ID'

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -51,54 +51,70 @@ export const PRIVACY_SETTINGS_HEADER_TITLE = 'Privacy Settings'
 export const PRIVACY_POLICY_HEADER_TITLE = 'Privacy Policy'
 export const REFRESH_BUTTON_TEXT = 'Refresh'
 export const DOWNLOAD_ISSUE_MESSAGE_OFFLINE = `You're currently offline. You can download it when you go online`
+export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
 
 // Sign in modal
-export const ONBOARDING_TITLE = 'Already a subscriber?'
-export const ONBOARDING_SUBTITLE =
-    'Sign in with your subscriber details to continue'
-export const EXPLAINER_TITLE = 'Not subscribed yet?'
-export const EXPLAINER_SUBTITLE = `${Platform.select({
-    ios: 'Get the Daily with a digital subscription from The Guardian website.',
+const SignIn = {
+    title: 'Already a subscriber?',
+    subtitle: 'Sign in with your subscriber details to continue',
+    explainerTitle: 'Not subscribed yet?',
+    explainerSubtitle: `${Platform.select({
+        ios:
+            'Get the Daily with a digital subscription from The Guardian website.',
 
-    android: 'Read the Daily with a digital subscription from The Guardian.',
-})}`
-export const FREE_TRIAL = 'Start your free 14 day trial'
+        android:
+            'Read the Daily with a digital subscription from The Guardian.',
+    })}`,
+    freeTrial: 'Start your free 14 day trial',
+}
 
 // Failed sign in modal
-export const APPLE_RELAY_TITLE = 'We are unable to verify your subscription'
-export const APPLE_RELAY_BODY = `We are unable to detect your subscription as it seems you chose not to share your email address with us. \n \nPlease try a different sign in method. You will need to use the same email address as your Digital subscription. Alternatively, use your subscriber ID.`
-export const APPLE_RELAY_RETRY = 'Try alternative sign in method'
-
-export const SIGN_IN_FAILED_TITLE = 'Subscription not found'
-export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
-export const SIGN_IN_FAILED_BODY = `We were unable to find a subscription associated with %email%. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`
-export const SIGN_IN_FAILED_RETRY = 'Try a different email'
+const FailedSignIn = {
+    appleRelayTitle: 'We are unable to verify your subscription',
+    appleRelayBody: `We are unable to detect your subscription as it seems you chose not to share your email address with us. \n \nPlease try a different sign in method. You will need to use the same email address as your Digital subscription. Alternatively, use your subscriber ID.`,
+    appleRelayRetry: 'Try alternative sign in method',
+    title: 'Subscription not found',
+    body: `We were unable to find a subscription associated with %email%. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`,
+    retryButtonTitle: 'Try a different email',
+}
 
 // Sub found modal
-export const SUB_FOUND_TITLE = 'Subscription found'
-export const SUB_FOUND_SUBTITLE =
-    'Enjoy the Guardian and thank you for your support'
+const SubFound = {
+    title: 'Subscription found',
+    subtitle: 'Enjoy the Guardian and thank you for your support',
+}
 
 // Sub not found modal
-export const SUB_NOT_FOUND_TITLE = 'Already a subscriber?'
-export const SUB_NOT_FOUND_EXPLAINER = 'Not subscribed yet?'
-export const SUB_NOT_FOUND_EXPLAINER_SUBTITLE = `${Platform.select({
-    ios: 'To get a free trial with our digital subscription, visit our website',
+const SubNotFound = {
+    title: 'Already a subscriber?',
+    explainer: 'Not subscribed yet?',
+    explainerSubtitle: `${Platform.select({
+        ios:
+            'To get a free trial with our digital subscription, visit our website',
 
-    android: 'Get a free trial with our digital subscription',
-})}`
-export const SUB_NOT_FOUND_SIGN_IN = 'Sign in to activate'
-export const SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON = 'Activate with subscriber ID'
+        android: 'Get a free trial with our digital subscription',
+    })}`,
+    signIn: 'Sign in to activate',
+    subscriberButton: 'Activate with subscriber ID',
+}
 
 // Already Subscribed
-export const ALREADY_SUBSCRIBED_SIGN_IN_TITLE = 'Sign in to activate'
-export const ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE =
-    'Activate with subscriber ID'
-export const ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE =
-    'Restore App Store subscription'
-export const ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE = 'Verification error'
-export const ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE =
-    'There was a problem whilst verifying your subscription'
-export const ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE = 'Subscription not found'
-export const ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE =
-    'We were unable to find a subscription associated with your Apple ID'
+const AlreadySubscribed = {
+    signInTitle: 'Sign in to activate',
+    subscriberIdTitle: 'Activate with subscriber ID',
+    restoreIapTitle: 'Restore App Store subscription',
+    restoreErrorTitle: 'Verification error',
+    restoreErrorSubtitle:
+        'There was a problem whilst verifying your subscription',
+    restoreMissingTitle: 'Subscription not found',
+    restoreMissingSubtitle:
+        'We were unable to find a subscription associated with your Apple ID',
+}
+
+export const Copy = {
+    signIn: SignIn,
+    failedSignIn: FailedSignIn,
+    subFound: SubFound,
+    subNotFound: SubNotFound,
+    alreadySubscribed: AlreadySubscribed,
+}

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -89,3 +89,16 @@ export const SUB_NOT_FOUND_EXPLAINER_SUBTITLE = `${Platform.select({
 })}`
 export const SUB_NOT_FOUND_SIGN_IN = 'Sign in to activate'
 export const SUB_NOT_FOUND_SUBSCRIBER_ID_BUTTON = 'Activate with subscriber ID'
+
+// Already Subscribed
+export const ALREADY_SUBSCRIBED_SIGN_IN_TITLE = 'Sign in to activate'
+export const ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE =
+    'Activate with subscriber ID'
+export const ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE =
+    'Restore App Store subscription'
+export const ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE = 'Verification error'
+export const ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE =
+    'There was a problem whilst verifying your subscription'
+export const ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE = 'Subscription not found'
+export const ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE =
+    'We were unable to find a subscription associated with your Apple ID'

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -71,14 +71,15 @@ export const APPLE_RELAY_RETRY = 'Try alternative sign in method'
 
 export const SIGN_IN_FAILED_TITLE = 'Subscription not found'
 export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
+export const SIGN_IN_FAILED_BODY = `We were unable to find a subscription associated with %email%. Try signing in with a different email or contact us at ${CUSTOMER_HELP_EMAIL}`
 export const SIGN_IN_FAILED_RETRY = 'Try a different email'
 
-//Sub found modal
+// Sub found modal
 export const SUB_FOUND_TITLE = 'Subscription found'
 export const SUB_FOUND_SUBTITLE =
     'Enjoy the Guardian and thank you for your support'
 
-//Sub not found modal
+// Sub not found modal
 export const SUB_NOT_FOUND_TITLE = 'Already a subscriber?'
 export const SUB_NOT_FOUND_EXPLAINER = 'Not subscribed yet?'
 export const SUB_NOT_FOUND_EXPLAINER_SUBTITLE = `${Platform.select({

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -18,6 +18,7 @@ import {
 } from 'src/helpers/settings/setters'
 import { useQuery } from 'src/hooks/apollo'
 import gql from 'graphql-tag'
+import { Copy } from 'src/helpers/words'
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
     <View
@@ -66,8 +67,8 @@ const OnboardingConsent = ({
         <Aligner>
             <OnboardingCard
                 appearance={CardAppearance.blue}
-                title="We care about your privacy"
-                explainerTitle="This app is free of ads"
+                title={Copy.consentOnboarding.title}
+                explainerTitle={Copy.consentOnboarding.explainerTitle}
                 bottomExplainerContent={
                     <>
                         <View style={styles.consentButtonContainer}>
@@ -80,7 +81,7 @@ const OnboardingConsent = ({
                                         ButtonAppearance.skeletonBlue
                                     }
                                 >
-                                    My options
+                                    {Copy.consentOnboarding.optionsButton}
                                 </ModalButton>
                             </View>
                             <View>
@@ -91,7 +92,7 @@ const OnboardingConsent = ({
                                     }}
                                     buttonAppearance={ButtonAppearance.dark}
                                 >
-                                    {`I'm okay with that`}
+                                    {Copy.consentOnboarding.okayButton}
                                 </ModalButton>
                             </View>
                         </View>

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -12,15 +12,7 @@ import { useModal } from 'src/components/modal'
 import { isValid, isError } from 'src/authentication/lib/Attempt'
 import { MissingIAPModalCard } from 'src/components/missing-iap-modal-card'
 import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
-import {
-    ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
-    ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
-    ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE,
-    ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE,
-    ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE,
-    ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE,
-    ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE,
-} from 'src/helpers/words'
+import { Copy } from 'src/helpers/words'
 
 const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     const canAccess = useAccess()
@@ -39,7 +31,9 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             ? [
                                   {
                                       key: 'Sign in to activate',
-                                      title: ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
+                                      title:
+                                      Copy.alreadySubscribed
+                                              .signInTitle,
                                       onPress: () => {
                                           navigation.navigate(routeNames.SignIn)
                                       },
@@ -48,7 +42,9 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                   },
                                   {
                                       key: 'Activate with subscriber ID',
-                                      title: ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
+                                      title:
+                                      Copy.alreadySubscribed
+                                              .subscriberIdTitle,
                                       onPress: () => {
                                           navigation.navigate(
                                               routeNames.CasSignIn,
@@ -69,7 +65,9 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             data={[
                                 {
                                     key: 'Restore App Store subscription',
-                                    title: ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE,
+                                    title:
+                                    Copy.alreadySubscribed
+                                            .restoreIapTitle,
                                     onPress: async () => {
                                         const {
                                             accessAttempt,
@@ -84,10 +82,14 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                             open(close => (
                                                 <MissingIAPModalCard
                                                     title={
-                                                        ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE
+                                                        Copy
+                                                            .alreadySubscribed
+                                                            .restoreErrorTitle
                                                     }
                                                     subtitle={
-                                                        ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE
+                                                        Copy
+                                                            .alreadySubscribed
+                                                            .restoreErrorSubtitle
                                                     }
                                                     close={close}
                                                     onTryAgain={authIAP}
@@ -97,10 +99,14 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                             open(close => (
                                                 <MissingIAPModalCard
                                                     title={
-                                                        ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE
+                                                        Copy
+                                                            .alreadySubscribed
+                                                            .restoreMissingTitle
                                                     }
                                                     subtitle={
-                                                        ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE
+                                                        Copy
+                                                            .alreadySubscribed
+                                                            .restoreMissingSubtitle
                                                     }
                                                     close={close}
                                                     onTryAgain={authIAP}

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -31,9 +31,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             ? [
                                   {
                                       key: 'Sign in to activate',
-                                      title:
-                                      Copy.alreadySubscribed
-                                              .signInTitle,
+                                      title: Copy.alreadySubscribed.signInTitle,
                                       onPress: () => {
                                           navigation.navigate(routeNames.SignIn)
                                       },
@@ -43,7 +41,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                   {
                                       key: 'Activate with subscriber ID',
                                       title:
-                                      Copy.alreadySubscribed
+                                          Copy.alreadySubscribed
                                               .subscriberIdTitle,
                                       onPress: () => {
                                           navigation.navigate(
@@ -66,8 +64,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                 {
                                     key: 'Restore App Store subscription',
                                     title:
-                                    Copy.alreadySubscribed
-                                            .restoreIapTitle,
+                                        Copy.alreadySubscribed.restoreIapTitle,
                                     onPress: async () => {
                                         const {
                                             accessAttempt,
@@ -82,13 +79,11 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                             open(close => (
                                                 <MissingIAPModalCard
                                                     title={
-                                                        Copy
-                                                            .alreadySubscribed
+                                                        Copy.alreadySubscribed
                                                             .restoreErrorTitle
                                                     }
                                                     subtitle={
-                                                        Copy
-                                                            .alreadySubscribed
+                                                        Copy.alreadySubscribed
                                                             .restoreErrorSubtitle
                                                     }
                                                     close={close}
@@ -99,13 +94,11 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                             open(close => (
                                                 <MissingIAPModalCard
                                                     title={
-                                                        Copy
-                                                            .alreadySubscribed
+                                                        Copy.alreadySubscribed
                                                             .restoreMissingTitle
                                                     }
                                                     subtitle={
-                                                        Copy
-                                                            .alreadySubscribed
+                                                        Copy.alreadySubscribed
                                                             .restoreMissingSubtitle
                                                     }
                                                     close={close}

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -12,6 +12,15 @@ import { useModal } from 'src/components/modal'
 import { isValid, isError } from 'src/authentication/lib/Attempt'
 import { MissingIAPModalCard } from 'src/components/missing-iap-modal-card'
 import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
+import {
+    ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
+    ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
+    ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE,
+    ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE,
+    ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE,
+    ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE,
+    ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE,
+} from 'src/helpers/words'
 
 const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     const canAccess = useAccess()
@@ -30,7 +39,9 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             ? [
                                   {
                                       key: 'Sign in to activate',
-                                      title: 'Sign in to activate',
+                                      title: {
+                                          ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
+                                      },
                                       onPress: () => {
                                           navigation.navigate(routeNames.SignIn)
                                       },
@@ -39,7 +50,9 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                   },
                                   {
                                       key: 'Activate with subscriber ID',
-                                      title: 'Activate with subscriber ID',
+                                      title: {
+                                          ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
+                                      },
                                       onPress: () => {
                                           navigation.navigate(
                                               routeNames.CasSignIn,
@@ -60,7 +73,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             data={[
                                 {
                                     key: 'Restore App Store subscription',
-                                    title: 'Restore App Store subscription',
+                                    title: ALREADY_SUBSCRIBED_RESTORE_IAP_TITLE,
                                     onPress: async () => {
                                         const {
                                             accessAttempt,
@@ -74,8 +87,12 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                         } else if (isError(accessAttempt)) {
                                             open(close => (
                                                 <MissingIAPModalCard
-                                                    title="Verification error"
-                                                    subtitle="There was a problem whilst verifying your subscription"
+                                                    title={
+                                                        ALREADY_SUBSCRIBED_RESTORE_ERROR_TITLE
+                                                    }
+                                                    subtitle={
+                                                        ALREADY_SUBSCRIBED_RESTORE_ERROR_SUBTITLE
+                                                    }
                                                     close={close}
                                                     onTryAgain={authIAP}
                                                 />
@@ -83,8 +100,12 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                         } else {
                                             open(close => (
                                                 <MissingIAPModalCard
-                                                    title="Subscription not found"
-                                                    subtitle="We were unable to find a subscription associated with your Apple ID"
+                                                    title={
+                                                        ALREADY_SUBSCRIBED_RESTORE_MISSING_TITLE
+                                                    }
+                                                    subtitle={
+                                                        ALREADY_SUBSCRIBED_RESTORE_MISSING_SUBTITLE
+                                                    }
                                                     close={close}
                                                     onTryAgain={authIAP}
                                                 />

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -39,9 +39,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                             ? [
                                   {
                                       key: 'Sign in to activate',
-                                      title: {
-                                          ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
-                                      },
+                                      title: ALREADY_SUBSCRIBED_SIGN_IN_TITLE,
                                       onPress: () => {
                                           navigation.navigate(routeNames.SignIn)
                                       },
@@ -50,9 +48,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                                   },
                                   {
                                       key: 'Activate with subscriber ID',
-                                      title: {
-                                          ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
-                                      },
+                                      title: ALREADY_SUBSCRIBED_SUBSCRIBER_ID_TITLE,
                                       onPress: () => {
                                           navigation.navigate(
                                               routeNames.CasSignIn,


### PR DESCRIPTION
## Summary
The PR moves the copy from the consent onboarding to `words.ts` and makes it accessible through the `Copy` object.
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/YtNXHZov/1456-centralise-copy-in-the-app)

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
