### PR TITLE
feat: Locale mapping via endpoint and general US cleaning

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -13,6 +13,7 @@ morning by 6am (GMT)`,
         editionType: 'Regional',
         topic: 'uk',
         notificationUTCOffset: 3,
+        locale: 'en_GB',
     },
     {
         title: 'Australia Weekend',
@@ -26,18 +27,6 @@ Saturday by 6 am (AEST)`,
         editionType: 'Regional',
         topic: 'au',
         notificationUTCOffset: -5,
-    },
-    {
-        title: 'US Weekend',
-        subTitle: `Published from New York every 
-Saturday morning by 6am (EST)`,
-        edition: editions.usWeekly,
-        header: {
-            title: 'US',
-            subTitle: 'Weekend',
-        },
-        editionType: 'Regional',
-        topic: 'us',
-        notificationUTCOffset: 8,
+        locale: 'en_AU',
     },
 ]

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -579,6 +579,8 @@ export interface EditionsList {
     trainingEditions: TrainingEdition[]
 }
 
+export type Locale = 'en_GB' | 'en_AU'
+
 interface EditionInterface {
     title: string
     subTitle: string
@@ -590,6 +592,7 @@ interface EditionInterface {
     editionType: 'Regional' | 'Training' | 'Special'
     notificationUTCOffset: number
     topic: string
+    locale: Locale
 }
 
 // disabling tslint here as  it's useful to give this types a different name

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -592,14 +592,15 @@ interface EditionInterface {
     editionType: 'Regional' | 'Training' | 'Special'
     notificationUTCOffset: number
     topic: string
-    locale: Locale
 }
 
 // disabling tslint here as  it's useful to give this types a different name
 // and in future Regional/Training editions may have unique properties
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface RegionalEdition extends EditionInterface {}
+export interface RegionalEdition extends EditionInterface {
+    locale: Locale
+}
 
 // disabling tslint here as  it's useful to give this types a different name
 // and in future Regional/Training editions may have unique properties

--- a/projects/Mallard/jest-setup.js
+++ b/projects/Mallard/jest-setup.js
@@ -1,5 +1,5 @@
 jest.mock('src/helpers/locale', () => ({
-    locale: 'en_US',
+    locale: 'en_AU',
 }))
 
 jest.mock('src/notifications/push-notifications', () => ({

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -31,6 +31,7 @@ const regionalEditions: RegionalEdition[] = [
         editionType: 'Regional',
         topic: 'au',
         notificationUTCOffset: 1,
+        locale: 'en_GB',
     },
     {
         title: 'Australia Daily',
@@ -43,18 +44,7 @@ const regionalEditions: RegionalEdition[] = [
         editionType: 'Regional',
         topic: 'au',
         notificationUTCOffset: 1,
-    },
-    {
-        title: 'US and Cananda Weekend',
-        subTitle: 'Published every Saturday by 8am (EST)',
-        edition: editions.usWeekly as Edition,
-        header: {
-            title: 'US',
-            subTitle: 'Weekend',
-        },
-        editionType: 'Regional',
-        topic: 'au',
-        notificationUTCOffset: 1,
+        locale: 'en_AU',
     },
 ]
 

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
               "subTitle": "Daily",
               "title": "UK Daily",
             },
+            "locale": "en_GB",
             "notificationUTCOffset": 1,
             "subTitle": "Published every day by 12am (GMT)",
             "title": "UK Daily",
@@ -27,21 +28,10 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
               "subTitle": "Weekend",
               "title": "Austraila",
             },
+            "locale": "en_AU",
             "notificationUTCOffset": 1,
             "subTitle": "Published every day by 9:30am (AEST)",
             "title": "Australia Daily",
-            "topic": "au",
-          },
-          Object {
-            "edition": "american-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "US",
-            },
-            "notificationUTCOffset": 1,
-            "subTitle": "Published every Saturday by 8am (EST)",
-            "title": "US and Cananda Weekend",
             "topic": "au",
           },
         ]
@@ -70,20 +60,6 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
       windowSize={21}
     >
       <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          RegionButton
-          <View
-            style={
-              Object {
-                "backgroundColor": "#121212",
-                "height": 1,
-              }
-            }
-          />
-        </View>
         <View
           onLayout={[Function]}
           style={null}
@@ -125,6 +101,7 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
               "subTitle": "Daily",
               "title": "UK",
             },
+            "locale": "en_GB",
             "notificationUTCOffset": 3,
             "subTitle": "Published from London every 
 morning by 6am (GMT)",
@@ -138,24 +115,12 @@ morning by 6am (GMT)",
               "subTitle": "Weekend",
               "title": "Australia",
             },
+            "locale": "en_AU",
             "notificationUTCOffset": -5,
             "subTitle": "Published from Sydney every 
 Saturday by 6 am (AEST)",
             "title": "Australia Weekend",
             "topic": "au",
-          },
-          Object {
-            "edition": "american-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "US",
-            },
-            "notificationUTCOffset": 8,
-            "subTitle": "Published from New York every 
-Saturday morning by 6am (EST)",
-            "title": "US Weekend",
-            "topic": "us",
           },
         ]
       }
@@ -183,20 +148,6 @@ Saturday morning by 6am (EST)",
       windowSize={21}
     >
       <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          RegionButton
-          <View
-            style={
-              Object {
-                "backgroundColor": "#121212",
-                "height": 1,
-              }
-            }
-          />
-        </View>
         <View
           onLayout={[Function]}
           style={null}
@@ -319,6 +270,7 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
               "subTitle": "Daily",
               "title": "UK",
             },
+            "locale": "en_GB",
             "notificationUTCOffset": 3,
             "subTitle": "Published from London every 
 morning by 6am (GMT)",
@@ -332,24 +284,12 @@ morning by 6am (GMT)",
               "subTitle": "Weekend",
               "title": "Australia",
             },
+            "locale": "en_AU",
             "notificationUTCOffset": -5,
             "subTitle": "Published from Sydney every 
 Saturday by 6 am (AEST)",
             "title": "Australia Weekend",
             "topic": "au",
-          },
-          Object {
-            "edition": "american-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "US",
-            },
-            "notificationUTCOffset": 8,
-            "subTitle": "Published from New York every 
-Saturday morning by 6am (EST)",
-            "title": "US Weekend",
-            "topic": "us",
           },
         ]
       }
@@ -377,20 +317,6 @@ Saturday morning by 6am (EST)",
       windowSize={21}
     >
       <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          RegionButton
-          <View
-            style={
-              Object {
-                "backgroundColor": "#121212",
-                "height": 1,
-              }
-            }
-          />
-        </View>
         <View
           onLayout={[Function]}
           style={null}

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
@@ -4,6 +4,7 @@ import {
     selectedEditionCache,
 } from 'src/helpers/storage'
 import { BASE_EDITION, defaultEditionDecider } from '../use-edition-provider'
+import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults'
 
 jest.mock('src/services/remote-config', () => ({
     remoteConfigService: {
@@ -23,8 +24,16 @@ describe('useEditions', () => {
         it('should set the BASE EDITION if locale is not in the list', async () => {
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
+            const editionsList = {
+                regionalEditions: defaultRegionalEditions,
+                specialEditions: [],
+            }
 
-            await defaultEditionDecider(defaultLocalState, selectedLocalState)
+            await defaultEditionDecider(
+                defaultLocalState,
+                selectedLocalState,
+                editionsList,
+            )
             expect(defaultLocalState).toBeCalledTimes(1)
             expect(defaultLocalState).toBeCalledWith(BASE_EDITION)
             expect(selectedLocalState).toBeCalledTimes(1)

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -35,7 +35,7 @@ describe('useEditions', () => {
             const editionSlug = await getSelectedEditionSlug()
             expect(editionSlug).toEqual(BASE_EDITION.edition)
         })
-        it('should return "australian-edition" slug when the US edition is set', async () => {
+        it('should return "australian-edition" slug when the AU edition is set', async () => {
             await selectedEditionCache.set(defaultRegionalEditions[1])
             const editionSlug = await getSelectedEditionSlug()
             expect(editionSlug).toEqual('australian-edition')

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -35,10 +35,10 @@ describe('useEditions', () => {
             const editionSlug = await getSelectedEditionSlug()
             expect(editionSlug).toEqual(BASE_EDITION.edition)
         })
-        it('should return "american-edition" slug when the US edition is set', async () => {
-            await selectedEditionCache.set(defaultRegionalEditions[2])
+        it('should return "australian-edition" slug when the US edition is set', async () => {
+            await selectedEditionCache.set(defaultRegionalEditions[1])
             const editionSlug = await getSelectedEditionSlug()
-            expect(editionSlug).toEqual('american-edition')
+            expect(editionSlug).toEqual('australian-edition')
         })
     })
 
@@ -127,9 +127,17 @@ describe('useEditions', () => {
         it('should set default and selected edition local state as well as selected storage if found in default storage', async () => {
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
+            const editionsList = {
+                regionalEditions: defaultRegionalEditions,
+                specialEditions: [],
+            }
             defaultEditionCache.set(defaultRegionalEditions[1])
 
-            await defaultEditionDecider(defaultLocalState, selectedLocalState)
+            await defaultEditionDecider(
+                defaultLocalState,
+                selectedLocalState,
+                editionsList,
+            )
             expect(defaultLocalState).toBeCalledTimes(1)
             expect(defaultLocalState).toBeCalledWith(defaultRegionalEditions[1])
             expect(selectedLocalState).toBeCalledTimes(1)
@@ -142,21 +150,29 @@ describe('useEditions', () => {
             expect(defaultEdition).toEqual(defaultRegionalEditions[1])
         })
         it('should set a default based on locale if the feature flag is on and nothing in the default edition cache', async () => {
-            // defaultRegionalEditions[2] = US and locale mock = US
+            // defaultRegionalEditions[1] = AU and locale mock = AU
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
+            const editionsList = {
+                regionalEditions: defaultRegionalEditions,
+                specialEditions: [],
+            }
 
-            await defaultEditionDecider(defaultLocalState, selectedLocalState)
+            await defaultEditionDecider(
+                defaultLocalState,
+                selectedLocalState,
+                editionsList,
+            )
             expect(defaultLocalState).toBeCalledTimes(1)
-            expect(defaultLocalState).toBeCalledWith(defaultRegionalEditions[2])
+            expect(defaultLocalState).toBeCalledWith(defaultRegionalEditions[1])
             expect(selectedLocalState).toBeCalledTimes(1)
             expect(selectedLocalState).toBeCalledWith(
-                defaultRegionalEditions[2],
+                defaultRegionalEditions[1],
             )
             const selectedEdition = await selectedEditionCache.get()
-            expect(selectedEdition).toEqual(defaultRegionalEditions[2])
+            expect(selectedEdition).toEqual(defaultRegionalEditions[1])
             const defaultEdition = await defaultEditionCache.get()
-            expect(defaultEdition).toEqual(defaultRegionalEditions[2])
+            expect(defaultEdition).toEqual(defaultRegionalEditions[1])
         })
     })
 

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -5,7 +5,7 @@ import React, {
     useState,
     Dispatch,
 } from 'react'
-import { RegionalEdition, SpecialEdition } from 'src/common'
+import { RegionalEdition, SpecialEdition, Locale } from 'src/common'
 import { eventEmitter } from 'src/helpers/event-emitter'
 import {
     defaultSettings,
@@ -53,10 +53,16 @@ export const DEFAULT_EDITIONS_LIST = {
 
 export const BASE_EDITION = defaultRegionalEditions[0]
 
-const localeToEdition = new Map<string, RegionalEdition>()
-localeToEdition.set('en_GB', defaultRegionalEditions[0])
-localeToEdition.set('en_AU', defaultRegionalEditions[1])
-localeToEdition.set('en_US', defaultRegionalEditions[2])
+const localeToEdition = (
+    locale: Locale,
+    editionsList: EditionsEndpoint,
+): RegionalEdition => {
+    return (
+        editionsList.regionalEditions.find(
+            edition => edition.locale === locale,
+        ) || BASE_EDITION
+    )
+}
 
 const defaultState: EditionState = {
     editionsList: DEFAULT_EDITIONS_LIST,
@@ -153,6 +159,7 @@ const setEdition = async (
 export const defaultEditionDecider = async (
     setDefaultEdition: Dispatch<RegionalEdition>,
     setSelectedEdition: Dispatch<RegionalEdition | SpecialEdition>,
+    editionsList: EditionsEndpoint,
 ): Promise<void> => {
     // When user already has default edition set then that edition
     const dE = await getDefaultEdition()
@@ -163,7 +170,7 @@ export const defaultEditionDecider = async (
         pushNotifcationRegistration()
     } else {
         // Get the correct edition for the device locale
-        const autoDetectedEdition = localeToEdition.get(locale)
+        const autoDetectedEdition = localeToEdition(locale, editionsList)
 
         if (autoDetectedEdition) {
             await setEdition(
@@ -207,7 +214,11 @@ export const EditionProvider = ({
      * also set this as the selected edition
      */
     useEffect(() => {
-        defaultEditionDecider(setDefaultEdition, setSelectedEdition)
+        defaultEditionDecider(
+            setDefaultEdition,
+            setSelectedEdition,
+            editionsList,
+        )
     }, [])
 
     /**

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -24,7 +24,7 @@ import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
 
-interface EditionsEndpoint {
+export interface EditionsEndpoint {
     regionalEditions: RegionalEdition[]
     specialEditions: SpecialEdition[]
 }
@@ -219,7 +219,7 @@ export const EditionProvider = ({
             setSelectedEdition,
             editionsList,
         )
-    }, [])
+    }, [editionsList])
 
     /**
      * List of Editions

--- a/projects/Mallard/src/notifications/helpers.ts
+++ b/projects/Mallard/src/notifications/helpers.ts
@@ -1,38 +1,25 @@
-import {
-    PushToken,
-    registerWithNotificationService,
-} from './notification-service'
-import { RegionalEdition } from 'src/common'
-import { defaultRegionalEditions } from '../../../Apps/common/src/editions-defaults'
-import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider'
-import { PushNotificationRegistration } from './push-notifications'
 import moment, { MomentInput } from 'moment'
 import {
     pushNotificationRegistrationCache,
     pushRegisteredTokens,
 } from 'src/helpers/storage'
+import { getDefaultEdition } from 'src/hooks/use-edition-provider'
+import {
+    PushToken,
+    registerWithNotificationService,
+} from './notification-service'
+import { PushNotificationRegistration } from './push-notifications'
 
 const BASE_PUSH_TOKEN = [{ name: 'uk', type: 'editions' }] as PushToken[]
-const topicToEdition = new Map<RegionalEdition['edition'], PushToken[]>()
-topicToEdition.set(defaultRegionalEditions[1].edition, [
-    {
-        name: 'au',
-        type: 'editions',
-    },
-])
-topicToEdition.set(defaultRegionalEditions[2].edition, [
-    {
-        name: 'us',
-        type: 'editions',
-    },
-])
-topicToEdition.set(defaultRegionalEditions[0].edition, BASE_PUSH_TOKEN)
 
 const getTopicName = async (): Promise<PushToken[]> => {
-    const defaultSlug = await getDefaultEditionSlug()
-    if (defaultSlug) {
-        const chosenTopic = topicToEdition.get(defaultSlug)
-        return chosenTopic || BASE_PUSH_TOKEN
+    const defaultEdition = await getDefaultEdition()
+    if (defaultEdition) {
+        return (
+            ([
+                { name: defaultEdition.topic, type: 'editions' },
+            ] as PushToken[]) || BASE_PUSH_TOKEN
+        )
     }
     return BASE_PUSH_TOKEN
 }


### PR DESCRIPTION
## Summary
This looks to remove the dependency for locally retrieved editions values. This makes `Locale` and `Topic` come from the editions list.

This applies the backend changes as mentioned in the Trello ticket.

[**Trello Card ->**](https://trello.com/c/7ubNJqO6/1529-update-local-app-preferences-to-match-the-backend)