### PR TITLE
Better logging for issue summary bug

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary.tsx
@@ -33,7 +33,9 @@ const getIssueSummary = async (
         const trimmedSummary = issueSummary.slice(0, maxAvailableEditions)
         return trimmedSummary
     } catch (e) {
-        e.message = `getIssueSummary error: maxAvailableEditions: ${maxAvailableEditions} & issueSummary: ${issueSummary}`
+        e.message = `getIssueSummary error: maxAvailableEditions: ${maxAvailableEditions} & issueSummary: ${JSON.stringify(
+            issueSummary,
+        )}`
         errorService.captureException(e)
         throw Error(e)
     }


### PR DESCRIPTION
## Summary

@jimhunty previous added some logging for IssueSummary bug that logging appears as:
`TypeError: getIssueSummary error: maxAvailableEditions: 30 & issueSummary: [object Object]`

We need to see what the `object` looks like to help us diagnose the [sentry issue](https://sentry.io/organizations/the-guardian/issues/1396286427/?project=1519156&query=dist%3A817&statsPeriod=7d)
 