### PR TITLE
iOS 14 - stop article overlay overlapping status bar

### DIFF
--- a/projects/Mallard/src/navigation/navigators/article/transition.tsx
+++ b/projects/Mallard/src/navigation/navigators/article/transition.tsx
@@ -16,7 +16,7 @@ const getScaleForArticle = (width: LayoutRectangle['width']) => {
 }
 
 const issueScreenInterpolator = (sceneProps: NavigationTransitionProps) => {
-    // FIXME - iOS13 hack for dodgy background scale issue
+    // FIXME - iOS13 and above hack for dodgy background scale issue
     const majorVersionIOS =
         Platform.OS === 'ios' ? parseInt(Platform.Version as string, 10) : 0
     const { position, scene } = sceneProps
@@ -34,7 +34,7 @@ const issueScreenInterpolator = (sceneProps: NavigationTransitionProps) => {
         outputRange: safeInterpolation([
             1,
             1,
-            majorVersionIOS === 13 ? 1 : minScale,
+            majorVersionIOS >= 13 ? 1 : minScale,
         ]),
     })
     const borderRadius = position.interpolate({

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -14,9 +14,9 @@ const basicMetrics = {
 const buttonHeight = getFont('sans', 1).fontSize + basicMetrics.vertical * 2.5
 const sides = basicMetrics.horizontal
 
-// FIXME - iOS13 hack for dodgy background scale issue
+// FIXME - iOS13 and above hack for dodgy background scale issue
 const slideCardSpacing = () => {
-    if (Platform.OS === 'ios' && iosMajorVersion === 13) {
+    if (Platform.OS === 'ios' && iosMajorVersion >= 13) {
         return 40
     } else if (Platform.OS === 'ios') {
         return spacing[5]


### PR DESCRIPTION
## Summary
When testing on iOS 14 we noticed that the article overlay is overlapping the status bar. 
This PR extends a hack we added for iOS 13 to include OS versions above 13 also. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/b/7LS3epPT/editions-platform)

## Test Plan
| Before | After |
| --- | --- |
![IMG-4311](https://user-images.githubusercontent.com/53755195/93605707-03709100-f9bf-11ea-9b65-2d1b00a719e9.png) | ![IMG-4312](https://user-images.githubusercontent.com/53755195/93605720-079cae80-f9bf-11ea-90e0-7215c6d87a8f.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
