### PR TITLE
Respect apiUrl from dev menu when fetching the editions list.

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -130,6 +130,9 @@ export const defaultSettings: Settings = {
         : 'https://editions-logging.guardianapis.com/log/mallard',
 }
 
+export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>
+    `${apiUrl}editions`
+
 export const isPreview = (apiUrl: Settings['apiUrl']): boolean => {
     const backend = backends.find(backend => backend.value === apiUrl)
     return (backend && backend.preview) || false

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -50,7 +50,9 @@ describe('useEditions', () => {
                 status: 200,
                 body,
             })
-            const editionsList = await fetchEditions()
+            const editionsList = await fetchEditions(
+                defaultSettings.editionsUrl,
+            )
             expect(editionsList).toEqual(body)
         })
         it('should return null if there is not a 200 response from the endpoint', async () => {
@@ -61,7 +63,9 @@ describe('useEditions', () => {
                 },
                 { overwriteRoutes: false },
             )
-            const editionsList = await fetchEditions()
+            const editionsList = await fetchEditions(
+                defaultSettings.editionsUrl,
+            )
             expect(editionsList).toEqual(null)
         })
     })


### PR DESCRIPTION
## Summary
This PR changes the edition provider to respect whatever backend has been set via the dev menu. Previously this was set to always use the prod published backend.

This is useful to allow for testing edition list changes on CODE. 

## Test Plan
I've tested this in the simulator and it looks ok to me.
