### PR TITLE
Handled topic difference for notification registration

### DIFF
--- a/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
+++ b/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
@@ -78,5 +78,22 @@ describe('push-notifications/helpers', () => {
                 ),
             ).toBe(true)
         })
+        it('should return false if the topics are but in different order', () => {
+            const registrationCache = {
+                token: 'token',
+                registrationDate: today().toISOString(),
+            }
+            const topics = [{ name: 'uk', type: 'editions' }] as PushToken[]
+            const topics2 = [{ type: 'editions', name: 'uk' }] as PushToken[]
+            expect(
+                shouldReRegister(
+                    'token',
+                    registrationCache,
+                    today().toISOString(),
+                    topics,
+                    topics2,
+                ),
+            ).toBe(false)
+        })
     })
 })

--- a/projects/Mallard/src/notifications/helpers.ts
+++ b/projects/Mallard/src/notifications/helpers.ts
@@ -37,6 +37,21 @@ const getTopicName = async (): Promise<PushToken[]> => {
     return BASE_PUSH_TOKEN
 }
 
+const objectsEqual = (token1: PushToken, token2: PushToken) =>
+    Object.keys(token1).length === Object.keys(token2).length &&
+    token1.name === token2.name &&
+    token2.type === token2.type
+
+const isSameTopics = (t1: PushToken[] | null, t2: PushToken[]) => {
+    if (t1 == null || t1.length != t2.length) return false
+
+    for (let index = 0; index < t1.length; index++) {
+        if (!objectsEqual(t1[index], t2[index])) return false
+    }
+
+    return true
+}
+
 const shouldReRegister = (
     newToken: string,
     registration: PushNotificationRegistration | null,
@@ -48,7 +63,7 @@ const shouldReRegister = (
         ? moment(now).diff(moment(registration.registrationDate), 'days') > 14
         : true
     const differentToken = registration ? newToken !== registration.token : true
-    const unmatchedTopics = currentTopics !== newTopics
+    const unmatchedTopics = !isSameTopics(currentTopics, newTopics)
     return exceedTime || differentToken || unmatchedTopics
 }
 


### PR DESCRIPTION
## Summary

Currently, the app does re-register with notification service every time app launches and resulted in extra load on the backend service and failure of the registration requests. This is due to a bug where we compare the old and new list of topics.

`[{"type":"editions","name":"uk"}]`
`[{"name":"uk","type":"editions"}]`

The above two sets of topics are essentially the same just in a different order. This PR updated the logic to handle this scenario.


[**Trello Card ->**](https://trello.com/c/aKRVTIPg/1526-the-app-seems-to-fail-to-register-with-push-notification)

## Test Plan
unit tested