### PR TITLE
Use special edition header styles in header.

### DIFF
--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -87,6 +87,7 @@ const Header = ({
 }: HeaderProps) => {
     const { top: marginTop } = useInsets()
     const bg = theme === 'light' ? styles.backgroundWhite : styles.background
+
     return (
         <WithAppAppearance value={theme === 'light' ? 'default' : 'primary'}>
             {theme === 'light' && (

--- a/projects/Mallard/src/components/layout/header/header.tsx
+++ b/projects/Mallard/src/components/layout/header/header.tsx
@@ -87,7 +87,6 @@ const Header = ({
 }: HeaderProps) => {
     const { top: marginTop } = useInsets()
     const bg = theme === 'light' ? styles.backgroundWhite : styles.background
-
     return (
         <WithAppAppearance value={theme === 'light' ? 'default' : 'primary'}>
             {theme === 'light' && (

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -5,7 +5,12 @@ import React, {
     useState,
     Dispatch,
 } from 'react'
-import { RegionalEdition, SpecialEdition, Locale } from 'src/common'
+import {
+    RegionalEdition,
+    SpecialEdition,
+    Locale,
+    SpecialEditionHeaderStyles,
+} from 'src/common'
 import { eventEmitter } from 'src/helpers/event-emitter'
 import {
     defaultSettings,
@@ -42,6 +47,14 @@ export interface StoreSelectedEditionFunc {
         chosenEdition: RegionalEdition | SpecialEdition,
         type: 'RegionalEdition' | 'SpecialEdition' | 'TrainingEdition',
     ): void
+}
+
+export const getSpecialEditionProps = (
+    edition: RegionalEdition | SpecialEdition,
+): { headerStyle?: SpecialEditionHeaderStyles } | undefined => {
+    return edition.editionType === 'Special'
+        ? (edition as SpecialEdition)
+        : undefined
 }
 
 export const DEFAULT_EDITIONS_LIST = {

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -45,7 +45,10 @@ import { color } from 'src/theme/color'
 import { metrics } from 'src/theme/spacing'
 import { IssueWithFronts } from '../../../Apps/common/src'
 import { ApiState } from './settings/api-screen'
-import { useEditions } from 'src/hooks/use-edition-provider'
+import {
+    useEditions,
+    getSpecialEditionProps,
+} from 'src/hooks/use-edition-provider'
 import { Copy } from 'src/helpers/words'
 
 const styles = StyleSheet.create({
@@ -437,15 +440,18 @@ const IssueListFetchContainer = () => {
 
 export const HomeScreen = () => {
     const { issueSummary, error } = useIssueSummary()
-    const {
-        selectedEdition: {
-            header: { title, subTitle },
-        },
-    } = useEditions()
+    const { selectedEdition } = useEditions()
 
+    const specialEditionProps = getSpecialEditionProps(selectedEdition)
     return (
         <WithAppAppearance value={'tertiary'}>
-            <IssuePickerHeader title={title} subTitle={subTitle} />
+            <IssuePickerHeader
+                title={selectedEdition.header.title}
+                subTitle={selectedEdition.header.subTitle}
+                headerStyles={
+                    specialEditionProps && specialEditionProps.headerStyle
+                }
+            />
             {issueSummary ? (
                 <IssueListFetchContainer />
             ) : error ? (

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -60,7 +60,11 @@ import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle'
 import { sendPageViewEvent } from 'src/services/ophan'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
-import { Front as TFront, IssueWithFronts } from '../../../Apps/common/src'
+import {
+    Front as TFront,
+    IssueWithFronts,
+    SpecialEditionHeaderStyles,
+} from '../../../Apps/common/src'
 import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
@@ -299,13 +303,19 @@ const PreviewReloadButton = ({ onPress }: { onPress: () => void }) => {
     return preview ? <ReloadButton onPress={onPress} /> : null
 }
 
-const handleError = (
+const handleError = (specialEditionProps?: {
+    headerStyle?: SpecialEditionHeaderStyles
+}) => (
     { message }: { message: string },
     _: unknown,
     { retry }: { retry: () => void },
 ) => (
     <>
-        <IssueScreenHeader />
+        <IssueScreenHeader
+            headerStyles={
+                specialEditionProps && specialEditionProps.headerStyle
+            }
+        />
 
         <FlexErrorMessage
             debugMessage={message}
@@ -316,9 +326,15 @@ const handleError = (
     </>
 )
 
-const handlePending = () => (
+const handlePending = (specialEditionProps?: {
+    headerStyle?: SpecialEditionHeaderStyles
+}) => () => (
     <>
-        <IssueScreenHeader />
+        <IssueScreenHeader
+            headerStyles={
+                specialEditionProps && specialEditionProps.headerStyle
+            }
+        />
         <FlexCenter>
             <Spinner />
         </FlexCenter>
@@ -366,8 +382,8 @@ const IssueScreenWithPath = React.memo(
         const specialEditionProps = getSpecialEditionProps(selectedEdition)
 
         return response({
-            error: handleError,
-            pending: handlePending,
+            error: handleError(specialEditionProps),
+            pending: handlePending(specialEditionProps),
             success: (issue, { retry }) => {
                 sendPageViewEvent({
                     path: `editions/uk/daily/${issue.key}`,

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -303,19 +303,13 @@ const PreviewReloadButton = ({ onPress }: { onPress: () => void }) => {
     return preview ? <ReloadButton onPress={onPress} /> : null
 }
 
-const handleError = (specialEditionProps?: {
-    headerStyle?: SpecialEditionHeaderStyles
-}) => (
+const handleError = (headerStyle?: SpecialEditionHeaderStyles) => (
     { message }: { message: string },
     _: unknown,
     { retry }: { retry: () => void },
 ) => (
     <>
-        <IssueScreenHeader
-            headerStyles={
-                specialEditionProps && specialEditionProps.headerStyle
-            }
-        />
+        <IssueScreenHeader headerStyles={headerStyle} />
 
         <FlexErrorMessage
             debugMessage={message}
@@ -326,24 +320,21 @@ const handleError = (specialEditionProps?: {
     </>
 )
 
-const handlePending = (specialEditionProps?: {
-    headerStyle?: SpecialEditionHeaderStyles
-}) => () => (
+const handlePending = (headerStyle?: SpecialEditionHeaderStyles) => () => (
     <>
-        <IssueScreenHeader
-            headerStyles={
-                specialEditionProps && specialEditionProps.headerStyle
-            }
-        />
+        <IssueScreenHeader headerStyles={headerStyle} />
         <FlexCenter>
             <Spinner />
         </FlexCenter>
     </>
 )
 
-const handleIssueScreenError = (error: string) => (
+const handleIssueScreenError = (
+    error: string,
+    headerStyle?: SpecialEditionHeaderStyles,
+) => (
     <>
-        <IssueScreenHeader />
+        <IssueScreenHeader headerStyles={headerStyle} />
         <FlexErrorMessage
             debugMessage={error}
             title={CONNECTION_FAILED_ERROR}
@@ -371,19 +362,19 @@ const IssueScreenWithPath = React.memo(
     ({
         path,
         initialFrontKey,
+        headerStyle,
     }: {
         path: PathToIssue
         initialFrontKey: string | null
+        headerStyle?: SpecialEditionHeaderStyles
     }) => {
         const isPreview = useIsPreview()
         const isProof = useIsProof()
         const response = useIssueResponse(path, isPreview)
-        const { selectedEdition } = useEditions()
-        const specialEditionProps = getSpecialEditionProps(selectedEdition)
 
         return response({
-            error: handleError(specialEditionProps),
-            pending: handlePending(specialEditionProps),
+            error: handleError(headerStyle),
+            pending: handlePending(headerStyle),
             success: (issue, { retry }) => {
                 sendPageViewEvent({
                     path: `editions/uk/daily/${issue.key}`,
@@ -410,11 +401,7 @@ const IssueScreenWithPath = React.memo(
                         />
                         <IssueScreenHeader
                             issue={issue}
-                            headerStyles={
-                                specialEditionProps
-                                    ? specialEditionProps.headerStyle
-                                    : undefined
-                            }
+                            headerStyles={headerStyle}
                         />
 
                         <WithBreakpoints>
@@ -481,20 +468,25 @@ const IssueScreenWithPath = React.memo(
 
 export const IssueScreen = () => {
     const { issueSummary, issueId, error, initialFrontKey } = useIssueSummary()
+    const { selectedEdition } = useEditions()
+    const specialEditionProps = getSpecialEditionProps(selectedEdition)
+    const headerStyle = specialEditionProps && specialEditionProps.headerStyle
     return (
         <Container>
             {issueId ? (
                 <IssueScreenWithPath
                     path={issueId}
                     initialFrontKey={initialFrontKey}
+                    headerStyle={headerStyle}
                 />
             ) : issueSummary ? (
                 <IssueScreenWithPath
                     path={issueSummaryToLatestPath(issueSummary)}
                     initialFrontKey={initialFrontKey}
+                    headerStyle={headerStyle}
                 />
             ) : error ? (
-                error && handleIssueScreenError(error)
+                error && handleIssueScreenError(error, headerStyle)
             ) : (
                 handlePending()
             )}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -64,7 +64,11 @@ import { Front as TFront, IssueWithFronts } from '../../../Apps/common/src'
 import { FrontSpec } from './article-screen'
 import { useIssueScreenSize, WithIssueScreenSize } from './issue/use-size'
 import { IssueScreenHeader } from 'src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader'
-import { useEditions, BASE_EDITION } from 'src/hooks/use-edition-provider'
+import {
+    useEditions,
+    BASE_EDITION,
+    getSpecialEditionProps,
+} from 'src/hooks/use-edition-provider'
 import RNRestart from 'react-native-restart'
 import { deleteIssueFiles } from 'src/download-edition/clear-issues'
 
@@ -358,6 +362,8 @@ const IssueScreenWithPath = React.memo(
         const isPreview = useIsPreview()
         const isProof = useIsProof()
         const response = useIssueResponse(path, isPreview)
+        const { selectedEdition } = useEditions()
+        const specialEditionProps = getSpecialEditionProps(selectedEdition)
 
         return response({
             error: handleError,
@@ -386,7 +392,14 @@ const IssueScreenWithPath = React.memo(
                                 retry()
                             }}
                         />
-                        <IssueScreenHeader issue={issue} />
+                        <IssueScreenHeader
+                            issue={issue}
+                            headerStyles={
+                                specialEditionProps
+                                    ? specialEditionProps.headerStyle
+                                    : undefined
+                            }
+                        />
 
                         <WithBreakpoints>
                             {{


### PR DESCRIPTION
## Summary

As far as I can't tell we aren't currently using the special edition header styles when instatntiating the issue header component (IssuePickerHeader/IssueScreenHeader). This change adds a function to extract these properties out of the current selected edition if it is a special edition so that we can use them.

Before:
<img width="583" alt="Screenshot 2020-09-22 at 17 35 32" src="https://user-images.githubusercontent.com/3606555/93911443-4b165600-fcfa-11ea-9e24-e4ee7b83e786.png">
After:
<img width="531" alt="Screenshot 2020-09-22 at 17 35 11" src="https://user-images.githubusercontent.com/3606555/93911435-48b3fc00-fcfa-11ea-8d52-bc7d751a85d5.png">


[**Trello Card ->**](https://trello.com/c/DKRNoRMV/1569-environment-special-switch-details)

## Test Plan
This change should have no impact on regional editions. On special editions the colours set in the fronts tool should be respected.