### PR TITLE
respect-locale-date-format-android

### DIFF
--- a/projects/Mallard/jest-setup.js
+++ b/projects/Mallard/jest-setup.js
@@ -26,3 +26,20 @@ jest.mock('react-native-permissions', () => {
         check: jest.fn().mockResolvedValue(2),
     }
 })
+
+jest.mock('react-native-localize', () => ({
+    getLocales: () => [
+        {
+            countryCode: 'GB',
+            languageTag: 'en-GB',
+            languageCode: 'en',
+            isRTL: false,
+        },
+        {
+            countryCode: 'US',
+            languageTag: 'en-US',
+            languageCode: 'en',
+            isRTL: false,
+        },
+    ],
+}))

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Text, TouchableWithoutFeedback, View, Image } from 'react-native'
 import { SpecialEditionButtonStyles } from 'src/common'
 import { styles } from './styles'
+import * as RNLocalize from 'react-native-localize'
 
 const SpecialEditionButton = ({
     expiry,
@@ -46,7 +47,10 @@ const SpecialEditionButton = ({
                     <Text style={defaultStyles.title}>{title}</Text>
                     <Text style={defaultStyles.subTitle}>{subTitle}</Text>
                     <Text style={defaultStyles.expiry}>
-                        Available until {expiry.toLocaleDateString()}
+                        Available until{' '}
+                        {expiry.toLocaleDateString(
+                            RNLocalize.getLocales()[0].languageTag,
+                        )}
                     </Text>
                 </View>
             </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -4,6 +4,9 @@ import { SpecialEditionButtonStyles } from 'src/common'
 import { styles } from './styles'
 import * as RNLocalize from 'react-native-localize'
 
+const localDate = (expiry: Date): string =>
+    expiry.toLocaleDateString(RNLocalize.getLocales()[0].languageTag)
+
 const SpecialEditionButton = ({
     expiry,
     buttonImageUri,
@@ -47,10 +50,7 @@ const SpecialEditionButton = ({
                     <Text style={defaultStyles.title}>{title}</Text>
                     <Text style={defaultStyles.subTitle}>{subTitle}</Text>
                     <Text style={defaultStyles.expiry}>
-                        Available until{' '}
-                        {expiry.toLocaleDateString(
-                            RNLocalize.getLocales()[0].languageTag,
-                        )}
+                        Available until {localDate(expiry)}
                     </Text>
                 </View>
             </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/SpecialEditionButton.tsx
@@ -2,10 +2,7 @@ import React, { useState } from 'react'
 import { Text, TouchableWithoutFeedback, View, Image } from 'react-native'
 import { SpecialEditionButtonStyles } from 'src/common'
 import { styles } from './styles'
-import * as RNLocalize from 'react-native-localize'
-
-const localDate = (expiry: Date): string =>
-    expiry.toLocaleDateString(RNLocalize.getLocales()[0].languageTag)
+import { localDate } from 'src/helpers/date'
 
 const SpecialEditionButton = ({
     expiry,

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -86,7 +86,8 @@ Monthly
         }
       }
     >
-      Available until 
+      Available until
+       
       2/1/1998
     </Text>
   </View>
@@ -179,7 +180,8 @@ Monthly
         }
       }
     >
-      Available until 
+      Available until
+       
       2/1/1998
     </Text>
   </View>

--- a/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/SpecialEditionButton/__tests__/__snapshots__/SpecialEditionButton.spec.tsx.snap
@@ -86,8 +86,7 @@ Monthly
         }
       }
     >
-      Available until
-       
+      Available until 
       2/1/1998
     </Text>
   </View>
@@ -180,8 +179,7 @@ Monthly
         }
       }
     >
-      Available until
-       
+      Available until 
       2/1/1998
     </Text>
   </View>

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,8 +1,12 @@
 import moment from 'moment-timezone'
+import * as RNLocalize from 'react-native-localize'
 
 const londonTime = (time?: string | number) => {
     if (time != null) return moment.tz(time, 'Europe/London')
     return moment.tz('Europe/London')
 }
 
-export { londonTime }
+const localDate = (date: Date): string =>
+    date.toLocaleDateString(RNLocalize.getLocales()[0].languageTag)
+
+export { londonTime, localDate }


### PR DESCRIPTION
## Summary
This PR fixes the date formatting on android so that it uses the device locale as expected. 
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/1hfFop0F/1615-android-expiry-date-isnt-respecting-locale)

## Test Plan
Test on iOS and android that the expiry date in the special edition respects the device language/region settings 

## iOS
| UK | US |
| --- | --- |
![image](https://user-images.githubusercontent.com/53755195/95172083-ba864e00-07ae-11eb-8d00-991646ce37cd.png) | ![image](https://user-images.githubusercontent.com/53755195/95172094-beb26b80-07ae-11eb-97f6-74abfa753649.png)

## Android 
| UK | US |
| --- | --- |
![Screenshot_1601934789](https://user-images.githubusercontent.com/53755195/95171952-90cd2700-07ae-11eb-856e-eec8a4e588c6.png) | ![Screenshot_1601934811](https://user-images.githubusercontent.com/53755195/95171993-9fb3d980-07ae-11eb-8427-f71d6ad80fe4.png)

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
