### PR TITLE
chore: Remove unused withNavigation

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -3,7 +3,6 @@ import { Animated, Easing, Platform, StyleSheet, View } from 'react-native'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { BasicArticleHeader } from '../header'
-import { supportsAnimation } from 'src/helpers/features'
 import { SliderTitle, SliderTitleProps } from './SliderTitle'
 import DeviceInfo from 'react-native-device-info'
 
@@ -45,23 +44,21 @@ const SliderHeaderLowEnd = ({
     sliderDetails: SliderTitleProps
 }) => {
     const [top] = useState(new Animated.Value(0))
-    if (supportsAnimation()) {
-        useEffect(() => {
-            if (isShown) {
-                Animated.timing(top, {
-                    toValue: 0,
-                    easing: Easing.out(Easing.ease),
-                    duration: 200,
-                }).start()
-            } else {
-                Animated.timing(top, {
-                    toValue: -HEADER_LOW_END_HEIGHT,
-                    easing: Easing.out(Easing.ease),
-                    duration: 200,
-                }).start()
-            }
-        }, [isShown, top])
-    }
+    useEffect(() => {
+        if (isShown) {
+            Animated.timing(top, {
+                toValue: 0,
+                easing: Easing.out(Easing.ease),
+                duration: 200,
+            }).start()
+        } else {
+            Animated.timing(top, {
+                toValue: -HEADER_LOW_END_HEIGHT,
+                easing: Easing.out(Easing.ease),
+                duration: 200,
+            }).start()
+        }
+    }, [isShown, top])
 
     return (
         <Animated.View style={[styles.header, { top }]}>

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { Animated, Easing, Platform, StyleSheet, View } from 'react-native'
-import { NavigationInjectedProps, withNavigation } from 'react-navigation'
 import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { BasicArticleHeader } from '../header'

--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -36,46 +36,42 @@ const styles = StyleSheet.create({
     },
 })
 
-const SliderHeaderLowEnd = withNavigation(
-    ({
-        isShown,
-        isAtTop,
-        sliderDetails,
-    }: {
-        isShown: boolean
-        isAtTop: boolean
-        sliderDetails: SliderTitleProps
-    } & NavigationInjectedProps) => {
-        const [top] = useState(new Animated.Value(0))
-        if (supportsAnimation()) {
-            useEffect(() => {
-                if (isShown) {
-                    Animated.timing(top, {
-                        toValue: 0,
-                        easing: Easing.out(Easing.ease),
-                        duration: 200,
-                    }).start()
-                } else {
-                    Animated.timing(top, {
-                        toValue: -HEADER_LOW_END_HEIGHT,
-                        easing: Easing.out(Easing.ease),
-                        duration: 200,
-                    }).start()
-                }
-            }, [isShown, top])
-        }
+const SliderHeaderLowEnd = ({
+    isShown,
+    isAtTop,
+    sliderDetails,
+}: {
+    isShown: boolean
+    isAtTop: boolean
+    sliderDetails: SliderTitleProps
+}) => {
+    const [top] = useState(new Animated.Value(0))
+    if (supportsAnimation()) {
+        useEffect(() => {
+            if (isShown) {
+                Animated.timing(top, {
+                    toValue: 0,
+                    easing: Easing.out(Easing.ease),
+                    duration: 200,
+                }).start()
+            } else {
+                Animated.timing(top, {
+                    toValue: -HEADER_LOW_END_HEIGHT,
+                    easing: Easing.out(Easing.ease),
+                    duration: 200,
+                }).start()
+            }
+        }, [isShown, top])
+    }
 
-        return (
-            <Animated.View style={[styles.header, { top }]}>
-                <BasicArticleHeader />
-                <View
-                    style={[styles.slider, isAtTop ? styles.sliderAtTop : null]}
-                >
-                    <SliderTitle {...sliderDetails} />
-                </View>
-            </Animated.View>
-        )
-    },
-)
+    return (
+        <Animated.View style={[styles.header, { top }]}>
+            <BasicArticleHeader />
+            <View style={[styles.slider, isAtTop ? styles.sliderAtTop : null]}>
+                <SliderTitle {...sliderDetails} />
+            </View>
+        </Animated.View>
+    )
+}
 
 export { SliderHeaderLowEnd, HEADER_LOW_END_HEIGHT }


### PR DESCRIPTION
## Summary
In an attempt to hunt down the errors in the app, this stood out as not required as navigation props are not used in this component.

This highlighted a conditional `useEffect` which is not allowed. This condition was around iOS devices under V12 which we now don't support. So it was safe to remove this condition.