### PR TITLE
More logging for notification registration bug 

### DIFF
--- a/projects/Mallard/src/notifications/notification-service.ts
+++ b/projects/Mallard/src/notifications/notification-service.ts
@@ -21,6 +21,9 @@ const registerWithNotificationService = async (
                 : notificationEdition.android,
         topics,
     }
+
+    console.log('*** NOTIFICATION REG PAYLOAD *** ' + JSON.stringify(options))
+
     return fetch(registerDeviceUrl as string, {
         method: 'post',
         body: JSON.stringify(options),
@@ -35,7 +38,6 @@ const registerWithNotificationService = async (
         )
         .catch(e => {
             errorService.captureException(e)
-            errorService.captureException(new Error(JSON.stringify(options)))
         })
 }
 

--- a/projects/Mallard/src/notifications/notification-service.ts
+++ b/projects/Mallard/src/notifications/notification-service.ts
@@ -2,6 +2,8 @@ import { Platform } from 'react-native'
 import { getSetting } from 'src/helpers/settings'
 import { notificationEdition } from 'src/helpers/settings/defaults'
 import { errorService } from 'src/services/errors'
+import { isInBeta } from 'src/helpers/release-stream'
+import { getDefaultEdition } from 'src/hooks/use-edition-provider'
 
 export interface PushToken {
     name: 'uk' | 'us' | 'au'
@@ -22,7 +24,12 @@ const registerWithNotificationService = async (
         topics,
     }
 
-    console.log('*** NOTIFICATION REG PAYLOAD *** ' + JSON.stringify(options))
+    if (isInBeta()) {
+        const defaultEdition = await getDefaultEdition()
+        console.log('*** NOTIFICATION REG PAYLOAD *** ')
+        console.log('*** default edition *** ' + defaultEdition)
+        console.log('*** body *** ' + JSON.stringify(options))
+    }
 
     return fetch(registerDeviceUrl as string, {
         method: 'post',


### PR DESCRIPTION
## Summary

There is an issue with missing `topics` that cause notification registration to fail. Hopefully, this will give us more info about why topics are missing.

Sentry errors:
https://sentry.io/organizations/the-guardian/issues/1885775400/events/latest/?project=1519156&query=dist%3A817&statsPeriod=7d