### PR TITLE
Escaped ampersand in <li> item - 'iTunes & App Store'

### DIFF
--- a/projects/Mallard/src/screens/settings/faq-screen.tsx
+++ b/projects/Mallard/src/screens/settings/faq-screen.tsx
@@ -421,7 +421,7 @@ const faqHtml = html`
         subscription via the settings menu on your iPhone or iPad as follows:
     </p>
     <ul>
-        <li>Go to Settings > [your name] > iTunes & App Store.</li>
+        <li>Go to Settings > [your name] > iTunes &amp; App Store.</li>
         <li>Tap your Apple ID at the top of the screen.</li>
         <li>
             Tap View Apple ID. You might need to authenticate your Apple ID.


### PR DESCRIPTION
## Summary

Lint failure for FAQ HTML:

```test.html:330: HTML parser error : htmlParseEntityRef: no name <li>Go to Settings > [your name] > iTunes & App Store.</li>```

[**Trello Card ->**](https://trello.com/c/xZzfL4cp)

[**Test**]

Extract HTML string and place inside a test.html file inside a suitable <html><body>...</body></html> block and run the following:

```xmllint --noout --html test.html```
