### PR TITLE
Special edition button - more padding

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -180,7 +180,7 @@ Monthly
       }
     >
       Available until 
-      01/02/1998
+      2/1/1998
     </Text>
   </View>
 </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -32,7 +32,6 @@ Monthly - Special Edition Button"
     style={
       Object {
         "height": 134,
-        "marginLeft": -43,
         "width": 87,
       }
     }
@@ -88,7 +87,7 @@ Monthly
       }
     >
       Available until 
-      2/1/1998
+      01/02/1998
     </Text>
   </View>
 </View>
@@ -126,7 +125,6 @@ Monthly - Special Edition Button"
     style={
       Object {
         "height": 134,
-        "marginLeft": -43,
         "width": 87,
       }
     }
@@ -182,7 +180,7 @@ Monthly
       }
     >
       Available until 
-      2/1/1998
+      01/02/1998
     </Text>
   </View>
 </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -87,7 +87,7 @@ Monthly
       }
     >
       Available until 
-      01/02/1998
+      2/1/1998
     </Text>
   </View>
 </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -32,6 +32,7 @@ Monthly - Special Edition Button"
     style={
       Object {
         "height": 134,
+        "marginLeft": -43,
         "width": 87,
       }
     }
@@ -41,7 +42,8 @@ Monthly - Special Edition Button"
       Object {
         "flexShrink": 1,
         "paddingBottom": 15,
-        "paddingLeft": 10,
+        "paddingLeft": 20,
+        "paddingRight": 20,
       }
     }
   >
@@ -124,6 +126,7 @@ Monthly - Special Edition Button"
     style={
       Object {
         "height": 134,
+        "marginLeft": -43,
         "width": 87,
       }
     }
@@ -133,7 +136,8 @@ Monthly - Special Edition Button"
       Object {
         "flexShrink": 1,
         "paddingBottom": 15,
-        "paddingLeft": 10,
+        "paddingLeft": 20,
+        "paddingRight": 20,
       }
     }
   >

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
@@ -43,8 +43,11 @@ const styles = ({
 }: {
     style: SpecialEditionButtonStyles
     selected: boolean
-}) =>
-    StyleSheet.create({
+}) => {
+    const imageWidth = (style && style.image && style.image.width) || 87
+    const imageNegativeOffset = -1 * Math.floor(imageWidth / 2)
+
+    return StyleSheet.create({
         container: {
             backgroundColor:
                 (selected ? color.primary : style && style.backgroundColor) ||
@@ -58,13 +61,16 @@ const styles = ({
             ...textFormatting(selected, style && style.expiry, expiryDefaults),
         },
         image: {
-            width: (style && style.image && style.image.width) || 87,
+            width: imageWidth,
             height: (style && style.image && style.image.height) || 134,
+            left: imageNegativeOffset,
         },
         textBox: {
             flexShrink: 1,
-            paddingLeft: 10,
+            paddingLeft: 20,
             paddingBottom: 15,
+            paddingRight: 20,
+            marginLeft: imageNegativeOffset,
         },
         title: {
             flexWrap: 'wrap',
@@ -81,5 +87,6 @@ const styles = ({
             ),
         },
     })
+}
 
 export { styles }

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
@@ -43,11 +43,8 @@ const styles = ({
 }: {
     style: SpecialEditionButtonStyles
     selected: boolean
-}) => {
-    const imageWidth = (style && style.image && style.image.width) || 87
-    const imageNegativeOffset = -1 * Math.floor(imageWidth / 2)
-
-    return StyleSheet.create({
+}) =>
+    StyleSheet.create({
         container: {
             backgroundColor:
                 (selected ? color.primary : style && style.backgroundColor) ||
@@ -61,9 +58,8 @@ const styles = ({
             ...textFormatting(selected, style && style.expiry, expiryDefaults),
         },
         image: {
-            width: imageWidth,
+            width: (style && style.image && style.image.width) || 87,
             height: (style && style.image && style.image.height) || 134,
-            marginLeft: imageNegativeOffset,
         },
         textBox: {
             flexShrink: 1,
@@ -86,6 +82,5 @@ const styles = ({
             ),
         },
     })
-}
 
 export { styles }

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
@@ -63,14 +63,13 @@ const styles = ({
         image: {
             width: imageWidth,
             height: (style && style.image && style.image.height) || 134,
-            left: imageNegativeOffset,
+            marginLeft: imageNegativeOffset,
         },
         textBox: {
             flexShrink: 1,
             paddingLeft: 20,
             paddingBottom: 15,
             paddingRight: 20,
-            marginLeft: imageNegativeOffset,
         },
         title: {
             flexWrap: 'wrap',


### PR DESCRIPTION
## Summary
I've been trying to bring the new special edition in line with the designs - this hust adds some more padding



Before:
<img width="463" alt="Screenshot 2020-09-24 at 14 31 10" src="https://user-images.githubusercontent.com/3606555/94152018-019d4680-fe73-11ea-8f51-48567d79498b.png">

After:
<img width="481" alt="Screenshot 2020-09-24 at 14 31 23" src="https://user-images.githubusercontent.com/3606555/94151959-ec281c80-fe72-11ea-9e66-d40e7b700202.png">

Figma:
<img width="795" alt="Screenshot 2020-09-24 at 14 34 26" src="https://user-images.githubusercontent.com/3606555/94152103-1c6fbb00-fe73-11ea-8783-642cda77fe4d.png">


[**Trello Card ->**](https://trello.com/c/DKRNoRMV/1569-environment-special-switch-details)

## Test Plan
This is looking pretty close to the figma design on my simulator, but we  can release to internal beta so that others can test it
