### PR TITLE
WIP: Add isShowcase property to article type picker.

### DIFF
--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -102,7 +102,6 @@ const getImages = (
         image: getMainImage(result, articleType),
         trailImage: getTrailImage(result, articleType),
     }
-    console.debug('Found images: ' + JSON.stringify(images))
     return images
 }
 

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -91,7 +91,6 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isEditorial) return ArticleType.Article
                 else if (isComment) return ArticleType.Opinion
-                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'lifestyle':

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -1,12 +1,6 @@
 import { IContent } from '@guardian/capi-ts/dist/Content'
 import { ArticleType, HeaderType } from '../../Apps/common/src/index'
-import {
-    TagType,
-    IElement,
-    Asset,
-    AssetType,
-    ElementType,
-} from '@guardian/capi-ts'
+import { TagType, IElement, ElementType } from '@guardian/capi-ts'
 
 const doesTagExist = (article: IContent, tagId: string): boolean => {
     return article.tags.find(tag => tag.id === tagId) != undefined

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -65,7 +65,6 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isShowcase) return ArticleType.Showcase
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
-                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'sport':

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -1,6 +1,12 @@
 import { IContent } from '@guardian/capi-ts/dist/Content'
 import { ArticleType, HeaderType } from '../../Apps/common/src/index'
-import { TagType } from '@guardian/capi-ts'
+import {
+    TagType,
+    IElement,
+    Asset,
+    AssetType,
+    ElementType,
+} from '@guardian/capi-ts'
 
 const doesTagExist = (article: IContent, tagId: string): boolean => {
     return article.tags.find(tag => tag.id === tagId) != undefined
@@ -8,6 +14,17 @@ const doesTagExist = (article: IContent, tagId: string): boolean => {
 
 const doesTypeExist = (article: IContent, tagType: TagType): boolean => {
     return article.tags.find(tag => tag.type === tagType) != undefined
+}
+
+const showCaseMainMedia = (elements: IElement[]): boolean => {
+    const mainImage = elements.find(
+        e => e.relation === 'main' && e.type === ElementType.IMAGE,
+    )
+    return mainImage
+        ? mainImage.assets.some(
+              a => a.typeData && a.typeData.role === 'showcase',
+          )
+        : false
 }
 
 const articleTypePicker = (article: IContent): ArticleType => {
@@ -36,6 +53,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
     const isReview: boolean = isTagPresent('tone/reviews')
     const isRecipe: boolean = isTagPresent('tone/recipes')
     const isMatchResult: boolean = isTagPresent('tone/matchreports')
+    const isShowcase: boolean = showCaseMainMedia(article.elements || [])
 
     /**
      * Order of conditionals under each pillar is important as certain conditions take precedent.
@@ -52,6 +70,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isReview) return ArticleType.Review
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
+                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'sport':
@@ -65,6 +84,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
+                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'opinion':
@@ -77,6 +97,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isEditorial) return ArticleType.Article
                 else if (isComment) return ArticleType.Opinion
+                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'lifestyle':
@@ -92,6 +113,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
+                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             case 'culture':
@@ -112,6 +134,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
+                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             default:

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -68,6 +68,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isLetter) return ArticleType.Letter
                 else if (isComment) return ArticleType.Opinion
                 else if (isReview) return ArticleType.Review
+                else if (isShowcase) return ArticleType.Showcase
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isShowcase) return ArticleType.Showcase
@@ -134,7 +135,6 @@ const articleTypePicker = (article: IContent): ArticleType => {
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isFeature) return ArticleType.Feature
-                else if (isShowcase) return ArticleType.Showcase
                 else return ArticleType.Article
 
             default:

--- a/projects/backend/capi/assets.ts
+++ b/projects/backend/capi/assets.ts
@@ -29,8 +29,6 @@ const extractImage: (
 }
 
 export const getImage = (assetArray: IAsset[]): Image | undefined => {
-    console.log('Asset array == ' + assetArray)
-    console.log('Asset array type == ' + typeof assetArray)
     const asset = extractImage(assetArray)
     if (!(asset && asset.file)) {
         console.warn('Image asset potentially invalid.', JSON.stringify(asset))

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -24,7 +24,9 @@ const getFrontsBucket = (bucketType: Path['bucket']) =>
 const getEditionsBucket = (bucketType: string) =>
     `editions-${bucketType}-${stage.toLowerCase()}`
 
-console.log(`Creating S3 client with role arn: ${process.env.arn}`)
+if (process.env.arn) {
+    console.log(`Creating S3 client with role arn: ${process.env.arn}`)
+}
 
 const s3FrontsClient = new S3({
     region: 'eu-west-1',


### PR DESCRIPTION
## Summary
We have a new showcase template. We want to use it (I think) for all content that has main media with role: 'showcase'. This PR adds a function to detect such content, and adds it to the type picker. I'm not certain whethere the 'else if' statements are in the right position at the moment - currently it is set up so that we only use showcase if it's none of the other templates, which I suspect isn't quite right.

Motivation for this draft PR is to get the ordering right, and to get ready to test on CODE to see what the impact of adding a new 'article type' is on old versions of the client that don't know about showcase templates, which were added in https://github.com/guardian/editions/pull/1428

[**Trello Card ->**](https://trello.com/c/TN3e0niI/1503-article-type-picker-change-to-support-showcase-template)

## Test Plan
Release to CODE, Make an edition with a showcase article in it, check on version 14001850 (android) and version 801 (ios) - these are the most recent versions before James' PR referenced above was merged. This should tell us whether or not adding the new template will break the app.

We should of course also test on the latest version to check out the new template in all it's glory!