### PR TITLE
Archiver/Backend: Drive editions lists from fronts tool. Mallard: 'Edition' is now a string

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -218,15 +218,7 @@ export const sizeDescriptions: { [k in ImageSize]: number } = {
     tabletXL: 1140,
 }
 
-export const Editions = [
-    'daily-edition',
-    'american-edition',
-    'australian-edition',
-    'training-edition',
-    'the-dummy-edition',
-] as const
-
-export type Edition = typeof Editions[number]
+export type Edition = string
 
 export const editions = {
     daily: 'daily-edition' as Edition,

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -581,7 +581,7 @@ export interface EditionsList {
 
 export type Locale = 'en_GB' | 'en_AU'
 
-interface EditionInterface {
+export interface EditionInterface {
     title: string
     subTitle: string
     edition: Edition

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -220,6 +220,8 @@ export const sizeDescriptions: { [k in ImageSize]: number } = {
 
 export type Edition = string
 
+// NOTE this list is incomplete and should not be relied on for
+// a complete list of editions - instead use the API/editions endpoint
 export const editions = {
     daily: 'daily-edition' as Edition,
     ausWeekly: 'australian-edition' as Edition,

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -13,6 +13,9 @@ export const getEditionDisplayName = async (editionId: Edition) => {
         .concat(maybeEditionsList.specialEditions)
         .concat(maybeEditionsList.trainingEditions)
 
+    console.log('editionsList', maybeEditionsList)
+    console.log('allEditions', allEditions)
+
     const edition = allEditions.find(e => e.edition === editionId)
 
     if (!edition) {

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -1,21 +1,23 @@
-import { Edition } from '../../common'
+import { Edition, hasFailed, EditionInterface } from '../../common'
+import { getEditions } from '../utils/backend-client'
 
-const createEditionToDisplayNameMap = () => {
-    const map = new Map<Edition, string>()
-    map.set('daily-edition', 'Daily Edition')
-    map.set('american-edition', 'American Edition')
-    map.set('australian-edition', 'Australian Edition')
-    map.set('training-edition', 'Training Edition')
-    map.set('the-dummy-edition', 'The Dummy Edition')
-    return map
-}
+export const getEditionDisplayName = async (editionId: Edition) => {
+    const maybeEditionsList = await getEditions()
 
-const editionToName = createEditionToDisplayNameMap()
+    if (hasFailed(maybeEditionsList)) {
+        console.error("Failed to fetch editions list, can't find display name")
+        throw new Error(`Could not fetch editions list`)
+    }
 
-export const getEditionDisplayName = (edition: Edition): string => {
-    if (!editionToName.has(edition)) {
+    const allEditions: EditionInterface[] = maybeEditionsList.regionalEditions
+        .concat(maybeEditionsList.specialEditions)
+        .concat(maybeEditionsList.trainingEditions)
+
+    const edition = allEditions.find(e => e.edition === editionId)
+
+    if (!edition) {
         throw new Error(`${edition} missing in editionToName mapping`)
     }
     // it will never be empty string because of above check, || '' is made to make compiler happy
-    return editionToName.get(edition) || ''
+    return edition.title
 }

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -1,6 +1,11 @@
 import { Edition, hasFailed, EditionInterface } from '../../common'
 import { getEditions } from '../utils/backend-client'
 
+const getTitle = (list: EditionInterface[], editionId: string) => {
+    const match = list.find(l => l.edition === editionId)
+    return match && match.title
+}
+
 export const getEditionDisplayName = async (editionId: Edition) => {
     const maybeEditionsList = await getEditions()
 
@@ -9,17 +14,15 @@ export const getEditionDisplayName = async (editionId: Edition) => {
         throw new Error(`Could not fetch editions list`)
     }
 
-    const allEditions: EditionInterface[] = maybeEditionsList.regionalEditions
-        .concat(maybeEditionsList.specialEditions)
-        .concat(maybeEditionsList.trainingEditions)
+    const editionTitle =
+        getTitle(maybeEditionsList.regionalEditions, editionId) ||
+        getTitle(maybeEditionsList.specialEditions, editionId)
 
-    const edition = allEditions.find(e => e.edition === editionId)
-
-    if (!edition) {
+    if (!editionTitle) {
         throw new Error(
-            `${edition} missing in editionToName mapping. Editions List: ${allEditions}`,
+            `${editionId} missing in editionToName mapping. Editions List: ${maybeEditionsList}`,
         )
     }
 
-    return edition.title
+    return editionTitle
 }

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -8,6 +8,7 @@ export const getEditionDisplayName = async (editionId: Edition) => {
         console.error("Failed to fetch editions list, can't find display name")
         throw new Error(`Could not fetch editions list`)
     }
+    console.log('fetched editions list', maybeEditionsList)
 
     const allEditions: EditionInterface[] = maybeEditionsList.regionalEditions
         .concat(maybeEditionsList.specialEditions)

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -8,7 +8,6 @@ export const getEditionDisplayName = async (editionId: Edition) => {
         console.error("Failed to fetch editions list, can't find display name")
         throw new Error(`Could not fetch editions list`)
     }
-    console.log('fetched editions list', maybeEditionsList)
 
     const allEditions: EditionInterface[] = maybeEditionsList.regionalEditions
         .concat(maybeEditionsList.specialEditions)

--- a/projects/archiver/src/services/editions-mappings.ts
+++ b/projects/archiver/src/services/editions-mappings.ts
@@ -13,14 +13,13 @@ export const getEditionDisplayName = async (editionId: Edition) => {
         .concat(maybeEditionsList.specialEditions)
         .concat(maybeEditionsList.trainingEditions)
 
-    console.log('editionsList', maybeEditionsList)
-    console.log('allEditions', allEditions)
-
     const edition = allEditions.find(e => e.edition === editionId)
 
     if (!edition) {
-        throw new Error(`${edition} missing in editionToName mapping`)
+        throw new Error(
+            `${edition} missing in editionToName mapping. Editions List: ${allEditions}`,
+        )
     }
-    // it will never be empty string because of above check, || '' is made to make compiler happy
+
     return edition.title
 }

--- a/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
@@ -58,10 +58,10 @@ const makeImageAssetObject = (assetFiles: {
  * includes simple metadata (key, localId, etc) and the list of zip assets.
  * If the issue isn't valid this will return undefined.
  */
-export const getIssueSummaryInternal = (
+export const getIssueSummaryInternal = async (
     issuePublication: IssuePublicationIdentifier,
     assetKeys: string[],
-): IssueSummary | undefined => {
+): Promise<IssueSummary | undefined> => {
     const { edition, issueDate } = issuePublication
 
     const publishedIssuePrefix = getPublishedId(issuePublication)
@@ -85,7 +85,7 @@ export const getIssueSummaryInternal = (
     const assets = { data, ...images }
     const localId = `${edition}/${issueDate}`
     const key = localId
-    const name = getEditionDisplayName(edition)
+    const name = await getEditionDisplayName(edition)
 
     return {
         key,
@@ -120,5 +120,5 @@ export const getIssueSummary = async (
         JSON.stringify(assetKeyList),
     )
 
-    return getIssueSummaryInternal(issuePublication, assetKeys)
+    return await getIssueSummaryInternal(issuePublication, assetKeys)
 }

--- a/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
+++ b/projects/archiver/src/tasks/indexer/helpers/get-issue-summary.ts
@@ -58,10 +58,11 @@ const makeImageAssetObject = (assetFiles: {
  * includes simple metadata (key, localId, etc) and the list of zip assets.
  * If the issue isn't valid this will return undefined.
  */
-export const getIssueSummaryInternal = async (
+export const getIssueSummaryInternal = (
     issuePublication: IssuePublicationIdentifier,
     assetKeys: string[],
-): Promise<IssueSummary | undefined> => {
+    name: string,
+): IssueSummary | undefined => {
     const { edition, issueDate } = issuePublication
 
     const publishedIssuePrefix = getPublishedId(issuePublication)
@@ -85,7 +86,6 @@ export const getIssueSummaryInternal = async (
     const assets = { data, ...images }
     const localId = `${edition}/${issueDate}`
     const key = localId
-    const name = await getEditionDisplayName(edition)
 
     return {
         key,
@@ -120,5 +120,7 @@ export const getIssueSummary = async (
         JSON.stringify(assetKeyList),
     )
 
-    return await getIssueSummaryInternal(issuePublication, assetKeys)
+    const displayName = await getEditionDisplayName(issuePublication.edition)
+
+    return getIssueSummaryInternal(issuePublication, assetKeys, displayName)
 }

--- a/projects/archiver/src/utils/backend-client.ts
+++ b/projects/archiver/src/utils/backend-client.ts
@@ -73,9 +73,9 @@ export const getEditions = async (): Promise<Attempt<EditionsList>> => {
     const path = `${URL}editions`
     console.log(`Attempt to get editions list from path: ${path}`)
     const response = await fetch(path)
-    const maybeEditionsList = await attempt(response.json() as Promise<
-        EditionsList
-    >)
+    const maybeEditionsList = await attempt(response.json() as Promise<{
+        content: EditionsList
+    }>)
     console.log(`Got response: ${JSON.stringify(maybeEditionsList)}`)
     if (hasFailed(maybeEditionsList)) {
         return withFailureMessage(
@@ -83,5 +83,5 @@ export const getEditions = async (): Promise<Attempt<EditionsList>> => {
             `Failed to download editions list from ${path}`,
         )
     }
-    return maybeEditionsList
+    return maybeEditionsList.content
 }

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -1,6 +1,5 @@
 import { IssuePublicationIdentifier, IssueSummary } from '../../../../common'
 import { getIssueSummaryInternal } from '../../../../src/tasks/indexer/helpers/get-issue-summary'
-import { defaultRegionalEditions } from '../../../../../Apps/common/src/editions-defaults'
 
 describe('getIssueSummaryInternal', () => {
     const assetKeys = [

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -10,14 +10,14 @@ describe('getIssueSummaryInternal', () => {
         'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
     ]
 
-    it('should return IssueSummary', () => {
+    it('should return IssueSummary', async () => {
         const issue: IssuePublicationIdentifier = {
             edition: 'american-edition',
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-10-09',
         }
 
-        const actual = getIssueSummaryInternal(issue, assetKeys)
+        const actual = await getIssueSummaryInternal(issue, assetKeys)
 
         const expected: IssueSummary = {
             key: 'american-edition/2019-10-09',
@@ -42,14 +42,14 @@ describe('getIssueSummaryInternal', () => {
         expect(actual).toStrictEqual(expected)
     })
 
-    it('should return undefined if issue date was invalid', () => {
+    it('should return undefined if issue date was invalid', async () => {
         const issueWithIncorrectDate: IssuePublicationIdentifier = {
             edition: 'american-edition',
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-1011-09',
         }
 
-        const actual = getIssueSummaryInternal(
+        const actual = await getIssueSummaryInternal(
             issueWithIncorrectDate,
             assetKeys,
         )
@@ -57,14 +57,14 @@ describe('getIssueSummaryInternal', () => {
         expect(actual).toBeUndefined()
     })
 
-    it('should return undefined if there was no assets', () => {
+    it('should return undefined if there was no assets', async () => {
         const issueWithIncorrectDate: IssuePublicationIdentifier = {
             edition: 'american-edition',
             version: '2019-10-04T16:08:35.951Z',
             issueDate: '2019-10-09',
         }
 
-        const actual = getIssueSummaryInternal(issueWithIncorrectDate, [])
+        const actual = await getIssueSummaryInternal(issueWithIncorrectDate, [])
 
         expect(actual).toBeUndefined()
     })

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -1,5 +1,6 @@
 import { IssuePublicationIdentifier, IssueSummary } from '../../../../common'
 import { getIssueSummaryInternal } from '../../../../src/tasks/indexer/helpers/get-issue-summary'
+import { defaultRegionalEditions } from '../../../../../Apps/common/src/editions-defaults'
 
 describe('getIssueSummaryInternal', () => {
     const assetKeys = [
@@ -17,7 +18,11 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-10-09',
         }
 
-        const actual = await getIssueSummaryInternal(issue, assetKeys)
+        const actual = getIssueSummaryInternal(
+            issue,
+            assetKeys,
+            'American Edition',
+        )
 
         const expected: IssueSummary = {
             key: 'american-edition/2019-10-09',
@@ -49,9 +54,10 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-1011-09',
         }
 
-        const actual = await getIssueSummaryInternal(
+        const actual = getIssueSummaryInternal(
             issueWithIncorrectDate,
             assetKeys,
+            'American Edition',
         )
 
         expect(actual).toBeUndefined()
@@ -64,7 +70,11 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-10-09',
         }
 
-        const actual = await getIssueSummaryInternal(issueWithIncorrectDate, [])
+        const actual = getIssueSummaryInternal(
+            issueWithIncorrectDate,
+            [],
+            'American Edition',
+        )
 
         expect(actual).toBeUndefined()
     })

--- a/projects/aws/lib/proof-step-function.ts
+++ b/projects/aws/lib/proof-step-function.ts
@@ -65,6 +65,9 @@ export const proofArchiverStepFunction = (
         'indexerProof',
         'Generate Index',
         lambdaParams,
+        {
+            backend: backendURL,
+        },
     )
 
     issue.task.next(frontMap)

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -24,7 +24,6 @@ describe('getEditionOrFallback', () => {
         expect(getEditionOrFallback(usEdition)).toStrictEqual(usEdition)
     })
     it('should fallback to daily-edition', () => {
-        expect(getEditionOrFallback('banana')).toStrictEqual(dailyEdition)
         expect(getEditionOrFallback('')).toStrictEqual(dailyEdition)
         expect(getEditionOrFallback(undefined)).toStrictEqual(dailyEdition)
     })

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,4 +1,4 @@
-import { IssuePublicationIdentifier, Edition, Editions } from '../common'
+import { IssuePublicationIdentifier, Edition } from '../common'
 import { Path } from '../s3'
 
 const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
@@ -6,9 +6,7 @@ const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 export const getEditionOrFallback = (
     maybeEdition: string | undefined,
 ): Edition => {
-    return (
-        (Editions.find(t => t === maybeEdition) as Edition) || 'daily-edition'
-    )
+    return maybeEdition || 'daily-edition'
 }
 
 export const buildIssueObjectPath = (

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -6,7 +6,9 @@ const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 export const getEditionOrFallback = (
     maybeEdition: string | undefined,
 ): Edition => {
-    return maybeEdition || 'daily-edition'
+    return maybeEdition && maybeEdition.length > 0
+        ? maybeEdition
+        : 'daily-edition'
 }
 
 export const buildIssueObjectPath = (

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -6,9 +6,7 @@ const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 export const getEditionOrFallback = (
     maybeEdition: string | undefined,
 ): Edition => {
-    return maybeEdition && maybeEdition.length > 0
-        ? maybeEdition
-        : 'daily-edition'
+    return maybeEdition || 'daily-edition'
 }
 
 export const buildIssueObjectPath = (


### PR DESCRIPTION
## Summary
To make it easier to publish new special editions, we should remove as many of the hard coded references to editions as possible from the app. This change updates the editions-mappings function so that it no longer has a hard coded list of editions but instead queries the editions backen (/editions) to get this information.

The editions backend (/editions) mentioned above currently returns a hard coded list of editions. This PR changes that behaviour so that that endpoint now returns the editions list directly from the fronts tool.

NOTE: This also contains CLIENT SIDE changes as I've removed the 'Editions' list from the common types file, made the 'Edition' type a string, as we want this to be driven by the API.

[**Trello Card ->**](https://trello.com/c/ALUUZ9uH/1521-prove-special-editions-basically-work)

## Test Plan
I've tested this on CODE and it works fine for the daily edition. Special editions still don't work, but that's because of the hard coded list of edition IDs [here](https://github.com/guardian/editions/blob/master/projects/Apps/common/src/index.ts#L221) which I'll address in a separate PR as it involves client side changes.
