### PR TITLE
chore: Supress network error

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -264,7 +264,7 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
         return issueSummary
     } catch (e) {
         const issueSummary = await readIssueSummary()
-        if (!issueSummary) {
+        if (!issueSummary && e.message !== 'Network request failed') {
             e.message = `Failed to fetch valid issue summary and empty cache: ${e.message}`
             errorService.captureException(e)
         }


### PR DESCRIPTION
## Summary
Sentry error: https://sentry.io/organizations/the-guardian/issues/1354326610/events/8b26f874396c450bb98cf226d9168e00/?project=1519156&query=is%3Aunresolved+dist%3A797&sort=freq&statsPeriod=14d

There is a high frequency of `Network request failed` being logged into Sentry. We dont care about this because we cannot do anything about it. This suppresses this error.