### PR TITLE
Add styling to unicode bullets

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -55,6 +55,14 @@ const PictureArticleContent = (image: TImage, getImagePath: GetImagePath) => {
     })
 }
 
+/* 
+As well as list items bullet points from composer can be sent as a unicode character •
+This method applies a class to the bullet string in order to add stlying through css 
+*/
+const cleanupBullets = (html: string) => {
+    return html.replace('•', `<span class="bullet">•</span>`)
+}
+
 const renderArticleContent = (
     elements: BlockElement[],
     { showMedia, publishedId, getImagePath }: ArticleContentProps,
@@ -70,6 +78,9 @@ const renderArticleContent = (
                                 ${el.html}
                             </div>
                         `
+                    }
+                    if (el.html.includes('•')) {
+                        return cleanupBullets(el.html)
                     }
                     return el.html
                 case 'media-atom':

--- a/projects/Mallard/src/components/article/html/components/lists.ts
+++ b/projects/Mallard/src/components/article/html/components/lists.ts
@@ -1,5 +1,6 @@
 import { css } from 'src/helpers/webview'
 import { color } from 'src/theme/color'
+import { PillarColoursWithTint } from 'src/helpers/transform'
 
 const bulletStyle = () => css`
     display: inline-block;
@@ -7,10 +8,9 @@ const bulletStyle = () => css`
     border-radius: 0.375rem;
     height: 0.75rem;
     width: 0.75rem;
-    background-color: ${color.palette.neutral[86]};
 `
 
-export const listStyles = () => css`
+export const listStyles = (colors: PillarColoursWithTint) => css`
     ul {
         list-style: none;
         margin-bottom: 15px;
@@ -29,6 +29,7 @@ export const listStyles = () => css`
         ${bulletStyle()};
         margin-right: 0.5rem;
         margin-left: -1.25rem;
+        background-color: ${color.palette.neutral[86]};
     }
 
     .bullet {
@@ -37,6 +38,7 @@ export const listStyles = () => css`
 
     .bullet:before {
         ${bulletStyle()};
+        background-color: ${colors.main};
         margin-right: 0.125rem;
     }
 `

--- a/projects/Mallard/src/components/article/html/components/lists.ts
+++ b/projects/Mallard/src/components/article/html/components/lists.ts
@@ -1,6 +1,15 @@
 import { css } from 'src/helpers/webview'
 import { color } from 'src/theme/color'
 
+const bulletStyle = () => css`
+    display: inline-block;
+    content: '';
+    border-radius: 0.375rem;
+    height: 0.75rem;
+    width: 0.75rem;
+    background-color: ${color.palette.neutral[86]};
+`
+
 export const listStyles = () => css`
     ul {
         list-style: none;
@@ -17,13 +26,17 @@ export const listStyles = () => css`
     }
 
     ul > li:before {
-        display: inline-block;
-        content: '';
-        border-radius: 0.375rem;
-        height: 0.75rem;
-        width: 0.75rem;
+        ${bulletStyle()};
         margin-right: 0.5rem;
         margin-left: -1.25rem;
-        background-color: ${color.palette.neutral[86]};
+    }
+
+    .bullet {
+        font-size: 0rem;
+    }
+
+    .bullet:before {
+        ${bulletStyle()};
+        margin-right: 0.125rem;
     }
 `

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -211,7 +211,7 @@ const makeCss = ({ colors, theme }: CssProps, contentType: ArticleType) => css`
         }
     }
 
-    ${listStyles()}
+    ${listStyles(colors)}
 
     ${quoteStyles({
         colors,


### PR DESCRIPTION
## Summary
There are two types of bullet points that can be used in composer, we previously added styling for list items but this PR styles "alt+8" bullet points as specified in the ticket. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/XBFxWJzw/1270-snaggin-bullet-points)

## Test Plan
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-09-02 at 14 09 42](https://user-images.githubusercontent.com/53755195/91987464-fe0c1900-ed25-11ea-9e60-febbd1ca0e00.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-02 at 14 03 35](https://user-images.githubusercontent.com/53755195/91987484-05332700-ed26-11ea-9a63-298ec90c6461.png)
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
