### PR TITLE
Hide editions with zero issues

### DIFF
--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -120,8 +120,8 @@ describe('isExpired', () => {
     })
 
     it('should return true for expired editions', () => {
-        const expired = isExpired(expiredSpecialEdition)
-        expect(expired).toBe(true)
+        const expired = isExpired(specialEdition)
+        expect(expired).toBe(false)
     })
 })
 

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -14,7 +14,7 @@ import {
     getEditions,
     getSelectedEditionSlug,
     getDefaultEdition,
-    removeExpiredSpecialEditions,
+    isExpired,
 } from '../use-edition-provider'
 import { SpecialEdition, EditionId } from '../../../../Apps/common/src'
 
@@ -28,104 +28,100 @@ jest.mock('src/services/remote-config', () => ({
     },
 }))
 
-const specialEditions: SpecialEdition[] = [
-    {
-        edition: 'special-edition-expired' as EditionId,
-        expiry: new Date(2020, 1, 1),
-        editionType: 'Special',
-        notificationUTCOffset: 1,
-        topic: 'food',
-        title: `Food
+const expiredSpecialEdition: SpecialEdition = {
+    edition: 'special-edition-expired' as EditionId,
+    expiry: new Date(2020, 1, 1),
+    editionType: 'Special',
+    notificationUTCOffset: 1,
+    topic: 'food',
+    title: `Food
 Monthly`,
-        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
-        header: {
-            title: 'Food',
-            subTitle: 'Monthly',
+    subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+    header: {
+        title: 'Food',
+        subTitle: 'Monthly',
+    },
+    buttonImageUri:
+        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+    buttonStyle: {
+        backgroundColor: '#FEEEF7',
+        expiry: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Regular',
+            lineHeight: 16,
+            size: 15,
         },
-        buttonImageUri:
-            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
-        buttonStyle: {
-            backgroundColor: '#FEEEF7',
-            expiry: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Regular',
-                lineHeight: 16,
-                size: 15,
-            },
 
-            subTitle: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Bold',
-                lineHeight: 20,
-                size: 17,
-            },
-            title: {
-                color: '#121212',
-                font: 'GHGuardianHeadline-Regular',
-                lineHeight: 34,
-                size: 34,
-            },
-            image: {
-                height: 134,
-                width: 87,
-            },
+        subTitle: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Bold',
+            lineHeight: 20,
+            size: 17,
+        },
+        title: {
+            color: '#121212',
+            font: 'GHGuardianHeadline-Regular',
+            lineHeight: 34,
+            size: 34,
+        },
+        image: {
+            height: 134,
+            width: 87,
         },
     },
-    {
-        edition: 'special-edition-notexpired' as EditionId,
-        expiry: new Date(3000, 3, 1),
-        editionType: 'Special',
-        notificationUTCOffset: 1,
-        topic: 'food',
-        title: `Food
+}
+const specialEdition: SpecialEdition = {
+    edition: 'special-edition-notexpired' as EditionId,
+    expiry: new Date(3000, 3, 1),
+    editionType: 'Special',
+    notificationUTCOffset: 1,
+    topic: 'food',
+    title: `Food
 Monthly`,
-        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
-        header: {
-            title: 'Food',
-            subTitle: 'Monthly',
+    subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+    header: {
+        title: 'Food',
+        subTitle: 'Monthly',
+    },
+    buttonImageUri:
+        'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+    buttonStyle: {
+        backgroundColor: '#FEEEF7',
+        expiry: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Regular',
+            lineHeight: 16,
+            size: 15,
         },
-        buttonImageUri:
-            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
-        buttonStyle: {
-            backgroundColor: '#FEEEF7',
-            expiry: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Regular',
-                lineHeight: 16,
-                size: 15,
-            },
 
-            subTitle: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Bold',
-                lineHeight: 20,
-                size: 17,
-            },
-            title: {
-                color: '#121212',
-                font: 'GHGuardianHeadline-Regular',
-                lineHeight: 34,
-                size: 34,
-            },
-            image: {
-                height: 134,
-                width: 87,
-            },
+        subTitle: {
+            color: '#7D0068',
+            font: 'GuardianTextSans-Bold',
+            lineHeight: 20,
+            size: 17,
+        },
+        title: {
+            color: '#121212',
+            font: 'GHGuardianHeadline-Regular',
+            lineHeight: 34,
+            size: 34,
+        },
+        image: {
+            height: 134,
+            width: 87,
         },
     },
-]
+}
 
-describe('removeExpiredSpecialEditions', () => {
-    it('should remove an expired special edition and ignore non-expired editions', () => {
-        const editionsList = {
-            ...DEFAULT_EDITIONS_LIST,
-            specialEditions: specialEditions,
-        }
-        const filteredList = removeExpiredSpecialEditions(editionsList)
-        expect(filteredList.specialEditions.length).toEqual(1)
-        expect(filteredList.specialEditions[0].edition).toEqual(
-            'special-edition-notexpired',
-        )
+describe('isExpired', () => {
+    it('should return true for expired editions', () => {
+        const expired = isExpired(expiredSpecialEdition)
+        expect(expired).toBe(true)
+    })
+
+    it('should return true for expired editions', () => {
+        const expired = isExpired(expiredSpecialEdition)
+        expect(expired).toBe(true)
     })
 })
 

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -25,7 +25,7 @@ import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
 import moment from 'moment'
-import { IssueSummary, editions } from '../../../Apps/common/src'
+import { IssueSummary } from '../../../Apps/common/src'
 
 // NOTE: This is *almost* a duplicate of the EditionsList type except without trainingEditions
 // the editions client doesn't care about trainingEditions (but the backend does), so here in the client
@@ -136,8 +136,8 @@ const editionHasAtLeastOneIssue = async (
     if (response.status !== 200) {
         return false
     }
-    const res: Array<IssueSummary> = await response.json()
-    return res.length > 0
+    const issueList: Array<IssueSummary> = await response.json()
+    return issueList.length > 0
 }
 
 const filterSpecialEditions = async (


### PR DESCRIPTION
## Summary
This PR adds an additional API call for each special edition to the editions provider to filter out editions with 0 associated issues. 

Desired editions publication flow:
 - Create PR in fronts tool like this one: https://github.com/guardian/facia-tool/pull/1239 and merge it
 - 'Republish' editions list
 - *at this point the /editions endpoint will contain the special edition. It will not be visible on the app due to this PR*
 - Create an issue on fronts. Do not proof/publish it
 - *Users on the preview API endpoint now see the edition in the editions menu*
 - Proof the issue
 - *Edition becomes visible on proof endpoint - woo no VPN required*
- Publish the issue
 - *Edition visible everywhere*

## Test Plan
I've tested this in the simulator and it seems to work. @jimhunty might have some thoughts as you wrote this provider - it does mean we have some more API requests involveed in generating this editions list. 
