### PR TITLE
Am use default regional editions prep filesystem

### DIFF
--- a/projects/Apps/common/src/helpers.ts
+++ b/projects/Apps/common/src/helpers.ts
@@ -1,4 +1,5 @@
 import { EditionId, EditionsList, IssueSummary } from '.'
+import { defaultRegionalEditions } from './editions-defaults'
 
 export const issueSummaryComparator = (a: IssueSummary, b: IssueSummary) => {
     return a.date.localeCompare(b.date)
@@ -8,7 +9,9 @@ export const issueSummarySort = (issues: IssueSummary[]): IssueSummary[] => {
     return issues.sort(issueSummaryComparator).reverse()
 }
 
-export const getEditionIds = (editionList: EditionsList): EditionId[] =>
-    editionList.regionalEditions
-        .map(e => e.edition)
-        .concat(editionList.specialEditions.map(e => e.edition))
+export const getEditionIds = (editionList: EditionsList | null): EditionId[] =>
+    editionList
+        ? editionList.regionalEditions
+              .map(e => e.edition)
+              .concat(editionList.specialEditions.map(e => e.edition))
+        : defaultRegionalEditions.map(e => e.edition)

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -87,7 +87,7 @@ Monthly
       }
     >
       Available until 
-      1998-2-1
+      2/1/1998
     </Text>
   </View>
 </View>
@@ -180,7 +180,7 @@ Monthly
       }
     >
       Available until 
-      1998-2-1
+      2/1/1998
     </Text>
   </View>
 </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -87,7 +87,7 @@ Monthly
       }
     >
       Available until 
-      2/1/1998
+      1998-2-1
     </Text>
   </View>
 </View>
@@ -180,7 +180,7 @@ Monthly
       }
     >
       Available until 
-      2/1/1998
+      1998-2-1
     </Text>
   </View>
 </View>

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -42,7 +42,7 @@ export const prepFileSystem = async (): Promise<void> => {
     await ensureDirExists(FSPaths.issuesDir)
     await ensureDirExists(FSPaths.downloadRoot)
     const editionsList = await editionsListCache.get()
-    const editionIds = editionsList ? getEditionIds(editionsList) : []
+    const editionIds = getEditionIds(editionsList)
 
     await Promise.all(
         editionIds.map(edition =>


### PR DESCRIPTION
## Summary
This fix should avoid the a connection error shown to user's who freshly install the app, this was happening on the android beta and also on iOS production builds. 
This PR falls back to the default regional editions list if the user's editions cache is empty. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/SjCAh4PG/1614-bug-index-unavailable-on-first-launch-on-android)

## Test Plan
I have kicked off an internal android build to test this
On android: 
1. Freshly install the app 
2. Edition should load as expected. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
