### PR TITLE
Ensure h2+strong use pillar colour regardless of article type

### DIFF
--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -175,12 +175,11 @@ const makeCss = ({ colors, theme }: CssProps, contentType: ArticleType) => css`
     }
 
     .app[data-type='${ArticleType.Immersive}'] h2 > strong { 
-        color: ${colors.main};
         font-family: ${families.headline.bold}
     }
 
     .app h2 > strong { 
-        color: #000000;
+        color: ${colors.main};
         font-weight: bold;
         font-family: ${families.text.bold};
       }


### PR DESCRIPTION
## Summary
This PR changes the colour of h2+strong (the second level of h2 styling) to always use the pillar colour, regardless of article type. This was a change requested by design. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/1R3yfko0/1505-h2-and-h2-bold-to-render-pillar-colours)

## Test Plan
The third article in CODE published August 31st in the Life section should have both layers of h2 styling. (see screenshots below)
| Before | After |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/91874604-51bd2a80-ec72-11ea-8ccb-7cd4f96e730a.png) | ![image](https://user-images.githubusercontent.com/53755195/91874629-58e43880-ec72-11ea-92e2-57acbe0e2d7e.png)
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
