### PR TITLE
chore: Supress download timeout error

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -93,12 +93,18 @@ export const downloadNamedIssueArchive = async ({
             progressInterval: 1,
         }).promise
         return {
-            promise: returnable.then(async res => {
-                // Ensure issue is removed from the cache on completion
-                const { clear } = withCache('issue')
-                clear(localIssueId)
-                return res
-            }),
+            promise: returnable
+                .then(async res => {
+                    // Ensure issue is removed from the cache on completion
+                    const { clear } = withCache('issue')
+                    clear(localIssueId)
+                    return res
+                })
+                .catch(
+                    e =>
+                        e.message !== 'timeout' &&
+                        errorService.captureException(e),
+                ),
         }
     } catch (e) {
         e.message = `downloadNamedIssueArchive failed: ${e.message}`


### PR DESCRIPTION
## Summary
https://sentry.io/organizations/the-guardian/issues/1672718141/?project=1519156&query=release%3Auk.co.guardian.gce%406.8%2B797&sort=freq&statsPeriod=24h

This is a timeout error on a download that wasn't previously being caught. As there isn't much to be done about a timeout error, I have suppressed this, and only this. This is because there is currently no strategy around re-downloading.