### PR TITLE
chore: UK daily name change

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -2,12 +2,13 @@ import { RegionalEdition, editions } from './index'
 
 export const defaultRegionalEditions: RegionalEdition[] = [
     {
-        title: 'The Daily',
+        title: 'UK Daily',
         subTitle: `Published every morning
 by 6am (GMT)`,
         edition: editions.daily,
         header: {
-            title: 'The Daily',
+            title: 'UK',
+            subTitle: 'Daily',
         },
         editionType: 'Regional',
         topic: 'uk',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -21,11 +21,12 @@ jest.mock('src/components/EditionsMenu/Header/Header', () => ({
 
 const regionalEditions: RegionalEdition[] = [
     {
-        title: 'The UK Daily Edition',
+        title: 'UK Daily',
         subTitle: 'Published every day by 12am (GMT)',
         edition: editions.daily as Edition,
         header: {
-            title: 'The Daily',
+            title: 'UK Daily',
+            subTitle: 'Daily',
         },
         editionType: 'Regional',
         topic: 'au',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -12,11 +12,12 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
             "edition": "daily-edition",
             "editionType": "Regional",
             "header": Object {
-              "title": "The Daily",
+              "subTitle": "Daily",
+              "title": "UK Daily",
             },
             "notificationUTCOffset": 1,
             "subTitle": "Published every day by 12am (GMT)",
-            "title": "The UK Daily Edition",
+            "title": "UK Daily",
             "topic": "au",
           },
           Object {
@@ -121,12 +122,13 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
             "edition": "daily-edition",
             "editionType": "Regional",
             "header": Object {
-              "title": "The Daily",
+              "subTitle": "Daily",
+              "title": "UK",
             },
             "notificationUTCOffset": 3,
             "subTitle": "Published every morning
 by 6am (GMT)",
-            "title": "The Daily",
+            "title": "UK Daily",
             "topic": "uk",
           },
           Object {
@@ -314,12 +316,13 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
             "edition": "daily-edition",
             "editionType": "Regional",
             "header": Object {
-              "title": "The Daily",
+              "subTitle": "Daily",
+              "title": "UK",
             },
             "notificationUTCOffset": 3,
             "subTitle": "Published every morning
 by 6am (GMT)",
-            "title": "The Daily",
+            "title": "UK Daily",
             "topic": "uk",
           },
           Object {

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/IssuePickerHeader.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('react-navigation', () => ({
 describe('IssuePickerHeader', () => {
     it('should match the default style', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
-            <IssuePickerHeader title="The Daily" />,
+            <IssuePickerHeader title="UK" subTitle="Daily" />,
         ).toJSON()
         expect(component).toMatchSnapshot()
     })
@@ -22,7 +22,8 @@ describe('IssuePickerHeader', () => {
     it('should match the altered style by the prop headerStyles', () => {
         const component: ReactTestRendererJSON | null = TestRenderer.create(
             <IssuePickerHeader
-                title="The Daily"
+                title="UK"
+                subTitle="Daily"
                 headerStyles={{
                     backgroundColor: '#7D0068',
                     textColorPrimary: '#007ABC',

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
@@ -209,7 +209,33 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                     ]
                   }
                 >
-                  The Daily
+                  UK
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {
+                          "color": "#F3C100",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  Daily
                 </Text>
               </View>
             </View>
@@ -508,7 +534,31 @@ exports[`IssuePickerHeader should match the default style 1`] = `
                     ]
                   }
                 >
-                  The Daily
+                  UK
+                </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "flexShrink": 0,
+                        "fontFamily": "GTGuardianTitlepiece-Bold",
+                        "fontSize": 24,
+                        "lineHeight": 26,
+                      },
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "marginTop": -2,
+                        },
+                        Object {
+                          "color": "#ffe500",
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  Daily
                 </Text>
               </View>
             </View>

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -6,7 +6,7 @@ import { errorService } from 'src/services/errors'
 import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider'
 
 // Purpose: To hide the weahter on the first load unless the user turns it on
-// Intended for use on lower powered devices and for users who do not use the daily edition as their default edition
+// Intended for use on lower powered devices and for users who do not use the UK Daily edition as their default edition
 
 const KEY = '@weatherLowRAMCheck'
 const EDITIONCHECKKEY = '@weatherEditionCheck'

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -211,7 +211,7 @@ export const EditionProvider = ({
      * Default Edition and Selected
      *
      * On clean install the cache will be empty, therefore defaultRegionalEditions[0]
-     * (aka The Daily) remains as the default until one is set. If found, we want to
+     * (aka UK Daily) remains as the default until one is set. If found, we want to
      * also set this as the selected edition
      */
     useEffect(() => {


### PR DESCRIPTION
## Summary
This changes it in the backup array if the endpoint is down and in some tests and comments for consistency.

[**Trello Card ->**](https://trello.com/c/mT67lHYI/1507-rename-the-daily-to-uk-daily)
