### PR TITLE
Feat/editions copy behind debug switch

### DIFF
--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { View, Platform, Linking, StyleSheet } from 'react-native'
 import { ModalButton } from './Button/ModalButton'
@@ -7,6 +7,7 @@ import { ButtonAppearance } from './Button/Button'
 import { getFont } from 'src/theme/typography'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
 import { Copy } from 'src/helpers/words'
+import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -27,57 +28,68 @@ const SignInModalCard = ({
     close: () => void
     onLoginPress: () => void
     onDismiss: () => void
-}) => (
-    <OnboardingCard
-        onDismissThisCard={onDismiss}
-        title={Copy.signIn.title}
-        subtitle={Copy.signIn.subtitle}
-        appearance={CardAppearance.blue}
-        size="medium"
-        bottomContent={
-            <>
-                <View style={styles.bottomContentContainer}>
-                    <ModalButton
-                        onPress={() => {
-                            close()
-                            onLoginPress()
-                            sendComponentEvent({
-                                componentType: ComponentType.appButton,
-                                action: Action.click,
-                                value: 'sign_in_continue_clicked',
-                            })
-                        }}
-                    >
-                        Sign in
-                    </ModalButton>
-                    <Link
-                        style={{ ...getFont('sans', 0.9, 'bold') }}
-                        href="https://www.theguardian.com/help/identity-faq"
-                    >
-                        Need help signing in?
-                    </Link>
-                </View>
-            </>
-        }
-        explainerTitle={Copy.signIn.explainerTitle}
-        explainerSubtitle={Copy.signIn.explainerSubtitle}
-        bottomExplainerContent={
-            <>
-                {/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
-                {Platform.OS === 'android' ? (
-                    <ModalButton
-                        onPress={() => {
-                            Linking.openURL(
-                                'https://support.theguardian.com/uk/subscribe/digital',
-                            )
-                        }}
-                        buttonAppearance={ButtonAppearance.dark}
-                    >
-                        {Copy.signIn.freeTrial}
-                    </ModalButton>
-                ) : null}
-                {/* Being hidden temporarily - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
-                {/* <ModalButton
+}) => {
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
+    return (
+        <OnboardingCard
+            onDismissThisCard={onDismiss}
+            title={Copy.signIn.title}
+            subtitle={Copy.signIn.subtitle}
+            appearance={CardAppearance.blue}
+            size="medium"
+            bottomContent={
+                <>
+                    <View style={styles.bottomContentContainer}>
+                        <ModalButton
+                            onPress={() => {
+                                close()
+                                onLoginPress()
+                                sendComponentEvent({
+                                    componentType: ComponentType.appButton,
+                                    action: Action.click,
+                                    value: 'sign_in_continue_clicked',
+                                })
+                            }}
+                        >
+                            Sign in
+                        </ModalButton>
+                        <Link
+                            style={{ ...getFont('sans', 0.9, 'bold') }}
+                            href="https://www.theguardian.com/help/identity-faq"
+                        >
+                            Need help signing in?
+                        </Link>
+                    </View>
+                </>
+            }
+            explainerTitle={Copy.signIn.explainerTitle}
+            explainerSubtitle={
+                editionsMenuEnabled
+                    ? Copy.signIn.explainerSubtitleEditions
+                    : Copy.signIn.explianerSubtitleDaily
+            }
+            bottomExplainerContent={
+                <>
+                    {/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
+                    {Platform.OS === 'android' ? (
+                        <ModalButton
+                            onPress={() => {
+                                Linking.openURL(
+                                    'https://support.theguardian.com/uk/subscribe/digital',
+                                )
+                            }}
+                            buttonAppearance={ButtonAppearance.dark}
+                        >
+                            {Copy.signIn.freeTrial}
+                        </ModalButton>
+                    ) : null}
+                    {/* Being hidden temporarily - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
+                    {/* <ModalButton
                     onPress={() => {
                         if (Platform.OS === 'android') {
                             Linking.openURL(
@@ -91,9 +103,10 @@ const SignInModalCard = ({
                         ? 'Learn more'
                         : 'Get your free 14 day trial'}
                 </ModalButton> */}
-            </>
-        }
-    />
-)
+                </>
+            }
+        />
+    )
+}
 
 export { SignInModalCard }

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { OnboardingCard, CardAppearance } from './onboarding/onboarding-card'
 import { View, Platform, Linking, StyleSheet } from 'react-native'
 import { ModalButton } from './Button/ModalButton'
@@ -7,7 +7,6 @@ import { ButtonAppearance } from './Button/Button'
 import { getFont } from 'src/theme/typography'
 import { sendComponentEvent, ComponentType, Action } from 'src/services/ophan'
 import { Copy } from 'src/helpers/words'
-import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const styles = StyleSheet.create({
     bottomContentContainer: {
@@ -29,12 +28,6 @@ const SignInModalCard = ({
     onLoginPress: () => void
     onDismiss: () => void
 }) => {
-    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
-    useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
-    }, [])
     return (
         <OnboardingCard
             onDismissThisCard={onDismiss}
@@ -68,11 +61,7 @@ const SignInModalCard = ({
                 </>
             }
             explainerTitle={Copy.signIn.explainerTitle}
-            explainerSubtitle={
-                editionsMenuEnabled
-                    ? Copy.signIn.explainerSubtitleEditions
-                    : Copy.signIn.explianerSubtitleDaily
-            }
+            explainerSubtitle={Copy.signIn.explainerSubtitle}
             bottomExplainerContent={
                 <>
                     {/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -57,19 +57,8 @@ const SignIn = {
     title: 'Already a subscriber?',
     subtitle: 'Sign in with your subscriber details to continue',
     explainerTitle: 'Not subscribed yet?',
-    explainerSubtitleEditions: `${Platform.select({
-        ios:
-            'Get the Editions app with a digital subscription from The Guardian website.',
-        android:
-            'Read the Editions app with a digital subscription from The Guardian.',
-    })}`,
-    explianerSubtitleDaily: `${Platform.select({
-        ios:
-            'Get the Daily with a digital subscription from The Guardian website.',
-
-        android:
-            'Read the Daily with a digital subscription from The Guardian.',
-    })}`,
+    explainerSubtitle:
+        'Get access with a digital subscription from The Guardian website.',
     freeTrial: 'Start your free 14 day trial',
 }
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -209,7 +209,8 @@ export const Weather = {
 }
 
 export const DeprecateModal = {
-    title: 'This version of the Daily app is no longer supported',
+    titleEditions: 'This version of the Editions app is no longer supported',
+    titleDaily: 'This version of the Daily app is no longer supported',
     subtitle: 'Please go to the %storeLink% to update to the latest version',
 }
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -58,7 +58,13 @@ const SignIn = {
     title: 'Already a subscriber?',
     subtitle: 'Sign in with your subscriber details to continue',
     explainerTitle: 'Not subscribed yet?',
-    explainerSubtitle: `${Platform.select({
+    explainerSubtitleEditions: `${Platform.select({
+        ios:
+            'Get the Editions app with a digital subscription from The Guardian website.',
+        android:
+            'Read the Editions app with a digital subscription from The Guardian.',
+    })}`,
+    explianerSubtitleDaily: `${Platform.select({
         ios:
             'Get the Daily with a digital subscription from The Guardian website.',
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -183,7 +183,8 @@ export const IssueListFooter = {
 export const SubscriptionDetails = {
     title: 'Subscription Details',
     heading: 'Paper + digital subscription',
-    iapHeading: 'Guardian Daily / App Store',
+    iapHeadingDaily: 'Guardian Daily / App Store',
+    iapHeadingEditions: 'Guardian Editions / App Store',
     loggedOutHeading: 'Not logged in',
     emailAddress: 'Email Address',
     userId: 'User ID',

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -6,7 +6,6 @@ export const REQUEST_INVALID_RESPONSE_VALIDATION = 'Failed to parse data'
 export const LOCAL_JSON_INVALID_RESPONSE_VALIDATION =
     'Failed to parse local data'
 
-export const APP_DISPLAY_NAME = 'Daily Edition'
 export const FEEDBACK_EMAIL = 'daily.feedback@theguardian.com'
 export const COOKIE_LINK = 'https://www.theguardian.com/info/cookies'
 export const PRIVACY_LINK = 'https://www.theguardian.com/info/privacy'
@@ -120,7 +119,8 @@ const AuthSwitcherScreen = {
 const AlreadySubscribed = {
     title: 'Subscription Activation',
     subscriptionHeading: 'Guardian digital subscription/Digital + Print',
-    appHeading: 'Daily Edition',
+    appHeadingDaily: 'Daily Edition',
+    appHeadingEditions: 'Guardian Editions',
     signInTitle: 'Sign in to activate',
     subscriberIdTitle: 'Activate with subscriber ID',
     restoreIapTitle: 'Restore App Store subscription',

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -57,8 +57,13 @@ const SignIn = {
     title: 'Already a subscriber?',
     subtitle: 'Sign in with your subscriber details to continue',
     explainerTitle: 'Not subscribed yet?',
-    explainerSubtitle:
-        'Get access with a digital subscription from The Guardian website.',
+    explainerSubtitle: `${Platform.select({
+        ios:
+            'Get access with a digital subscription from The Guardian website.',
+
+        android:
+            'Get access with a digital subscription from The Guardian website',
+    })}`,
     freeTrial: 'Start your free 14 day trial',
 }
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -112,6 +112,9 @@ const AuthSwitcherScreen = {
 
 // Already Subscribed
 const AlreadySubscribed = {
+    title: 'Subscription Activation',
+    subscriptionHeading: 'Guardian digital subscription/Digital + Print',
+    appHeading: 'Daily Edition',
     signInTitle: 'Sign in to activate',
     subscriberIdTitle: 'Activate with subscriber ID',
     restoreIapTitle: 'Restore App Store subscription',
@@ -172,7 +175,10 @@ export const IssueListFooter = {
 }
 
 export const SubscriptionDetails = {
+    title: 'Subscription Details',
     heading: 'Paper + digital subscription',
+    iapHeading: 'Guardian Daily / App Store',
+    loggedOutHeading: 'Not logged in',
     emailAddress: 'Email Address',
     userId: 'User ID',
     subscriptionType: 'Subscription type',
@@ -196,6 +202,43 @@ export const Weather = {
     cancelButton: 'No thanks',
 }
 
+export const DeprecateModal = {
+    title: 'This version of the Daily app is no longer supported',
+    subtitle: 'Please go to the %storeLink% to update to the latest version',
+}
+
+export const WeatherConsentHtml = {
+    content: `<h2>Location-based weather</h2>
+    <p>
+        This is a 3rd party service provided by AccuWeather. It works by taking
+        your location coordinates and bringing the weather to you.
+    </p>
+    <ul>
+        <li>
+            The Daily app only collects your geolocation and Accuweather uses it
+            for getting your weather forecast
+        </li>
+        <li>
+            Your geolocation is not used for advertising or any other purposes
+        </li>
+        <li>
+            Your geolocation is not linked to other identifiers such as your
+            name or email address
+        </li>
+        <li>
+            You can switch the weather feature on/off at any time on the app
+            Settings
+        </li>
+        </ul>
+        <p>
+            For more information about how Accuweather uses your location,
+            please check their
+            <a href="https://www.accuweather.com/en/privacy"> privacy policy</a>
+        </p>
+    </ul>
+`,
+}
+
 export const Copy = {
     signIn: SignIn,
     failedSignIn: FailedSignIn,
@@ -210,4 +253,6 @@ export const Copy = {
     weather: Weather,
     subscriptionDetails: SubscriptionDetails,
     authSwitcherScreen: AuthSwitcherScreen,
+    deprecateModal: DeprecateModal,
+    weatherConsentHtml: WeatherConsentHtml,
 }

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -215,7 +215,7 @@ export const DeprecateModal = {
 }
 
 export const WeatherConsentHtml = {
-    content: `<h2>Location-based weather</h2>
+    contentDaily: `<h2>Location-based weather</h2>
     <p>
         This is a 3rd party service provided by AccuWeather. It works by taking
         your location coordinates and bringing the weather to you.
@@ -243,6 +243,35 @@ export const WeatherConsentHtml = {
             <a href="https://www.accuweather.com/en/privacy"> privacy policy</a>
         </p>
     </ul>
+`,
+    contentEditions: `<h2>Location-based weather</h2>
+<p>
+    This is a 3rd party service provided by AccuWeather. It works by taking
+    your location coordinates and bringing the weather to you.
+</p>
+<ul>
+    <li>
+        The Editions app only collects your geolocation and Accuweather uses it
+        for getting your weather forecast
+    </li>
+    <li>
+        Your geolocation is not used for advertising or any other purposes
+    </li>
+    <li>
+        Your geolocation is not linked to other identifiers such as your
+        name or email address
+    </li>
+    <li>
+        You can switch the weather feature on/off at any time on the app
+        Settings
+    </li>
+    </ul>
+    <p>
+        For more information about how Accuweather uses your location,
+        please check their
+        <a href="https://www.accuweather.com/en/privacy"> privacy policy</a>
+    </p>
+</ul>
 `,
 }
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -120,7 +120,6 @@ const AlreadySubscribed = {
     title: 'Subscription Activation',
     subscriptionHeading: 'Guardian digital subscription/Digital + Print',
     appHeadingDaily: 'Daily Edition',
-    appHeadingEditions: 'Guardian Editions',
     signInTitle: 'Sign in to activate',
     subscriberIdTitle: 'Activate with subscriber ID',
     restoreIapTitle: 'Restore App Store subscription',

--- a/projects/Mallard/src/screens/deprecate-screen.tsx
+++ b/projects/Mallard/src/screens/deprecate-screen.tsx
@@ -15,6 +15,7 @@ import { getFont } from 'src/theme/typography'
 import { TitlepieceText } from '../components/styled-text'
 import { useNetInfo } from '../hooks/use-net-info'
 import { defaultSettings } from 'src/helpers/settings/defaults'
+import { Copy } from 'src/helpers/words'
 
 const styles = StyleSheet.create({
     container: {
@@ -73,7 +74,7 @@ const DeprecateVersionModal = () => {
                         accessibilityRole="header"
                         style={[getFont('titlepiece', 2), styles.title]}
                     >
-                        This version of the Daily app is no longer supported
+                        {Copy.deprecateModal.title}
                     </TitlepieceText>
                     <TitlepieceText
                         style={[getFont('titlepiece', 1.5), styles.subTitle]}

--- a/projects/Mallard/src/screens/deprecate-screen.tsx
+++ b/projects/Mallard/src/screens/deprecate-screen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import {
     Image,
     Modal,
@@ -16,6 +16,7 @@ import { TitlepieceText } from '../components/styled-text'
 import { useNetInfo } from '../hooks/use-net-info'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { Copy } from 'src/helpers/words'
+import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const styles = StyleSheet.create({
     container: {
@@ -65,6 +66,12 @@ const StoreLink = () => {
 const DeprecateVersionModal = () => {
     const { isConnected } = useNetInfo()
     const { showModal } = useDeprecationModal()
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
 
     return (
         <Modal visible={isConnected && showModal}>
@@ -74,7 +81,9 @@ const DeprecateVersionModal = () => {
                         accessibilityRole="header"
                         style={[getFont('titlepiece', 2), styles.title]}
                     >
-                        {Copy.deprecateModal.title}
+                        {editionsMenuEnabled
+                            ? Copy.deprecateModal.titleEditions
+                            : Copy.deprecateModal.titleDaily}
                     </TitlepieceText>
                     <TitlepieceText
                         style={[getFont('titlepiece', 1.5), styles.subTitle]}

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -13,20 +13,13 @@ import { isValid, isError } from 'src/authentication/lib/Attempt'
 import { MissingIAPModalCard } from 'src/components/missing-iap-modal-card'
 import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
 import { Copy } from 'src/helpers/words'
-import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     const canAccess = useAccess()
     const { authIAP } = useContext(AccessContext)
     const { open } = useModal()
-    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     const rightChevronIcon = <RightChevron />
 
-    useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
-    }, [])
     return (
         <WithAppAppearance value={'settings'}>
             <ScrollContainer>
@@ -65,9 +58,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                     <>
                         <Heading>{``}</Heading>
                         <Heading>
-                            {editionsMenuEnabled
-                                ? Copy.alreadySubscribed.appHeadingEditions
-                                : Copy.alreadySubscribed.appHeadingDaily}
+                            {Copy.alreadySubscribed.appHeadingDaily}
                         </Heading>
                         <List
                             data={[

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext } from 'react'
 import { List } from 'src/components/lists/list'
 import { Heading } from 'src/components/layout/ui/row'
 import { NavigationInjectedProps } from 'react-navigation'

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { List } from 'src/components/lists/list'
 import { Heading } from 'src/components/layout/ui/row'
 import { NavigationInjectedProps } from 'react-navigation'

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -24,7 +24,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     return (
         <WithAppAppearance value={'settings'}>
             <ScrollContainer>
-                <Heading>{`Guardian digital subscription/Digital + Print`}</Heading>
+                <Heading>{Copy.alreadySubscribed.subscriptionHeading}</Heading>
                 <List
                     data={
                         !canAccess
@@ -58,7 +58,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                 {Platform.OS === 'ios' ? (
                     <>
                         <Heading>{``}</Heading>
-                        <Heading>{`Daily Edition`}</Heading>
+                        <Heading>{Copy.alreadySubscribed.appHeading}</Heading>
                         <List
                             data={[
                                 {
@@ -122,7 +122,7 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
 }
 
 AlreadySubscribedScreen.navigationOptions = {
-    title: <Text style={{ fontSize: 20 }}>Subscription Activation</Text>,
+    title: <Text style={{ fontSize: 20 }}>{Copy.alreadySubscribed.title}</Text>,
 }
 
 export { AlreadySubscribedScreen }

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -13,14 +13,20 @@ import { isValid, isError } from 'src/authentication/lib/Attempt'
 import { MissingIAPModalCard } from 'src/components/missing-iap-modal-card'
 import { SubFoundModalCard } from 'src/components/sub-found-modal-card'
 import { Copy } from 'src/helpers/words'
+import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
     const canAccess = useAccess()
     const { authIAP } = useContext(AccessContext)
     const { open } = useModal()
-
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     const rightChevronIcon = <RightChevron />
 
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
     return (
         <WithAppAppearance value={'settings'}>
             <ScrollContainer>
@@ -58,7 +64,11 @@ const AlreadySubscribedScreen = ({ navigation }: NavigationInjectedProps) => {
                 {Platform.OS === 'ios' ? (
                     <>
                         <Heading>{``}</Heading>
-                        <Heading>{Copy.alreadySubscribed.appHeading}</Heading>
+                        <Heading>
+                            {editionsMenuEnabled
+                                ? Copy.alreadySubscribed.appHeadingEditions
+                                : Copy.alreadySubscribed.appHeadingDaily}
+                        </Heading>
                         <List
                             data={[
                                 {

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -256,12 +256,12 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         },
                     },
                     {
-                        key: 'Enable edition menu',
-                        title: 'Enable edition menu',
+                        key: 'Enable multiple editions',
+                        title: 'Enable multiple editions',
                         onPress: () => {},
                         proxy: (
                             <Switch
-                                value={editionsMenuEnabled}
+                                value={editionsMenuEnabled} // this will also update the copy for multiple editions
                                 onValueChange={toggleEditionsMenuEnabled}
                             />
                         ),

--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -129,7 +129,9 @@ const SubscriptionDetailsScreen = () => {
 }
 
 SubscriptionDetailsScreen.navigationOptions = {
-title: <Text style={{ fontSize: 20 }}>{Copy.subscriptionDetails.title}</Text>,
+    title: (
+        <Text style={{ fontSize: 20 }}>{Copy.subscriptionDetails.title}</Text>
+    ),
 }
 
 export { SubscriptionDetailsScreen }

--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { Text } from 'react-native'
 import { AccessContext } from 'src/authentication/AccessContext'
 import { isValid } from 'src/authentication/lib/Attempt'
@@ -10,6 +10,7 @@ import { CASExpiry } from '../../../../Apps/common/src/cas-expiry'
 import { Heading } from 'src/components/layout/ui/row'
 import { ReceiptIOS } from 'src/authentication/services/iap'
 import { Copy } from 'src/helpers/words'
+import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const keyValueItem = (key: string, value: string) =>
     ({
@@ -80,18 +81,33 @@ const productIdPrettyLabels: { [key: string]: string } = {
 const getIAPType = (iapData: ReceiptIOS) =>
     productIdPrettyLabels[iapData.product_id] || iapData.name || 'Unknown'
 
-const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => (
-    <>
-        <Heading>{Copy.subscriptionDetails.iapHeading}</Heading>
-        <List
-            data={[
-                keyValueItem('Subscription type', getIAPType(iapData)),
-                keyValueItem('Purchase date', iapData.original_purchase_date),
-                keyValueItem('Expiry date', iapData.expires_date),
-            ]}
-        />
-    </>
-)
+const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => {
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
+    return (
+        <>
+            <Heading>
+                {editionsMenuEnabled
+                    ? Copy.subscriptionDetails.iapHeadingEditions
+                    : Copy.subscriptionDetails.iapHeadingDaily}
+            </Heading>
+            <List
+                data={[
+                    keyValueItem('Subscription type', getIAPType(iapData)),
+                    keyValueItem(
+                        'Purchase date',
+                        iapData.original_purchase_date,
+                    ),
+                    keyValueItem('Expiry date', iapData.expires_date),
+                ]}
+            />
+        </>
+    )
+}
 
 const LoggedOutDetails = () => (
     <Heading>{Copy.subscriptionDetails.loggedOutHeading}</Heading>

--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -82,7 +82,7 @@ const getIAPType = (iapData: ReceiptIOS) =>
 
 const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => (
     <>
-        <Heading>Guardian Daily / App Store</Heading>
+        <Heading>{Copy.subscriptionDetails.iapHeading}</Heading>
         <List
             data={[
                 keyValueItem('Subscription type', getIAPType(iapData)),
@@ -93,7 +93,9 @@ const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => (
     </>
 )
 
-const LoggedOutDetails = () => <Heading>Not logged in</Heading>
+const LoggedOutDetails = () => (
+    <Heading>{Copy.subscriptionDetails.loggedOutHeading}</Heading>
+)
 
 const SubscriptionDetailsScreen = () => {
     const { identityData, iapData, casData, attempt } = useContext(
@@ -127,7 +129,7 @@ const SubscriptionDetailsScreen = () => {
 }
 
 SubscriptionDetailsScreen.navigationOptions = {
-    title: <Text style={{ fontSize: 20 }}>Subscription Details</Text>,
+title: <Text style={{ fontSize: 20 }}>{Copy.subscriptionDetails.title}</Text>,
 }
 
 export { SubscriptionDetailsScreen }

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { StyleSheet, View, Alert, Platform, Linking } from 'react-native'
 import { NavigationInjectedProps } from 'react-navigation'
 import { DefaultInfoTextWebview } from './settings/default-info-text-webview'
@@ -11,10 +11,7 @@ import { requestLocationPermission } from 'src/helpers/location-permission'
 import { RESULTS } from 'react-native-permissions'
 import { getGeolocation } from 'src/helpers/weather'
 import { Copy } from 'src/helpers/words'
-
-const content = html`
-    ${Copy.weatherConsentHtml.content}
-`
+import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
 
 const styles = StyleSheet.create({
     button: {
@@ -37,6 +34,7 @@ const showIsDisabledAlert = () => {
 const WeatherGeolocationConsentScreen = ({
     navigation,
 }: NavigationInjectedProps) => {
+    const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     const apolloClient = useApolloClient()
     const onConsentPress = async () => {
         const result = await requestLocationPermission(apolloClient)
@@ -74,9 +72,21 @@ const WeatherGeolocationConsentScreen = ({
         navigation.dismiss()
     }
 
+    useEffect(() => {
+        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
+            setEditionsMenuEnabled(editionsMenuToggle)
+        })
+    }, [])
+
     return (
         <>
-            <DefaultInfoTextWebview html={content} />
+            <DefaultInfoTextWebview
+                html={
+                    editionsMenuEnabled
+                        ? Copy.weatherConsentHtml.contentEditions
+                        : Copy.weatherConsentHtml.contentDaily
+                }
+            />
             <View style={styles.buttons}>
                 <Button
                     appearance={ButtonAppearance.skeletonBlue}

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -13,34 +13,7 @@ import { getGeolocation } from 'src/helpers/weather'
 import { Copy } from 'src/helpers/words'
 
 const content = html`
-    <h2>Location-based weather</h2>
-    <p>
-        This is a 3rd party service provided by AccuWeather. It works by taking
-        your location coordinates and bringing the weather to you.
-    </p>
-    <ul>
-        <li>
-            The Daily app only collects your geolocation and Accuweather uses it
-            for getting your weather forecast
-        </li>
-        <li>
-            Your geolocation is not used for advertising or any other purposes
-        </li>
-        <li>
-            Your geolocation is not linked to other identifiers such as your
-            name or email address
-        </li>
-        <li>
-            You can switch the weather feature on/off at any time on the app
-            Settings
-        </li>
-        </ul>
-        <p>
-            For more information about how Accuweather uses your location,
-            please check their
-            <a href="https://www.accuweather.com/en/privacy"> privacy policy</a>
-        </p>
-    </ul>
+    ${Copy.weatherConsentHtml.content}
 `
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -81,11 +81,11 @@ const WeatherGeolocationConsentScreen = ({
     return (
         <>
             <DefaultInfoTextWebview
-                html={
-                    editionsMenuEnabled
+                html={html`
+                    ${editionsMenuEnabled
                         ? Copy.weatherConsentHtml.contentEditions
-                        : Copy.weatherConsentHtml.contentDaily
-                }
+                        : Copy.weatherConsentHtml.contentDaily}
+                `}
             />
             <View style={styles.buttons}>
                 <Button


### PR DESCRIPTION
## Summary
In preparation for our launch with multiple editions, this PR identifies all user-facing copy which refers to the app as "the Daily" (excluding FAQs, T&C's, and Privacy Policy) and adds an "Editions" version or as you'll see on the Sign-in modal, replaces the current string with a more generic string. 
Since we do not want to release this to users before launching to beta all edition specific copy is behind the "Enable multiple editions" switch in the duck menu which is also used to enable the editions menu switch. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/Jsyqi5hf/1437-update-the-ui-copy-to-accommodate-multiple-editions)

## Test Plan
To test enable the Multiple editions setting in the duck menu. 
### Screenshots when debug setting is enabled
| | |
| --- | --- |
 ![Simulator Screen Shot - iPhone 11 - 2020-08-04 at 12 28 13](https://user-images.githubusercontent.com/53755195/89295913-95b01600-d659-11ea-8fe8-bf307bdb88d6.png) | ![Screenshot_1596548570](https://user-images.githubusercontent.com/53755195/89300978-f2fb9580-d660-11ea-8ab3-3dae0123c1a6.png)
![image](https://user-images.githubusercontent.com/53755195/89286590-6645dd00-d64a-11ea-9d35-5346acda3d57.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-04 at 10 19 46](https://user-images.githubusercontent.com/53755195/89286441-1ebf5100-d64a-11ea-878c-59d101f7aaf3.png)


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
