### PR TITLE
Remove editions from /editions endpoint when they have 0 issues.

### DIFF
--- a/projects/archiver/src/utils/backend-client.ts
+++ b/projects/archiver/src/utils/backend-client.ts
@@ -73,9 +73,9 @@ export const getEditions = async (): Promise<Attempt<EditionsList>> => {
     const path = `${URL}editions`
     console.log(`Attempt to get editions list from path: ${path}`)
     const response = await fetch(path)
-    const maybeEditionsList = await attempt(response.json() as Promise<{
-        content: EditionsList
-    }>)
+    const maybeEditionsList = await attempt(response.json() as Promise<
+        EditionsList
+    >)
     console.log(`Got response: ${JSON.stringify(maybeEditionsList)}`)
     if (hasFailed(maybeEditionsList)) {
         return withFailureMessage(
@@ -83,5 +83,5 @@ export const getEditions = async (): Promise<Attempt<EditionsList>> => {
             `Failed to download editions list from ${path}`,
         )
     }
-    return maybeEditionsList.content
+    return maybeEditionsList
 }

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -225,7 +225,7 @@ export class EditionsStack extends cdk.Stack {
                                 `arn:aws:s3:::editions-store-${lowerCaseStageParameter.valueAsString}/*`,
                                 `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}/*`,
                                 `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}`,
-                                `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}`,
+                                `arn:aws:s3:::editions-store-${lowerCaseStageParameter.valueAsString}`,
                             ],
                             actions: [
                                 's3:PutObject',

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -225,7 +225,11 @@ export class EditionsStack extends cdk.Stack {
                                 `arn:aws:s3:::editions-store-${lowerCaseStageParameter.valueAsString}/*`,
                                 `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}/*`,
                             ],
-                            actions: ['s3:PutObject', 's3:PutObjectAcl'],
+                            actions: [
+                                's3:PutObject',
+                                's3:PutObjectAcl',
+                                's3:ListBucket',
+                            ],
                         }),
                     ],
                 },

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -224,11 +224,14 @@ export class EditionsStack extends cdk.Stack {
                             resources: [
                                 `arn:aws:s3:::editions-store-${lowerCaseStageParameter.valueAsString}/*`,
                                 `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}/*`,
+                                `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}`,
+                                `arn:aws:s3:::editions-proof-${lowerCaseStageParameter.valueAsString}`,
                             ],
                             actions: [
                                 's3:PutObject',
                                 's3:PutObjectAcl',
                                 's3:ListBucket',
+                                's3:GetObject',
                             ],
                         }),
                     ],

--- a/projects/backend/controllers/__tests__/issue.spec.ts
+++ b/projects/backend/controllers/__tests__/issue.spec.ts
@@ -149,6 +149,7 @@ const issueList = [
 
 jest.mock('../../s3', () => ({
     s3List: () => Promise.resolve(issueList),
+    getFrontsBucket: (bucketType: string) => `${bucketType}-editions-dev)}`,
 }))
 
 const getNthKey = (n: number) => {

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -61,7 +61,10 @@ const filterEditionsList = async (
 }
 
 export const editionsControllerGet = async (req: Request, res: Response) => {
-    const bucket = getFrontsBucket(isPreview ? 'preview' : 'published')
+    // we are always using the published bucket here as editionsList doesn't seem to
+    // exist in the preview bucket but leaving ternary in case we want to do something better in future
+    const bucket = getFrontsBucket(isPreview ? 'published' : 'published')
+
     const result = await s3fetch({
         key: 'editionsList',
         bucket: bucket,

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -1,22 +1,85 @@
 import { Request, Response } from 'express'
-import { EditionsList } from '../../Apps/common/src'
-import { s3Put, s3fetch } from '../s3'
+import { EditionsList, SpecialEdition } from '../../Apps/common/src'
+import {
+    s3Put,
+    s3fetch,
+    s3FrontsClient,
+    s3EditionClient,
+    getEditionsBucket,
+    getFrontsBucket,
+    s3ListDirectories,
+} from '../s3'
 import { isPreview } from '../preview'
 import { hasFailed } from '../utils/try'
+import { S3 } from 'aws-sdk'
+
+const hasAtLeastOneIssue = async (
+    editionId: string,
+    s3Client: S3,
+    bucket: string,
+): Promise<boolean> => {
+    const issues = await s3ListDirectories(
+        { bucket: bucket, key: `${editionId}/` },
+        s3Client,
+    )
+    if (hasFailed(issues)) {
+        return false
+    } else {
+        if (issues.length > 0) {
+            console.log(
+                `Found ${issues.length} issue for ${editionId} in bucket ${bucket}. Removing ${editionId} from editions list.`,
+            )
+        }
+        return issues.length > 0
+    }
+}
+
+const removeEditionsWith0Issues = async (
+    editionsList: SpecialEdition[],
+    s3Client: S3,
+    bucket: string,
+) => {
+    const withOneIssue = await Promise.all(
+        editionsList.map(e => hasAtLeastOneIssue(e.edition, s3Client, bucket)),
+    )
+    return editionsList.filter((e, index) => withOneIssue[index])
+}
+
+const filterEditionsList = async (
+    editionsList: EditionsList,
+    s3Client: S3,
+    bucket: string,
+) => {
+    return {
+        ...editionsList,
+        specialEditions: await removeEditionsWith0Issues(
+            editionsList.specialEditions,
+            s3Client,
+            bucket,
+        ),
+    }
+}
 
 export const editionsControllerGet = async (req: Request, res: Response) => {
-    const editionsList = await s3fetch({
+    const bucket = getFrontsBucket(isPreview ? 'preview' : 'published')
+    const result = await s3fetch({
         key: 'editionsList',
-        bucket: isPreview ? 'preview' : 'published',
+        bucket: bucket,
     })
-    if (hasFailed(editionsList)) {
+    if (hasFailed(result)) {
         res.status(500)
         res.send('failed to fetch editions list - do you have credentials')
     } else {
-        const json = await editionsList.json()
+        const editionsList = (await result.json()) as { content: EditionsList }
+
+        const filteredJson: EditionsList = await filterEditionsList(
+            editionsList.content,
+            s3FrontsClient,
+            bucket,
+        )
 
         res.setHeader('Content-Type', 'application/json')
-        res.send(JSON.stringify(json))
+        res.send(JSON.stringify(filteredJson))
     }
 }
 
@@ -56,23 +119,39 @@ export const validateEditionsList = (editionList: any): boolean => {
     return false
 }
 
-const uploadEditionsList = async (list: EditionsList) => {
-    const listString = JSON.stringify(list)
+const uploadEditionsList = async (
+    proofList: EditionsList,
+    publishedList: EditionsList,
+) => {
     // write to s3 bucket for both proof/store(published)
-    await s3Put({ key: 'editions', bucket: 'proof' }, listString)
-    await s3Put({ key: 'editions', bucket: 'store' }, listString)
+    await s3Put(
+        { key: 'editions', bucket: getEditionsBucket('proof') },
+        JSON.stringify(proofList),
+    )
+    await s3Put(
+        { key: 'editions', bucket: getEditionsBucket('store') },
+        JSON.stringify(publishedList),
+    )
 }
 
 export const editionsControllerPost = async (req: Request, res: Response) => {
     const editionsListValid = validateEditionsList(req.body)
     if (editionsListValid) {
-        console.log(
-            `Edition list parsed successfully: ${JSON.stringify(
-                editionsListValid,
-            )}`,
-        )
         try {
-            await uploadEditionsList(req.body)
+            const list = req.body as EditionsList
+            const filteredProofList = await filterEditionsList(
+                list,
+                s3EditionClient(),
+                getEditionsBucket('proof'),
+            )
+
+            const filteredPublishedList = await filterEditionsList(
+                list,
+                s3EditionClient(),
+                getEditionsBucket('store'),
+            )
+
+            await uploadEditionsList(filteredProofList, filteredPublishedList)
             res.send(
                 'Succesfully uploaded editions list to proof and published buckets',
             )

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -24,7 +24,7 @@ const hasAtLeastOneIssue = async (
     )
     if (hasFailed(issues)) {
         console.log(
-            `Failed to find issue directories in bucket ${bucket}, key ${editionId}`,
+            `Failed to find issue directories in bucket ${bucket}, key ${editionId}. Error: ${issues.error} msg: ${issues.messages}`,
         )
         return false
     } else {

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -68,7 +68,9 @@ export const editionsControllerGet = async (req: Request, res: Response) => {
     })
     if (hasFailed(result)) {
         res.status(500)
-        res.send('failed to fetch editions list - do you have credentials')
+        res.send(
+            `failed to fetch editions list from bucket ${bucket} S3 Result: ${result}`,
+        )
     } else {
         const editionsList = (await result.json()) as { content: EditionsList }
 

--- a/projects/backend/controllers/editions.ts
+++ b/projects/backend/controllers/editions.ts
@@ -23,9 +23,12 @@ const hasAtLeastOneIssue = async (
         s3Client,
     )
     if (hasFailed(issues)) {
+        console.log(
+            `Failed to find issue directories in bucket ${bucket}, key ${editionId}`,
+        )
         return false
     } else {
-        if (issues.length > 0) {
+        if (issues.length == 0) {
             console.log(
                 `Found ${issues.length} issue for ${editionId} in bucket ${bucket}. Removing ${editionId} from editions list.`,
             )

--- a/projects/backend/controllers/issue.ts
+++ b/projects/backend/controllers/issue.ts
@@ -8,7 +8,7 @@ import {
 } from '../common'
 import { getIssue } from '../issue'
 import { isPreview as isPreviewStage } from '../preview'
-import { s3List } from '../s3'
+import { s3List, s3FrontsClient } from '../s3'
 import { Attempt, hasFailed } from '../utils/try'
 import {
     buildEditionRootPath as buildEditionPath,
@@ -57,7 +57,7 @@ export const getIssuesSummary = async (
      */
     const edition: EditionId = getEditionOrFallback(maybeEdition)
     const editionPath = buildEditionPath(maybeEdition, isPreview)
-    const issueKeys = await s3List(editionPath)
+    const issueKeys = await s3List(editionPath, s3FrontsClient)
 
     if (hasFailed(issueKeys)) {
         console.error('Error in issue index controller')

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -87,22 +87,19 @@ export const s3ListDirectories = async (
             }`,
         )
     }
-    if (response.KeyCount === 0) {
+    if (!response.CommonPrefixes || response.CommonPrefixes.length === 0) {
         return failure({
             httpStatus: 404,
             error: new Error(
-                `No keys returned from listObject of ${JSON.stringify(path)}`,
+                `No directories returned from listObject of ${JSON.stringify(
+                    path,
+                )}`,
             ),
         })
+    } else {
+        const directories = response.CommonPrefixes.map(cp => cp.Prefix || '')
+        return directories
     }
-    const directories = response.CommonPrefixes
-        ? response.CommonPrefixes.map(cp => cp.Prefix || '')
-        : []
-
-    if (directories.length == 0)
-        throw new Error(`Nothing at ${JSON.stringify(path)}`)
-
-    return directories
 }
 
 export const s3List = async (

--- a/projects/backend/utils/__tests__/issue.spec.ts
+++ b/projects/backend/utils/__tests__/issue.spec.ts
@@ -35,7 +35,7 @@ describe('buildIssueObjectPath', () => {
         const actual = buildIssueObjectPath(issue, isPreview)
         const expected: Path = {
             key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
-            bucket: 'preview',
+            bucket: 'preview-editions-code',
         }
         expect(actual).toStrictEqual(expected)
     })
@@ -44,7 +44,7 @@ describe('buildIssueObjectPath', () => {
         const actual = buildIssueObjectPath(issue, isPreview)
         const expected: Path = {
             key: 'daily-edition/2019-09-11/2019-10-04T11:28:04.07Z.json',
-            bucket: 'published',
+            bucket: 'published-editions-code',
         }
         expect(actual).toStrictEqual(expected)
     })
@@ -56,7 +56,7 @@ describe('buildEditionRootPath', () => {
         const actual = buildEditionRootPath(usEdition, isPreview)
         const expected: Path = {
             key: `${usEdition}/`,
-            bucket: 'preview',
+            bucket: 'preview-editions-code',
         }
         expect(actual).toStrictEqual(expected)
     })
@@ -65,7 +65,7 @@ describe('buildEditionRootPath', () => {
         const actual = buildEditionRootPath(usEdition, isPreview)
         const expected: Path = {
             key: `${usEdition}/`,
-            bucket: 'published',
+            bucket: 'published-editions-code',
         }
         expect(actual).toStrictEqual(expected)
     })
@@ -73,7 +73,7 @@ describe('buildEditionRootPath', () => {
         const isPreview = true
         const expected: Path = {
             key: 'daily-edition/',
-            bucket: 'preview',
+            bucket: 'preview-editions-code',
         }
         expect(buildEditionRootPath('', isPreview)).toStrictEqual(expected)
         expect(buildEditionRootPath(undefined, isPreview)).toStrictEqual(
@@ -84,7 +84,7 @@ describe('buildEditionRootPath', () => {
         const isPreview = false
         const expected: Path = {
             key: 'daily-edition/',
-            bucket: 'published',
+            bucket: 'published-editions-code',
         }
         expect(buildEditionRootPath('', isPreview)).toStrictEqual(expected)
         expect(buildEditionRootPath(undefined, isPreview)).toStrictEqual(

--- a/projects/backend/utils/issue.ts
+++ b/projects/backend/utils/issue.ts
@@ -1,5 +1,5 @@
 import { IssuePublicationIdentifier, EditionId } from '../common'
-import { Path } from '../s3'
+import { Path, getFrontsBucket } from '../s3'
 
 const pickBucket = (asPreview: boolean) => (asPreview ? 'preview' : 'published')
 
@@ -16,7 +16,7 @@ export const buildIssueObjectPath = (
     const { edition, issueDate, version } = issue
     return {
         key: `${edition}/${issueDate}/${version}.json`,
-        bucket: pickBucket(asPreview),
+        bucket: getFrontsBucket(pickBucket(asPreview)),
     }
 }
 
@@ -27,7 +27,7 @@ export const buildEditionRootPath = (
     const edition: EditionId = getEditionOrFallback(maybeEdition)
     return {
         key: `${edition}/`,
-        bucket: pickBucket(asPreview),
+        bucket: getFrontsBucket(pickBucket(asPreview)),
     }
 }
 


### PR DESCRIPTION
## Summary
We don't want users to see editions which have no issues. This change modifies the two places where the /editions endpoint is generated - in the `editionsControllerGet` controller (used by Preview API) and the `editionsControllerPost` (used to update the editions list in PROOF/PROD when someone clicks the 'republish' button in the fronts tool). 

The change in itself is pretty simple - count the number of issues and check if that number is greater than 0. As part of this I had to add a new function to 'list directories' rather than keys - this essentially counts each 'date' folder (so if an issue was republished N times in one day it still only counts as 1 issue).

To confuse things, I've also modified the existing s3 functions to make them more generic - they now take an `s3Client` rather than being hard coded to a specific s3 client - likewise the `bucket` is now passed in as a string rather than generated. Sorry about this - I think these changes are an improvement, but should really be in a different PR. Happy to pull them out, but it would be a bit of a pain to do so. 

[**Trello Card ->**](https://trello.com/c/LzFr1DhC/1570-editions-list-should-not-prematurely-expose-forthcoming-special-editions)

## Test Plan
I've tested this on CODE:
 - verified that the daily edition still publishes
 - verified that editions with 0 issues don't appear in /editions list
 - verified that editions with 1 issue appear in /editions list
