### PR TITLE
Remove (screenshots) from FAQs

### DIFF
--- a/projects/Mallard/src/screens/settings/faq-screen.tsx
+++ b/projects/Mallard/src/screens/settings/faq-screen.tsx
@@ -348,8 +348,8 @@ const faqHtml = html`
     </p>
     <h3>How do I share content?</h3>
     <p>
-        Articles available for sharing have a share icon (screenshot) on the
-        right hand side near the top of the article page.
+        Articles available for sharing have a share icon on the right hand side
+        near the top of the article page.
     </p>
     <p>
         For technical reasons, currently, not all articles are available for


### PR DESCRIPTION
## Summary
Why are we doing this?
A user found a mistake on the FAQs. 
Remove the wording '(screenshot)'.

[**Trello Card ->**](https://trello.com)

## Test Plan
Search for the word (screenshot) - it should have been removed.