### PR TITLE
Fix: Editions defaults match endpoint

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -3,8 +3,8 @@ import { RegionalEdition, editions } from './index'
 export const defaultRegionalEditions: RegionalEdition[] = [
     {
         title: 'UK Daily',
-        subTitle: `Published every morning
-by 6am (GMT)`,
+        subTitle: `Published from London every 
+morning by 6am (GMT)`,
         edition: editions.daily,
         header: {
             title: 'UK',
@@ -15,26 +15,26 @@ by 6am (GMT)`,
         notificationUTCOffset: 3,
     },
     {
-        title: 'Australia Weekender',
-        subTitle: `Published every Saturday morning
-by 6am (AEST)`,
+        title: 'Australia Weekend',
+        subTitle: `Published from Sydney every 
+Saturday by 6 am (AEST)`,
         edition: editions.ausWeekly,
         header: {
             title: 'Australia',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
         editionType: 'Regional',
         topic: 'au',
         notificationUTCOffset: -5,
     },
     {
-        title: 'US Weekender',
-        subTitle: `Published every Saturday morning
-by 6am (EST)`,
+        title: 'US Weekend',
+        subTitle: `Published from New York every 
+Saturday morning by 6am (EST)`,
         edition: editions.usWeekly,
         header: {
             title: 'US',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
         editionType: 'Regional',
         topic: 'us',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -126,8 +126,8 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
               "title": "UK",
             },
             "notificationUTCOffset": 3,
-            "subTitle": "Published every morning
-by 6am (GMT)",
+            "subTitle": "Published from London every 
+morning by 6am (GMT)",
             "title": "UK Daily",
             "topic": "uk",
           },
@@ -135,26 +135,26 @@ by 6am (GMT)",
             "edition": "australian-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "Australia",
             },
             "notificationUTCOffset": -5,
-            "subTitle": "Published every Saturday morning
-by 6am (AEST)",
-            "title": "Australia Weekender",
+            "subTitle": "Published from Sydney every 
+Saturday by 6 am (AEST)",
+            "title": "Australia Weekend",
             "topic": "au",
           },
           Object {
             "edition": "american-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "US",
             },
             "notificationUTCOffset": 8,
-            "subTitle": "Published every Saturday morning
-by 6am (EST)",
-            "title": "US Weekender",
+            "subTitle": "Published from New York every 
+Saturday morning by 6am (EST)",
+            "title": "US Weekend",
             "topic": "us",
           },
         ]
@@ -320,8 +320,8 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
               "title": "UK",
             },
             "notificationUTCOffset": 3,
-            "subTitle": "Published every morning
-by 6am (GMT)",
+            "subTitle": "Published from London every 
+morning by 6am (GMT)",
             "title": "UK Daily",
             "topic": "uk",
           },
@@ -329,26 +329,26 @@ by 6am (GMT)",
             "edition": "australian-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "Australia",
             },
             "notificationUTCOffset": -5,
-            "subTitle": "Published every Saturday morning
-by 6am (AEST)",
-            "title": "Australia Weekender",
+            "subTitle": "Published from Sydney every 
+Saturday by 6 am (AEST)",
+            "title": "Australia Weekend",
             "topic": "au",
           },
           Object {
             "edition": "american-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "US",
             },
             "notificationUTCOffset": 8,
-            "subTitle": "Published every Saturday morning
-by 6am (EST)",
-            "title": "US Weekender",
+            "subTitle": "Published from New York every 
+Saturday morning by 6am (EST)",
+            "title": "US Weekend",
             "topic": "us",
           },
         ]


### PR DESCRIPTION
## Summary

As title.

[**Trello Card ->**](https://trello.com/c/B8qguVYN/1514-ensure-local-back-up-of-the-editions-metadata-matches-the-settings-provided-by-tooling)