### PR TITLE
chore: Error Boundary Signposting

### DIFF
--- a/projects/Mallard/src/components/layout/ui/errors/error-boundary.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-boundary.tsx
@@ -24,6 +24,7 @@ class ErrorBoundary extends Component<
     }
 
     componentDidCatch(err: Error) {
+        err.message = `Error Boundary: ${err.message}`
         errorService.captureException(err)
     }
 


### PR DESCRIPTION
## Summary
Adds some signposting to errors captured in Sentry for the Error Boundary. This is to help highlight the issues being thrown around the "Unable to render articles" error.