### PR TITLE
Add new fields to EditionsList type

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -9,25 +9,34 @@ by 6am (GMT)`,
         header: {
             title: 'The Daily',
         },
+        editionType: 'Regional',
+        topic: 'uk',
+        notificationUTCOffset: 3,
     },
     {
         title: 'Australia Weekender',
-        subTitle: `Published every Saturday morning 
+        subTitle: `Published every Saturday morning
 by 6am (AEST)`,
         edition: editions.ausWeekly,
         header: {
             title: 'Australia',
             subTitle: 'Weekender',
         },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: -5,
     },
     {
         title: 'US Weekender',
-        subTitle: `Published every Saturday morning 
+        subTitle: `Published every Saturday morning
 by 6am (EST)`,
         edition: editions.usWeekly,
         header: {
             title: 'US',
             subTitle: 'Weekender',
         },
+        editionType: 'Regional',
+        topic: 'us',
+        notificationUTCOffset: 8,
     },
 ]

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -591,8 +591,16 @@ interface EditionInterface {
     topic: string
 }
 
+// disabling tslint here as  it's useful to give this types a different name
+// and in future Regional/Training editions may have unique properties
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface RegionalEdition extends EditionInterface {}
 
+// disabling tslint here as  it's useful to give this types a different name
+// and in future Regional/Training editions may have unique properties
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface TrainingEdition extends EditionInterface {}
 
 export interface SpecialEdition extends EditionInterface {

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -578,7 +578,7 @@ export interface EditionsList {
     trainingEditions: TrainingEdition[]
 }
 
-export interface RegionalEdition {
+interface EditionInterface {
     title: string
     subTitle: string
     edition: Edition
@@ -586,29 +586,19 @@ export interface RegionalEdition {
         title: string
         subTitle?: string
     }
+    editionType: 'Regional' | 'Training' | 'Special'
+    notificationUTCOffset: number
+    topic: string
 }
 
-export interface TrainingEdition {
-    title: string
-    subTitle: string
-    edition: Edition
-    header: {
-        title: string
-        subTitle?: string
-    }
-}
+export interface RegionalEdition extends EditionInterface {}
 
-export interface SpecialEdition {
+export interface TrainingEdition extends EditionInterface {}
+
+export interface SpecialEdition extends EditionInterface {
     buttonStyle: SpecialEditionButtonStyles
     devUri?: string
-    edition: Edition
     expiry: Date
-    header: {
-        title: string
-        subTitle?: string
-    }
     headerStyle?: SpecialEditionHeaderStyles
     image: Image
-    subTitle: string
-    title: string
 }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -3,8 +3,9 @@ import { storiesOf } from '@storybook/react-native'
 import { withKnobs } from '@storybook/addon-knobs'
 import { EditionsMenu } from './EditionsMenu'
 import { editions, Edition } from 'src/common'
+import { SpecialEdition } from '../../../../Apps/common/src'
 
-const props = {
+const props: { specialEditions: SpecialEdition[] } = {
     specialEditions: [
         {
             edition: 'daily-edition' as Edition,
@@ -15,6 +16,9 @@ const props = {
                 source: 'media',
                 path: '/path/to/image',
             },
+            topic: 'food',
+            editionType: 'Special',
+            notificationUTCOffset: 0,
             header: {
                 title: `Food
 Monthly`,

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
 import { Edition, editions } from 'src/common'
 import { EditionsMenu } from '../EditionsMenu'
+import { RegionalEdition, SpecialEdition } from '../../../../../Apps/common/src'
 
 jest.mock('src/components/EditionsMenu/RegionButton/RegionButton', () => ({
     RegionButton: () => 'RegionButton',
@@ -18,7 +19,7 @@ jest.mock('src/components/EditionsMenu/Header/Header', () => ({
     EditionsMenuHeader: () => 'EditionsMenuHeader',
 }))
 
-const regionalEditions = [
+const regionalEditions: RegionalEdition[] = [
     {
         title: 'The UK Daily Edition',
         subTitle: 'Published every day by 12am (GMT)',
@@ -26,6 +27,9 @@ const regionalEditions = [
         header: {
             title: 'The Daily',
         },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: 1,
     },
     {
         title: 'Australia Daily',
@@ -35,6 +39,9 @@ const regionalEditions = [
             title: 'Austraila',
             subTitle: 'Weekender',
         },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: 1,
     },
     {
         title: 'US and Cananda Weekend',
@@ -44,10 +51,13 @@ const regionalEditions = [
             title: 'US',
             subTitle: 'Weekender',
         },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: 1,
     },
 ]
 
-const specialEditions = [
+const specialEditions: SpecialEdition[] = [
     {
         edition: 'daily-edition' as Edition,
         expiry: new Date(98, 1),
@@ -55,6 +65,9 @@ const specialEditions = [
             source: 'media',
             path: '/path/to/image',
         },
+        editionType: 'Special',
+        notificationUTCOffset: 1,
+        topic: 'food',
         title: `Food
 Monthly`,
         subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -10,29 +10,38 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
         Array [
           Object {
             "edition": "daily-edition",
+            "editionType": "Regional",
             "header": Object {
               "title": "The Daily",
             },
+            "notificationUTCOffset": 1,
             "subTitle": "Published every day by 12am (GMT)",
             "title": "The UK Daily Edition",
+            "topic": "au",
           },
           Object {
             "edition": "australian-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "Austraila",
             },
+            "notificationUTCOffset": 1,
             "subTitle": "Published every day by 9:30am (AEST)",
             "title": "Australia Daily",
+            "topic": "au",
           },
           Object {
             "edition": "american-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "US",
             },
+            "notificationUTCOffset": 1,
             "subTitle": "Published every Saturday by 8am (EST)",
             "title": "US and Cananda Weekend",
+            "topic": "au",
           },
         ]
       }
@@ -110,32 +119,41 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
         Array [
           Object {
             "edition": "daily-edition",
+            "editionType": "Regional",
             "header": Object {
               "title": "The Daily",
             },
+            "notificationUTCOffset": 3,
             "subTitle": "Published every morning
 by 6am (GMT)",
             "title": "The Daily",
+            "topic": "uk",
           },
           Object {
             "edition": "australian-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "Australia",
             },
-            "subTitle": "Published every Saturday morning 
+            "notificationUTCOffset": -5,
+            "subTitle": "Published every Saturday morning
 by 6am (AEST)",
             "title": "Australia Weekender",
+            "topic": "au",
           },
           Object {
             "edition": "american-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "US",
             },
-            "subTitle": "Published every Saturday morning 
+            "notificationUTCOffset": 8,
+            "subTitle": "Published every Saturday morning
 by 6am (EST)",
             "title": "US Weekender",
+            "topic": "us",
           },
         ]
       }
@@ -230,6 +248,7 @@ by 6am (EST)",
               },
             },
             "edition": "daily-edition",
+            "editionType": "Special",
             "expiry": 1998-02-01T00:00:00.000Z,
             "header": Object {
               "subTitle": "Monthly",
@@ -239,9 +258,11 @@ by 6am (EST)",
               "path": "/path/to/image",
               "source": "media",
             },
+            "notificationUTCOffset": 1,
             "subTitle": "Store cupboard special: 20 quick and easy lockdown suppers",
             "title": "Food
 Monthly",
+            "topic": "food",
           },
         ]
       }
@@ -291,32 +312,41 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
         Array [
           Object {
             "edition": "daily-edition",
+            "editionType": "Regional",
             "header": Object {
               "title": "The Daily",
             },
+            "notificationUTCOffset": 3,
             "subTitle": "Published every morning
 by 6am (GMT)",
             "title": "The Daily",
+            "topic": "uk",
           },
           Object {
             "edition": "australian-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "Australia",
             },
-            "subTitle": "Published every Saturday morning 
+            "notificationUTCOffset": -5,
+            "subTitle": "Published every Saturday morning
 by 6am (AEST)",
             "title": "Australia Weekender",
+            "topic": "au",
           },
           Object {
             "edition": "american-edition",
+            "editionType": "Regional",
             "header": Object {
               "subTitle": "Weekender",
               "title": "US",
             },
-            "subTitle": "Published every Saturday morning 
+            "notificationUTCOffset": 8,
+            "subTitle": "Published every Saturday morning
 by 6am (EST)",
             "title": "US Weekender",
+            "topic": "us",
           },
         ]
       }


### PR DESCRIPTION
## Summary

Following from https://github.com/guardian/editions/pull/1421 there are a few fields the fronts too provides which don't currently exist in our edition list type. This PR adds them, as well as adding some inheritance to the different edition types to avoid some repetition

## Test Plan
Check that editions menu is still working..!