### PR TITLE
apply bullet styling to match dotcom

### DIFF
--- a/projects/Mallard/src/components/article/html/components/lists.ts
+++ b/projects/Mallard/src/components/article/html/components/lists.ts
@@ -12,11 +12,11 @@ export const listStyles = () => css`
         display: inline-block;
     }
 
-    ul>li>p:first-child {
+    ul > li > p:first-child {
         display: inline;
     }
 
-    ul>li:before {
+    ul > li:before {
         display: inline-block;
         content: '';
         border-radius: 0.375rem;

--- a/projects/Mallard/src/components/article/html/components/lists.ts
+++ b/projects/Mallard/src/components/article/html/components/lists.ts
@@ -1,0 +1,29 @@
+import { css } from 'src/helpers/webview'
+import { color } from 'src/theme/color'
+
+export const listStyles = () => css`
+    ul {
+        list-style: none;
+        margin-bottom: 15px;
+    }
+
+    li {
+        padding-left: 1.25rem;
+        display: inline-block;
+    }
+
+    ul>li>p:first-child {
+        display: inline;
+    }
+
+    ul>li:before {
+        display: inline-block;
+        content: '';
+        border-radius: 0.375rem;
+        height: 0.75rem;
+        width: 0.75rem;
+        margin-right: 0.5rem;
+        margin-left: -1.25rem;
+        background-color: ${color.palette.neutral[86]};
+    }
+`

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -16,6 +16,7 @@ import { CssProps, themeColors } from './helpers/css'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { mediaAtomStyles } from './components/media-atoms'
 import { twitterEmbedStyles } from './components/twitter-embed'
+import { listStyles } from './components/lists'
 
 const makeFontsCss = () => css`
     /* text */
@@ -164,6 +165,8 @@ const makeCss = ({ colors, theme }: CssProps, contentType: string) => css`
 
         }
     }
+
+    ${listStyles()}
 
     ${quoteStyles({
         colors,


### PR DESCRIPTION
## Summary
This PR adds custom styling to unordered lists to match what is visible on dotcom. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/XBFxWJzw/1270-snaggin-bullet-points)

## Test Plan
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-08-17 at 09 59 34](https://user-images.githubusercontent.com/53755195/90378102-d6a02580-e070-11ea-8124-92812aad32bc.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-17 at 09 59 44](https://user-images.githubusercontent.com/53755195/90378074-d2740800-e070-11ea-8f64-40570083ddd9.png)


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
