### PR TITLE
Updated ophan library

### DIFF
--- a/projects/Apps/ophan/build.gradle
+++ b/projects/Apps/ophan/build.gradle
@@ -35,7 +35,7 @@ kotlin {
                 implementation kotlin('stdlib-common')
                 implementation("io.ktor:ktor-client-core:1.2.3")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-common:1.3.0-RC")
-                api 'com.gu.kotlin:multiplatform-ophan:0.1.8'
+                api 'com.gu.kotlin:multiplatform-ophan:0.1.9'
             }
         }
         androidMain {


### PR DESCRIPTION
## Summary
There is a crash which occuring for android on regular basis (small scale) and this [PR](https://github.com/guardian/multiplatform-ophan/pull/22) fixed that issue. In this PR we are just updating to the latest version of the ophan library. 


[**Trello Card ->**](https://trello.com/c/6opQniSU/1476-fix-an-ophan-crash-on-android)

## Test Plan
TODO: need to verify android is sending all the ophan tracking (using charles or logcat) as expected.
