### PR TITLE
Remove FirebaseInstanceId

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/InstallationIdHelper.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/InstallationIdHelper.java
@@ -1,9 +1,9 @@
 package com.guardian.editions.ophan;
 
 import android.content.Context;
+import android.util.Log;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -11,13 +11,15 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 public class InstallationIdHelper {
 
     @Nullable
     private String sID;
     private static final String INSTALLATION_FILE_NAME = "INSTALLATION";
 
-    public InstallationIdHelper(@NonNull Context context){
+    public InstallationIdHelper(@NonNull Context context) {
         sID = readId(context);
     }
 
@@ -37,7 +39,6 @@ public class InstallationIdHelper {
         return sID;
     }
 
-    @NotNull
     public synchronized String id() {
         if (sID == null) {
             throw new IllegalStateException("Installation.id has not been initialised");

--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/InstallationIdHelper.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/InstallationIdHelper.java
@@ -1,0 +1,63 @@
+package com.guardian.editions.ophan;
+
+import android.content.Context;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.UUID;
+
+public class InstallationIdHelper {
+
+    @Nullable
+    private String sID;
+    private static final String INSTALLATION_FILE_NAME = "INSTALLATION";
+
+    public InstallationIdHelper(@NonNull Context context){
+        sID = readId(context);
+    }
+
+    @Nullable
+    private synchronized String readId(@NonNull Context context) {
+        if (sID == null) {
+            File installation = new File(context.getFilesDir(), INSTALLATION_FILE_NAME);
+            try {
+                if (!installation.exists()) {
+                    writeInstallationFile(installation);
+                }
+                return readInstallationFile(installation);
+            } catch (Exception e) {
+                Log.w("InstallationIdHelper", "Error reading Id from installation file", e);
+            }
+        }
+        return sID;
+    }
+
+    @NotNull
+    public synchronized String id() {
+        if (sID == null) {
+            throw new IllegalStateException("Installation.id has not been initialised");
+        }
+        return sID;
+    }
+
+    @NonNull
+    private String readInstallationFile(File installation) throws IOException {
+        RandomAccessFile f = new RandomAccessFile(installation, "r");
+        byte[] bytes = new byte[(int) f.length()];
+        f.readFully(bytes);
+        f.close();
+        return new String(bytes);
+    }
+
+    private void writeInstallationFile(@NonNull File installation) throws IOException {
+        FileOutputStream out = new FileOutputStream(installation);
+        String id = UUID.randomUUID().toString();
+        out.write(id.getBytes());
+        out.close();
+    }
+}

--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
@@ -6,7 +6,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.google.firebase.iid.FirebaseInstanceId;
 import com.guardian.editions.BuildConfig;
 import com.guardian.editions.R;
 
@@ -32,6 +31,10 @@ class RNOphanModule extends ReactContextBaseJavaModule {
     @Nullable
     private String lastViewId = null;
 
+    @Nullable
+    private InstallationIdHelper installationIdHelper = null;
+
+
     public RNOphanModule(@Nonnull ReactApplicationContext reactContext) {
         super(reactContext);
         recordStoreDir = new File(reactContext.getCacheDir(), "ophan");
@@ -40,6 +43,7 @@ class RNOphanModule extends ReactContextBaseJavaModule {
         } else {
             deviceClass = DeviceClass.PHONE;
         }
+        installationIdHelper = new InstallationIdHelper(reactContext);
         ophanApi = newOphanApi(null);
     }
 
@@ -59,8 +63,8 @@ class RNOphanModule extends ReactContextBaseJavaModule {
     }
 
     @Nonnull
-    private static String getDeviceId() {
-        return FirebaseInstanceId.getInstance().getId();
+    private String getDeviceId() {
+        return installationIdHelper.id();
     }
 
     @Nonnull

--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -10,8 +10,6 @@ buildscript {
         androidXVersion = '1.0.2' // This is for react-native-inappbrowser-reborn
         mediaCompatVersion = '1.0.1' // Do not specify if using old libraries, specify '1.0.1' or similar for androidx.media:media dependency
         supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
-        firebaseVersion = "19.0.1"
-        firebaseMessagingVersion = "20.2.1"
         androidXAnnotation = "1.1.0"
         androidXBrowser = "1.0.0"
     }


### PR DESCRIPTION
## Summary

Issues have been raised with data quality and our implementation of Ophan client libs. In particular, the Editions apps is sometimes sending a `browserId` that does not matching the expected number of characters (for instance "fHSn_pnKRMs").

In the Editions Android Ophan implementation, we are still using the Firebase API to generate an id namely **FirebaseInstanceId** This is not ideal, not best practice and the Firebase dependency should be removed.

The recommended approach, as outlined by the the Android (Live) team is that we should use a **InstallationIdHelper** class to generate a unique id. 

[**Trello: FirebaseInstanceId - Cease and desist**](https://trello.com/c/P8Z0NGr3)

## Test Plan

Ensure that Firebase SDK dependency is removed and not longer being used

## References
For further information regarding best practices for generating unique identifiers on Android, see https://developer.android.com/training/articles/user-data-ids#java
Original Android Live app **InstallationIdHelper** - https://github.com/guardian/android-news-app/blob/master/android-news-app/src/main/java/com/guardian/util/InstallationIdHelper.java