### PR TITLE
Stop scaling gallery caption fonts.

### DIFF
--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -1,6 +1,6 @@
 import { ImageElement } from 'src/common'
 import { Direction } from 'src/common'
-import { css, getScaledFontCss, html, px } from 'src/helpers/webview'
+import { css, getFontCss, html, px } from 'src/helpers/webview'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { Arrow } from './arrow'
@@ -54,7 +54,7 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         .image figcaption {
             font-family: 'GuardianTextSans-Regular';
             color: ${themeColors(theme).dimText};
-            ${getScaledFontCss('sans', 0.5)}
+            ${getFontCss('sans', 0.5)}
             position: relative;
             margin-top: 0.5em;
         }
@@ -69,7 +69,7 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         /* Tablet captions */
         @media (min-width: ${px(Breakpoints.tabletVertical)}) {
             .image figcaption {
-                ${getScaledFontCss('sans', 0.9)}
+                ${getFontCss('sans', 0.9)}
             }
         }
 

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -1,7 +1,12 @@
 import { Platform } from 'react-native'
 import { ArticleType } from 'src/common'
 import { bundles } from 'src/html-bundle-info.json'
-import { FontFamily, FontSizes, getScaledFont } from 'src/theme/typography'
+import {
+    FontFamily,
+    FontSizes,
+    getScaledFont,
+    getFont,
+} from 'src/theme/typography'
 
 export type WebViewPing =
     | {
@@ -39,6 +44,16 @@ export const html = passthrough
 
 export const px = (value: string | number) => `${value}px`
 
+export const getFontCss = <F extends FontFamily>(
+    family: F,
+    level: FontSizes<F>,
+) => {
+    const font = getFont(family, level)
+    return css`
+        font-size: ${px(font.fontSize)};
+        line-height: ${px(font.lineHeight)};
+    `
+}
 export const getScaledFontCss = <F extends FontFamily>(
     family: F,
     level: FontSizes<F>,


### PR DESCRIPTION
## Summary

Font scaling (in device accessibility settings) is causing captions to overlap sometimes. This disables font scaling to stop this from happening.

There's a bigger question as to whether these captions should perhaps be inline instead, as was done in https://github.com/guardian/editions/pull/974/files but seems to have stopped working


Before:
<img width="826" alt="Screenshot 2020-08-26 at 13 12 43" src="https://user-images.githubusercontent.com/3606555/91302115-e1a83380-e79d-11ea-8ec5-e18ff8a9a21e.png">

After
<img width="802" alt="Screenshot 2020-08-26 at 13 12 23" src="https://user-images.githubusercontent.com/3606555/91302118-e371f700-e79d-11ea-8b16-f8ebd7108b26.png">




[**Trello Card ->**](https://trello.com/c/fpSlx6m1/1509-disable-font-scaling-on-captions)

## Test Plan

