### PR TITLE
Refactored edition api usages

### DIFF
--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -253,8 +253,6 @@ export const EditionProvider = ({
 
     const [apiUrl, setApiUrl] = useState('')
 
-    getSetting('apiUrl').then(apiUrl => setApiUrl(editionsEndpoint(apiUrl)))
-
     /**
      * Default Edition and Selected
      *
@@ -277,7 +275,14 @@ export const EditionProvider = ({
      * editions that are set in the initial state
      */
     useEffect(() => {
-        getEditions(apiUrl).then(ed => ed && setEditionsList(ed))
+        // apiUrl get set in async manner
+        getSetting('apiUrl').then(async url => {
+            setApiUrl(editionsEndpoint(url))
+            const ed = await getEditions(apiUrl)
+            if (ed) {
+                setEditionsList(ed)
+            }
+        })
     }, [apiUrl])
 
     /**

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -275,7 +275,7 @@ export const EditionProvider = ({
      * editions that are set in the initial state
      */
     useEffect(() => {
-        // apiUrl get set in async manner
+        // Get the api url and then make network request to fetch edition list
         getSetting('apiUrl').then(async url => {
             setApiUrl(editionsEndpoint(url))
             const ed = await getEditions(apiUrl)


### PR DESCRIPTION
## Summary
We have observed a spike in handled exception in [crashlytics](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/ios:uk.co.guardian.gce/issues/478416e472734656cae0512d4a570620?time=last-thirty-days&sessionEventKey=a643b3817007440298cc839a301da292_1464828015575953598) after the last app release. It turns out due to a change in edition api usages ([PR](https://github.com/guardian/editions/pull/1556)) app makes network requests when the edition api url is null/empty.

This PR factored the edition api usages to avoid making those invalid network calls.
 
