### PR TITLE
If selectedEdition cache set, don't override.

### DIFF
--- a/projects/Apps/common/src/__tests__/fixtures/editions-fixtures.ts
+++ b/projects/Apps/common/src/__tests__/fixtures/editions-fixtures.ts
@@ -1,0 +1,81 @@
+import { EditionId, editions, RegionalEdition, SpecialEdition } from '../..'
+
+export const regionalEditions: RegionalEdition[] = [
+    {
+        title: 'UK Daily',
+        subTitle: 'Published every day by 12am (GMT)',
+        edition: editions.daily as EditionId,
+        header: {
+            title: 'UK Daily',
+            subTitle: 'Daily',
+        },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: 1,
+        locale: 'en_GB',
+    },
+    {
+        title: 'Australia Daily',
+        subTitle: 'Published every day by 9:30am (AEST)',
+        edition: editions.ausWeekly as EditionId,
+        header: {
+            title: 'Austraila',
+            subTitle: 'Weekend',
+        },
+        editionType: 'Regional',
+        topic: 'au',
+        notificationUTCOffset: 1,
+        locale: 'en_AU',
+    },
+]
+
+export const specialEditions: SpecialEdition[] = [
+    {
+        edition: 'special-edition' as EditionId,
+        expiry: new Date(98, 1).toISOString(),
+        editionType: 'Special',
+        notificationUTCOffset: 1,
+        topic: 'food',
+        title: `Food
+Monthly`,
+        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
+        header: {
+            title: 'Food',
+            subTitle: 'Monthly',
+        },
+        buttonImageUri:
+            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
+        buttonStyle: {
+            backgroundColor: '#FEEEF7',
+            expiry: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Regular',
+                lineHeight: 16,
+                size: 15,
+            },
+
+            subTitle: {
+                color: '#7D0068',
+                font: 'GuardianTextSans-Bold',
+                lineHeight: 20,
+                size: 17,
+            },
+            title: {
+                color: '#121212',
+                font: 'GHGuardianHeadline-Regular',
+                lineHeight: 34,
+                size: 34,
+            },
+            image: {
+                height: 134,
+                width: 87,
+            },
+        },
+    },
+]
+
+export const editionsListFixture = {
+    regionalEditions: regionalEditions,
+    specialEditions: specialEditions,
+    trainingEditions: [],
+}

--- a/projects/Apps/common/src/__tests__/helpers.spec.ts
+++ b/projects/Apps/common/src/__tests__/helpers.spec.ts
@@ -1,4 +1,5 @@
-import { issueSummarySort } from '../helpers'
+import { getEditionIds, issueSummarySort } from '../helpers'
+import { editionsListFixture } from './fixtures/editions-fixtures'
 
 describe('issueSummarySort', () => {
     it('should sort issues', () => {
@@ -29,6 +30,18 @@ describe('issueSummarySort', () => {
             '2019-09-29',
             '2019-09-27',
             '2019-09-24',
+        ])
+    })
+})
+
+describe('getEditionIds', () => {
+    it('should get regional and special edition ids', () => {
+        const ids = getEditionIds(editionsListFixture)
+
+        expect(ids).toEqual([
+            'daily-edition',
+            'australian-edition',
+            'special-edition',
         ])
     })
 })

--- a/projects/Apps/common/src/helpers.ts
+++ b/projects/Apps/common/src/helpers.ts
@@ -1,4 +1,4 @@
-import { IssueSummary } from '.'
+import { EditionId, EditionsList, IssueSummary } from '.'
 
 export const issueSummaryComparator = (a: IssueSummary, b: IssueSummary) => {
     return a.date.localeCompare(b.date)
@@ -7,3 +7,8 @@ export const issueSummaryComparator = (a: IssueSummary, b: IssueSummary) => {
 export const issueSummarySort = (issues: IssueSummary[]): IssueSummary[] => {
     return issues.sort(issueSummaryComparator).reverse()
 }
+
+export const getEditionIds = (editionList: EditionsList): EditionId[] =>
+    editionList.regionalEditions
+        .map(e => e.edition)
+        .concat(editionList.specialEditions.map(e => e.edition))

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/EditionsMenu.spec.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import TestRenderer, { ReactTestRendererJSON } from 'react-test-renderer'
-import { EditionId, editions } from 'src/common'
+import { editions } from 'src/common'
 import { EditionsMenu } from '../EditionsMenu'
-import { RegionalEdition, SpecialEdition } from '../../../../../Apps/common/src'
+import {
+    regionalEditions,
+    specialEditions,
+} from '../../../../../Apps/common/src/__tests__/fixtures/editions-fixtures'
 
 jest.mock('src/components/EditionsMenu/RegionButton/RegionButton', () => ({
     RegionButton: () => 'RegionButton',
@@ -18,80 +21,6 @@ jest.mock(
 jest.mock('src/components/EditionsMenu/Header/Header', () => ({
     EditionsMenuHeader: () => 'EditionsMenuHeader',
 }))
-
-const regionalEditions: RegionalEdition[] = [
-    {
-        title: 'UK Daily',
-        subTitle: 'Published every day by 12am (GMT)',
-        edition: editions.daily as EditionId,
-        header: {
-            title: 'UK Daily',
-            subTitle: 'Daily',
-        },
-        editionType: 'Regional',
-        topic: 'au',
-        notificationUTCOffset: 1,
-        locale: 'en_GB',
-    },
-    {
-        title: 'Australia Daily',
-        subTitle: 'Published every day by 9:30am (AEST)',
-        edition: editions.ausWeekly as EditionId,
-        header: {
-            title: 'Austraila',
-            subTitle: 'Weekend',
-        },
-        editionType: 'Regional',
-        topic: 'au',
-        notificationUTCOffset: 1,
-        locale: 'en_AU',
-    },
-]
-
-const specialEditions: SpecialEdition[] = [
-    {
-        edition: 'daily-edition' as EditionId,
-        expiry: new Date(98, 1).toISOString(),
-        editionType: 'Special',
-        notificationUTCOffset: 1,
-        topic: 'food',
-        title: `Food
-Monthly`,
-        subTitle: 'Store cupboard special: 20 quick and easy lockdown suppers',
-        header: {
-            title: 'Food',
-            subTitle: 'Monthly',
-        },
-        buttonImageUri:
-            'https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png',
-        buttonStyle: {
-            backgroundColor: '#FEEEF7',
-            expiry: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Regular',
-                lineHeight: 16,
-                size: 15,
-            },
-
-            subTitle: {
-                color: '#7D0068',
-                font: 'GuardianTextSans-Bold',
-                lineHeight: 20,
-                size: 17,
-            },
-            title: {
-                color: '#121212',
-                font: 'GHGuardianHeadline-Regular',
-                lineHeight: 34,
-                size: 34,
-            },
-            image: {
-                height: 134,
-                width: 87,
-            },
-        },
-    },
-]
 
 const props = {
     navigationPress: () => {},

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -201,7 +201,7 @@ Saturday by 6 am (AEST)",
                 "size": 34,
               },
             },
-            "edition": "daily-edition",
+            "edition": "special-edition",
             "editionType": "Special",
             "expiry": "1998-02-01T00:00:00.000Z",
             "header": Object {

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -1,8 +1,8 @@
 import { unzip } from 'react-native-zip-archive'
 import RNFS from 'react-native-fs'
-import { Issue } from 'src/common'
+import { Issue, IssueSummary } from 'src/common'
 import { FSPaths } from 'src/paths'
-import { IssueSummary, EditionInterface } from '../../../Apps/common/src'
+import { getEditionIds } from '../../../Apps/common/src/helpers'
 import { imageForScreenSize } from './screen'
 import { getSetting } from './settings'
 import { defaultSettings } from './settings/defaults'
@@ -35,9 +35,6 @@ export const fileIsIssue = (file: File): file is IssueFile =>
 export const ensureDirExists = (dir: string): Promise<void> =>
     RNFS.mkdir(dir).catch(() => Promise.resolve())
 
-const extractEditionIds = (editionList: EditionInterface[]) =>
-    editionList.map(e => e.edition)
-
 /*
 We always try to prep the file system before accessing issuesDir
 */
@@ -45,11 +42,7 @@ export const prepFileSystem = async (): Promise<void> => {
     await ensureDirExists(FSPaths.issuesDir)
     await ensureDirExists(FSPaths.downloadRoot)
     const editionsList = await editionsListCache.get()
-    const editionIds = editionsList
-        ? extractEditionIds(editionsList.regionalEditions).concat(
-              extractEditionIds(editionsList.specialEditions),
-          )
-        : []
+    const editionIds = editionsList ? getEditionIds(editionsList) : []
 
     await Promise.all(
         editionIds.map(edition =>

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -133,6 +133,7 @@ describe('useEditions', () => {
     describe('getSelectedEditionSlug', () => {
         beforeEach(async () => {
             await selectedEditionCache.reset()
+            await editionsListCache.reset()
         })
         it('should return the default slug as there is nothing in Async Storage', async () => {
             const editionSlug = await getSelectedEditionSlug()
@@ -140,6 +141,7 @@ describe('useEditions', () => {
         })
         it('should return "australian-edition" slug when the AU edition is set', async () => {
             await selectedEditionCache.set(defaultRegionalEditions[1])
+            await editionsListCache.set(DEFAULT_EDITIONS_LIST)
             const editionSlug = await getSelectedEditionSlug()
             expect(editionSlug).toEqual('australian-edition')
         })

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -85,8 +85,16 @@ const defaultState: EditionState = {
 
 const EditionContext = createContext(defaultState)
 
+const getSelectedEdition = async () => {
+    try {
+        return await selectedEditionCache.get()
+    } catch {
+        return null
+    }
+}
+
 export const getSelectedEditionSlug = async () => {
-    const edition = await selectedEditionCache.get()
+    const edition = await getSelectedEdition()
     return edition ? edition.edition : BASE_EDITION.edition
 }
 
@@ -196,12 +204,17 @@ export const defaultEditionDecider = async (
     setSelectedEdition: Dispatch<RegionalEdition | SpecialEdition>,
     editionsList: EditionsList,
 ): Promise<void> => {
+    const selectedEdition = await getSelectedEdition()
     // When user already has default edition set then that edition
-    const dE = await getDefaultEdition()
-    if (dE) {
-        setDefaultEdition(dE)
-        setSelectedEdition(dE)
-        await selectedEditionCache.set(dE)
+    const defaultEdition = await getDefaultEdition()
+
+    // if user has already selected an edition, use that one
+    if (selectedEdition) {
+        setSelectedEdition(selectedEdition)
+    } else if (defaultEdition) {
+        setDefaultEdition(defaultEdition)
+        setSelectedEdition(defaultEdition)
+        await selectedEditionCache.set(defaultEdition)
         pushNotificationRegistration()
     } else {
         // Get the correct edition for the device locale

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -31,6 +31,7 @@ import { pushNotificationRegistration } from 'src/notifications/push-notificatio
 import { useApiUrl } from './use-settings'
 import moment from 'moment'
 import { EditionsList } from 'src/common'
+import { getEditionIds } from '../../../Apps/common/src/helpers'
 
 interface EditionState {
     editionsList: EditionsList
@@ -87,7 +88,13 @@ const EditionContext = createContext(defaultState)
 
 const getSelectedEdition = async () => {
     try {
-        return await selectedEditionCache.get()
+        const selected = await selectedEditionCache.get()
+        const editionsList = await editionsListCache.get()
+        const editionIds = editionsList ? getEditionIds(editionsList) : []
+
+        return selected && editionIds.includes(selected.edition)
+            ? selected
+            : null
     } catch {
         return null
     }


### PR DESCRIPTION
## Summary

Currently we have an issue where if you select a non-Regional edition then background the app, it gets overridden by the current default edition. I'm not certain what the right thing to do here is, but I *think* we should just respect whatever edition the user last selected, if they have selected one. The situation where we don't want to do that is if their selected edition is an expired  special edition, so this PR includes a check that the selectedEdition is in the editionList.

...I ended up pulling the function to turn an EditionsList into a list of ids out of the `files` file and into common as I think it'll be useful in the backend too. Have added a test for this functionality as well


[**Trello Card ->**](https://trello.com/c/0OBo4nQl/1591-special-edition-issue-menu-sometimes-has-the-wrong-title)

## Test Plan

I've tested this in the simulator. Things to test:

 - correct edition is set on app restart
 - correct editions issue picker header after backgrounding the app
 - correct edition highlighted in editions menu on restart and after backgrounding the app
