### PR TITLE
Remove animation method to support < iOS 12

### DIFF
--- a/projects/Mallard/src/helpers/features.ts
+++ b/projects/Mallard/src/helpers/features.ts
@@ -1,9 +1,5 @@
 import { Platform } from 'react-native'
 
-export const supportsAnimation = () =>
-    (Platform.OS === 'ios' && parseInt(String(Platform.Version), 10) >= 12) ||
-    Platform.OS === 'android'
-
 export const supportsTransparentCards = () => Platform.OS === 'ios'
 
 export const supportsAnimatedClipView = () => Platform.OS === 'ios'

--- a/projects/Mallard/src/navigation/navigators/article.tsx
+++ b/projects/Mallard/src/navigation/navigators/article.tsx
@@ -8,10 +8,7 @@ import {
     NavigationTransitionProps,
 } from 'react-navigation'
 import { ClipFromTop } from 'src/components/layout/animators/clipFromTop'
-import {
-    supportsTransparentCards,
-    supportsAnimation,
-} from 'src/helpers/features'
+import { supportsTransparentCards } from 'src/helpers/features'
 import { getScreenPositionOfItem } from 'src/navigation/navigators/article/positions'
 import { useDimensions } from 'src/hooks/use-config-provider'
 import { color } from 'src/theme/color'
@@ -199,10 +196,9 @@ const createArticleNavigator = (
             front,
             () => animatedValue,
         ),
-        [routeNames.Article]:
-            !supportsAnimation() || !supportsTransparentCards()
-                ? wrapInBasicCard(article, () => new Animated.Value(1))
-                : wrapInSlideCard(article, () => animatedValue),
+        [routeNames.Article]: !supportsTransparentCards()
+            ? wrapInBasicCard(article, () => new Animated.Value(1))
+            : wrapInSlideCard(article, () => animatedValue),
     }
 
     const transitionConfig = (transitionProps: NavigationTransitionProps) => {
@@ -216,24 +212,13 @@ const createArticleNavigator = (
         }
     }
 
-    if (!supportsAnimation()) {
-        return createStackNavigator(navigation, {
-            initialRouteName: routeNames.Issue,
-            defaultNavigationOptions: {
-                gesturesEnabled: false,
-            },
-            headerMode: 'none',
-            mode: 'modal',
-        })
-    }
-
     return createStackNavigator(navigation, {
         initialRouteName: routeNames.Issue,
         defaultNavigationOptions: {
             gesturesEnabled: false,
         },
         headerMode: 'none',
-        ...(supportsTransparentCards() && supportsAnimation()
+        ...(supportsTransparentCards()
             ? {
                   mode: 'modal',
                   transparentCard: true,

--- a/projects/Mallard/src/navigation/navigators/sidebar.tsx
+++ b/projects/Mallard/src/navigation/navigators/sidebar.tsx
@@ -14,7 +14,6 @@ import {
     NavigationTransitionProps,
 } from 'react-navigation'
 import { ariaHidden } from 'src/helpers/a11y'
-import { supportsAnimation } from 'src/helpers/features'
 import { safeInterpolation } from 'src/helpers/math'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { color } from 'src/theme/color'
@@ -125,14 +124,7 @@ export const createSidebarNavigator = (
         _: addViewsForMainLayer(mainRoute, () => animatedValue),
     }
     for (const [key, value] of Object.entries(sidebarRoute)) {
-        if (!supportsAnimation()) {
-            navigation[key] = value
-        } else {
-            navigation[key] = addViewsForSidebarLayer(
-                value,
-                () => animatedValue,
-            )
-        }
+        navigation[key] = addViewsForSidebarLayer(value, () => animatedValue)
     }
 
     const transitionConfig = (transitionProps: NavigationTransitionProps) => {

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -2,7 +2,6 @@ import ViewPagerAndroid from '@react-native-community/viewpager'
 import React, { useEffect, useRef, useState } from 'react'
 import { Animated, Platform, StyleSheet, View } from 'react-native'
 import { AnimatedFlatListRef } from 'src/components/front/helpers/helpers'
-import { supportsAnimation } from 'src/helpers/features'
 import { clamp } from 'src/helpers/math'
 import { getColor } from 'src/helpers/transform'
 import { getAppearancePillar } from 'src/hooks/use-article'
@@ -305,32 +304,18 @@ const ArticleSlider = React.memo(
                             position={index}
                             onShouldShowHeaderChange={onShouldShowHeaderChange}
                             shouldShowHeader={shouldShowHeader}
-                            topPadding={
-                                supportsAnimation()
-                                    ? HEADER_HIGH_END_HEIGHT
-                                    : HEADER_LOW_END_HEIGHT
-                            }
+                            topPadding={HEADER_HIGH_END_HEIGHT}
                             onIsAtTopChange={onIsAtTopChange}
                         />
                     )}
                 />
 
-                {!supportsAnimation() && (
-                    <SliderHeaderLowEnd
-                        isShown={shouldShowHeader}
-                        isAtTop={isAtTop}
-                        sliderDetails={sliderDetails}
-                    />
-                )}
-
-                {supportsAnimation() && (
-                    <SliderHeaderHighEnd
-                        isShown={shouldShowHeader}
-                        isAtTop={isAtTop}
-                        panResponder={panResponder}
-                        sliderDetails={sliderDetails}
-                    />
-                )}
+                <SliderHeaderHighEnd
+                    isShown={shouldShowHeader}
+                    isAtTop={isAtTop}
+                    panResponder={panResponder}
+                    sliderDetails={sliderDetails}
+                />
 
                 {preview && (
                     <PreviewControls goNext={goNext} goPrevious={goPrevious} />


### PR DESCRIPTION
## Summary
When investigating the issue with tops of some articles being cropped on android I noticed that there is a legacy `supportsAnimation` method which was only required for older devices specifically < iOS 12, which we no longer support.
This PR cleans up the related code. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->