### PR TITLE
chore: Revive Storybook

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -28,13 +28,9 @@ const createSettingsCacheIOS = Platform.select({
         },
     }),
     default: () => ({
-        set: async () => {
-            throw new Error('not implemented')
-        },
+        set: async () => Promise.resolve(),
         get: async () => null,
-        reset: async () => {
-            throw new Error('not implemented')
-        },
+        reset: async () => Promise.resolve(),
     }),
 })
 

--- a/projects/Mallard/src/navigation/index.ts
+++ b/projects/Mallard/src/navigation/index.ts
@@ -35,7 +35,7 @@ import {
 } from 'src/screens/settings/privacy-policy-screen'
 import { SubscriptionDetailsScreen } from 'src/screens/settings/subscription-details-screen'
 import { TermsAndConditionsScreen } from 'src/screens/settings/terms-and-conditions-screen'
-// import StorybookScreen from 'src/screens/storybook-screen'
+import StorybookScreen from 'src/screens/storybook-screen'
 import { WeatherGeolocationConsentScreen } from 'src/screens/weather-geolocation-consent-screen'
 import { color } from 'src/theme/color'
 import { ArticleScreen } from '../screens/article-screen'
@@ -105,7 +105,7 @@ const AppStack = createModalNavigator(
                 [routeNames.AlreadySubscribed]: AlreadySubscribedScreen,
                 [routeNames.SubscriptionDetails]: SubscriptionDetailsScreen,
                 // Turned off to remove Promise rejection error on Android
-                // [routeNames.Storybook]: StorybookScreen,
+                [routeNames.Storybook]: StorybookScreen,
             },
             {
                 defaultNavigationOptions: {


### PR DESCRIPTION
## Summary
Very happy with this one...

This no only removes the Promise rejection error, but also reinstates Storybook.

This wrapper around a settings cache is only used on iOS, yet it was causing Android to fail. Removing the errors thrown for no reason has solved it.