### PR TITLE
Simplify special edition images

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -606,7 +606,7 @@ export interface TrainingEdition extends EditionInterface {}
 
 export interface SpecialEdition extends EditionInterface {
     buttonStyle: SpecialEditionButtonStyles
-    buttonImageUri?: string
+    buttonImageUri: string
     expiry: Date
     headerStyle?: SpecialEditionHeaderStyles
 }

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -606,8 +606,7 @@ export interface TrainingEdition extends EditionInterface {}
 
 export interface SpecialEdition extends EditionInterface {
     buttonStyle: SpecialEditionButtonStyles
-    devUri?: string
+    imageUri?: string
     expiry: Date
     headerStyle?: SpecialEditionHeaderStyles
-    image: Image
 }

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -606,7 +606,7 @@ export interface TrainingEdition extends EditionInterface {}
 
 export interface SpecialEdition extends EditionInterface {
     buttonStyle: SpecialEditionButtonStyles
-    imageUri?: string
+    buttonImageUri?: string
     expiry: Date
     headerStyle?: SpecialEditionHeaderStyles
 }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -10,12 +10,8 @@ const props: { specialEditions: SpecialEdition[] } = {
         {
             edition: 'daily-edition' as Edition,
             expiry: new Date(98, 1),
-            devUri:
+            imageUri:
                 'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
-            image: {
-                source: 'media',
-                path: '/path/to/image',
-            },
             topic: 'food',
             editionType: 'Special',
             notificationUTCOffset: 0,

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -10,7 +10,7 @@ const props: { specialEditions: SpecialEdition[] } = {
         {
             edition: 'daily-edition' as Edition,
             expiry: new Date(98, 1),
-            imageUri:
+            buttonImageUri:
                 'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
             topic: 'food',
             editionType: 'Special',

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -51,18 +51,16 @@ const EditionsMenu = ({
                         renderItem={({ item }: { item: SpecialEdition }) => {
                             const {
                                 buttonStyle,
-                                devUri,
+                                imageUri,
                                 edition,
                                 expiry,
-                                image,
                                 title,
                                 subTitle,
                             } = item
                             return (
                                 <SpecialEditionButton
-                                    devUri={devUri}
+                                    imageUri={imageUri}
                                     expiry={expiry}
-                                    image={image}
                                     onPress={() => {
                                         storeSelectedEdition(
                                             item,

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -51,7 +51,7 @@ const EditionsMenu = ({
                         renderItem={({ item }: { item: SpecialEdition }) => {
                             const {
                                 buttonStyle,
-                                imageUri,
+                                buttonImageUri,
                                 edition,
                                 expiry,
                                 title,
@@ -59,7 +59,7 @@ const EditionsMenu = ({
                             } = item
                             return (
                                 <SpecialEditionButton
-                                    imageUri={imageUri}
+                                    buttonImageUri={buttonImageUri}
                                     expiry={expiry}
                                     onPress={() => {
                                         storeSelectedEdition(

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
@@ -4,7 +4,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import { SpecialEditionButton } from './SpecialEditionButton'
 
 const props = {
-    imageUri:
+    buttonImageUri:
         'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
     expiry: new Date(),
     onPress: () => {},

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.stories.tsx
@@ -4,13 +4,9 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import { SpecialEditionButton } from './SpecialEditionButton'
 
 const props = {
-    devUri:
+    imageUri:
         'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
     expiry: new Date(),
-    image: {
-        source: '',
-        path: '',
-    },
     onPress: () => {},
     title: text(
         'Title',

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -1,17 +1,12 @@
 import moment from 'moment'
 import React, { useState } from 'react'
-import { Text, TouchableWithoutFeedback, View } from 'react-native'
-import { ImageResource } from 'src/components/front/image-resource'
-import {
-    Image,
-    SpecialEditionButtonStyles,
-} from '../../../../../Apps/common/src'
+import { Text, TouchableWithoutFeedback, View, Image } from 'react-native'
+import { SpecialEditionButtonStyles } from '../../../../../Apps/common/src'
 import { styles } from './styles'
 
 const SpecialEditionButton = ({
     expiry,
-    devUri,
-    image,
+    imageUri,
     onPress,
     selected = false,
     subTitle,
@@ -19,8 +14,7 @@ const SpecialEditionButton = ({
     title,
 }: {
     expiry: Date
-    devUri?: string
-    image: Image
+    imageUri?: string
     onPress: () => void
     selected?: boolean
     style: SpecialEditionButtonStyles
@@ -39,12 +33,16 @@ const SpecialEditionButton = ({
             onPress={onPress}
         >
             <View style={defaultStyles.container}>
-                <ImageResource
-                    devUri={devUri}
-                    image={image}
-                    use="full-size"
-                    style={defaultStyles.image}
-                />
+                {imageUri ? (
+                    <Image
+                        key={imageUri}
+                        resizeMethod={'resize'}
+                        style={defaultStyles.image}
+                        source={{ uri: imageUri }}
+                    />
+                ) : (
+                    <View style={defaultStyles.image}></View>
+                )}
                 <View style={defaultStyles.textBox}>
                     <Text style={defaultStyles.title}>{title}</Text>
                     <Text style={defaultStyles.subTitle}>{subTitle}</Text>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import React, { useState } from 'react'
 import { Text, TouchableWithoutFeedback, View, Image } from 'react-native'
-import { SpecialEditionButtonStyles } from '../../../../../Apps/common/src'
+import { SpecialEditionButtonStyles } from 'src/common'
 import { styles } from './styles'
 
 const SpecialEditionButton = ({

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -6,7 +6,7 @@ import { styles } from './styles'
 
 const SpecialEditionButton = ({
     expiry,
-    imageUri,
+    buttonImageUri,
     onPress,
     selected = false,
     subTitle,
@@ -14,7 +14,7 @@ const SpecialEditionButton = ({
     title,
 }: {
     expiry: Date
-    imageUri?: string
+    buttonImageUri?: string
     onPress: () => void
     selected?: boolean
     style: SpecialEditionButtonStyles
@@ -33,12 +33,12 @@ const SpecialEditionButton = ({
             onPress={onPress}
         >
             <View style={defaultStyles.container}>
-                {imageUri ? (
+                {buttonImageUri ? (
                     <Image
-                        key={imageUri}
+                        key={buttonImageUri}
                         resizeMethod={'resize'}
                         style={defaultStyles.image}
-                        source={{ uri: imageUri }}
+                        source={{ uri: buttonImageUri }}
                     />
                 ) : (
                     <View style={defaultStyles.image}></View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -14,7 +14,7 @@ const SpecialEditionButton = ({
     title,
 }: {
     expiry: Date
-    buttonImageUri?: string
+    buttonImageUri: string
     onPress: () => void
     selected?: boolean
     style: SpecialEditionButtonStyles

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/SpecialEditionButton.spec.tsx
@@ -42,6 +42,8 @@ Monthly`,
             width: 87,
         },
     },
+    buttonImageUri:
+        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
 }
 
 describe('SpecialEditionButton', () => {

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -22,7 +22,14 @@ Monthly - Special Edition Button"
     }
   }
 >
-  ImageResource
+  <View
+    style={
+      Object {
+        "height": 134,
+        "width": 87,
+      }
+    }
+  />
   <View
     style={
       Object {
@@ -102,7 +109,14 @@ Monthly - Special Edition Button"
     }
   }
 >
-  ImageResource
+  <View
+    style={
+      Object {
+        "height": 134,
+        "width": 87,
+      }
+    }
+  />
   <View
     style={
       Object {

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -22,7 +22,13 @@ Monthly - Special Edition Button"
     }
   }
 >
-  <View
+  <Image
+    resizeMethod="resize"
+    source={
+      Object {
+        "uri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
+      }
+    }
     style={
       Object {
         "height": 134,
@@ -109,7 +115,13 @@ Monthly - Special Edition Button"
     }
   }
 >
-  <View
+  <Image
+    resizeMethod="resize"
+    source={
+      Object {
+        "uri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
+      }
+    }
     style={
       Object {
         "height": 134,

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -62,10 +62,6 @@ const specialEditions: SpecialEdition[] = [
     {
         edition: 'daily-edition' as Edition,
         expiry: new Date(98, 1),
-        image: {
-            source: 'media',
-            path: '/path/to/image',
-        },
         editionType: 'Special',
         notificationUTCOffset: 1,
         topic: 'food',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -72,6 +72,8 @@ Monthly`,
             title: 'Food',
             subTitle: 'Monthly',
         },
+        buttonImageUri:
+            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
         buttonStyle: {
             backgroundColor: '#FEEEF7',
             expiry: {

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -256,10 +256,6 @@ Saturday morning by 6am (EST)",
               "subTitle": "Monthly",
               "title": "Food",
             },
-            "image": Object {
-              "path": "/path/to/image",
-              "source": "media",
-            },
             "notificationUTCOffset": 1,
             "subTitle": "Store cupboard special: 20 quick and easy lockdown suppers",
             "title": "Food

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -224,6 +224,7 @@ Saturday morning by 6am (EST)",
       data={
         Array [
           Object {
+            "buttonImageUri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
             "buttonStyle": Object {
               "backgroundColor": "#FEEEF7",
               "expiry": Object {

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -16,7 +16,6 @@ type ImageResourceProps = {
     use: ImageUse
     style?: StyleProp<ImageStyle>
     setAspectRatio?: boolean
-    devUri?: string
 } & Omit<ImageProps, 'source'>
 
 const ImageResource = ({
@@ -24,20 +23,19 @@ const ImageResource = ({
     style,
     setAspectRatio = false,
     use,
-    devUri,
     ...props
 }: ImageResourceProps) => {
     const imagePath = useImagePath(image, use)
     const aspectRatio = useAspectRatio(imagePath)
     const styles = [style, setAspectRatio && aspectRatio ? { aspectRatio } : {}]
 
-    return imagePath || devUri ? (
+    return imagePath ? (
         <Image
             key={imagePath}
             resizeMethod={'resize'}
             {...props}
             style={[styles, style]}
-            source={{ uri: devUri || imagePath }}
+            source={{ uri: imagePath }}
         />
     ) : (
         <View style={styles}></View>


### PR DESCRIPTION
## Summary
Images in special editions won't go through the archiver, and therefore won't be served by the editions API. This modifies the editions menu to take this into account - no longer using `ImageResource` - which is really for generating API/filesystem urls and using `Image` directly. With this, we can then replace `devUri` and `image` with a single property - `buttonImageUri`

This is an example image:
<img width="484" alt="Screenshot 2020-09-03 at 15 36 30" src="https://user-images.githubusercontent.com/3606555/92129341-4a755880-edfb-11ea-945d-b06f57de1f27.png">


[**Trello Card ->**](https://trello.com/c/ALUUZ9uH/1521-prove-special-editions-basically-work)

## Test Plan
I've tested that storybook is still happy! 

We don't have any live special editions at the moment so this should be fairly safe. Testing steps would be: 

 - update facia tool with new buttonImageUri property
 - Republish editions using facia tool on CODE
 - Run a simulator pointed at CODE and check that the image pulls through. 
