### PR TITLE
lower kicker within header

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -40,7 +40,7 @@ const outieKicker = (type: ArticleType) => css`
     .header-container[data-type='${type}'] .header-kicker {
         display: inline-block;
         height: 1.70em;
-        margin-top: -1.75em;
+        margin-top: -1.71em;
         padding-right: ${metrics.article.sides};
         margin-left: -20em;
         padding-left: 20.5em;

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -40,7 +40,7 @@ const outieKicker = (type: ArticleType) => css`
     .header-container[data-type='${type}'] .header-kicker {
         display: inline-block;
         height: 1.70em;
-        margin-top: -1.71em;
+        margin-top: -1.70em;
         padding-right: ${metrics.article.sides};
         margin-left: -20em;
         padding-left: 20.5em;


### PR DESCRIPTION
## Summary
This is a second very tiny regression found from the interview template work after fixing the standfirst. 
This PR reduces the margin-top for the kicker within the header 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/XaNCRpFh/1495-weve-lost-the-standfirst-on-the-long-read-template-also-possibly-galleries)

## Test Plan
| Before | After |
| --- | --- | 
![Screenshot_1597827383](https://user-images.githubusercontent.com/53755195/90616256-1e57b600-e205-11ea-9da3-84f0d00fd9fa.png) | ![Screenshot_1597827351](https://user-images.githubusercontent.com/53755195/90616234-1861d500-e205-11ea-9faa-f4af3ceb299c.png)
![Screenshot_1597827605](https://user-images.githubusercontent.com/53755195/90616332-37f8fd80-e205-11ea-9728-6c1899271a5b.png) | ![Screenshot_1597827618](https://user-images.githubusercontent.com/53755195/90616354-3deede80-e205-11ea-89de-1fd64a4d4f40.png)

Interviews should remain unchanged: 
![Screenshot_1597827299](https://user-images.githubusercontent.com/53755195/90616402-4e06be00-e205-11ea-9117-3927bf160204.png)
![Screenshot_1597827305](https://user-images.githubusercontent.com/53755195/90616407-4e9f5480-e205-11ea-9579-e4d988b0bcfa.png)



<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
