### PR TITLE
Change heading of FAQ from h1 to h2.

### DIFF
--- a/projects/Mallard/src/screens/settings/faq-screen.tsx
+++ b/projects/Mallard/src/screens/settings/faq-screen.tsx
@@ -94,7 +94,7 @@ const editionsMenuButton = () => html`
 `
 
 const faqHtml = html`
-    <h1>The Guardian Editions FAQs</h1>
+    <h2>The Guardian Editions FAQs</h2>
     <h3>Contents</h3>
     <ul>
         <li>What is The Guardian Editions app?</li>


### PR DESCRIPTION
Tiny change to bring the headings in line with the other help sections