### PR TITLE
Reduce font size for opinion cards on small phones

### DIFF
--- a/projects/Mallard/src/theme/typography.ts
+++ b/projects/Mallard/src/theme/typography.ts
@@ -185,8 +185,8 @@ const scale = {
         },
         1.25: {
             [Breakpoints.smallPhone]: {
-                fontSize: 24,
-                lineHeight: 26,
+                fontSize: 20,
+                lineHeight: 23,
             },
             [Breakpoints.phone]: {
                 fontSize: 24,


### PR DESCRIPTION
## Summary
The byline wasn't always showing on smaller screens, particularly on opinion cards. 
This PR reduces the font size so that both the byline fits below the headline on smaller phones. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/Wq3Crctl/1589-byline-not-showing-on-smaller-screens-opinion-fronts-au-edition)

## Test Plan
| Before | After |
| --- | --- |
![Simulator Screen Shot - iPhone 5s - 2020-09-29 at 08 33 34](https://user-images.githubusercontent.com/53755195/94527177-8222c500-022e-11eb-89ed-67b875d02243.png) | ![Simulator Screen Shot - iPhone 5s - 2020-09-28 at 15 56 00](https://user-images.githubusercontent.com/53755195/94527288-a67ea180-022e-11eb-80d8-87c4fb5f2b9f.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
