### PR TITLE
Show dialog title only for bug related feedback

### DIFF
--- a/projects/Mallard/src/components/Button/BugButtonHandler.tsx
+++ b/projects/Mallard/src/components/Button/BugButtonHandler.tsx
@@ -5,13 +5,20 @@ import { isInBeta } from 'src/helpers/release-stream'
 import { AccessContext } from 'src/authentication/AccessContext'
 import { useApolloClient } from '@apollo/react-hooks'
 import { createMailtoHandler } from 'src/helpers/diagnostics'
+import { DIAGNOSTICS_TITLE } from 'src/helpers/words'
 
 const BugButtonHandler = () => {
     const { attempt } = useContext(AccessContext)
     const client = useApolloClient()
     return isInBeta() ? (
         <BugButton
-            onPress={createMailtoHandler(client, 'Report a bug', '', attempt)}
+            onPress={createMailtoHandler(
+                client,
+                'Report a bug',
+                '',
+                attempt,
+                DIAGNOSTICS_TITLE,
+            )}
         />
     ) : null
 }

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -18,7 +18,6 @@ import { iapReceiptCache, userDataCache, pushRegisteredTokens } from './storage'
 import {
     ANDROID_BETA_EMAIL,
     DIAGNOSTICS_REQUEST,
-    DIAGNOSTICS_TITLE,
     IOS_BETA_EMAIL,
 } from './words'
 import { OnCompletionToast } from 'src/screens/settings/help-screen'
@@ -162,8 +161,9 @@ const createMailtoHandler = (
     text: string,
     releaseURL: string,
     authAttempt: AnyAttempt<string>,
+    dialogTitle = '',
 ) => () =>
-    runActionSheet(DIAGNOSTICS_TITLE, DIAGNOSTICS_REQUEST, [
+    runActionSheet(dialogTitle, DIAGNOSTICS_REQUEST, [
         {
             text: 'Include',
             onPress: async () => {
@@ -192,11 +192,18 @@ const createSupportMailto = (
     text: string,
     releaseURL: string,
     authAttempt: AnyAttempt<string>,
+    dialogTitle = '',
 ) => ({
     key: text,
     title: text,
     linkWeight: 'regular' as const,
-    onPress: createMailtoHandler(client, text, releaseURL, authAttempt),
+    onPress: createMailtoHandler(
+        client,
+        text,
+        releaseURL,
+        authAttempt,
+        dialogTitle,
+    ),
 })
 
 const copyDiagnosticInfo = (

--- a/projects/Mallard/src/screens/settings/help-screen.tsx
+++ b/projects/Mallard/src/screens/settings/help-screen.tsx
@@ -15,6 +15,7 @@ import {
     SUBSCRIPTION_EMAIL,
     READERS_EMAIL,
     APPS_FEEDBACK_EMAIL,
+    DIAGNOSTICS_TITLE,
 } from 'src/helpers/words'
 import { AccessContext } from 'src/authentication/AccessContext'
 import { useApolloClient } from '@apollo/react-hooks'
@@ -56,6 +57,7 @@ const HelpScreen = ({ navigation }: NavigationInjectedProps) => {
                             'Report an issue',
                             ISSUE_EMAIL,
                             attempt,
+                            DIAGNOSTICS_TITLE,
                         ),
                         createSupportMailto(
                             client,


### PR DESCRIPTION
## Summary
Support email dialog 'title' always had a fixed title "Found a bug?"
This PR change that behaviour and uses that title only for bug related feedback email dialog.


[**Trello Card ->**](https://trello.com/c/KXmM3Z8w/819-user-help-bug-contact-us-dialog-copy)