### PR TITLE
chore: Remove interview quote

### DIFF
--- a/projects/Mallard/src/components/article/html/components/headline.ts
+++ b/projects/Mallard/src/components/article/html/components/headline.ts
@@ -16,8 +16,7 @@ const getHeadline = (
         return html`
             <h1>
                 <span class="header-top-headline"
-                    >${(articleType === ArticleType.Opinion ||
-                        articleType === ArticleType.Interview) &&
+                    >${articleType === ArticleType.Opinion &&
                         Quotes()}${headerProps.headline}
                 </span>
                 ${articleType !== ArticleType.Interview &&


### PR DESCRIPTION
## Summary
Removes the quote from the Interview template.

[**Trello Card ->**](https://trello.com/c/m0uVo0NB/1534-remove-leading-quote-mark-on-interview-headline-styling)
