### PR TITLE
Use device locale for date formatting

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import React, { useState } from 'react'
 import { Text, TouchableWithoutFeedback, View, Image } from 'react-native'
 import { SpecialEditionButtonStyles } from 'src/common'
@@ -47,10 +46,7 @@ const SpecialEditionButton = ({
                     <Text style={defaultStyles.title}>{title}</Text>
                     <Text style={defaultStyles.subTitle}>{subTitle}</Text>
                     <Text style={defaultStyles.expiry}>
-                        Available until{' '}
-                        {moment(expiry)
-                            .local()
-                            .format('l')}
+                        Available until {expiry.toLocaleDateString()}
                     </Text>
                 </View>
             </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -85,8 +85,7 @@ Monthly
         }
       }
     >
-      Available until
-       
+      Available until 
       2/1/1998
     </Text>
   </View>
@@ -178,8 +177,7 @@ Monthly
         }
       }
     >
-      Available until
-       
+      Available until 
       2/1/1998
     </Text>
   </View>


### PR DESCRIPTION
## Summary
This PR is a small fix to use the device locale to format the expiry date for special editions, it seems `moment` wasn't working as expected so I have chosen to use the `toLocaleDateString` which defaults to use the devices locale and the short format we require. 
<!-- 
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/kHD3DpG4/1571-respect-locale-on-expiry-of-special-editions)

## Test Plan
There was no special edition at the time of testing so I tested it by displaying the localized string in the regional buttons and by changing device locales (see screenshots)
| UK | US |
| --- | --- |
![Simulator Screen Shot - iPad Air - 2020-09-17 at 14 37 29](https://user-images.githubusercontent.com/53755195/93482740-f2108180-f8f7-11ea-9261-81b41fb54fa1.png) | ![Simulator Screen Shot - iPad Air - 2020-09-17 at 14 36 45](https://user-images.githubusercontent.com/53755195/93482809-03598e00-f8f8-11ea-81c9-3cefb847c474.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
