### PR TITLE
feat: Less aggressive download clean

### DIFF
--- a/projects/Mallard/src/download-edition/clear-issues.ts
+++ b/projects/Mallard/src/download-edition/clear-issues.ts
@@ -16,6 +16,7 @@ const clearDownloadsDirectory = async () => {
         files.map(
             async (file: RNFS.ReadDirItem) => await RNFS.unlink(file.path),
         )
+        await prepFileSystem()
     } catch (error) {
         await pushTracking(
             'tempFileRemoveError',

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -46,6 +46,11 @@ export const prepFileSystem = async (): Promise<void> => {
             ensureDirExists(`${FSPaths.issuesDir}/${edition}`),
         ),
     )
+    await Promise.all(
+        Object.values(editions).map(edition =>
+            ensureDirExists(`${FSPaths.downloadRoot}/${edition}`),
+        ),
+    )
 }
 
 export const getJson = <T extends any>(path: string): Promise<T> =>


### PR DESCRIPTION
## Summary
We get the occasional error that the `download/daily-edition` folder does not exist. See image below

![Simulator Screen Shot - iPhone 11 - 2020-08-17 at 13 05 59](https://user-images.githubusercontent.com/935975/90615291-d2584180-e203-11ea-9878-854f72de74b3.png)

As a result, this PR creates the required folders for each edition ahead of time. 
When downloads are cleared, we do delete those folders but recreate them straight after.