### PR TITLE
chore: Weekender removal

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -38,7 +38,7 @@ const regionalEditions: RegionalEdition[] = [
         edition: editions.ausWeekly as Edition,
         header: {
             title: 'Austraila',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
         editionType: 'Regional',
         topic: 'au',
@@ -50,7 +50,7 @@ const regionalEditions: RegionalEdition[] = [
         edition: editions.usWeekly as Edition,
         header: {
             title: 'US',
-            subTitle: 'Weekender',
+            subTitle: 'Weekend',
         },
         editionType: 'Regional',
         topic: 'au',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
             "edition": "australian-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "Austraila",
             },
             "notificationUTCOffset": 1,
@@ -36,7 +36,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
             "edition": "american-edition",
             "editionType": "Regional",
             "header": Object {
-              "subTitle": "Weekender",
+              "subTitle": "Weekend",
               "title": "US",
             },
             "notificationUTCOffset": 1,

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.stories.tsx
@@ -9,7 +9,7 @@ storiesOf('IssuePickerHeader', module)
         <IssuePickerHeader title="Recent" subTitle="Editions" />
     ))
     .add('With Different Title and SubTitle', () => (
-        <IssuePickerHeader title="Australia" subTitle="Weekender" />
+        <IssuePickerHeader title="Australia" subTitle="Weekend" />
     ))
     .add('With Header Styles', () => (
         <IssuePickerHeader


### PR DESCRIPTION
## Summary
Minor one this. We changed the branding from `weekender` to `weekend`. This just removes this from stories and tests.