### PR TITLE
Remove notification short circuit for non-daily-editions in Prod

### DIFF
--- a/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
+++ b/projects/archiver/src/tasks/notification/helpers/device-notifications.ts
@@ -74,15 +74,6 @@ export const scheduleDeviceNotificationIfEligibleInternal = async (
         issueData.notificationUTCOffset,
     )
 
-    const stage: string = process.env.stage || 'code'
-
-    if (edition != 'daily-edition' && stage.toLowerCase() == 'prod') {
-        console.log(
-            `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the stage is prod and the edition is not eligible for Device Notification`,
-        )
-        return 'skipped'
-    }
-
     if (!shouldSchedule(scheduleTime, now)) {
         console.log(
             `skipping schedule Device Notification for ${edition}, ${scheduleTime} because the schedule time is in the past`,


### PR DESCRIPTION
## Summary

We have a short circuit for _not_ sending notifications if the edition is _not_ daily-edition and the stage is prod.

This can be removed (which is what this PR does) *only* when we have tested notifications work correctly.

## Test Plan

Create a non-daily-edition (eg US Weekend edition) in CODE and ensure that the notification is received by a CODE device subscribed to that edition.  Simultaneously, check that a CODE device subscribed to daily-edition _does not_ receive a notification.