### PR TITLE
chore: Disable Storybook

### DIFF
--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -35,7 +35,7 @@ import {
 } from 'src/screens/settings/privacy-policy-screen'
 import { SubscriptionDetailsScreen } from 'src/screens/settings/subscription-details-screen'
 import { TermsAndConditionsScreen } from 'src/screens/settings/terms-and-conditions-screen'
-import StorybookScreen from 'src/screens/storybook-screen'
+// import StorybookScreen from 'src/screens/storybook-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 import { color } from 'src/theme/color'
 import { ArticleScreen } from '../screens/article-screen'
@@ -104,7 +104,8 @@ const AppStack = createModalNavigator(
                 [routeNames.FAQ]: FAQScreen,
                 [routeNames.AlreadySubscribed]: AlreadySubscribedScreen,
                 [routeNames.SubscriptionDetails]: SubscriptionDetailsScreen,
-                [routeNames.Storybook]: StorybookScreen,
+                // Turned off to remove Promise rejection error on Android
+                // [routeNames.Storybook]: StorybookScreen,
             },
             {
                 defaultNavigationOptions: {


### PR DESCRIPTION
## Summary
Those `Error not implemented` crashes are to do with Storybook. I don't think this is the route cause of the crashing problems we see, but certainly improves Android development for the time being.

Storybook needs upgrading, here is the ticket for it: https://trello.com/c/hZOHI4E4/1498-enable-and-upgrade-storybook