### PR TITLE
Spike: introducing Source to Editions

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,6 +37,7 @@
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
+        "@guardian/src-foundations": "^2.5.0-rc.1",
         "@invertase/react-native-apple-authentication": "^1.0.0",
         "@react-native-community/async-storage": "^1.5.0",
         "@react-native-community/geolocation": "^2.0.2",

--- a/projects/Mallard/src/components/Button/__tests__/__snapshots__/ModalButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/Button/__tests__/__snapshots__/ModalButton.spec.tsx.snap
@@ -125,7 +125,7 @@ exports[`ModalButton should display a ModalButton with an alternative appearance
           "paddingHorizontal": 21,
         },
         Object {
-          "backgroundColor": "#ff7f0f",
+          "backgroundColor": "#FF7F0F",
         },
         false,
         undefined,

--- a/projects/Mallard/src/components/Button/__tests__/__snapshots__/ReloadButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/Button/__tests__/__snapshots__/ReloadButton.spec.tsx.snap
@@ -50,7 +50,7 @@ exports[`ReloadButton should display a ReloadButton 1`] = `
             "paddingHorizontal": 21,
           },
           Object {
-            "backgroundColor": "#ff4e36",
+            "backgroundColor": "#FF5943",
           },
           false,
           Object {

--- a/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
+++ b/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
@@ -192,7 +192,7 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
     <View
       style={
         Object {
-          "color": "#ffffff",
+          "color": "#FFFFFF",
           "paddingLeft": 2,
           "paddingRight": 13,
         }
@@ -204,7 +204,7 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
           onPress={null}
           style={
             Object {
-              "color": "#ffffff",
+              "color": "#FFFFFF",
               "fontFamily": "GuardianTextSans-Regular",
               "fontSize": 14,
             }
@@ -215,7 +215,7 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
               Array [
                 null,
                 Object {
-                  "color": "#ffffff",
+                  "color": "#FFFFFF",
                   "fontFamily": "GuardianTextSans-Regular",
                   "fontSize": 14,
                 },

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/__tests__/__snapshots__/IssuePickerHeader.spec.tsx.snap
@@ -91,7 +91,7 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                 },
                 Object {
                   "backgroundColor": undefined,
-                  "borderColor": "#ffffff",
+                  "borderColor": "#FFFFFF",
                   "borderWidth": 1,
                 },
                 Object {
@@ -116,7 +116,7 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                   },
                   Array [
                     Object {
-                      "color": "#ffffff",
+                      "color": "#FFFFFF",
                     },
                     undefined,
                   ],
@@ -198,7 +198,7 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -222,7 +222,7 @@ exports[`IssuePickerHeader should match the altered style by the prop headerStyl
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -418,7 +418,7 @@ exports[`IssuePickerHeader should match the default style 1`] = `
                 },
                 Object {
                   "backgroundColor": undefined,
-                  "borderColor": "#ffffff",
+                  "borderColor": "#FFFFFF",
                   "borderWidth": 1,
                 },
                 Object {
@@ -443,7 +443,7 @@ exports[`IssuePickerHeader should match the default style 1`] = `
                   },
                   Array [
                     Object {
-                      "color": "#ffffff",
+                      "color": "#FFFFFF",
                     },
                     undefined,
                   ],
@@ -525,7 +525,7 @@ exports[`IssuePickerHeader should match the default style 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -547,7 +547,7 @@ exports[`IssuePickerHeader should match the default style 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -741,7 +741,7 @@ exports[`IssuePickerHeader should match the default style with a subTitle 1`] = 
                 },
                 Object {
                   "backgroundColor": undefined,
-                  "borderColor": "#ffffff",
+                  "borderColor": "#FFFFFF",
                   "borderWidth": 1,
                 },
                 Object {
@@ -766,7 +766,7 @@ exports[`IssuePickerHeader should match the default style with a subTitle 1`] = 
                   },
                   Array [
                     Object {
-                      "color": "#ffffff",
+                      "color": "#FFFFFF",
                     },
                     undefined,
                   ],
@@ -848,7 +848,7 @@ exports[`IssuePickerHeader should match the default style with a subTitle 1`] = 
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -870,7 +870,7 @@ exports[`IssuePickerHeader should match the default style with a subTitle 1`] = 
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
@@ -455,7 +455,7 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -479,7 +479,7 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -1038,7 +1038,7 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -1060,7 +1060,7 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {

--- a/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/EditionMenuScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/EditionMenuScreenHeader.spec.tsx.snap
@@ -118,7 +118,7 @@ exports[`Edition Menu Screen Header Edition menu screen Header should render wit
                 },
                 Array [
                   Object {
-                    "color": "#ffffff",
+                    "color": "#FFFFFF",
                     "marginTop": -2,
                   },
                   undefined,

--- a/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/ScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/ScreenHeader.spec.tsx.snap
@@ -119,7 +119,7 @@ exports[`ScreenHeader should show a default version 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -390,7 +390,7 @@ exports[`ScreenHeader should show a version with title 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -412,7 +412,7 @@ exports[`ScreenHeader should show a version with title 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -561,7 +561,7 @@ exports[`ScreenHeader should show a version with title and subTitle 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -583,7 +583,7 @@ exports[`ScreenHeader should show a version with title and subTitle 1`] = `
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -1264,7 +1264,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction an
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -1286,7 +1286,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction an
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -1843,7 +1843,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction, l
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -1865,7 +1865,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction, l
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {
@@ -2424,7 +2424,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction, l
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         undefined,
@@ -2448,7 +2448,7 @@ exports[`ScreenHeader should show a version with title, subTitle, rightAction, l
                       },
                       Array [
                         Object {
-                          "color": "#ffffff",
+                          "color": "#FFFFFF",
                           "marginTop": -2,
                         },
                         Object {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -224,6 +224,7 @@ const Article = ({
                         wasShowingHeader.current = parsed.shouldShowHeader
                         onShouldShowHeaderChange(parsed.shouldShowHeader)
                     }
+
                     if (parsed.type === 'isAtTopChange') {
                         onIsAtTopChange(parsed.isAtTop)
                     }

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -1,4 +1,17 @@
 import { palette } from '@guardian/pasteup/palette'
+import {
+    neutral,
+    brand,
+    text,
+    brandText,
+    background,
+    brandBackground,
+    border,
+    brandBorder,
+    news,
+    opinion,
+    sport,
+} from '@guardian/src-foundations/palette'
 
 /*
 Roles for colors.  Prefer using these over the palette.  It makes it easier
@@ -13,44 +26,44 @@ export const color = {
     /*
     Backgrounds
     */
-    background: palette.neutral[100],
-    text: palette.neutral[7],
-    dimBackground: palette.neutral[93],
-    dimmerBackground: palette.neutral[86],
-    dimText: palette.neutral[20],
-    darkBackground: palette.neutral[20],
-    photoBackground: palette.neutral[7],
-    textOverPhotoBackground: palette.neutral[100],
-    textOverDarkBackground: palette.neutral[100],
-    artboardBackground: palette.neutral[7],
-    skeleton: palette.neutral[60],
+    background: background.primary,
+    text: text.primary,
+    dimBackground: neutral[93],
+    dimmerBackground: neutral[86],
+    dimText: neutral[20],
+    darkBackground: neutral[20],
+    photoBackground: neutral[7],
+    textOverPhotoBackground: background.primary,
+    textOverDarkBackground: background.primary,
+    artboardBackground: neutral[7],
+    skeleton: neutral[60],
 
     /*
     Brand (our blue)
     */
-    textOverPrimary: palette.neutral[100],
-    primary: palette.brand.main,
-    primaryDarker: palette.brand.dark,
+    textOverPrimary: brandText.primary,
+    primary: brandBackground.primary,
+    primaryDarker: brand[300],
 
     /*
     Border colors
     */
-    line: palette.neutral[60],
-    dimLine: palette.neutral[85],
-    lineOverPrimary: palette.brand.pastel,
+    line: border.primary,
+    dimLine: border.secondary,
+    lineOverPrimary: brandBorder.primary,
 
     /*
     Error messages and icons.
     */
-    error: palette.news.main,
+    error: text.error,
 
     /*
     Onboarding & button UI.
     */
     ui: {
-        tomato: palette.news.bright,
-        apricot: palette.opinion.bright,
-        shark: palette.sport.main,
+        tomato: news[500],
+        apricot: opinion[500],
+        shark: sport[400],
         sea: '#279DDC',
         supportBlue: '#41A9E0',
     },

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1883,6 +1883,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.11.tgz#a1e442b6dba4540fce1273eff74abb74c0652f2d"
   integrity sha512-MLzUhb0+oaMS1g9FQ8nL3G3cdEsQTzC8/Hq1vdrIV/ufbu/6u7sult/AXXk602WodE4ugRZoJMZ5N90Z0WCfBg==
 
+"@guardian/src-foundations@^2.5.0-rc.1":
+  version "2.5.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.5.0-rc.1.tgz#e21869dac88f848241ea8f3da8205b1da808ee1d"
+  integrity sha512-7ukVvo2ZGHvMOf1t1iVzHYDRcZ4XY95Wzkgr4GxmZz8rDLXqDkyePKm005v5WHqLbShUVZfyPNYi3Ya+Dr/lcQ==
+
 "@hapi/address@2.x.x":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"


### PR DESCRIPTION
## Summary

[Source](https://www.theguardian.design/) is the Guardian's design system. It attempts to unify the design process across all Guardian digital products. It replaces pasteup, which has been deleted from the dotcom-rendering repo where it lived (see guardian/dotcom-rendering#733)

The colours used here are mostly described on the [Colour Tokens](https://www.theguardian.design/2a1e5182b/p/1377a6-tokens/b/293ddb) page. A few are described on the [Light Palette](https://www.theguardian.design/2a1e5182b/p/492a30-light-palette) page

This PR is a spike to see how easy it would be to integrate Source into the Editions team's codebase and workflow. It's the start of the conversation that we have booked in on Monday 19th October

If you have any questions in the meantime, please let me know

c/c @JamieB-gu 
