### PR TITLE
Remove expired special editions

### DIFF
--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -14,7 +14,9 @@ import {
     getEditions,
     getSelectedEditionSlug,
     getDefaultEdition,
+    removeExpiredSpecialEditions,
 } from '../use-edition-provider'
+import { SpecialEdition, Edition } from '../../../../Apps/common/src'
 
 jest.mock('@react-native-community/netinfo', () => ({
     fetch: jest.fn(() => Promise.resolve({ isConnected: true })),
@@ -25,6 +27,107 @@ jest.mock('src/services/remote-config', () => ({
         getBoolean: jest.fn().mockReturnValue(true),
     },
 }))
+
+const specialEditions: SpecialEdition[] = [
+    {
+        edition: 'special-edition-expired' as Edition,
+        expiry: new Date(2020, 1, 1),
+        editionType: 'Special',
+        notificationUTCOffset: 1,
+        topic: 'food',
+        title: `Food
+Monthly`,
+        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+        header: {
+            title: 'Food',
+            subTitle: 'Monthly',
+        },
+        buttonImageUri:
+            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+        buttonStyle: {
+            backgroundColor: '#FEEEF7',
+            expiry: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Regular',
+                lineHeight: 16,
+                size: 15,
+            },
+
+            subTitle: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Bold',
+                lineHeight: 20,
+                size: 17,
+            },
+            title: {
+                color: '#121212',
+                font: 'GHGuardianHeadline-Regular',
+                lineHeight: 34,
+                size: 34,
+            },
+            image: {
+                height: 134,
+                width: 87,
+            },
+        },
+    },
+    {
+        edition: 'special-edition-notexpired' as Edition,
+        expiry: new Date(3000, 3, 1),
+        editionType: 'Special',
+        notificationUTCOffset: 1,
+        topic: 'food',
+        title: `Food
+Monthly`,
+        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+        header: {
+            title: 'Food',
+            subTitle: 'Monthly',
+        },
+        buttonImageUri:
+            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+        buttonStyle: {
+            backgroundColor: '#FEEEF7',
+            expiry: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Regular',
+                lineHeight: 16,
+                size: 15,
+            },
+
+            subTitle: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Bold',
+                lineHeight: 20,
+                size: 17,
+            },
+            title: {
+                color: '#121212',
+                font: 'GHGuardianHeadline-Regular',
+                lineHeight: 34,
+                size: 34,
+            },
+            image: {
+                height: 134,
+                width: 87,
+            },
+        },
+    },
+]
+
+describe('removeExpiredSpecialEditions', () => {
+    it('should remove an expired special edition and ignore non-expired editions', () => {
+        const editionsList = {
+            ...DEFAULT_EDITIONS_LIST,
+            specialEditions: specialEditions,
+        }
+        const filteredList = removeExpiredSpecialEditions(editionsList)
+        expect(filteredList.specialEditions.length).toEqual(1)
+        expect(filteredList.specialEditions[0].edition).toEqual(
+            'special-edition-notexpired',
+        )
+    })
+})
 
 describe('useEditions', () => {
     describe('getSelectedEditionSlug', () => {

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -24,6 +24,9 @@ import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
 
+// NOTE: This is *almost* a duplicate of the EditionsList type except without trainingEditions
+// the editions client doesn't care about trainingEditions (but the backend does), so here in the client
+// we use a type without trainingEditions so we can ignore them
 export interface EditionsEndpoint {
     regionalEditions: RegionalEdition[]
     specialEditions: SpecialEdition[]

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -23,6 +23,7 @@ import { AppState, AppStateStatus } from 'react-native'
 import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
+import moment from 'moment'
 
 // NOTE: This is *almost* a duplicate of the EditionsList type except without trainingEditions
 // the editions client doesn't care about trainingEditions (but the backend does), so here in the client
@@ -120,8 +121,8 @@ export const fetchEditions = async (
 }
 
 export const removeExpiredSpecialEditions = (
-    editionsList: EditionsList,
-): EditionsList => {
+    editionsList: EditionsEndpoint,
+): EditionsEndpoint => {
     return {
         ...editionsList,
         specialEditions: editionsList.specialEditions.filter(e =>

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -116,6 +116,17 @@ export const fetchEditions = async (
     }
 }
 
+const removeExpiredSpecialEditions = (
+    editionsList: EditionsList,
+): EditionsList => {
+    return {
+        ...editionsList,
+        specialEditions: editionsList.specialEditions.filter(e =>
+            moment().isBefore(e.expiry),
+        ),
+    }
+}
+
 export const getEditions = async (
     apiUrl: string = defaultSettings.editionsUrl,
 ) => {
@@ -126,9 +137,10 @@ export const getEditions = async (
             // Grab editions list from the endpoint
             const editionsList = await fetchEditions(apiUrl)
             if (editionsList) {
+                const filteredList = removeExpiredSpecialEditions(editionsList)
                 // Successful? Store in the cache and return
-                await editionsListCache.set(editionsList)
-                return editionsList
+                await editionsListCache.set(filteredList)
+                return filteredList
             }
             // Unsuccessful, try getting it from our local storage
             const cachedEditionsList = await editionsListCache.get()

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -116,7 +116,7 @@ export const fetchEditions = async (
     }
 }
 
-const removeExpiredSpecialEditions = (
+export const removeExpiredSpecialEditions = (
     editionsList: EditionsList,
 ): EditionsList => {
     return {


### PR DESCRIPTION
## Summary
This PR modifies the use-editions provider so that it filters out expired special editions. 

[**Trello Card ->**](https://trello.com/c/ALUUZ9uH/1521-prove-special-editions-basically-work)

## Test Plan
I wrote a unit test! Oh my! I've also tested this using the simulator pointed at the special edition we currently have on CODE. 
