### PR TITLE
chore: Supress unlink warnings

### DIFF
--- a/projects/Mallard/src/download-edition/clear-issues.ts
+++ b/projects/Mallard/src/download-edition/clear-issues.ts
@@ -14,8 +14,12 @@ const clearDownloadsDirectory = async () => {
     try {
         const files = await RNFS.readDir(FSPaths.downloadRoot)
         files.map(
-            async (file: RNFS.ReadDirItem) => await RNFS.unlink(file.path),
+            async (file: RNFS.ReadDirItem) =>
+                await RNFS.unlink(file.path).catch(() => {
+                    // Android says nothing exists here but they are empty folders, so this supresses the warning
+                }),
         )
+        await Promise.all(files)
         await prepFileSystem()
     } catch (error) {
         await pushTracking(


### PR DESCRIPTION
## Summary
There seems to be a bit of a bug in the RNFS unlink code for Android. When unlinking it doesn't seem to link removing empty folders.

This PR suppresses warnings around this, and ensures that all promise are completed before prepping the file system again.