### PR TITLE
fix: Show Inline Privacy on Consent Options

### DIFF
--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -201,7 +201,8 @@ const GdprConsent = ({
                             <LinkNav
                                 onPress={() =>
                                     navigation.navigate(
-                                        routeNames.PrivacyPolicy,
+                                        routeNames.onboarding
+                                            .PrivacyPolicyInline,
                                     )
                                 }
                             >


### PR DESCRIPTION
## Summary
Privacy policy will now show the inline one rather than the page.

![privacy-fix](https://user-images.githubusercontent.com/935975/91434948-77ef5e80-e85d-11ea-8635-7ce93c5e23d2.gif)

[**Trello Card ->**](https://trello.com/c/a21Cn65X/1519-privacy-settings-can-be-bypassed-issue-on-first-install)
