### PR TITLE
Increased some download timeout values

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -78,6 +78,8 @@ export const downloadNamedIssueArchive = async ({
         const returnable = RNFS.downloadFile({
             fromUrl: zipUrl,
             toFile: `${downloadFolderLocation}/${filename}`,
+            readTimeout: 120 * 1000, // set it to 2 mins, default is 15sec (android & iOS)
+            connectionTimeout: 20 * 1000, // set it to 20sec, default is 5sec (android only)
             background: true,
             begin: () => console.log('start download'),
             progress: response => {

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -78,8 +78,8 @@ export const downloadNamedIssueArchive = async ({
         const returnable = RNFS.downloadFile({
             fromUrl: zipUrl,
             toFile: `${downloadFolderLocation}/${filename}`,
-            readTimeout: 120 * 1000, // set it to 2 mins, default is 15sec (android & iOS)
-            connectionTimeout: 20 * 1000, // set it to 20sec, default is 5sec (android only)
+            readTimeout: 300 * 1000, // set it to 5 mins, default is 15sec (android & iOS)
+            connectionTimeout: 30 * 1000, // set it to 30sec, default is 5sec (android only)
             background: true,
             begin: () => console.log('start download'),
             progress: response => {


### PR DESCRIPTION
## Summary

Sentry error:
https://sentry.io/organizations/the-guardian/issues/1747362358/?project=1519156&query=is%3Aunresolved+files&statsPeriod=14d

We are seeing lots of `read timeout` exceptions on a daily basis (400-500 events per day) related to zip download. This PR increases some timeout values with aim to reduce those exceptions.


