### PR TITLE
Expiry date is a string.

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -605,6 +605,6 @@ export interface TrainingEdition extends EditionInterface {}
 export interface SpecialEdition extends EditionInterface {
     buttonStyle: SpecialEditionButtonStyles
     buttonImageUri: string
-    expiry: Date
+    expiry: string // ISO string e.g. 2020-11-07T23:59:00.000Z
     headerStyle?: SpecialEditionHeaderStyles
 }

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.stories.tsx
@@ -9,7 +9,7 @@ const props: { specialEditions: SpecialEdition[] } = {
     specialEditions: [
         {
             edition: 'daily-edition' as EditionId,
-            expiry: new Date(98, 1),
+            expiry: new Date(98, 1).toISOString(),
             buttonImageUri:
                 'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
             topic: 'food',

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -60,7 +60,7 @@ const EditionsMenu = ({
                             return (
                                 <SpecialEditionButton
                                     buttonImageUri={buttonImageUri}
-                                    expiry={expiry}
+                                    expiry={new Date(expiry)}
                                     onPress={() => {
                                         storeSelectedEdition(
                                             item,

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -51,7 +51,7 @@ const regionalEditions: RegionalEdition[] = [
 const specialEditions: SpecialEdition[] = [
     {
         edition: 'daily-edition' as EditionId,
-        expiry: new Date(98, 1),
+        expiry: new Date(98, 1).toISOString(),
         editionType: 'Special',
         notificationUTCOffset: 1,
         topic: 'food',

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -203,7 +203,7 @@ Saturday by 6 am (AEST)",
             },
             "edition": "daily-edition",
             "editionType": "Special",
-            "expiry": 1998-02-01T00:00:00.000Z,
+            "expiry": "1998-02-01T00:00:00.000Z",
             "header": Object {
               "subTitle": "Monthly",
               "title": "Food",

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -31,7 +31,7 @@ jest.mock('src/services/remote-config', () => ({
 const specialEditions: SpecialEdition[] = [
     {
         edition: 'special-edition-expired' as EditionId,
-        expiry: new Date(2020, 1, 1),
+        expiry: new Date(2020, 1, 1).toISOString(),
         editionType: 'Special',
         notificationUTCOffset: 1,
         topic: 'food',
@@ -73,7 +73,7 @@ Monthly`,
     },
     {
         edition: 'special-edition-notexpired' as EditionId,
-        expiry: new Date(3000, 3, 1),
+        expiry: new Date(3000, 3, 1).toISOString(),
         editionType: 'Special',
         notificationUTCOffset: 1,
         topic: 'food',


### PR DESCRIPTION
## Summary

We have a bug at the moment when trying to load the editions menu. This is caused by a [call to `toLocaleDateString`](https://github.com/guardian/editions/blob/master/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx#L49) on expiry, which turns out to not be a `Date`after all but really a string. My solution (up for debate) is that - since we are getting the editions list from a JSON endpoint with no type information - we should treat it as a string until we have explicitly converted it into a `Date`. 

The alternative I guess would be to write some kind of 'special edition parser' which does this step...

Screenshot of the bug:

<img width="421" alt="Screenshot 2020-09-22 at 15 48 24" src="https://user-images.githubusercontent.com/3606555/93898384-1353e200-fceb-11ea-815d-f7687de83292.png">


[**Trello Card ->**](https://trello.com)

## Test Plan
This PR solves the problem indicated above, and the special editions is fairly well tested so this feels like a safe change
