### PR TITLE
Add dev menu flag to show all editions.

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -77,6 +77,8 @@ const selectedEditionCache = createAsyncCache<RegionalEdition | SpecialEdition>(
     'selectedEdition',
 )
 
+const showAllEditionsCache = createAsyncCache<boolean>('showAllEditions')
+
 const defaultEditionCache = createAsyncCache<RegionalEdition>('defaultEdition')
 
 const editionsListCache = createAsyncCache<{
@@ -159,4 +161,5 @@ export {
     editionsListCache,
     pushRegisteredTokens,
     notificationsEnabledCache,
+    showAllEditionsCache,
 }

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -15,6 +15,7 @@ import {
     defaultEditionCache,
     selectedEditionCache,
     editionsListCache,
+    showAllEditionsCache,
 } from 'src/helpers/storage'
 import { errorService } from 'src/services/errors'
 import { defaultRegionalEditions } from '../../../Apps/common/src/editions-defaults'
@@ -141,7 +142,10 @@ export const getEditions = async (
             // Grab editions list from the endpoint
             const editionsList = await fetchEditions(apiUrl)
             if (editionsList) {
-                const filteredList = removeExpiredSpecialEditions(editionsList)
+                const showAllEditions = await showAllEditionsCache.get()
+                const filteredList = showAllEditions
+                    ? editionsList
+                    : removeExpiredSpecialEditions(editionsList)
                 // Successful? Store in the cache and return
                 await editionsListCache.set(filteredList)
                 return filteredList

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -232,6 +232,8 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                     {
                         key: 'Show All Editions',
                         title: 'Show All Editions',
+                        explainer:
+                            'Show all editions in the editions menu - including expired editions and those with 0 issues',
                         onPress: onToggleNetInfoButton,
                         proxy: (
                             <Switch

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -30,7 +30,7 @@ import {
 } from 'src/notifications/push-tracking'
 import { metrics } from 'src/theme/spacing'
 import { useEditions } from 'src/hooks/use-edition-provider'
-import { pushRegisteredTokens } from 'src/helpers/storage'
+import { pushRegisteredTokens, showAllEditionsCache } from 'src/helpers/storage'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -57,6 +57,12 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
         isDevButtonShown: showNetInfoButton,
         setIsDevButtonShown: setShowNetInfoButton,
     } = useNetInfo()
+    const [showAllEditions, setShowAllEditions] = useState(false)
+
+    const onToggleShowAllEditions = () => {
+        showAllEditionsCache.set(!showAllEditions)
+        setShowAllEditions(!showAllEditions)
+    }
     const onToggleNetInfoButton = () => setShowNetInfoButton(!showNetInfoButton)
     const {
         selectedEdition: { edition },
@@ -70,6 +76,11 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [imageSize, setImageSize] = useState('fetching...')
     const [pushTokens, setPushTokens] = useState('fetching...')
     const [downloadedIssues, setDownloadedIssues] = useState('fetching...')
+
+    // initialise local showAllEditions property
+    useEffect(() => {
+        showAllEditionsCache.get().then(v => v != null && setShowAllEditions(v))
+    }, [])
 
     useEffect(() => {
         getEdtionIssuesCount().then(stats => {
@@ -217,6 +228,17 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         onPress: () => {
                             navigation.navigate(routeNames.Edition)
                         },
+                    },
+                    {
+                        key: 'Show All Editions',
+                        title: 'Show All Editions',
+                        onPress: onToggleNetInfoButton,
+                        proxy: (
+                            <Switch
+                                value={showAllEditions}
+                                onValueChange={onToggleShowAllEditions}
+                            />
+                        ),
                     },
                     {
                         key: 'Hide this menu',


### PR DESCRIPTION
## Summary
It's going to be useful when testing special editions if we can launch them in PROD but keep them hidden unless they are enabled via the dev menu. This PR adds a flag to the dev menu to show/hide 'all editions' - using asyncstorage to store the value. Currently this is just used to show expired editions, but with a new flag set in the fronts tool we could use it to show/hide arbitrary editions.

[**Trello Card ->**](https://trello.com/c/ALUUZ9uH/1521-prove-special-editions-basically-work)

## Test Plan
You can test this now - if you switch backend to CODE and set the flag in the dev menu to 'true' then reload (to reset the editions cache) you should see the expired test edition