### PR TITLE
fix: Clears the cache on editions endpoint

### DIFF
--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -92,7 +92,9 @@ export const getDefaultEditionSlug = async () => {
     return defaultEdition ? defaultEdition.edition : null
 }
 
-export const fetchEditions = async (apiUrl: string) => {
+export const fetchEditions = async (
+    apiUrl: string,
+): Promise<EditionsEndpoint | null> => {
     try {
         const response = await fetch(apiUrl, {
             headers: {

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -94,13 +94,19 @@ export const getDefaultEditionSlug = async () => {
 
 export const fetchEditions = async (apiUrl: string) => {
     try {
-        const response = await fetch(apiUrl)
+        const response = await fetch(apiUrl, {
+            headers: {
+                'Content-Type': 'application/json',
+                'cache-control': 'max-age=300',
+            },
+        })
         if (response.status !== 200) {
             throw new Error(
                 `Bad response from Editions URL - status: ${response.status}`,
             )
         }
-        return response.json()
+        const json = await response.json()
+        return json
     } catch (e) {
         e.message = `Unable to fetch ${apiUrl} : ${e.message}`
         errorService.captureException(e)


### PR DESCRIPTION
## Summary
Fixes the edition endpoint caching. Sets a max age to 5 minutes.