### PR TITLE
Feat/templates add twitter embed

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -12,6 +12,7 @@ import { Header, ArticleHeaderProps } from './components/header'
 import { Image } from './components/images'
 import { Line } from './components/line'
 import { Pullquote } from './components/pull-quote'
+import { renderTweet } from './components/twitter-embed'
 import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
 import { GetImagePath } from 'src/hooks/use-image-paths'
@@ -83,6 +84,8 @@ const renderArticleContent = (
                         role: el.role || 'inline',
                         ...el,
                     })
+                case 'tweet':
+                    return renderTweet(el.html)
                 default:
                     return ''
             }

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -12,7 +12,7 @@ import { Header, ArticleHeaderProps } from './components/header'
 import { Image } from './components/images'
 import { Line } from './components/line'
 import { Pullquote } from './components/pull-quote'
-import { renderTweet } from './components/twitter-embed'
+import { TwitterEmbed } from './components/twitter-embed'
 import { makeCss } from './css'
 import { renderMediaAtom } from './components/media-atoms'
 import { GetImagePath } from 'src/hooks/use-image-paths'
@@ -85,7 +85,7 @@ const renderArticleContent = (
                         ...el,
                     })
                 case 'tweet':
-                    return renderTweet(el.html)
+                    return TwitterEmbed(el.html)
                 default:
                     return ''
             }

--- a/projects/Mallard/src/components/article/html/components/twitter-embed.ts
+++ b/projects/Mallard/src/components/article/html/components/twitter-embed.ts
@@ -1,0 +1,34 @@
+import { html, css } from 'src/helpers/webview'
+
+export const renderTweet = (elHtml: string) =>
+    // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+    html`
+        <script>
+            window.twttr = (function(d, s, id) {
+                var js,
+                    fjs = d.getElementsByTagName(s)[0],
+                    t = window.twttr || {}
+                if (d.getElementById(id)) return t
+                js = d.createElement(s)
+                js.id = id
+                js.src = 'https://platform.twitter.com/widgets.js'
+                fjs.parentNode.insertBefore(js, fjs)
+
+                t._e = []
+                t.ready = function(f) {
+                    t._e.push(f)
+                }
+
+                return t
+            })(document, 'script', 'twitter-wjs')
+        </script>
+    ` + elHtml
+
+export const twitterEmbedStyles = () => css`
+    .twitter-tweet {
+        border: none;
+        font-style: italic;
+        color: #999999;
+        padding: 10px;
+    }
+`

--- a/projects/Mallard/src/components/article/html/components/twitter-embed.ts
+++ b/projects/Mallard/src/components/article/html/components/twitter-embed.ts
@@ -1,19 +1,6 @@
 import { html, css } from 'src/helpers/webview'
 import { color } from 'src/theme/color'
 
-export const TwitterEmbed = (elHtml: string) =>
-    makeTwitterEmbedJavaScript() +
-    html`
-        ${elHtml}
-    `
-
-export const twitterEmbedStyles = css`
-    .twitter-tweet {
-        border: none;
-        font-style: italic;
-        color: ${color.palette.neutral[46]};
-    }
-`
 // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
 const makeTwitterEmbedJavaScript = () => html`
     <script>
@@ -35,4 +22,18 @@ const makeTwitterEmbedJavaScript = () => html`
             return t
         })(document, 'script', 'twitter-wjs')
     </script>
+`
+
+export const TwitterEmbed = (elHtml: string) =>
+    makeTwitterEmbedJavaScript() +
+    html`
+        ${elHtml}
+    `
+
+export const twitterEmbedStyles = css`
+    .twitter-tweet {
+        border: none;
+        font-style: italic;
+        color: ${color.palette.neutral[46]};
+    }
 `

--- a/projects/Mallard/src/components/article/html/components/twitter-embed.ts
+++ b/projects/Mallard/src/components/article/html/components/twitter-embed.ts
@@ -24,11 +24,10 @@ export const renderTweet = (elHtml: string) =>
         </script>
     ` + elHtml
 
-export const twitterEmbedStyles = () => css`
+export const twitterEmbedStyles = css`
     .twitter-tweet {
         border: none;
         font-style: italic;
-        color: #999999;
-        padding: 10px;
+        color: #767676;
     }
 `

--- a/projects/Mallard/src/components/article/html/components/twitter-embed.ts
+++ b/projects/Mallard/src/components/article/html/components/twitter-embed.ts
@@ -1,33 +1,38 @@
 import { html, css } from 'src/helpers/webview'
+import { color } from 'src/theme/color'
 
-export const renderTweet = (elHtml: string) =>
-    // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+export const TwitterEmbed = (elHtml: string) =>
+    makeTwitterEmbedJavaScript() +
     html`
-        <script>
-            window.twttr = (function(d, s, id) {
-                var js,
-                    fjs = d.getElementsByTagName(s)[0],
-                    t = window.twttr || {}
-                if (d.getElementById(id)) return t
-                js = d.createElement(s)
-                js.id = id
-                js.src = 'https://platform.twitter.com/widgets.js'
-                fjs.parentNode.insertBefore(js, fjs)
-
-                t._e = []
-                t.ready = function(f) {
-                    t._e.push(f)
-                }
-
-                return t
-            })(document, 'script', 'twitter-wjs')
-        </script>
-    ` + elHtml
+        ${elHtml}
+    `
 
 export const twitterEmbedStyles = css`
     .twitter-tweet {
         border: none;
         font-style: italic;
-        color: #767676;
+        color: ${color.palette.neutral[46]};
     }
+`
+// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+const makeTwitterEmbedJavaScript = () => html`
+    <script>
+        window.twttr = (function(d, s, id) {
+            var js,
+                fjs = d.getElementsByTagName(s)[0],
+                t = window.twttr || {}
+            if (d.getElementById(id)) return t
+            js = d.createElement(s)
+            js.id = id
+            js.src = 'https://platform.twitter.com/widgets.js'
+            fjs.parentNode.insertBefore(js, fjs)
+
+            t._e = []
+            t.ready = function(f) {
+                t._e.push(f)
+            }
+
+            return t
+        })(document, 'script', 'twitter-wjs')
+    </script>
 `

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -15,6 +15,7 @@ import { sportScoreStyles } from './components/sport-score'
 import { CssProps, themeColors } from './helpers/css'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { mediaAtomStyles } from './components/media-atoms'
+import { twitterEmbedStyles } from './components/twitter-embed'
 
 const makeFontsCss = () => css`
     /* text */
@@ -164,6 +165,7 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         }
     }
 
+    ${twitterEmbedStyles}
     ${quoteStyles({
         colors,
         theme,

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -165,7 +165,6 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
         }
     }
 
-    ${twitterEmbedStyles}
     ${quoteStyles({
         colors,
         theme,
@@ -179,6 +178,7 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
     ${starRatingStyles({ colors, theme })}
     ${sportScoreStyles({ colors, theme })}
     ${mediaAtomStyles}
+    ${twitterEmbedStyles}
 `
 
 export { makeCss }

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -188,8 +188,8 @@ const Article = ({
                 path={path}
                 scrollEnabled={true}
                 useWebKit={false}
-                allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
-                mediaPlaybackRequiresUserAction={false}
+                // allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
+                // mediaPlaybackRequiresUserAction={false}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -188,6 +188,8 @@ const Article = ({
                 path={path}
                 scrollEnabled={true}
                 useWebKit={false}
+                allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
+                mediaPlaybackRequiresUserAction={false}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -188,8 +188,8 @@ const Article = ({
                 path={path}
                 scrollEnabled={true}
                 useWebKit={false}
-                // allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
-                // mediaPlaybackRequiresUserAction={false}
+                allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
+                mediaPlaybackRequiresUserAction={false}
                 style={[styles.webview]}
                 _ref={r => {
                     ref.current = r


### PR DESCRIPTION
## Summary
This adds twitter embeds to articles when available in the editions api. 
The twitter embed is made up of two parts: 
1. A HTML snippet we receive from CAPI 
2. Twitter for Websites Javascript - transforms the code into a fully-rendered Tweet

When the user is offline, the twitter.js will not run, and instead the user will just be shown the HTML snippet from CAPI which has been styled. (see screenshots below)

Also note: 
There is currently a known issue with embed script from Twitter and a thread has been opened here https://twittercommunity.com/t/embedded-tweets-not-expanding-to-full-screen/140374. 
This issue appears to be affecting iOS webviews in particular when trying to view videos full screen, the live app along with others are currently affected. 
This should be resolved by twitter when they re-deploy the embed script and we shouldn't have to make any updates. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/azbfS99W/212-atoms-embeds-twitter-embed)

## Test Plan
| Online | Offline |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/89529469-b062c600-d7e4-11ea-8cda-f188647776b7.png) | ![image](https://user-images.githubusercontent.com/53755195/89529583-e56f1880-d7e4-11ea-8d50-0a8cc462065c.png) 
![image](https://user-images.githubusercontent.com/53755195/89529723-1d765b80-d7e5-11ea-8a7b-a9d0d9036e23.png) | ![image](https://user-images.githubusercontent.com/53755195/89529690-0e8fa900-d7e5-11ea-87ff-810bfd9b3021.png)


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
