### PR TITLE
Fix expiry locale

### DIFF
--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -11,6 +11,7 @@ const localDate = (date: Date): string => {
     if (Platform.OS === 'ios') {
         return date.toLocaleDateString(languageLocale)
     } else {
+        // toLocaleDateString is not a reliable way of getting the format we need on android
         return languageLocale === 'en-US'
             ? moment(date).format('MM/DD/YYYY')
             : moment(date).format('DD/MM/YYYY')

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,12 +1,18 @@
 import moment from 'moment-timezone'
-import * as RNLocalize from 'react-native-localize'
+import { languageLocale } from './locale'
+import { Platform } from 'react-native'
 
 const londonTime = (time?: string | number) => {
     if (time != null) return moment.tz(time, 'Europe/London')
     return moment.tz('Europe/London')
 }
 
-const localDate = (date: Date): string =>
-    date.toLocaleDateString(RNLocalize.getLocales()[0].languageTag)
+const localDate = (date: Date): string => {
+    if (Platform.OS === 'ios') {
+        return date.toLocaleDateString(languageLocale)
+    } else {
+        return languageLocale === "en-US" ? moment(date).format('MM/DD/YYYY') : moment(date).format('DD/MM/YYYY')
+    }
+}
 
 export { londonTime, localDate }

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -11,7 +11,9 @@ const localDate = (date: Date): string => {
     if (Platform.OS === 'ios') {
         return date.toLocaleDateString(languageLocale)
     } else {
-        return languageLocale === "en-US" ? moment(date).format('MM/DD/YYYY') : moment(date).format('DD/MM/YYYY')
+        return languageLocale === 'en-US'
+            ? moment(date).format('MM/DD/YYYY')
+            : moment(date).format('DD/MM/YYYY')
     }
 }
 

--- a/projects/Mallard/src/helpers/locale.ts
+++ b/projects/Mallard/src/helpers/locale.ts
@@ -6,4 +6,6 @@ const locale =
           NativeModules.SettingsManager.settings.AppleLanguages[0] //iOS 13
         : NativeModules.I18nManager.localeIdentifier
 
-export { locale }
+const languageLocale = locale.replace('_', '-')
+
+export { locale, languageLocale }


### PR DESCRIPTION
## Summary
This PR adds extra android specific logic for dates as `toLocaleDateString` doesn't work on android. 
The `moment` library also didn't work when just passing in a language locale so I have had to go for a less elegant solution of using "MM/DD/YYYY" for US locale only.  (We had to do something similar for the weather units on android)
<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->

[**Trello Card ->**](https://trello.com/c/1hfFop0F/1615-android-expiry-date-isnt-respecting-locale)

## Test Plan

<!--
Describe what steps where followed to reproduce the bug and/or to access the
feature, and what observation confirms it works as expected.

Please try to add visuals!
This is worthwhile for historical reasons as well as to allow other
contributors who aren't developers to collaborate.
-->
