### PR TITLE
Added loggings to find out buggy notification registration

### DIFF
--- a/projects/Mallard/src/notifications/notification-service.ts
+++ b/projects/Mallard/src/notifications/notification-service.ts
@@ -33,7 +33,10 @@ const registerWithNotificationService = async (
                 ? Promise.resolve(response.json())
                 : Promise.reject(response.status),
         )
-        .catch(e => errorService.captureException(e))
+        .catch(e => {
+            errorService.captureException(e)
+            errorService.captureException(new Error(JSON.stringify(options)))
+        })
 }
 
 export { registerWithNotificationService }


### PR DESCRIPTION
## Summary
We are seeing this notification registration [error](https://sentry.io/organizations/the-guardian/issues/1885775400/events/baf3646520cc4de8b89ee4e237db3c0c/?project=1519156&query=dist%3A817&statsPeriod=7d) that is occurring very frequently. This extra loggin will help us to identify what goes when it fails to register with the notification service. 

