### PR TITLE
fix: Sentry - EDITIONS-HSK

### DIFF
--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import { receiptIOS } from 'src/authentication/__tests__/fixtures'
-import { isReceiptValid } from '../iap'
+import { isReceiptValid, findValidReceipt } from '../iap'
 
 describe('iap', () => {
     describe('isReceiptValid', () => {
@@ -24,6 +24,58 @@ describe('iap', () => {
             )
 
             expect(isValid).toBe(true)
+        })
+    })
+    describe('findValidReceipt', () => {
+        it('should return a valid iap receipt if its found', () => {
+            const twoDaysInFuture = moment()
+                .add(2, 'days')
+                .toDate()
+            const receipt = receiptIOS({ expires_date: twoDaysInFuture })
+            const receiptValidationResponse = {
+                status: 0,
+                receipt: {
+                    bundle_id: 'test',
+                    application_version: '1.2',
+                    in_app: [],
+                    original_application_version: '',
+                    receipt_creation_date: '',
+                },
+                latest_receipt_info: [receipt],
+            }
+            expect(findValidReceipt(receiptValidationResponse)).toEqual(receipt)
+        })
+        it('should return null if latest_receipt_info param is empty', () => {
+            const receiptValidationResponse = {
+                status: 0,
+                receipt: {
+                    bundle_id: 'test',
+                    application_version: '1.2',
+                    in_app: [],
+                    original_application_version: '',
+                    receipt_creation_date: '',
+                },
+                latest_receipt_info: [],
+            }
+            expect(findValidReceipt(receiptValidationResponse)).toEqual(null)
+        })
+        it('should return null if it cant find a valid receipt', () => {
+            const fourDaysAgo = moment()
+                .subtract(4, 'days')
+                .toDate()
+            const receipt = receiptIOS({ expires_date: fourDaysAgo })
+            const receiptValidationResponse = {
+                status: 0,
+                receipt: {
+                    bundle_id: 'test',
+                    application_version: '1.2',
+                    in_app: [],
+                    original_application_version: '',
+                    receipt_creation_date: '',
+                },
+                latest_receipt_info: [receipt],
+            }
+            expect(findValidReceipt(receiptValidationResponse)).toEqual(null)
         })
     })
 })

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -57,7 +57,10 @@ const isReceiptValid = (receipt: ReceiptIOS) => {
 }
 
 const findValidReceipt = (receipt: ReceiptValidationResponse) =>
-    (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid) || null
+    receipt
+        ? (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid) ||
+          null
+        : null
 
 /**
  * This will attempt to restore existing purchases
@@ -120,4 +123,5 @@ export {
     fetchActiveIOSSubscriptionReceipt,
     tryRestoreActiveIOSSubscriptionReceipt,
     isReceiptValid,
+    findValidReceipt,
 }


### PR DESCRIPTION
## Summary
Despite typescript, empty receipt values are passed through further down the object. I believe this is because `latest_receipt_info` is not required by the iAP library. So this firms it up and has tests around it.

[**Sentry Card ->**](https://sentry.io/organizations/the-guardian/issues/1672718141/?project=1519156&query=release%3Auk.co.guardian.gce%406.8%2B797&sort=freq&statsPeriod=24h