### PR TITLE
chore: getIssueSummary needs more info to debug

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -8,6 +8,7 @@ import { IssueSummary } from '../common'
 import { fetchAndStoreIssueSummary, readIssueSummary } from '../helpers/files'
 import { getSetting } from '../helpers/settings'
 import { useQuery } from './apollo'
+import { errorService } from 'src/services/errors'
 
 interface IssueSummaryState {
     __typename: 'IssueSummary'
@@ -28,8 +29,14 @@ const getIssueSummary = async (
             ? await fetchAndStoreIssueSummary()
             : await readIssueSummary()
     const maxAvailableEditions = await getSetting('maxAvailableEditions')
-    const trimmedSummary = issueSummary.slice(0, maxAvailableEditions)
-    return trimmedSummary
+    try {
+        const trimmedSummary = issueSummary.slice(0, maxAvailableEditions)
+        return trimmedSummary
+    } catch (e) {
+        e.message = `getIssueSummary error: maxAvailableEditions: ${maxAvailableEditions} & issueSummary: ${issueSummary}`
+        errorService.captureException(e)
+        throw Error(e)
+    }
 }
 
 const issueSummaryToLatestPath = (issueSummary: IssueSummary[]): PathToIssue =>


### PR DESCRIPTION
## Summary
Relates to this error: https://sentry.io/organizations/the-guardian/issues/1396286427/?project=1519156&query=dist%3A817&statsPeriod=7d

Its clear the issueSummary is not an array. But it cannot be null with all the fallbacks in place. If it is, we need to replace the file system logic with async storage. If it isn't, we should get a better idea of what is going on from this PR.