### PR TITLE
Use EditionsList type everywhere.

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -3,7 +3,7 @@ import { Platform, Settings } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { IdentityAuthData } from 'src/authentication/authorizers/IdentityAuthorizer'
 import { ReceiptIOS } from 'src/authentication/services/iap'
-import { RegionalEdition, SpecialEdition } from 'src/common'
+import { RegionalEdition, SpecialEdition, EditionsList } from 'src/common'
 import {
     LEGACY_SUBSCRIBER_ID_USER_DEFAULT_KEY,
     LEGACY_SUBSCRIBER_POSTCODE_USER_DEFAULT_KEY,
@@ -81,10 +81,7 @@ const showAllEditionsCache = createAsyncCache<boolean>('showAllEditions')
 
 const defaultEditionCache = createAsyncCache<RegionalEdition>('defaultEdition')
 
-const editionsListCache = createAsyncCache<{
-    regionalEditions: RegionalEdition[]
-    specialEditions: SpecialEdition[]
-}>('editionsList')
+const editionsListCache = createAsyncCache<EditionsList>('editionsList')
 
 const pushRegisteredTokens = createAsyncCache<PushToken[]>(
     'push-registered-tokens',

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
@@ -27,6 +27,7 @@ describe('useEditions', () => {
             const editionsList = {
                 regionalEditions: defaultRegionalEditions,
                 specialEditions: [],
+                trainingEditions: [],
             }
 
             await defaultEditionDecider(

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -230,16 +230,12 @@ describe('useEditions', () => {
         it('should set default and selected edition local state as well as selected storage if found in default storage', async () => {
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
-            const editionsList = {
-                regionalEditions: defaultRegionalEditions,
-                specialEditions: [],
-            }
             defaultEditionCache.set(defaultRegionalEditions[1])
 
             await defaultEditionDecider(
                 defaultLocalState,
                 selectedLocalState,
-                editionsList,
+                DEFAULT_EDITIONS_LIST,
             )
             expect(defaultLocalState).toBeCalledTimes(1)
             expect(defaultLocalState).toBeCalledWith(defaultRegionalEditions[1])
@@ -256,15 +252,11 @@ describe('useEditions', () => {
             // defaultRegionalEditions[1] = AU and locale mock = AU
             const defaultLocalState = jest.fn()
             const selectedLocalState = jest.fn()
-            const editionsList = {
-                regionalEditions: defaultRegionalEditions,
-                specialEditions: [],
-            }
 
             await defaultEditionDecider(
                 defaultLocalState,
                 selectedLocalState,
-                editionsList,
+                DEFAULT_EDITIONS_LIST,
             )
             expect(defaultLocalState).toBeCalledTimes(1)
             expect(defaultLocalState).toBeCalledWith(defaultRegionalEditions[1])

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -25,17 +25,10 @@ import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
 import moment from 'moment'
-
-// NOTE: This is *almost* a duplicate of the EditionsList type except without trainingEditions
-// the editions client doesn't care about trainingEditions (but the backend does), so here in the client
-// we use a type without trainingEditions so we can ignore them
-export interface EditionsEndpoint {
-    regionalEditions: RegionalEdition[]
-    specialEditions: SpecialEdition[]
-}
+import { EditionsList } from '../../../Apps/common/src'
 
 interface EditionState {
-    editionsList: EditionsEndpoint
+    editionsList: EditionsList
     selectedEdition: RegionalEdition | SpecialEdition
     defaultEdition: RegionalEdition
     storeSelectedEdition: (
@@ -54,13 +47,14 @@ export interface StoreSelectedEditionFunc {
 export const DEFAULT_EDITIONS_LIST = {
     regionalEditions: defaultRegionalEditions,
     specialEditions: [],
+    trainingEditions: [],
 }
 
 export const BASE_EDITION = defaultRegionalEditions[0]
 
 const localeToEdition = (
     locale: Locale,
-    editionsList: EditionsEndpoint,
+    editionsList: EditionsList,
 ): RegionalEdition => {
     return (
         editionsList.regionalEditions.find(
@@ -99,7 +93,7 @@ export const getDefaultEditionSlug = async () => {
 
 export const fetchEditions = async (
     apiUrl: string,
-): Promise<EditionsEndpoint | null> => {
+): Promise<EditionsList | null> => {
     try {
         const response = await fetch(apiUrl, {
             headers: {
@@ -122,8 +116,8 @@ export const fetchEditions = async (
 }
 
 export const removeExpiredSpecialEditions = (
-    editionsList: EditionsEndpoint,
-): EditionsEndpoint => {
+    editionsList: EditionsList,
+): EditionsList => {
     return {
         ...editionsList,
         specialEditions: editionsList.specialEditions.filter(e =>
@@ -187,7 +181,7 @@ const setEdition = async (
 export const defaultEditionDecider = async (
     setDefaultEdition: Dispatch<RegionalEdition>,
     setSelectedEdition: Dispatch<RegionalEdition | SpecialEdition>,
-    editionsList: EditionsEndpoint,
+    editionsList: EditionsList,
 ): Promise<void> => {
     // When user already has default edition set then that edition
     const dE = await getDefaultEdition()
@@ -222,10 +216,9 @@ export const EditionProvider = ({
 }: {
     children: React.ReactNode
 }) => {
-    const [editionsList, setEditionsList] = useState<EditionsEndpoint>({
-        regionalEditions: defaultRegionalEditions,
-        specialEditions: [],
-    })
+    const [editionsList, setEditionsList] = useState<EditionsList>(
+        DEFAULT_EDITIONS_LIST,
+    )
     const [selectedEdition, setSelectedEdition] = useState<
         RegionalEdition | SpecialEdition
     >(BASE_EDITION)

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -25,7 +25,7 @@ import { locale } from 'src/helpers/locale'
 import { pushNotifcationRegistration } from 'src/notifications/push-notifications'
 import { useApiUrl } from './use-settings'
 import moment from 'moment'
-import { EditionsList } from '../../../Apps/common/src'
+import { EditionsList } from 'src/common'
 
 interface EditionState {
     editionsList: EditionsList


### PR DESCRIPTION
## Summary
Following a discussion, we have agreed that the editions app might in future want to know about training editions, so here I've deprecated the `EditionsEndpoint` type which dropped these and switched to using `EditionsList` everywhere. 

## Test Plan

I've run this in the simulator and it seems ok, I'm mainly relying on typescript to shout at me if I've messed this up!
