### PR TITLE
tweak-showcase-template

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -814,7 +814,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
 
     .header-container[data-type='${ArticleType.Showcase}'] h1 {
-        color: ${colors.main};
+        color: ${colors.dark};
         font-family: ${families.headline.bold};
         font-size: 28px;
         line-height: 30px;
@@ -867,6 +867,19 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             font-size: 20px;
             line-height: 25px;
         }
+
+        .header-container[data-type='${
+            ArticleType.Showcase
+        }'] .share-touch-zone { 
+            margin: -8px 0 0 0;
+        }
+
+        .header-container[data-type='${
+            ArticleType.Showcase
+        }'] .header-byline:not(:empty):after {
+            right: 4px;
+        }
+
     }
 
     /*obit*/


### PR DESCRIPTION
## Summary
After reviewing the showcase template @pradasa noticed a few minor issues. 
1. Use the dark pillar colour for the headline instead of main
2. Add extra padding to share button and reduce horizontal length below byline (only on tablet)
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/TN3e0niI/1503-article-type-picker-change-to-support-showcase-template)

## Test Plan
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-09-04 at 11 11 41](https://user-images.githubusercontent.com/53755195/92228240-7518ed00-ee9f-11ea-9d1d-7b11425133bf.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-09-04 at 11 11 22](https://user-images.githubusercontent.com/53755195/92228226-6e8a7580-ee9f-11ea-822d-09436f21b5ca.png)


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
