### PR TITLE
Increase header height on android tablet 

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderHeaderLowEnd.tsx
@@ -9,7 +9,7 @@ import DeviceInfo from 'react-native-device-info'
 const HEADER_LOW_END_HEIGHT = DeviceInfo.isTablet()
     ? Platform.OS === 'ios'
         ? 160
-        : 100
+        : 140
     : 110
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
There have been reports in the beta that the captions in main media image are cut off on android tablet, there has also recently been a report of a header in cartoon articles also being hidden. 

This PR increases the `HEADER_LOW_END_HEIGHT` constant which we use to apply top padding to the article header. 
This value I have changed is **only** applicable to android tablets. 

Interestingly this value was updated as part of this [PR](https://github.com/guardian/editions/pull/1059) which was a design request to reduce top padding so by increasing this constant there shouldn't be any breaking changes only increase the top space. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/TJADXMvM/1392-bug-android-headlines-images-and-captions-obscured-on-tablet)

## Test Plan
Check a cartoon article's header or select a caption on main media on android tablet to ensure they are no longer obscured. 

| Before | After |
| --- | --- | 
![Screenshot_1600434483](https://user-images.githubusercontent.com/53755195/93607094-ca392080-f9c0-11ea-8579-9dcf0b9c890a.png) | ![Screenshot_1600434465](https://user-images.githubusercontent.com/53755195/93607103-cc02e400-f9c0-11ea-8950-5e92f1c0744a.png)
![Screenshot_1600434488](https://user-images.githubusercontent.com/53755195/93607127-d4f3b580-f9c0-11ea-83d3-af80f3c81d32.png) | ![Screenshot_1600434501](https://user-images.githubusercontent.com/53755195/93607139-d7560f80-f9c0-11ea-878c-13b211eee6c3.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
