### PR TITLE
Adding a chevron icon to Subscription details on the Settings for consistency

### DIFF
--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -168,6 +168,7 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                       onPress: () => {
                           navigation.navigate(routeNames.SubscriptionDetails)
                       },
+                      proxy: rightChevronIcon,
                   },
               ]
             : [
@@ -177,7 +178,6 @@ const SettingsScreen = ({ navigation }: NavigationInjectedProps) => {
                       onPress: () => {
                           navigation.navigate(routeNames.AlreadySubscribed)
                       },
-
                       proxy: rightChevronIcon,
                   },
               ]),


### PR DESCRIPTION
## Summary

Why are we doing this?
**Issue**
Once signed in, the Subscription details option has no arrow indicating there is another screen.

**Work to be done**
Add a right chevron to the Subscription details option on the Settings.


[**Trello Card ->**](https://trello.com/c/TAPPiaHi/1486-add-an-arrow-chevron-to-the-subscription-details-option-on-the-settings)

## Test Plan
Once signed in, check if the Subscription details option has a chevron.
