### PR TITLE
Fix interview template small tablets in portrait

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -752,15 +752,34 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             ${threeLines};
         }
 
+        .app[data-type='${ArticleType.Interview}'] .content-wrap {
+            padding-left: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? metrics.article.sides
+                    : metrics.article.sides * 2
+            }
+        }
+
         .interview-tablet-wrapper { 
-            margin-left: ${px(
-                (Dimensions.get('window').width - metrics.article.maxWidth) / 2,
-            )};
-            margin-right: ${px(
-                (Dimensions.get('window').width - metrics.article.maxWidth) /
-                    2 +
-                    metrics.article.rightRail,
-            )};
+            margin-left: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? px(
+                          (Dimensions.get('window').width -
+                              metrics.article.maxWidth) /
+                              2,
+                      )
+                    : px(metrics.article.sides * 2)
+            };
+            margin-right: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? px(
+                          (Dimensions.get('window').width -
+                              metrics.article.maxWidth) /
+                              2 +
+                              metrics.article.rightRail,
+                      )
+                    : px(metrics.article.rightRail + metrics.article.sides)
+            };
         }
 
         .interview-tablet .standfirst--interview p {

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -755,8 +755,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         .app[data-type='${ArticleType.Interview}'] .content-wrap {
             padding-left: ${
                 Dimensions.get('window').width > metrics.article.maxWidth
-                    ? metrics.article.sides
-                    : metrics.article.sides * 2
+                    ? px(metrics.article.sides)
+                    : px(metrics.article.sides * 2)
             }
         }
 


### PR DESCRIPTION
## Summary
Beta users have reported that the interview template is cut off on the left margin on small tablets in portrait mode. 
This PR fixes the calculation we use for determining the margins on tablet, instead, we now check that the window is wider than the `maxWidth` constant before we use it in the calculation to avoid getting a negative margin on smaller devices.

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/qn2WiQPF/1551-interview-template-left-margins-seems-to-be-cut-tablet-portrait)

## Test Plan
I have tested this on an iPad mini and small android tablet, see screenshots. 
| Before | After |
| --- | --- |
![Screenshot_1600259832](https://user-images.githubusercontent.com/53755195/93338716-91fbdb80-f822-11ea-8742-63fb391f9d17.png) | ![Screenshot_1600259822](https://user-images.githubusercontent.com/53755195/93338732-958f6280-f822-11ea-8007-6e643effe2f4.png)
![Simulator Screen Shot - iPad Air - 2020-09-16 at 13 50 42](https://user-images.githubusercontent.com/53755195/93339565-a42a4980-f823-11ea-899c-80de50031b7b.png) | ![Simulator Screen Shot - iPad Air - 2020-09-16 at 13 50 24](https://user-images.githubusercontent.com/53755195/93339570-a68ca380-f823-11ea-9b59-745176238328.png)
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
