### PR TITLE
fix: Missing images backup strategy

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -42,6 +42,7 @@ const usesDarkTheme = (type: Content['type']) =>
 
 const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
     const path = getImagePath(image)
+    const backupPath = getImagePath(image, 'full-size', true)
     return Image({
         imageElement: {
             src: image,
@@ -50,6 +51,7 @@ const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
         },
         index: 0, // allows us to open lightbox
         path,
+        backupPath,
     })
 }
 

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -42,7 +42,7 @@ const usesDarkTheme = (type: Content['type']) =>
 
 const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
     const path = getImagePath(image)
-    const backupPath = getImagePath(image, 'full-size', true)
+    const remotePath = getImagePath(image, 'full-size', true)
     return Image({
         imageElement: {
             src: image,
@@ -51,7 +51,7 @@ const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
         },
         index: 0, // allows us to open lightbox
         path,
-        backupPath,
+        remotePath,
     })
 }
 

--- a/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
+++ b/projects/Mallard/src/components/article/html/components/__tests__/__snapshots__/header.spec.ts.snap
@@ -41,7 +41,11 @@ exports[`article html Header getStandFirst should display LargeByline Header Typ
                     
                             <div>
                                 
-        <img class=\\"\\" src=\\"\\" />
+        <img
+            class=\\"\\"
+            src=\\"\\"
+            onerror=\\"this.src=''\\"
+        />
     
                             </div>
                         

--- a/projects/Mallard/src/components/article/html/components/__tests__/header.spec.ts
+++ b/projects/Mallard/src/components/article/html/components/__tests__/header.spec.ts
@@ -11,7 +11,10 @@ describe('article html Header', () => {
             const html = getStandFirst(
                 HeaderType.LargeByline,
                 ArticleType.Opinion,
-                { headline: 'Test Headline', bylineHtml: '<p>Test Byline</p>' },
+                {
+                    headline: 'Test Headline',
+                    bylineHtml: '<p>Test Byline</p>',
+                },
                 null,
                 () => undefined,
                 'news',

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -914,12 +914,12 @@ const Image = ({
     getImagePath: GetImagePath
 }) => {
     const path = getImagePath(image)
-    const backupPath = getImagePath(image, 'full-size', true)
+    const remotePath = getImagePath(image, 'full-size', true)
     return html`
         <img
             class="${className}"
             src="${path}"
-            onerror="this.src='${backupPath}'"
+            onerror="this.src='${remotePath}'"
         />
     `
 }
@@ -942,13 +942,13 @@ const MainMediaImage = ({
     getImagePath: GetImagePath
 }) => {
     const path = getImagePath(image)
-    const backupPath = getImagePath(image, 'full-size', true)
+    const remotePath = getImagePath(image, 'full-size', true)
     return html`
         <div class="header-image" data-type="${articleType}">
             <div
                 class="image-as-bg ${className}"
                 data-preserve-ratio="${preserveRatio || 'false'}"
-                style="background-image: url(${path}), url(${backupPath}); "
+                style="background-image: url(${path}), url(${remotePath}); "
                 ${!isGallery &&
                     `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
                 data-open="false"
@@ -959,7 +959,7 @@ const MainMediaImage = ({
                             class="image-as-bg__img"
                             src="${path}"
                             aria-hidden
-                            onerror="this.src='${backupPath}'"
+                            onerror="this.src='${remotePath}'"
                         />
                     `}
                 <button

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -914,8 +914,13 @@ const Image = ({
     getImagePath: GetImagePath
 }) => {
     const path = getImagePath(image)
+    const backupPath = getImagePath(image, 'full-size', true)
     return html`
-        <img class="${className}" src="${path}" />
+        <img
+            class="${className}"
+            src="${path}"
+            onerror="this.src='${backupPath}'"
+        />
     `
 }
 
@@ -943,7 +948,7 @@ const MainMediaImage = ({
             <div
                 class="image-as-bg ${className}"
                 data-preserve-ratio="${preserveRatio || 'false'}"
-                style="background-image: url(${path}); "
+                style="background-image: url(${path}), url(${backupPath}); "
                 ${!isGallery &&
                     `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
                 data-open="false"

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -937,6 +937,7 @@ const MainMediaImage = ({
     getImagePath: GetImagePath
 }) => {
     const path = getImagePath(image)
+    const backupPath = getImagePath(image, 'full-size', true)
     return html`
         <div class="header-image" data-type="${articleType}">
             <div
@@ -953,6 +954,7 @@ const MainMediaImage = ({
                             class="image-as-bg__img"
                             src="${path}"
                             aria-hidden
+                            onerror="this.src='${backupPath}'"
                         />
                     `}
                 <button

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -185,7 +185,7 @@ const ImageBase = ({
     credit,
     displayCredit,
     role,
-    backupPath,
+    remotePath,
 }: {
     path: string
     index?: number
@@ -194,7 +194,7 @@ const ImageBase = ({
     credit?: string
     displayCredit?: boolean
     role?: ImageElement['role']
-    backupPath?: string
+    remotePath?: string
 }) => {
     const figcaption = renderCaption({ caption, credit, displayCredit })
     return html`
@@ -204,7 +204,7 @@ const ImageBase = ({
                 onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
                 alt="${alt}"
                 id="img-${index}"
-                onerror="this.src='${backupPath}'"
+                onerror="this.src='${remotePath}'"
             />
 
             ${figcaption &&
@@ -221,15 +221,15 @@ const Image = ({
     imageElement,
     path,
     index,
-    backupPath,
+    remotePath,
 }: {
     imageElement: ImageElement
     path: string | undefined
     index?: number | undefined
-    backupPath?: string
+    remotePath?: string
 }) => {
     if (path) {
-        return ImageBase({ path, index, backupPath, ...imageElement })
+        return ImageBase({ path, index, remotePath, ...imageElement })
     }
     return null
 }

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -185,6 +185,7 @@ const ImageBase = ({
     credit,
     displayCredit,
     role,
+    backupPath,
 }: {
     path: string
     index?: number
@@ -193,6 +194,7 @@ const ImageBase = ({
     credit?: string
     displayCredit?: boolean
     role?: ImageElement['role']
+    backupPath?: string
 }) => {
     const figcaption = renderCaption({ caption, credit, displayCredit })
     return html`
@@ -202,6 +204,7 @@ const ImageBase = ({
                 onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
                 alt="${alt}"
                 id="img-${index}"
+                onerror="this.src='${backupPath}'"
             />
 
             ${figcaption &&
@@ -218,13 +221,15 @@ const Image = ({
     imageElement,
     path,
     index,
+    backupPath,
 }: {
     imageElement: ImageElement
     path: string | undefined
     index?: number | undefined
+    backupPath?: string
 }) => {
     if (path) {
-        return ImageBase({ path, index, ...imageElement })
+        return ImageBase({ path, index, backupPath, ...imageElement })
     }
     return null
 }

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -12,7 +12,6 @@ import { FSPaths, APIPaths, PathToArticle } from 'src/paths'
 import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
-import { errorService } from 'src/services/errors'
 
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
@@ -63,7 +62,7 @@ const WebviewWithArticle = ({
     const getImagePath = (
         image?: Image,
         use: ImageUse = 'full-size',
-        backup: boolean = false,
+        backup = false,
     ) => {
         if (image == null) return undefined
 

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -62,13 +62,13 @@ const WebviewWithArticle = ({
     const getImagePath = (
         image?: Image,
         use: ImageUse = 'full-size',
-        backup = false,
+        forceRemotePath = false,
     ) => {
         if (image == null) return undefined
 
         const issueId = publishedIssueId
 
-        if (backup) {
+        if (forceRemotePath) {
             // Duplicates the below, but we want an early return
             const imagePath = APIPaths.image(issueId, imageSize, image, use)
             return `${apiUrl}${imagePath}`

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -10,7 +10,7 @@ import { useApiUrl } from './use-settings'
 export type GetImagePath = (
     image?: Image,
     use?: ImageUse,
-    backup?: boolean,
+    forceRemotePath?: boolean,
 ) => string | undefined
 
 const getFsPath = (

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -7,7 +7,11 @@ import { useIssueSummary } from './use-issue-summary'
 import { Platform } from 'react-native'
 import { useApiUrl } from './use-settings'
 
-export type GetImagePath = (image?: Image, use?: ImageUse) => string | undefined
+export type GetImagePath = (
+    image?: Image,
+    use?: ImageUse,
+    backup?: boolean,
+) => string | undefined
 
 const getFsPath = (
     localIssueId: Issue['localId'],


### PR DESCRIPTION
Following users reports of missing images...
## Summary

1. Update to the `getImagePath` function to force an API path if you request it.
2. Use a "backup" url on the `onerror` of the HTML image wherever possible
3. Removal of the error thrown on `origin` as we will always backup to the API url.
4. Use backup for `background-image` for immersive style headers in case the first image does not load