### PR TITLE
fix/standifrst-styling-regression

### DIFF
--- a/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
+++ b/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
@@ -117,8 +117,7 @@ exports[`article html Header getStandFirst should display RegularByline Header T
         
                 
         <p
-            class=\\"\\"
-            style=\\"color: #121212;\\"
+            
         >
             Test Standfirst
         </p>

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -891,17 +891,16 @@ const getStandFirstText = ({
     standfirst: ArticleHeaderProps['standfirst']
     type: ArticleType
 }) => {
-    const color =
+    const interviewColor =
         pillar === 'lifestyle'
             ? getPillarColors(pillar).dark
             : palette.neutral[7]
 
     return html`
         <p
-            class="${type === ArticleType.Interview
-                ? 'interview-standfirst'
-                : ''}"
-            style="color: ${color};"
+            ${type === ArticleType.Interview &&
+                `class=interview-standfirst` &&
+                `style=color:${interviewColor};`}
         >
             ${standfirst}
         </p>


### PR DESCRIPTION
## Summary
A regression has been found in the latest production build, after investigating it seems it was introduced by changes to the interview template https://github.com/guardian/editions/compare/ac4a7c3a...df867f7e.
This change restricts interview color style to the interview templates only and should leave other templates as they are. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/XaNCRpFh/1495-weve-lost-the-standfirst-on-the-long-read-template-also-possibly-galleries)

## Test Plan
| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/90498599-6fea3d00-e140-11ea-8042-56f3e4293a9c.png) | ![image](https://user-images.githubusercontent.com/53755195/90498631-77114b00-e140-11ea-9a02-bf1568ea78e9.png)
![image](https://user-images.githubusercontent.com/53755195/90498664-7f698600-e140-11ea-919b-9f3f61989938.png) | ![image](https://user-images.githubusercontent.com/53755195/90498678-85f7fd80-e140-11ea-925c-1aa03034835c.png)

I also hardcoded templates to be interview to ensure the correct styling remained. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
