### PR TITLE
Align special edition text with regional edition text.

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -8,6 +8,8 @@ import { ItemSeperator } from './ItemSeperator/ItemSeperator'
 import { RegionButton } from './RegionButton/RegionButton'
 import { SpecialEditionButton } from './SpecialEditionButton/SpecialEditionButton'
 
+export const EDITIONS_MENU_TEXT_LEFT_PADDING = 96
+
 const EditionsMenu = ({
     navigationPress,
     regionalEditions,

--- a/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/RegionButton/RegionButton.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native'
 import { TitlepieceText } from 'src/components/styled-text'
 import { color } from 'src/theme/color'
 import { families } from 'src/theme/typography'
+import { EDITIONS_MENU_TEXT_LEFT_PADDING } from '../EditionsMenu'
 
 const styles = (selected: boolean) =>
     StyleSheet.create({
@@ -11,7 +12,7 @@ const styles = (selected: boolean) =>
                 ? color.primary
                 : color.palette.neutral[97],
             paddingBottom: 32,
-            paddingLeft: 96,
+            paddingLeft: EDITIONS_MENU_TEXT_LEFT_PADDING,
             paddingTop: 4,
         },
         title: {

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -41,7 +41,7 @@ Monthly - Special Edition Button"
       Object {
         "flexShrink": 1,
         "paddingBottom": 15,
-        "paddingLeft": 20,
+        "paddingLeft": 9,
         "paddingRight": 20,
       }
     }
@@ -134,7 +134,7 @@ Monthly - Special Edition Button"
       Object {
         "flexShrink": 1,
         "paddingBottom": 15,
-        "paddingLeft": 20,
+        "paddingLeft": 9,
         "paddingRight": 20,
       }
     }

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/styles.ts
@@ -4,6 +4,7 @@ import {
     SpecialEditionButtonStyles,
 } from '../../../../../Apps/common/src'
 import { StyleSheet } from 'react-native'
+import { EDITIONS_MENU_TEXT_LEFT_PADDING } from '../EditionsMenu'
 
 const expiryDefaults = {
     color: color.text,
@@ -43,8 +44,9 @@ const styles = ({
 }: {
     style: SpecialEditionButtonStyles
     selected: boolean
-}) =>
-    StyleSheet.create({
+}) => {
+    const imageWidth = (style && style.image && style.image.width) || 67
+    return StyleSheet.create({
         container: {
             backgroundColor:
                 (selected ? color.primary : style && style.backgroundColor) ||
@@ -58,12 +60,12 @@ const styles = ({
             ...textFormatting(selected, style && style.expiry, expiryDefaults),
         },
         image: {
-            width: (style && style.image && style.image.width) || 87,
+            width: imageWidth,
             height: (style && style.image && style.image.height) || 134,
         },
         textBox: {
             flexShrink: 1,
-            paddingLeft: 20,
+            paddingLeft: EDITIONS_MENU_TEXT_LEFT_PADDING - imageWidth,
             paddingBottom: 15,
             paddingRight: 20,
         },
@@ -82,5 +84,5 @@ const styles = ({
             ),
         },
     })
-
+}
 export { styles }


### PR DESCRIPTION
## Summary

Things look better when they are in alignment!

Before:
<img width="358" alt="Screenshot 2020-09-29 at 15 17 48" src="https://user-images.githubusercontent.com/3606555/94571558-080f3200-0268-11eb-8796-9c677b9606a2.png">
After:
<img width="354" alt="Screenshot 2020-09-29 at 15 17 34" src="https://user-images.githubusercontent.com/3606555/94571569-0b0a2280-0268-11eb-9025-6c8ea6ee73e8.png">


