### PR TITLE
chore: Gather more data around notification service 500s

### DIFF
--- a/projects/Mallard/src/push-notifications/notification-service.ts
+++ b/projects/Mallard/src/push-notifications/notification-service.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native'
 import { getSetting } from 'src/helpers/settings'
 import { notificationEdition } from 'src/helpers/settings/defaults'
+import { errorService } from 'src/services/errors'
 
 export interface PushToken {
     name: 'uk' | 'us' | 'au'
@@ -26,11 +27,13 @@ const registerWithNotificationService = async (
         headers: {
             'Content-Type': 'application/json',
         },
-    }).then(response =>
-        response.ok
-            ? Promise.resolve(response.json())
-            : Promise.reject(response.status),
-    )
+    })
+        .then(response =>
+            response.ok
+                ? Promise.resolve(response.json())
+                : Promise.reject(response.status),
+        )
+        .catch(e => errorService.captureException(e))
 }
 
 export { registerWithNotificationService }


### PR DESCRIPTION
## Summary
https://sentry.io/organizations/the-guardian/issues/1364228058/events/3d98ec0506a54985ab5e55a6ace890bc/?project=1519156&query=is%3Aunresolved+dist%3A797&sort=priority&statsPeriod=14d

This is an uncaught error. It appears that we are getting 500 status codes from the notification service. This will hopefully give us some more data on this.