### PR TITLE
Implemented POST endpoint

### DIFF
--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -16,6 +16,7 @@ import { IssueParams } from '../tasks/issue'
 import { fetchfromCMSFrontsS3, GetS3ObjParams } from '../utils/s3'
 import { parseIssueActionRecord, parseEditionListActionRecord } from './parser'
 import { URL } from '../utils/backend-client'
+import fetch from 'node-fetch'
 
 export interface Record {
     s3: { bucket: { name: string }; object: { key: string } }

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -16,6 +16,7 @@ import {
 import { IssueParams } from '../tasks/issue'
 import { fetchfromCMSFrontsS3, GetS3ObjParams } from '../utils/s3'
 import { parseIssueActionRecord, parseEditionListActionRecord } from './parser'
+import { URL } from '../utils/backend-client'
 
 export interface Record {
     s3: { bucket: { name: string }; object: { key: string } }
@@ -96,9 +97,18 @@ const invokeEditionList = async (
     console.log('Found following edition lists:', JSON.stringify(editionLists))
 
     return await Promise.all(
-        editionLists.map(() => {
-            return failFast(
-                `No backend address to PUT edition list to yet - TODO`,
+        editionLists.map(async data => {
+            const editionList = data.content
+            const response = await fetch(URL, {
+                method: 'POST',
+                body: JSON.stringify(editionList),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            })
+            console.log(
+                'Editionlist post response: ',
+                `${response.status} ${response.statusText}`,
             )
         }),
     )

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -99,7 +99,9 @@ const invokeEditionList = async (
     return await Promise.all(
         editionLists.map(async data => {
             const editionList = data.content
-            const response = await fetch(URL, {
+            const endpoint = `${URL}editions`
+            console.log(`Posting editions list to ${endpoint}`)
+            const response = await fetch(endpoint, {
                 method: 'POST',
                 body: JSON.stringify(editionList),
                 headers: {

--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -5,7 +5,6 @@ import {
     Attempt,
     attempt,
     Failure,
-    failFast,
     hasFailed,
     hasSucceeded,
     withFailureMessage,
@@ -110,6 +109,12 @@ const invokeEditionList = async (
                 'Editionlist post response: ',
                 `${response.status} ${response.statusText}`,
             )
+
+            // we just need to return success or failue in a form IssuePublicationIdentifier
+            // so it can be reported upstream and logs all success or failed tasks
+            return response.ok
+                ? ({ version: 'success' } as IssuePublicationIdentifier)
+                : fail(response.statusText)
         }),
     )
 }

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -142,15 +142,15 @@ export class EditionsStack extends cdk.Stack {
          * which isn't ideal, but I can't find a sensible alternative way to allow the listener lambda
          * to execute the backend API, which it needs to do to post the editions list.
          */
-        const listenerFunctionArn = new cdk.CfnParameter(
-            this,
-            'listener-function-arn',
-            {
-                type: 'String',
-                description:
-                    'ARN of the archiver listener function. NOTE: circular dependency. If creating from scratch you can leave this blank',
-            },
-        )
+        // const listenerFunctionArn = new cdk.CfnParameter(
+        //     this,
+        //     'listener-function-arn',
+        //     {
+        //         type: 'String',
+        //         description:
+        //             'ARN of the archiver listener function. NOTE: circular dependency. If creating from scratch you can leave this blank',
+        //     },
+        // )
 
         const deployBucket = s3.Bucket.fromBucketName(
             this,

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -268,14 +268,14 @@ export class EditionsStack extends cdk.Stack {
         })
         previewApiIpAccessPolicyStatement.addAnyPrincipal()
 
-        const previewApiListenerAccessPolicyStatement = new iam.PolicyStatement(
-            {
-                effect: Effect.ALLOW,
-                actions: ['execute-api:invoke'],
-                resources: [`${listenerFunctionArn.valueAsString}`],
-            },
-        )
-        previewApiListenerAccessPolicyStatement.addAnyPrincipal()
+        // const previewApiListenerAccessPolicyStatement = new iam.PolicyStatement(
+        //     {
+        //         effect: Effect.ALLOW,
+        //         actions: ['execute-api:invoke'],
+        //         resources: [`${listenerFunctionArn.valueAsString}`],
+        //     },
+        // )
+        // previewApiListenerAccessPolicyStatement.addAnyPrincipal()
 
         const previewApi = new apigateway.LambdaRestApi(
             this,
@@ -286,7 +286,7 @@ export class EditionsStack extends cdk.Stack {
                 policy: new iam.PolicyDocument({
                     statements: [
                         previewApiIpAccessPolicyStatement,
-                        previewApiListenerAccessPolicyStatement,
+                        // previewApiListenerAccessPolicyStatement,
                     ],
                 }),
             },

--- a/projects/aws/lib/listener.ts
+++ b/projects/aws/lib/listener.ts
@@ -15,6 +15,7 @@ export const s3EventListenerFunction = (
     proofStateMachineArn: string,
     publishStateMachineArn: string,
     frontsRoleARN: string,
+    backendURL: string,
 ) => {
     const fn = new lambda.Function(
         scope,
@@ -34,6 +35,7 @@ export const s3EventListenerFunction = (
                 proofStateMachineARN: proofStateMachineArn,
                 publishStateMachineARN: publishStateMachineArn,
                 arn: frontsRoleARN,
+                backend: backendURL,
             },
         },
     )
@@ -104,6 +106,7 @@ export const constructTriggeredStepFunction = (
         proofArchiverStateMachine.stateMachineArn,
         publishArchiverStateMachine.stateMachineArn,
         frontsRoleARN,
+        backendURL,
     )
 
     new CfnOutput(scope, 'archiver-s3-event-listener-arn', {

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -12,12 +12,10 @@ const stub = (req: Request, res: Response) => {
 }
 
 const stubEditionController = {
-    READ: (req: Request, res: Response) => {
-        console.log(`endpoint (READ): ${req.path} called`)
+    GET: (req: Request, res: Response) => {
         res.sendStatus(200)
     },
-    WRITE: (req: Request, res: Response) => {
-        console.log(`endpoint (WRITE): ${req.path} called`)
+    POST: (req: Request, res: Response) => {
         res.sendStatus(200)
     },
 }

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -11,12 +11,17 @@ const stub = (req: Request, res: Response) => {
     res.sendStatus(200)
 }
 
+const stubEditionController = {
+    READ: (req: Request, res: Response) => {},
+    WRITE: (req: Request, res: Response) => {},
+}
+
 const testStubControllers: EditionsBackendControllers = {
     issuesSummaryController: stub,
     issueController: stub,
     frontController: stub,
     imageController: stub,
-    editionsController: stub,
+    editionsController: stubEditionController,
 }
 
 describe('Endpoints contract test for Preview Editions Backend application', () => {

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -12,8 +12,14 @@ const stub = (req: Request, res: Response) => {
 }
 
 const stubEditionController = {
-    READ: (req: Request, res: Response) => {},
-    WRITE: (req: Request, res: Response) => {},
+    READ: (req: Request, res: Response) => {
+        console.log(`endpoint (READ): ${req.path} called`)
+        res.sendStatus(200)
+    },
+    WRITE: (req: Request, res: Response) => {
+        console.log(`endpoint (WRITE): ${req.path} called`)
+        res.sendStatus(200)
+    },
 }
 
 const testStubControllers: EditionsBackendControllers = {

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -15,8 +15,8 @@ export interface EditionsBackendControllers {
     frontController: (req: Request, res: Response) => void
     imageController: (req: Request, res: Response) => void
     editionsController: {
-        READ: (req: Request, res: Response) => void
-        WRITE: (req: Request, res: Response) => void
+        GET: (req: Request, res: Response) => void
+        POST: (req: Request, res: Response) => void
     }
 }
 
@@ -44,9 +44,9 @@ export const createApp = (
     // it should return the issues list for the daily-edition
     app.get('/issues', controllers.issuesSummaryController)
 
-    app.get('/editions', controllers.editionsController.READ)
+    app.get('/editions', controllers.editionsController.GET)
 
-    app.post('/editions', express.json(), controllers.editionsController.WRITE)
+    app.post('/editions', express.json(), controllers.editionsController.POST)
 
     app.get(
         '/' + issueSummaryPath(':edition'),

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -14,7 +14,10 @@ export interface EditionsBackendControllers {
     issueController: (req: Request, res: Response) => void
     frontController: (req: Request, res: Response) => void
     imageController: (req: Request, res: Response) => void
-    editionsController: (req: Request, res: Response) => void
+    editionsController: {
+        READ: (req: Request, res: Response) => void
+        WRITE: (req: Request, res: Response) => void
+    }
 }
 
 export const createApp = (
@@ -41,7 +44,9 @@ export const createApp = (
     // it should return the issues list for the daily-edition
     app.get('/issues', controllers.issuesSummaryController)
 
-    app.get('/editions', controllers.editionsController)
+    app.get('/editions', controllers.editionsController.READ)
+
+    app.post('/editions', express.json(), controllers.editionsController.WRITE)
 
     app.get(
         '/' + issueSummaryPath(':edition'),

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -18,8 +18,8 @@ const runtimeControllers: EditionsBackendControllers = {
     frontController,
     imageController,
     editionsController: {
-        READ: editionsControllerGet,
-        WRITE: editionsControllerPost,
+        GET: editionsControllerGet,
+        POST: editionsControllerPost,
     },
 }
 

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -5,7 +5,10 @@ import { Handler } from 'aws-lambda'
 import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController } from './controllers/image'
-import { editionsController } from './controllers/editions'
+import {
+    editionsControllerGet,
+    editionsControllerPost,
+} from './controllers/editions'
 import { createApp, EditionsBackendControllers } from './application'
 import { isPreview } from './preview'
 
@@ -14,7 +17,10 @@ const runtimeControllers: EditionsBackendControllers = {
     issueController,
     frontController,
     imageController,
-    editionsController,
+    editionsController: {
+        READ: editionsControllerGet,
+        WRITE: editionsControllerPost,
+    },
 }
 
 const asPreview = isPreview

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import { SpecialEdition, EditionsList } from '../../Apps/common/src'
 import { defaultRegionalEditions } from '../../Apps/common/src/editions-defaults'
+import { s3Put } from '../s3'
 
 const getSpecialEditions = (): Array<SpecialEdition> => {
     return []
@@ -12,7 +13,23 @@ const editionsList: EditionsList = {
     trainingEditions: [],
 }
 
-export const editionsController = (req: Request, res: Response) => {
+export const editionsControllerGet = (req: Request, res: Response) => {
     res.setHeader('Content-Type', 'application/json')
     res.send(JSON.stringify(editionsList))
+}
+
+export const editionsControllerPost = (req: Request, res: Response) => {
+    try {
+        // TODO: doing simple validation now but would be good to enhance this further
+        const editionsList: EditionsList = JSON.parse(JSON.stringify(req.body))
+
+        // write to s3 bucket for both proof/store(published)
+        s3Put({ key: 'editions', bucket: 'proof' }, JSON.stringify(req.body))
+        s3Put({ key: 'editions', bucket: 'store' }, JSON.stringify(req.body))
+        res.send('success')
+    } catch (error) {
+        console.log('Unable to parse edition list')
+        console.error(error)
+        res.send('Error: ' + error)
+    }
 }

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -18,21 +18,31 @@ export const editionsControllerGet = (req: Request, res: Response) => {
     res.send(JSON.stringify(editionsList))
 }
 
-export const editionsControllerPost = (req: Request, res: Response) => {
+export const editionsControllerPost = async (req: Request, res: Response) => {
     try {
         // TODO: doing simple validation now but would be good to enhance this further
         const editionsList: EditionsList = JSON.parse(JSON.stringify(req.body))
         console.log(
             `Edition list parsed successfully: ${JSON.stringify(editionsList)}`,
         )
-
-        // write to s3 bucket for both proof/store(published)
-        s3Put({ key: 'editions', bucket: 'proof' }, JSON.stringify(req.body))
-        s3Put({ key: 'editions', bucket: 'store' }, JSON.stringify(req.body))
-        res.send('success')
     } catch (error) {
         console.log('Unable to parse edition list')
         console.error(error)
-        res.send('Error: ' + error)
+        res.send('Parse error')
+    }
+
+    try {
+        // write to s3 bucket for both proof/store(published)
+        await s3Put(
+            { key: 'editions', bucket: 'proof' },
+            JSON.stringify(req.body),
+        )
+        await s3Put(
+            { key: 'editions', bucket: 'store' },
+            JSON.stringify(req.body),
+        )
+        res.send('success')
+    } catch (error) {
+        res.send('Failed to upload to both S3 buckets')
     }
 }

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -22,7 +22,9 @@ export const editionsControllerPost = (req: Request, res: Response) => {
     try {
         // TODO: doing simple validation now but would be good to enhance this further
         const editionsList: EditionsList = JSON.parse(JSON.stringify(req.body))
-        console.log(`Edition list parsed successfully: ${editionsList}`)
+        console.log(
+            `Edition list parsed successfully: ${JSON.stringify(editionsList)}`,
+        )
 
         // write to s3 bucket for both proof/store(published)
         s3Put({ key: 'editions', bucket: 'proof' }, JSON.stringify(req.body))

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -22,6 +22,7 @@ export const editionsControllerPost = (req: Request, res: Response) => {
     try {
         // TODO: doing simple validation now but would be good to enhance this further
         const editionsList: EditionsList = JSON.parse(JSON.stringify(req.body))
+        console.log(`Edition list parsed successfully: ${editionsList}`)
 
         // write to s3 bucket for both proof/store(published)
         s3Put({ key: 'editions', bucket: 'proof' }, JSON.stringify(req.body))


### PR DESCRIPTION
## Summary
Implemented POST endpoint to store edition-list into edition s3 and make it available for the app/clients. Currently, when front tools publish edition-list it does not come through to the edition backend to make it available for the mobile apps. This work fills that gap by the store the published 'edition list' into relevant s3 bucket.



[**Trello Card ->**](https://trello.com/c/Is0CxWix/1449-put-endpoint-to-consume-editions-json-from-fronts-tool)

## Test Plan
Need to deploy this to code first and see everything is working as expected.