### PR TITLE
Update privacy-policy (remove [a][b][c])

### DIFF
--- a/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
+++ b/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
@@ -265,10 +265,10 @@ const privacyPolicyHtml = html`
     </p>
     <h3>Using children’s personal data</h3>
     <p>
-        This app is not aimed directly at children under the age of 13[a][b][c]
-        and we do not knowingly collect personal data via this app about
-        children under 13. Some of our services may have a higher age
-        restriction and this will be shown at the point of registration.
+        This app is not aimed directly at children under the age of 13 and we do
+        not knowingly collect personal data via this app about children under
+        13. Some of our services may have a higher age restriction and this will
+        be shown at the point of registration.
     </p>
     <h3>Security of your personal data</h3>
     <p>


### PR DESCRIPTION
## Summary
Why are we doing this?
Privacy policy update to remove [a][b][c]

[**Trello Card ->**](https://trello.com/c/0sMZRkzb/1470-privacy-policy-update-ready-to-be-added-to-the-app)

## Test Plan
Review copy and layout to check if anything is broken.
