### PR TITLE
Fix proof reload button

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -279,6 +279,8 @@ PODS:
     - React
   - react-native-netinfo (5.6.2):
     - React
+  - react-native-restart (0.0.17):
+    - React
   - react-native-safe-area-context (0.6.4):
     - React
   - react-native-safe-area-insets (0.1.0):
@@ -407,6 +409,7 @@ DEPENDENCIES:
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - react-native-in-app-utils (from `../node_modules/react-native-in-app-utils`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-safe-area-insets (from `../node_modules/@delightfulstudio/react-native-safe-area-insets`)"
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
@@ -508,6 +511,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-in-app-utils"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
+  react-native-restart:
+    :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-safe-area-insets:
@@ -620,6 +625,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-in-app-utils: 07ea1df4bb6e8cbb27337d42a65ffe4cf7a35e97
   react-native-netinfo: 73303369946c2487c600418961bfdc87748b832f
+  react-native-restart: d19a0f8d053d065fe64cd2baebb6487111c77149
   react-native-safe-area-context: 52342d2d80ea8faadd0ffa76d83b6051f20c5329
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -82,6 +82,7 @@
         "react-native-permissions": "^2.0.3",
         "react-native-progress-circle": "^2.1.0",
         "react-native-push-notification": "^3.5.2",
+        "react-native-restart": "^0.0.17",
         "react-native-safe-area-context": "^0.6.4",
         "react-native-splash-screen": "^3.2.0",
         "react-native-status-bar-height": "^2.4.0",

--- a/projects/Mallard/src/hooks/use-settings.ts
+++ b/projects/Mallard/src/hooks/use-settings.ts
@@ -27,6 +27,11 @@ export const useIsPreview = () => {
     return apiUrl != null && isPreview(apiUrl)
 }
 
+export const useIsProof = () => {
+    const apiUrl = useApiUrl()
+    return apiUrl && apiUrl.includes('proof')
+}
+
 const PROD_DEV_QUERY = gql('{ isUsingProdDevtools @client }')
 export const useIsUsingProdDevtools = () => {
     const query = useQuery<{ isUsingProdDevtools: boolean }>(PROD_DEV_QUERY)

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -369,17 +369,18 @@ const IssueScreenWithPath = React.memo(
                 return (
                     <>
                         <PreviewReloadButton
-                            onPress={() => {
+                            onPress={async () => {
                                 if (isProof) {
-                                    deleteIssueFiles()
-                                        .then(RNRestart.Restart)
-                                        .catch(error => {
-                                            console.error(
-                                                'failed to delete files',
-                                                error,
-                                            ),
-                                                RNRestart.Restart()
-                                        })
+                                    try {
+                                        await deleteIssueFiles()
+                                    } catch (error) {
+                                        console.error(
+                                            'failed to delete files',
+                                            error,
+                                        )
+                                    } finally {
+                                        RNRestart.Restart()
+                                    }
                                 }
                                 clearCache()
                                 retry()

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -355,9 +355,9 @@ const IssueScreenWithPath = React.memo(
         path: PathToIssue
         initialFrontKey: string | null
     }) => {
-        const preview = useIsPreview()
-        const proof = useIsProof()
-        const response = useIssueResponse(path, preview)
+        const isPreview = useIsPreview()
+        const isProof = useIsProof()
+        const response = useIssueResponse(path, isPreview)
 
         return response({
             error: handleError,
@@ -369,10 +369,17 @@ const IssueScreenWithPath = React.memo(
                 return (
                     <>
                         <PreviewReloadButton
-                            onPress={async () => {
-                                if (proof) {
-                                    await deleteIssueFiles()
-                                    RNRestart.Restart()
+                            onPress={() => {
+                                if (isProof) {
+                                    deleteIssueFiles()
+                                        .then(RNRestart.Restart)
+                                        .catch(error => {
+                                            console.error(
+                                                'failed to delete files',
+                                                error,
+                                            ),
+                                                RNRestart.Restart()
+                                        })
                                 }
                                 clearCache()
                                 retry()

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -371,11 +371,10 @@ const IssueScreenWithPath = React.memo(
                         <PreviewReloadButton
                             onPress={async () => {
                                 if (proof) {
+                                    await getIssueSummary()
                                     RNRestart.Restart()
                                 }
                                 clearCache()
-                                const issueSummary = await getIssueSummary()
-                                path = issueSummaryToLatestPath(issueSummary)
                                 retry()
                             }}
                         />

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -52,7 +52,6 @@ import { useIssueResponse } from 'src/hooks/use-issue'
 import {
     issueSummaryToLatestPath,
     useIssueSummary,
-    getIssueSummary,
 } from 'src/hooks/use-issue-summary'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
 import { useIsPreview, useIsProof } from 'src/hooks/use-settings'
@@ -67,6 +66,7 @@ import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
 import { useEditions, BASE_EDITION } from 'src/hooks/use-edition-provider'
 import RNRestart from 'react-native-restart'
+import { deleteIssueFiles } from 'src/download-edition/clear-issues'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -371,7 +371,7 @@ const IssueScreenWithPath = React.memo(
                         <PreviewReloadButton
                             onPress={async () => {
                                 if (proof) {
-                                    await getIssueSummary()
+                                    await deleteIssueFiles()
                                     RNRestart.Restart()
                                 }
                                 clearCache()

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -55,7 +55,7 @@ import {
     getIssueSummary,
 } from 'src/hooks/use-issue-summary'
 import { useNavPositionChange } from 'src/hooks/use-nav-position'
-import { useIsPreview } from 'src/hooks/use-settings'
+import { useIsPreview, useIsProof } from 'src/hooks/use-settings'
 import { PathToIssue } from 'src/paths'
 import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 import { sendPageViewEvent } from 'src/services/ophan'
@@ -66,6 +66,7 @@ import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
 import { useEditions, BASE_EDITION } from 'src/hooks/use-edition-provider'
+import RNRestart from 'react-native-restart'
 
 const styles = StyleSheet.create({
     emptyWeatherSpace: {
@@ -355,6 +356,7 @@ const IssueScreenWithPath = React.memo(
         initialFrontKey: string | null
     }) => {
         const preview = useIsPreview()
+        const proof = useIsProof()
         const response = useIssueResponse(path, preview)
 
         return response({
@@ -368,6 +370,9 @@ const IssueScreenWithPath = React.memo(
                     <>
                         <PreviewReloadButton
                             onPress={async () => {
+                                if (proof) {
+                                    RNRestart.Restart()
+                                }
                                 clearCache()
                                 const issueSummary = await getIssueSummary()
                                 path = issueSummaryToLatestPath(issueSummary)

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11245,6 +11245,11 @@ react-native-push-notification@^3.5.2:
   dependencies:
     "@react-native-community/push-notification-ios" "^1.2.0"
 
+react-native-restart@^0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.17.tgz#c1f38e019d1a2114248d496698e7951e9435ba91"
+  integrity sha512-UwFPDssMFoyDbF2aLARIHWt5g/o0TtxCXK9WIY+0iNpkgG9qWd+n80XBwXioNCdgy39ZQ5yfJBJRwtMLDgABag==
+
 react-native-safe-area-context@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.6.4.tgz#624bd50cebc9f47853f179373501511931d2a0c3"


### PR DESCRIPTION
## Summary
This is another attempt at the work in https://github.com/guardian/editions/pull/1374 to get the 'Refresh' button to work properly for the 'proof' endpoint. I spent a long time trying to write some code to refetch the issues list (to get the publishedId of the new proof version) and then refetch the issue, but without success. 

This is a lazier approach which uses the [react native restart](https://www.npmjs.com/package/react-native-restart) library to force a full app restart. In proof mode the refresh button now also deletes all issues downlodaed as otherwise even with the app restart you still end up on the previously fetched issue. 

Currently, this button works on ios, but crashes the app on android. Since the editorial team would need to restart the app anyway as a manual alternative to the refresh button, I'm counting the crash as a feature..! 

[**Trello Card ->**](https://trello.com/c/PkjPqlFR/1336-production-edition-switching)

## Test Plan
Change backend API to one of the 'proof' APIs. Make a change in the fronts tool then click the 'proof' button, wait for the proof to run then press the refresh button in the app. The change should appear (or if android, the whole app will crash)

