### PR TITLE
Display app build number in settings page

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -122,6 +122,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
     const { signOutIdentity } = useContext(AccessContext)
 
     const versionNumber = DeviceInfo.getVersion()
+    const buildNumber = DeviceInfo.getBuildNumber()
 
     if (query.loading) return null
     const { client } = query
@@ -257,7 +258,11 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                             key: 'Version',
                             title: Copy.settings.version,
                             onPress: versionClickHandler,
-                            proxy: <Text>{versionNumber}</Text>,
+                            proxy: (
+                                <Text>
+                                    {versionNumber} ({buildNumber})
+                                </Text>
+                            ),
                         },
                     ]}
                 />


### PR DESCRIPTION
## Summary
As it says on the tin.

(no ticket)


![Simulator Screen Shot - iPhone 11 - 2020-08-06 at 17 47 09](https://user-images.githubusercontent.com/6583174/89558980-e6b43b80-d80c-11ea-8fe4-faf2a3082165.png)
