### PR TITLE
Am remove telephone autolinking from dropcap articles

### DIFF
--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -246,6 +246,8 @@ export const makeHtml = ({
                 name="viewport"
                 content="width=device-width, initial-scale=1"
             />
+            <!-- Avoid iOS formatting issues disable telephone auto-linking on articles -->
+            ${type && `<meta name="format-detection" content="telephone=no" />`}
         </head>
         <body style="padding-top:${px(topPadding)}">
             <div id="app" class="app" data-type="${type}">

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -225,6 +225,17 @@ const makeJavaScript = (topPadding: number) => html`
     </script>
 `
 
+const DROP_CAP_ARTICLE_TYPES: ArticleType[] = [
+    ArticleType.Immersive,
+    ArticleType.Longread,
+    ArticleType.Interview,
+]
+
+// Telephone auto-linking can create formatting issues with drop caps
+const shouldDisableTelephoneLinking = (type: ArticleType): boolean => {
+    return DROP_CAP_ARTICLE_TYPES.includes(type)
+}
+
 /* makes some HTML and posts the height back */
 export const makeHtml = ({
     styles,
@@ -246,8 +257,9 @@ export const makeHtml = ({
                 name="viewport"
                 content="width=device-width, initial-scale=1"
             />
-            <!-- Avoid iOS formatting issues disable telephone auto-linking on articles -->
-            ${type && `<meta name="format-detection" content="telephone=no" />`}
+            ${type &&
+                shouldDisableTelephoneLinking(type) &&
+                `<meta name="format-detection" content="telephone=no" />`}
         </head>
         <body style="padding-top:${px(topPadding)}">
             <div id="app" class="app" data-type="${type}">


### PR DESCRIPTION
## Summary
When investigating this issue I found the iOS auto-linking of telephone numbers was affecting our drop-cap css and could result in the wrong character being styled in the drop cap. (I think this is down to the use of the "first-letter" selector)
I looked into other CSS options but I couldn't find a way of making them both work together, other than disabling telephone autodetection on articles that may contain drop caps. 

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/5WxQV15k/1613-drop-cap-replaced-by-another-character)

## Test Plan
Open the last article in Top Stories and observe the drop cap, it should no longer change character. 
<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
