### PR TITLE
Use proper domain names for proof endpoints.

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -13,7 +13,7 @@ export const backends = [
     },
     {
         title: 'PROD proofed',
-        value: 'https://editions-proof-prod.s3-eu-west-1.amazonaws.com/',
+        value: 'https://editions-proof.guardianapis.com/',
         preview: true,
     },
     {
@@ -28,7 +28,7 @@ export const backends = [
     },
     {
         title: 'CODE proofed',
-        value: 'https://editions-proof-code.s3-eu-west-1.amazonaws.com/',
+        value: 'https://editions-proof.code.dev-guardianapis.com/',
         preview: true,
     },
     {


### PR DESCRIPTION
## Summary

Rather than refer to the S3 bucket directly we should use a domain name. This way if we want to change the backend in the future we can do so without releasing the app. The two editions-proof domains included below are set up in fastly.