### PR TITLE
Use correct class names for hiding/showing share button.

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1117,8 +1117,9 @@ const getByLine = (
 ): string => {
     const bylineText = getByLineText(headerType, headerProps, articleType)
     const headerClass = getHeaderClassForType(headerType)
-    const hideByline = bylineText || webUrl ? '' : 'byline-hidden'
-    const hideShareButton = webUrl ? '' : 'share-hidden'
+    const displayNoneClass = 'display-none'
+    const hideByline = bylineText || webUrl ? '' : displayNoneClass
+    const hideShareButton = webUrl ? '' : displayNoneClass
 
     const shareButton = html`
         <button

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -189,7 +189,7 @@ const Article = ({
     })
     const isConnected = data && data.netInfo.isConnected
     const shareUrlFetchEnabled =
-        !shareUrl &&
+        !article.webUrl &&
         isConnected &&
         // TODO: remove remote switch once we are happy this feature is stable
         remoteConfigService.getBoolean('generate_share_url')
@@ -226,13 +226,13 @@ const Article = ({
         const updateShareUrl = async () => {
             const url = await checkPathExists(article.key)
             if (url) {
-                setShareUrl(url)
                 injectJavascript(
                     ref,
-                    `document.getElementById('.share-button').classList.remove('display-none');
-                     document.getElementById('.byline-area').classList.remove('display-none');
+                    `document.getElementById('share-button').classList.remove('display-none');
+                     document.getElementById('byline-area').classList.remove('display-none');
                     `,
                 )
+                setShareUrl(url)
             }
         }
 

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -14,7 +14,7 @@ const remoteConfigDefaults = {
     logging_enabled: true,
     join_beta_button_enabled: false,
     lightbox_enabled: true,
-    generate_share_url: false,
+    generate_share_url: true,
 }
 
 export const RemoteConfigProperties = [


### PR DESCRIPTION
## Summary

<!--
Why are we doing this?

Explain the scope of the change and how that fits within the bug or the feature
being worked on. Link the corresponding Trello Card below.

If this PR is a fix, please include a link to the original PR that introduced
the breakage, if any, for reference.
-->
This fixes some pretty major bugs introduced in https://github.com/guardian/editions/pull/1555 as a result of some poorly tested last minute refactoring. The main issue is that I introduced a 'display-none' class but in header.ts was still using the classes 'byline-hidden' and 'share-hidden'. This fixes that, as well as resolving a race condition in article.tsx where setting the newly fetched shareUrl would trigger a useEffect change, resulting in the article to re-render.

[**Trello Card ->**](https://trello.com/c/jghUcUNv/925-improvement-share-functionality-10-of-content-unavailable)

## Test Plan
I've tested this in the simulator but not on device yet