### PR TITLE
Updated Keychain library

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
     - React
   - RNInAppBrowser (3.3.3):
     - React
-  - RNKeychain (3.1.3):
+  - RNKeychain (5.0.1):
     - React
   - RNLocalize (1.4.0):
     - React
@@ -655,7 +655,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
-  RNKeychain: c658833a9cb2cbcba6423bdd6e16cce59e27da0e
+  RNKeychain: a5623de13ec5378bfb8035422e3dee4fa538660d
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
   RNSentry: 0a70359ddacbfb9b1cbbb0971e54065b9f70ac57

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -78,7 +78,7 @@
         "react-native-image-zoom-viewer": "^3.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",
-        "react-native-keychain": "^3.1.3",
+        "react-native-keychain": "5.0.1",
         "react-native-localize": "^1.4.0",
         "react-native-permissions": "^2.0.3",
         "react-native-progress-circle": "^2.1.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11214,10 +11214,10 @@ react-native-inappbrowser-reborn@^3.3.3:
     invariant "^2.2.4"
     opencollective-postinstall "^2.0.2"
 
-react-native-keychain@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-3.1.3.tgz#fce176e7b95243cecda1896a7e6bdfe0335d778a"
-  integrity sha512-eWUbjYJge4icX8FhWJk/OPlyGxPnW9bZDysBX3WwOG37iurdH692HKnM2Ih+S+0te65RytImvUrcVnHVBbumYg==
+react-native-keychain@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-5.0.1.tgz#2751de436f017c87b8aabb32533bee88657d643e"
+  integrity sha512-CLIPNexPBufPpNqgF7/smZNAiv6x0SCsztfEi/hWPCQ7yHxNwdRUyUzOLGrw1lPe/6fQE+TC3iS1+cbDTaRJag==
 
 react-native-localize@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary
We have noticed errors in Keychain in Sentry. But it was not reproducible locally. Our current library is from May 2019 which is a bit old. This PR updates to the latest library (up until a breaking change), 5.0.1. There are lots of fixes between 3.1.3 and 5.0.1 and hopefully, this will help to resolve the issue we are seeing in Sentry  


[**Trello Card ->**](https://trello.com/c/etJdu6Rl/1555-android-error-in-public-beta)

Testing:
I have tested the login/cas code subscription feature and they are working as expected 