### PR TITLE
Updated 'locale' and 'multi-edition' logic

### DIFF
--- a/projects/Mallard/src/helpers/settings/__tests__/debug.spec.ts
+++ b/projects/Mallard/src/helpers/settings/__tests__/debug.spec.ts
@@ -1,0 +1,37 @@
+import { fetchEditionMenuEnabledSetting } from '../debug'
+import { remoteConfigService } from 'src/services/remote-config'
+
+jest.mock('src/services/remote-config', () => ({
+    remoteConfigService: {
+        getBoolean: jest.fn(),
+    },
+}))
+
+describe('debug settings', () => {
+    describe('when user in Beta', () => {
+        const isInBeta = true
+        it('edition switch should be On when remote switch is On', async () => {
+            remoteConfigService.getBoolean = jest.fn().mockReturnValue(true)
+            const result = await fetchEditionMenuEnabledSetting(isInBeta)
+            expect(result).toEqual(true)
+        })
+        it('edition switch should be On even when remote switch is Off', async () => {
+            remoteConfigService.getBoolean = jest.fn().mockReturnValue(false)
+            const result = await fetchEditionMenuEnabledSetting(isInBeta)
+            expect(result).toEqual(true)
+        })
+    })
+    describe('when user NOT in Beta', () => {
+        const isInBeta = false
+        it('edition switch should be On when remote switch is On', async () => {
+            remoteConfigService.getBoolean = jest.fn().mockReturnValue(true)
+            const result = await fetchEditionMenuEnabledSetting(isInBeta)
+            expect(result).toEqual(true)
+        })
+        it('edition switch should be Off when remote switch is Off', async () => {
+            remoteConfigService.getBoolean = jest.fn().mockReturnValue(false)
+            const result = await fetchEditionMenuEnabledSetting(isInBeta)
+            expect(result).toEqual(false)
+        })
+    })
+})

--- a/projects/Mallard/src/helpers/settings/debug.ts
+++ b/projects/Mallard/src/helpers/settings/debug.ts
@@ -1,6 +1,5 @@
 import { enableEditionMenuCache } from 'src/helpers/storage'
 import { AsyncCache } from 'src/authentication/lib/Authorizer'
-import { isInBeta } from '../release-stream'
 import { remoteConfigService } from 'src/services/remote-config'
 
 const setDebugSetting = async (toggle: boolean, cache: AsyncCache<boolean>) => {

--- a/projects/Mallard/src/helpers/settings/debug.ts
+++ b/projects/Mallard/src/helpers/settings/debug.ts
@@ -1,5 +1,7 @@
 import { enableEditionMenuCache } from 'src/helpers/storage'
 import { AsyncCache } from 'src/authentication/lib/Authorizer'
+import { isInBeta } from '../release-stream'
+import { remoteConfigService } from 'src/services/remote-config'
 
 const setDebugSetting = async (toggle: boolean, cache: AsyncCache<boolean>) => {
     await cache.set(toggle)
@@ -21,8 +23,13 @@ const fetchDebugSetting = async (
     }
 }
 
-const fetchEditionMenuEnabledSetting = () =>
-    fetchDebugSetting(enableEditionMenuCache)
+const fetchEditionMenuEnabledSetting = (isInBeta: boolean) => {
+    if (isInBeta || remoteConfigService.getBoolean('enable_multi_edition'))
+        return Promise.resolve(true)
+
+    return fetchDebugSetting(enableEditionMenuCache)
+}
+
 const setEditionMenuEnabledSetting = (toggle: boolean) =>
     setDebugSetting(toggle, enableEditionMenuCache)
 

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.remoteoff.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.remoteoff.spec.tsx
@@ -11,12 +11,16 @@ jest.mock('src/services/remote-config', () => ({
     },
 }))
 
+jest.mock('src/helpers/release-stream', () => ({
+    isInBeta: () => false,
+}))
+
 describe('useEditions', () => {
     describe('defaultEditionDecider', () => {
         beforeEach(async () => {
             await editionsListCache.reset()
         })
-        it('should set the BASE EDITION if remote config is turned off', async () => {
+        it('should set the BASE EDITION if remote config is turned off and not in Beta', async () => {
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
 

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -6,6 +6,7 @@ import {
     fetchEditionMenuEnabledSetting,
     setEditionMenuEnabledSetting,
 } from 'src/helpers/settings/debug'
+import { isInBeta } from 'src/helpers/release-stream'
 
 const oneGB = 1073741824
 
@@ -74,9 +75,11 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     }, [])
 
     useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
+        fetchEditionMenuEnabledSetting(isInBeta()).then(
+            (editionsMenuToggle: boolean) => {
+                setEditionsMenuEnabled(editionsMenuToggle)
+            },
+        )
     }, [])
 
     return (

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -51,9 +51,9 @@ export const DEFAULT_EDITIONS_LIST = {
 export const BASE_EDITION = defaultRegionalEditions[0]
 
 const localeToEdition = new Map<string, RegionalEdition>()
+localeToEdition.set('en_GB', defaultRegionalEditions[0])
 localeToEdition.set('en_AU', defaultRegionalEditions[1])
 localeToEdition.set('en_US', defaultRegionalEditions[2])
-localeToEdition.set('en_GB', defaultRegionalEditions[0])
 
 const defaultState: EditionState = {
     editionsList: DEFAULT_EDITIONS_LIST,
@@ -111,13 +111,6 @@ export const getEditions = async () => {
                 await editionsListCache.set(editionsList)
                 return editionsList
             }
-            // Unsuccessful, try getting it from our local storage
-            const cachedEditionsList = await editionsListCache.get()
-            if (cachedEditionsList) {
-                return cachedEditionsList
-            }
-            // Not in local storage either?
-            throw new Error('Unable to Get Editions')
         }
         // Not connected? Try local storage
         const cachedEditionsList = await editionsListCache.get()
@@ -159,7 +152,6 @@ export const defaultEditionDecider = async (
         const defaultLocaleEnabled = remoteConfigService.getBoolean(
             'default_locale',
         )
-        // Feature flag on?
         if (defaultLocaleEnabled) {
             // Get the correct edition for the locale
             const dE = localeToEdition.get(locale)
@@ -174,7 +166,7 @@ export const defaultEditionDecider = async (
                 )
             }
         } else {
-            // FF is off, so set to the default
+            // Feature Flag is off, so set to the default
             await setEdition(
                 BASE_EDITION,
                 setDefaultEdition,

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -150,10 +150,10 @@ export const defaultEditionDecider = async (
         await selectedEditionCache.set(dE)
         pushNotifcationRegistration()
     } else {
-        const defaultLocaleEnabled = remoteConfigService.getBoolean(
-            'default_locale',
+        const autoDetectEdition = remoteConfigService.getBoolean(
+            'auto_edition_detection',
         )
-        const useUserLocaleToDecideEdition = defaultLocaleEnabled || isInBeta()
+        const useUserLocaleToDecideEdition = autoDetectEdition || isInBeta()
         if (useUserLocaleToDecideEdition) {
             // Get the correct edition for the locale
             const dE = localeToEdition.get(locale)

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -20,6 +20,7 @@ import { AppState, AppStateStatus } from 'react-native'
 import { remoteConfigService } from 'src/services/remote-config'
 import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/push-notifications/push-notifications'
+import { isInBeta } from 'src/helpers/release-stream'
 
 interface EditionsEndpoint {
     regionalEditions: RegionalEdition[]
@@ -152,7 +153,8 @@ export const defaultEditionDecider = async (
         const defaultLocaleEnabled = remoteConfigService.getBoolean(
             'default_locale',
         )
-        if (defaultLocaleEnabled) {
+        const useUserLocaleToDecideEdition = defaultLocaleEnabled || isInBeta()
+        if (useUserLocaleToDecideEdition) {
             // Get the correct edition for the locale
             const dE = localeToEdition.get(locale)
             // Here as it "can" be undefined, but previous branch says not

--- a/projects/Mallard/src/screens/deprecate-screen.tsx
+++ b/projects/Mallard/src/screens/deprecate-screen.tsx
@@ -17,6 +17,7 @@ import { useNetInfo } from '../hooks/use-net-info'
 import { defaultSettings } from 'src/helpers/settings/defaults'
 import { Copy } from 'src/helpers/words'
 import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
+import { isInBeta } from 'src/helpers/release-stream'
 
 const styles = StyleSheet.create({
     container: {
@@ -68,9 +69,11 @@ const DeprecateVersionModal = () => {
     const { showModal } = useDeprecationModal()
     const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
+        fetchEditionMenuEnabledSetting(isInBeta()).then(
+            (editionsMenuToggle: boolean) => {
+                setEditionsMenuEnabled(editionsMenuToggle)
+            },
+        )
     }, [])
 
     return (

--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -11,6 +11,7 @@ import { Heading } from 'src/components/layout/ui/row'
 import { ReceiptIOS } from 'src/authentication/services/iap'
 import { Copy } from 'src/helpers/words'
 import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
+import { isInBeta } from 'src/helpers/release-stream'
 
 const keyValueItem = (key: string, value: string) =>
     ({
@@ -84,9 +85,11 @@ const getIAPType = (iapData: ReceiptIOS) =>
 const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => {
     const [editionsMenuEnabled, setEditionsMenuEnabled] = useState(false)
     useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
+        fetchEditionMenuEnabledSetting(isInBeta()).then(
+            (editionsMenuToggle: boolean) => {
+                setEditionsMenuEnabled(editionsMenuToggle)
+            },
+        )
     }, [])
     return (
         <>

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -12,6 +12,7 @@ import { RESULTS } from 'react-native-permissions'
 import { getGeolocation } from 'src/helpers/weather'
 import { Copy } from 'src/helpers/words'
 import { fetchEditionMenuEnabledSetting } from 'src/helpers/settings/debug'
+import { isInBeta } from 'src/helpers/release-stream'
 
 const styles = StyleSheet.create({
     button: {
@@ -73,9 +74,11 @@ const WeatherGeolocationConsentScreen = ({
     }
 
     useEffect(() => {
-        fetchEditionMenuEnabledSetting().then((editionsMenuToggle: boolean) => {
-            setEditionsMenuEnabled(editionsMenuToggle)
-        })
+        fetchEditionMenuEnabledSetting(isInBeta()).then(
+            (editionsMenuToggle: boolean) => {
+                setEditionsMenuEnabled(editionsMenuToggle)
+            },
+        )
     }, [])
 
     return (

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -33,28 +33,23 @@ const configValues = {
 }
 
 class RemoteConfigService implements RemoteConfig {
-    private initialized: boolean
-
-    constructor() {
-        this.initialized = false
-    }
-
-    private setInitialized(isInitialized: boolean) {
-        this.initialized = isInitialized
-    }
-
     init() {
         remoteConfig()
             .setDefaults(remoteConfigDefaults)
             .then(() => remoteConfig().setConfigSettings(configValues))
             .then(() => {
-                remoteConfig().fetchAndActivate()
-                this.setInitialized(true)
-                console.log('Remote config fetched & activated!')
-                if (__DEV__) console.log(remoteConfig().getAll())
+                remoteConfig()
+                    .fetchAndActivate()
+                    .then(activated => {
+                        if (activated) {
+                            console.log('Remote config fetched & activated!')
+                            if (__DEV__) console.log(remoteConfig().getAll())
+                        } else {
+                            console.log('Remote config NOT activated!')
+                        }
+                    })
             })
             .catch(() => {
-                this.setInitialized(false)
                 console.log(
                     'Remote config not activated - something went wrong',
                 )
@@ -62,19 +57,11 @@ class RemoteConfigService implements RemoteConfig {
     }
 
     getBoolean(key: RemoteConfigProperty): boolean {
-        if (this.initialized) {
-            return remoteConfig().getValue(key).value as boolean
-        }
-
-        return false
+        return remoteConfig().getValue(key).value as boolean
     }
 
     getString(key: RemoteConfigProperty): RemoteStringValue {
-        if (this.initialized) {
-            return remoteConfig().getValue(key).value as string
-        }
-
-        return undefined
+        return remoteConfig().getValue(key).value as string
     }
 }
 

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -14,12 +14,14 @@ const remoteConfigDefaults = {
     logging_enabled: true,
     default_locale: false,
     join_beta_button_enabled: false,
+    enable_multi_edition: false,
 }
 
 export const RemoteConfigProperties = [
     'logging_enabled',
     'default_locale',
     'join_beta_button_enabled',
+    'enable_multi_edition',
 ] as const
 
 export type RemoteConfigProperty = typeof RemoteConfigProperties[number]

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -12,16 +12,16 @@ interface RemoteConfig {
 
 const remoteConfigDefaults = {
     logging_enabled: true,
-    default_locale: false,
     join_beta_button_enabled: false,
     enable_multi_edition: false,
+    auto_edition_detection: false,
 }
 
 export const RemoteConfigProperties = [
     'logging_enabled',
-    'default_locale',
     'join_beta_button_enabled',
     'enable_multi_edition',
+    'auto_edition_detection',
 ] as const
 
 export type RemoteConfigProperty = typeof RemoteConfigProperties[number]


### PR DESCRIPTION
## Summary

Currently, we have:
* `Locale`: that we use to auto-detect initial edition based on user device locale. It is remotely switched controlled
* `Multi edition`: this flag we use to show hide `edition switcher` button and also to decide which text to show, for example Daily vs Edition. It is now controlled from debug settings

This PR changes the behavior to:
* `Locale`: all beta users (including debug build) will have it on, we have removed the previous `default_locale` remote switch from the app and introduced a new one to avoid any incidents. The new one called `auto_edition_detection`
* `Multi edition`: all beta users (including debug build) will see it, we added a remote switch so we can turn in on later for the general public. The new remote switch is `auto_edition_detection`


We are making this change so we can test multi-edition change for the beta users before we go to production.
 

[**Trello Card ->**](https://trello.com/c/OMvasp0M/1478-allow-the-edition-switch-to-be-available-to-beta-users-but-not-live-users)
[**Trello Card ->**](https://trello.com/c/Z5xDC6im/1479-deprecate-existing-locale-remote-switch)

## Test Plan
To test in beta: we can just test internal beta build
To test in prod: we have some unit test for validation and also we can test this on locally produced prod build from Android Studio or Xode.