### PR TITLE
Simplify storeSelectedEdition function.

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { FlatList, ScrollView } from 'react-native'
 import { EditionId, RegionalEdition, SpecialEdition } from 'src/common'
-import { StoreSelectedEditionFunc } from 'src/hooks/use-edition-provider'
 import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults'
 import { EditionsMenuHeader } from './Header/Header'
 import { ItemSeperator } from './ItemSeperator/ItemSeperator'
@@ -19,7 +18,9 @@ const EditionsMenu = ({
     regionalEditions?: RegionalEdition[]
     selectedEdition: EditionId
     specialEditions?: SpecialEdition[]
-    storeSelectedEdition: StoreSelectedEditionFunc
+    storeSelectedEdition: (
+        chosenEdition: RegionalEdition | SpecialEdition,
+    ) => void
 }) => {
     return (
         <ScrollView>
@@ -33,7 +34,7 @@ const EditionsMenu = ({
                                 selectedEdition === item.edition ? true : false
                             }
                             onPress={() => {
-                                storeSelectedEdition(item, 'RegionalEdition')
+                                storeSelectedEdition(item)
                                 navigationPress()
                             }}
                             title={item.title}
@@ -62,10 +63,7 @@ const EditionsMenu = ({
                                     buttonImageUri={buttonImageUri}
                                     expiry={new Date(expiry)}
                                     onPress={() => {
-                                        storeSelectedEdition(
-                                            item,
-                                            'SpecialEdition',
-                                        )
+                                        storeSelectedEdition(item)
                                         navigationPress()
                                     }}
                                     title={title}

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -39,15 +39,7 @@ interface EditionState {
     defaultEdition: RegionalEdition
     storeSelectedEdition: (
         chosenEdition: RegionalEdition | SpecialEdition,
-        type: 'RegionalEdition' | 'SpecialEdition' | 'TrainingEdition',
     ) => void
-}
-
-export interface StoreSelectedEditionFunc {
-    (
-        chosenEdition: RegionalEdition | SpecialEdition,
-        type: 'RegionalEdition' | 'SpecialEdition' | 'TrainingEdition',
-    ): void
 }
 
 export const getSpecialEditionProps = (
@@ -288,13 +280,12 @@ export const EditionProvider = ({
     /**
      * If a chosen edition is regional, then we mark that as default for future reference
      */
-    const storeSelectedEdition: StoreSelectedEditionFunc = async (
-        chosenEdition,
-        type,
+    const storeSelectedEdition = async (
+        chosenEdition: RegionalEdition | SpecialEdition,
     ) => {
         await selectedEditionCache.set(chosenEdition)
         setSelectedEdition(chosenEdition)
-        if (type === 'RegionalEdition') {
+        if (chosenEdition.editionType === 'Regional') {
             await defaultEditionCache.set(chosenEdition as RegionalEdition)
             setDefaultEdition(chosenEdition as RegionalEdition)
             pushNotificationRegistration()

--- a/projects/Mallard/src/screens/settings/editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/editions-screen.tsx
@@ -26,7 +26,7 @@ const EditionsScreen = ({
                     key: edition.title,
                     data: consolidatedEditions,
                     onPress: () => {
-                        storeSelectedEdition(edition, 'TrainingEdition')
+                        storeSelectedEdition(edition)
                         navigation.goBack()
                     },
                 }))}


### PR DESCRIPTION
## Summary

Editions now have an `editionType` property so we don't need to pass the type through to this function. 

## Test Plan
Tested in the simulator, doesn't seem to break anything!