### PR TITLE
IAP handle missing last receipt info from ReceiptValidationResponse

### DIFF
--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -78,10 +78,6 @@ describe('iap', () => {
             expect(findValidReceipt(receiptValidationResponse)).toEqual(null)
         })
         it('should return null if last_receipt_info is missing', () => {
-            const fourDaysAgo = moment()
-                .subtract(4, 'days')
-                .toDate()
-            const receipt = receiptIOS({ expires_date: fourDaysAgo })
             const receiptValidationResponse = {
                 status: 0,
                 receipt: {

--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import { receiptIOS } from 'src/authentication/__tests__/fixtures'
+import { isNullOrUndefined } from 'util'
 import { isReceiptValid, findValidReceipt } from '../iap'
 
 describe('iap', () => {
@@ -74,6 +75,23 @@ describe('iap', () => {
                     receipt_creation_date: '',
                 },
                 latest_receipt_info: [receipt],
+            }
+            expect(findValidReceipt(receiptValidationResponse)).toEqual(null)
+        })
+        it('should return null if last_receipt_info is missing', () => {
+            const fourDaysAgo = moment()
+                .subtract(4, 'days')
+                .toDate()
+            const receipt = receiptIOS({ expires_date: fourDaysAgo })
+            const receiptValidationResponse = {
+                status: 0,
+                receipt: {
+                    bundle_id: 'test',
+                    application_version: '1.2',
+                    in_app: [],
+                    original_application_version: '',
+                    receipt_creation_date: '',
+                },
             }
             expect(findValidReceipt(receiptValidationResponse)).toEqual(null)
         })

--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,6 +1,5 @@
 import moment from 'moment'
 import { receiptIOS } from 'src/authentication/__tests__/fixtures'
-import { isNullOrUndefined } from 'util'
 import { isReceiptValid, findValidReceipt } from '../iap'
 
 describe('iap', () => {

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -49,18 +49,29 @@ const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {
         .transactionReceipt
 }
 
+const findValidReceipt = (receipt: ReceiptValidationResponse) =>
+    hasLatestReceiptInfo(receipt)
+        ? findValidReceiptFromLatestInfo(receipt) || null
+        : null
+
+const hasLatestReceiptInfo = (receipt: ReceiptValidationResponse) => {
+    return (
+        receipt &&
+        receipt.latest_receipt_info &&
+        (receipt.latest_receipt_info as ReceiptIOS[]).length > 0
+    )
+}
+
+const findValidReceiptFromLatestInfo = (receipt: ReceiptValidationResponse) => {
+    return (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid)
+}
+
 const isReceiptValid = (receipt: ReceiptIOS) => {
     const expirationInMilliseconds = Number(receipt.expires_date_ms)
     const expirationWithGracePeriod = expirationInMilliseconds + THREE_DAYS
     const nowInMilliseconds = Date.now()
     return expirationWithGracePeriod > nowInMilliseconds
 }
-
-const findValidReceipt = (receipt: ReceiptValidationResponse) =>
-    receipt
-        ? (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid) ||
-          null
-        : null
 
 /**
  * This will attempt to restore existing purchases

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -49,10 +49,12 @@ const getMostRecentTransactionReceipt = (purchases: Purchase[]) => {
         .transactionReceipt
 }
 
-const findValidReceipt = (receipt: ReceiptValidationResponse) =>
-    hasLatestReceiptInfo(receipt)
-        ? findValidReceiptFromLatestInfo(receipt) || null
-        : null
+const isReceiptValid = (receipt: ReceiptIOS) => {
+    const expirationInMilliseconds = Number(receipt.expires_date_ms)
+    const expirationWithGracePeriod = expirationInMilliseconds + THREE_DAYS
+    const nowInMilliseconds = Date.now()
+    return expirationWithGracePeriod > nowInMilliseconds
+}
 
 const hasLatestReceiptInfo = (receipt: ReceiptValidationResponse) => {
     return (
@@ -66,12 +68,10 @@ const findValidReceiptFromLatestInfo = (receipt: ReceiptValidationResponse) => {
     return (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid)
 }
 
-const isReceiptValid = (receipt: ReceiptIOS) => {
-    const expirationInMilliseconds = Number(receipt.expires_date_ms)
-    const expirationWithGracePeriod = expirationInMilliseconds + THREE_DAYS
-    const nowInMilliseconds = Date.now()
-    return expirationWithGracePeriod > nowInMilliseconds
-}
+const findValidReceipt = (receipt: ReceiptValidationResponse) =>
+    hasLatestReceiptInfo(receipt)
+        ? findValidReceiptFromLatestInfo(receipt) || null
+        : null
 
 /**
  * This will attempt to restore existing purchases


### PR DESCRIPTION
## Summary

Corner case in IAP flow when a ReceiptValidationResponse is returned with a missing **last_receipt_info** field which triggers the following 

```
undefined is not an object (evaluating 't.latest_receipt_info.find')
```
 
[**Trello Card ->**](https://trello.com/c/afvF50vO)

## Test Plan

Add a new test case  - 'should return null if last_receipt_info is missing'