### PR TITLE
format-all-bullets-not-just-the-first

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -60,7 +60,7 @@ As well as list items bullet points from composer can be sent as a unicode chara
 This method applies a class to the bullet string in order to add stlying through css 
 */
 const cleanupBullets = (html: string) => {
-    return html.replaceAll('•', `<span class="bullet">•</span>`)
+    return html.replace(/•/g, `<span class="bullet">•</span>`)
 }
 
 const renderArticleContent = (

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -60,7 +60,7 @@ As well as list items bullet points from composer can be sent as a unicode chara
 This method applies a class to the bullet string in order to add stlying through css 
 */
 const cleanupBullets = (html: string) => {
-    return html.replace('•', `<span class="bullet">•</span>`)
+    return html.replaceAll('•', `<span class="bullet">•</span>`)
 }
 
 const renderArticleContent = (


### PR DESCRIPTION
## Summary
This PR formats all alt-8 bullets and not just the first 🤦🏻‍♀️
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/XBFxWJzw/1270-snaggin-bullet-points)

## Test Plan
Go to Journal and view 3rd last article Eric obituary and check both bullet points render correctly. (see screenshots) 
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 11 - 2020-09-18 at 11 03 14](https://user-images.githubusercontent.com/53755195/93585600-f2b02300-f99e-11ea-940b-e90f88d9d692.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-18 at 11 03 06](https://user-images.githubusercontent.com/53755195/93585605-f479e680-f99e-11ea-91e3-d263483cdbd4.png)


<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
