### PR TITLE
Add sleep and improve logging

### DIFF
--- a/projects/archiver/src/tasks/copier/index.ts
+++ b/projects/archiver/src/tasks/copier/index.ts
@@ -6,6 +6,8 @@ import { getBucket, recursiveCopy } from '../../utils/s3'
 import { attempt, hasFailed } from '../../../../backend/utils/try'
 import { getPublishedId } from '../../utils/path-builder'
 import { getIssue } from '../../utils/backend-client'
+import { sleep } from '../../utils/sleep'
+import { ServerlessApplicationRepository } from 'aws-sdk'
 
 type CopyTaskInput = IndexTaskOutput
 export type CopyTaskOutput = Pick<
@@ -20,6 +22,7 @@ export const handler: Handler<CopyTaskInput, CopyTaskOutput> = handleAndNotify(
     'copied',
     async ({ issuePublication }) => {
         console.log(`Copying all files from ${inputBucket} to ${outputBucket}`)
+        await sleep(1000)
 
         const key = `${issuePublication.edition}/${issuePublication.issueDate}/${issuePublication.version}/`
         const copyPromises = await recursiveCopy(key, inputBucket, outputBucket)

--- a/projects/archiver/src/tasks/copier/index.ts
+++ b/projects/archiver/src/tasks/copier/index.ts
@@ -7,7 +7,6 @@ import { attempt, hasFailed } from '../../../../backend/utils/try'
 import { getPublishedId } from '../../utils/path-builder'
 import { getIssue } from '../../utils/backend-client'
 import { sleep } from '../../utils/sleep'
-import { ServerlessApplicationRepository } from 'aws-sdk'
 
 type CopyTaskInput = IndexTaskOutput
 export type CopyTaskOutput = Pick<

--- a/projects/archiver/src/tasks/editions-list/index.ts
+++ b/projects/archiver/src/tasks/editions-list/index.ts
@@ -8,6 +8,7 @@ import {
     IssuePublicationIdentifier,
 } from '../../../../Apps/common/src'
 import { IndexTaskOutput } from '../indexer'
+import { sleep } from '../../utils/sleep'
 
 type EditionsListTaskInput = IndexTaskOutput
 interface EditionsListOutput {
@@ -30,6 +31,9 @@ export const handler: Handler<
 > = handleAndNotify(
     'editionsListUpdated',
     async ({ issuePublication }) => {
+        console.log(`Uploading editions list file`)
+        await sleep(1000)
+
         const editionsList = await getEditions()
 
         if (hasFailed(editionsList)) {

--- a/projects/archiver/src/tasks/front/index.ts
+++ b/projects/archiver/src/tasks/front/index.ts
@@ -19,6 +19,7 @@ import {
     getImageUses,
 } from './helpers/media'
 import pAll = require('p-all')
+import { sleep } from '../../utils/sleep'
 
 export interface FrontTaskInput extends IssueParams {
     issue: Issue
@@ -31,6 +32,9 @@ export const handler: Handler<
     FrontTaskInput,
     { message: string } //This is ignored by the state machine
 > = handleAndNotifyOnError(async ({ issue, front }) => {
+    console.log(`Uploading front+images for ${front}, ${issue}`)
+    await sleep(1000)
+
     const { publishedId } = issue
 
     const maybeFront = await getFront(publishedId, front)

--- a/projects/archiver/src/tasks/indexer/index.ts
+++ b/projects/archiver/src/tasks/indexer/index.ts
@@ -6,6 +6,7 @@ import { upload, FIVE_SECONDS, getBucket } from '../../utils/s3'
 import { UploadTaskOutput } from '../upload'
 import { handleAndNotify } from '../../services/task-handler'
 import { Status } from '../../services/status'
+import { sleep } from '../../utils/sleep'
 
 type IndexTaskInput = UploadTaskOutput
 export interface IndexTaskOutput extends UploadTaskOutput {
@@ -20,6 +21,9 @@ const handlerCurry: (
     handleAndNotify(
         statusOnSuccess,
         async ({ issuePublication, issue }) => {
+            console.log(`Updating index for ${issue.name}, ${issue.date}`)
+            await sleep(1000)
+
             const Bucket = getBucket(bucket)
             // at the moment we create and recreate these issue summaries every time
             // an optimisation would be to move the issue summary creation to the previous task

--- a/projects/archiver/src/tasks/issue/index.ts
+++ b/projects/archiver/src/tasks/issue/index.ts
@@ -5,6 +5,7 @@ import { getIssue } from '../../utils/backend-client'
 import { getBucket } from '../../utils/s3'
 import { getPublishedId } from '../../utils/path-builder'
 import { handleAndNotify } from '../../services/task-handler'
+import { sleep } from '../../utils/sleep'
 
 export interface IssueParams {
     issuePublication: IssuePublicationActionIdentifier
@@ -24,6 +25,8 @@ export const handler: Handler<IssueParams, IssueTaskOutput> = handleAndNotify(
                 Bucket.name
             }`,
         )
+        await sleep(1000)
+
         const publishedId = getPublishedId(issuePublication)
         const issue = await attempt(getIssue(publishedId))
         if (hasFailed(issue)) {

--- a/projects/archiver/src/tasks/notification/index.ts
+++ b/projects/archiver/src/tasks/notification/index.ts
@@ -7,6 +7,7 @@ import {
 import { IndexTaskOutput } from '../indexer'
 import { IssuePublicationIdentifier } from '../../../common'
 import { getBucket } from '../../utils/s3'
+import { sleep } from '../../utils/sleep'
 
 export type NotificationTaskInput = IndexTaskOutput
 export interface NotificationTaskOutput {
@@ -22,6 +23,9 @@ export const handler: Handler<
 > = handleAndNotify(
     'notified',
     async ({ issuePublication, issue }) => {
+        console.log(`Scheduling notification for ${issue.name}, ${issue.date}`)
+        await sleep(1000)
+
         const stage: string = process.env.stage || 'code'
 
         const {

--- a/projects/archiver/src/tasks/upload/index.ts
+++ b/projects/archiver/src/tasks/upload/index.ts
@@ -4,6 +4,7 @@ import { issuePath } from '../../../common'
 import { handleAndNotify } from '../../services/task-handler'
 import { getBucket, ONE_WEEK, upload } from '../../utils/s3'
 import { IssueTaskOutput } from '../issue'
+import { sleep } from '../../utils/sleep'
 
 type UploadTaskInput = IssueTaskOutput
 export type UploadTaskOutput = Pick<
@@ -19,6 +20,9 @@ export const handler: Handler<
 > = handleAndNotify(
     'assembled',
     async ({ issuePublication, issue }) => {
+        console.log(`Uploading issue for ${issue.name}, ${issue.date}`)
+        await sleep(1000)
+
         const { publishedId } = issue
         const path = issuePath(publishedId)
         const Bucket = getBucket('proof')

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -11,6 +11,7 @@ import { UploadTaskOutput } from '../upload'
 import { handleAndNotify } from '../../services/task-handler'
 import { thumbsDir } from '../../../../Apps/common/src'
 import { getBucket } from '../../utils/s3'
+import { sleep } from '../../utils/sleep'
 
 type ZipTaskInput = UploadTaskOutput
 type ZipTaskOutput = UploadTaskOutput
@@ -20,9 +21,11 @@ const bucket = getBucket('proof')
 export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
     'bundled',
     async ({ issuePublication, issue }) => {
+        console.log(`Compressing issue ${issue.name}, ${issue.date}`)
+        await sleep(1000)
+
         const { issueDate, version } = issuePublication
         const { publishedId } = issue
-        console.log('Compressing')
         await zip(
             `${publishedId}/data`,
             [issuePath(publishedId), frontPath(publishedId, '')],

--- a/projects/archiver/src/utils/sleep.ts
+++ b/projects/archiver/src/utils/sleep.ts
@@ -1,3 +1,4 @@
-import { integer } from "aws-sdk/clients/cloudfront";
+import { integer } from 'aws-sdk/clients/cloudfront'
 
-export const sleep = (waitTimeInMs: integer) => new Promise(resolve => setTimeout(resolve, waitTimeInMs));
+export const sleep = (waitTimeInMs: integer) =>
+    new Promise(resolve => setTimeout(resolve, waitTimeInMs))

--- a/projects/archiver/src/utils/sleep.ts
+++ b/projects/archiver/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+import { integer } from "aws-sdk/clients/cloudfront";
+
+export const sleep = (waitTimeInMs: integer) => new Promise(resolve => setTimeout(resolve, waitTimeInMs));


### PR DESCRIPTION
## Summary

Insanely, the Facia database (which ultimately stores the messages from editions proof / publish) only supports one message per second.

Occasionally, in testing with small issues, we end up losing messages as a result.  This is a trivial fix.  Sorry.

https://trello.com/c/GNinraji/285-add-1s-delay-to-each-archiver-step

## Test Plan

The lambda has been deployed in code, and proof/publish still works consistently with small issues, and we do not observe any dropped messages.  ✔️ 