### PR TITLE
iPhone SE: Font-size reduction (section titles and article headlines)

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -38,14 +38,14 @@ const styles = (color: string, location: string, isTablet: boolean) => {
 
     const titleArticle = {
         ...titleShared,
-        fontSize: isTablet ? 30 : 20,
-        lineHeight: isTablet ? 33 : 22,
+        fontSize: getFont('titlepiece', 1.1).fontSize,
+        lineHeight: getFont('titlepiece', 1.1).lineHeight,
     }
 
     const titleFront = {
         ...titleShared,
-        fontSize: isTablet ? 38 : 28,
-        lineHeight: isTablet ? 42 : 32,
+        fontSize: getFont('titlepiece', 1.4).fontSize,
+        lineHeight: getFont('titlepiece', 1.4).lineHeight,
     }
 
     const title = location === 'article' ? titleArticle : titleFront

--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -30,7 +30,7 @@ interface SliderTitleProps {
     editionDate: Date | undefined //temporary until we have subtitles for the last 30 editions
 }
 
-const styles = (color: string, location: string, isTablet: boolean) => {
+const styles = (color: string, location: string) => {
     const titleShared = {
         color,
         fontFamily: getFont('titlepiece', 1).fontFamily,
@@ -79,8 +79,7 @@ const SliderTitle = React.memo(
         startIndex,
         editionDate,
     }: SliderTitleProps) => {
-        const isTablet = DeviceInfo.isTablet()
-        const appliedStyle = styles(color, location, isTablet)
+        const appliedStyle = styles(color, location)
         // takes a key e.g. O:Top Stories and provides the end part
         const transformedSubtitle =
             subtitle && subtitle.split(':')[subtitle.split(':').length - 1]

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.spec.tsx
@@ -4,6 +4,15 @@ jest.mock('react-native-device-info', () => ({
     isTablet: () => false,
 }))
 
+jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
+    const Dimensions = {
+        get: anything => {
+            return { width: 400, height: 100 }
+        },
+    }
+    return Dimensions
+})
+
 jest.mock('react-native/Libraries/Utilities/Platform', () => {
     const Platform = require.requireActual(
         'react-native/Libraries/Utilities/Platform',

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.spec.tsx
@@ -6,7 +6,7 @@ jest.mock('react-native-device-info', () => ({
 
 jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
     const Dimensions = {
-        get: anything => {
+        get: () => {
             return { width: 400, height: 100 }
         },
     }

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.tablet.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.tablet.spec.tsx
@@ -6,7 +6,7 @@ jest.mock('react-native-device-info', () => ({
 
 jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
     const Dimensions = {
-        get: anything => {
+        get: () => {
             return { width: 700, height: 100 }
         },
     }

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.tablet.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.android.tablet.spec.tsx
@@ -4,6 +4,15 @@ jest.mock('react-native-device-info', () => ({
     isTablet: () => true,
 }))
 
+jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
+    const Dimensions = {
+        get: anything => {
+            return { width: 700, height: 100 }
+        },
+    }
+    return Dimensions
+})
+
 jest.mock('react-native/Libraries/Utilities/Platform', () => {
     const Platform = require.requireActual(
         'react-native/Libraries/Utilities/Platform',

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.spec.tsx
@@ -4,4 +4,13 @@ jest.mock('react-native-device-info', () => ({
     isTablet: () => false,
 }))
 
+jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
+    const Dimensions = {
+        get: anything => {
+            return { width: 400, height: 100 }
+        },
+    }
+    return Dimensions
+})
+
 baseTests('SliderTitle - iOS - Mobile')

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.spec.tsx
@@ -6,7 +6,7 @@ jest.mock('react-native-device-info', () => ({
 
 jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
     const Dimensions = {
-        get: anything => {
+        get: () => {
             return { width: 400, height: 100 }
         },
     }

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.tablet.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.tablet.spec.tsx
@@ -6,7 +6,7 @@ jest.mock('react-native-device-info', () => ({
 
 jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
     const Dimensions = {
-        get: anything => {
+        get: () => {
             return { width: 700, height: 100 }
         },
     }

--- a/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.tablet.spec.tsx
+++ b/projects/Mallard/src/screens/article/slider/__tests__/SliderTitle.ios.tablet.spec.tsx
@@ -4,4 +4,13 @@ jest.mock('react-native-device-info', () => ({
     isTablet: () => true,
 }))
 
+jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
+    const Dimensions = {
+        get: anything => {
+            return { width: 700, height: 100 }
+        },
+    }
+    return Dimensions
+})
+
 baseTests('SliderTitle - iOS - Tablet')

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -280,6 +280,21 @@ const scale = {
                 lineHeight: 20,
             },
         },
+        // 1.1 is just for article titles
+        1.1: {
+            [Breakpoints.smallPhone]: {
+                fontSize: 18,
+                lineHeight: 20,
+            },
+            [Breakpoints.phone]: {
+                fontSize: 20,
+                lineHeight: 22,
+            },
+            [Breakpoints.tabletVertical]: {
+                fontSize: 30,
+                lineHeight: 33,
+            },
+        },
         1.25: {
             [Breakpoints.smallPhone]: {
                 fontSize: 20,
@@ -288,6 +303,21 @@ const scale = {
             [Breakpoints.phone]: {
                 fontSize: 24,
                 lineHeight: 26,
+            },
+        },
+        // 1.4 is just for fronts section titles and sub-titles
+        1.4: {
+            [Breakpoints.smallPhone]: {
+                fontSize: 24,
+                lineHeight: 26,
+            },
+            [Breakpoints.phone]: {
+                fontSize: 28,
+                lineHeight: 32,
+            },
+            [Breakpoints.tabletVertical]: {
+                fontSize: 38,
+                lineHeight: 42,
             },
         },
         1.5: {

--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -280,7 +280,7 @@ const scale = {
                 lineHeight: 20,
             },
         },
-        // 1.1 is just for article titles
+        // 1.1 is NOT in the design system - for use only in SliderTitle
         1.1: {
             [Breakpoints.smallPhone]: {
                 fontSize: 18,
@@ -305,7 +305,7 @@ const scale = {
                 lineHeight: 26,
             },
         },
-        // 1.4 is just for fronts section titles and sub-titles
+        // 1.4 is NOT in the design system - for use only in SliderTitle
         1.4: {
             [Breakpoints.smallPhone]: {
                 fontSize: 24,


### PR DESCRIPTION
## Summary

Why are we doing this?

The font-size of section titles on the fronts and article headlines on the article pages are too big on iPhone SE. On 1st of September, the Coronavirus Education titles were not fully visible on the screen.


[**Trello Card ->**](https://trello.com/c/lvwBYVG1/1525-font-size-of-section-and-sub-section-titles-too-big-on-iphone-se)

## Test Plan

- Open iPhone SE, check if the section titles are smaller 

![Screenshot 2020-09-04 at 15 31 01](https://user-images.githubusercontent.com/10372380/92250838-e36fa680-eec3-11ea-9f4e-c1150a7d5f7b.png)
![Screenshot 2020-09-04 at 15 31 13](https://user-images.githubusercontent.com/10372380/92250868-e8ccf100-eec3-11ea-9eff-611edc8f8d26.png)
