### PR TITLE
fix: Sentry - EDITIONS-MXX

### DIFF
--- a/projects/Mallard/src/download-edition/clear-issues.ts
+++ b/projects/Mallard/src/download-edition/clear-issues.ts
@@ -27,12 +27,17 @@ const clearDownloadsDirectory = async () => {
     }
 }
 
-const deleteIssue = (localId: string): Promise<void> => {
-    const promise = RNFS.unlink(FSPaths.issueRoot(localId)).catch(e => {
-        errorService.captureException(e)
-    })
-    promise.then(() => localIssueListStore.remove(localId))
-    return promise
+const deleteIssue = async (localId: string): Promise<boolean> => {
+    const issuePath = FSPaths.issueRoot(localId)
+    const doesItExist = await RNFS.exists(issuePath)
+    if (doesItExist) {
+        await RNFS.unlink(issuePath).catch(e => {
+            errorService.captureException(e)
+        })
+        localIssueListStore.remove(localId)
+        return true
+    }
+    return false
 }
 
 const deleteIssueFiles = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
Sentry ticket: https://sentry.io/organizations/the-guardian/issues/1736134906/?project=1519156&query=is%3Aunresolved+dist%3A777&sort=freq&statsPeriod=14d

We record an error every time we try to delete an issue and it does exist in full when clearing old issues. This does an extra check that the issue exists and if it does it then attempts to delete it. This should resolve this error.