### PR TITLE
fix: Remove whitespace on email input

### DIFF
--- a/projects/Mallard/src/screens/log-in.tsx
+++ b/projects/Mallard/src/screens/log-in.tsx
@@ -116,8 +116,9 @@ const Login = ({
     const [showError, setShowError] = useState(false)
 
     const onInputChange = (fn: (value: string) => void) => (value: string) => {
+        const email = value.trim()
         setShowError(false)
-        fn(value)
+        fn(email)
     }
 
     return (


### PR DESCRIPTION
## Summary
Emails are invalid if they have a space in them. This removes whitespace on email entry.

[**Trello Card ->**](https://trello.com/c/WdfTMnyd/1444-blank-spaces-not-removed-from-email-address-field-in-subscription-form)