### PR TITLE
Add /render endpoint to backend.

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -212,6 +212,11 @@ export type CAPIArticle =
 export const imageSizes = ['phone', 'tablet', 'tabletL', 'tabletXL'] as const
 export type ImageSize = typeof imageSizes[number]
 
+export interface RenderedContent {
+    size: ImageSize
+    html: string
+}
+
 export const sizeDescriptions: { [k in ImageSize]: number } = {
     phone: 375,
     tablet: 740,

--- a/projects/aws/lib/aws-stack.ts
+++ b/projects/aws/lib/aws-stack.ts
@@ -57,6 +57,15 @@ export class EditionsStack extends cdk.Stack {
             description: 'print sent url parameter',
         })
 
+        const appsRenderingEndpoint = new cdk.CfnParameter(
+            this,
+            'apps-rendering-endpoint',
+            {
+                type: 'String',
+                description: 'Apps rendering endpoint',
+            },
+        )
+
         const frontsRoleARN = new cdk.CfnParameter(this, 'fronts-role-arn', {
             type: 'String',
             description: 'fronts s3 access',
@@ -207,6 +216,7 @@ export class EditionsStack extends cdk.Stack {
                         publicationStage,
                         capiAccessArn: capiRoleARN.valueAsString,
                         capiPreviewUrl: capiPreviewUrl.valueAsString,
+                        APPS_RENDERING_URL: appsRenderingEndpoint.valueAsString,
                     },
                     initialPolicy: [
                         new iam.PolicyStatement({

--- a/projects/backend/README.md
+++ b/projects/backend/README.md
@@ -13,7 +13,7 @@ Ensure you have Janus credentials for `cmsFronts`, `capi` and `frontend`.
 ### Env vars
 
 You will need a `.env` file to run the backend. This file should have following details in it:
-APPS_RENDERING_ROOT='<apps rendering url>'
+APPS_RENDERING_URL='<apps rendering url>'
 frontsStage=<code/prod>
 capiPreviewUrl=<capi preview url>
 CAPI_KEY=<a capi key>

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -25,6 +25,7 @@ const testStubControllers: EditionsBackendControllers = {
     issueController: stub,
     frontController: stub,
     imageController: stub,
+    renderController: stub,
     editionsController: stubEditionController,
 }
 

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -14,6 +14,7 @@ export interface EditionsBackendControllers {
     issueController: (req: Request, res: Response) => void
     frontController: (req: Request, res: Response) => void
     imageController: (req: Request, res: Response) => void
+    renderController: (req: Request, res: Response) => void
     editionsController: {
         GET: (req: Request, res: Response) => void
         POST: (req: Request, res: Response) => void
@@ -57,6 +58,8 @@ export const createApp = (
         '/' + frontPath(issuePathSegments, '*?'),
         controllers.frontController,
     )
+
+    app.get('/render/:path(*)', controllers.renderController)
 
     app.get(
         '/' +

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -5,6 +5,7 @@ import { Handler } from 'aws-lambda'
 import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController } from './controllers/image'
+import { renderController } from './controllers/render'
 import {
     editionsControllerGet,
     editionsControllerPost,
@@ -17,6 +18,7 @@ const runtimeControllers: EditionsBackendControllers = {
     issueController,
     frontController,
     imageController,
+    renderController,
     editionsController: {
         GET: editionsControllerGet,
         POST: editionsControllerPost,

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -1,6 +1,21 @@
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
-import { ImageSize } from '../../Apps/common/src'
+import { ImageSize, imageSizes, RenderedContent } from '../../Apps/common/src'
+
+const fetchRenderedArticle = async (url: string) => {
+    const response = await fetch(url, {
+        headers: {
+            Accept:
+                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        },
+    })
+    const responseBody = await response.text()
+    return {
+        success: response.statusText === 'OK',
+        status: response.status,
+        body: responseBody,
+    }
+}
 
 // TODO: this needs a test once we're happy with the correct format for the paths
 const replaceImageUrls = (html: string, imageSize: ImageSize): string => {
@@ -10,33 +25,48 @@ const replaceImageUrls = (html: string, imageSize: ImageSize): string => {
     )
 }
 
+const getAllImageSizesHtml = (renderedArticle: string): RenderedContent[] => {
+    return imageSizes.map(size => {
+        return {
+            size,
+            html: replaceImageUrls(renderedArticle, size),
+        }
+    })
+}
+
+const getRenderResponse = (renderedArticle: string, imageSize: string) => {
+    if (imageSize === 'all') {
+        return {
+            contentType: 'application/json',
+            responseBody: JSON.stringify(getAllImageSizesHtml(renderedArticle)),
+        }
+    } else {
+        const responseBody = (imageSizes as readonly string[]).includes(
+            imageSize,
+        )
+            ? replaceImageUrls(renderedArticle, imageSize as ImageSize)
+            : renderedArticle
+        return { contentType: 'text/html', responseBody }
+    }
+}
+
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
-    const replaceImagePaths = req.query.replaceImagePaths
-    const imageSize = req.query.imageSize as ImageSize
-    const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}`
+    const imageSize = req.query.imageSize
+    const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
     console.log(
-        `Fetching ${renderingUrl} from apps rendering. replaceImagePaths: ${replaceImagePaths}`,
+        `Fetching ${renderingUrl} from apps rendering. imageSize: ${imageSize}`,
     )
-    const response = await fetch(renderingUrl, {
-        headers: {
-            Accept:
-                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        },
-    })
-    const responseBody = await response.text()
+    const renderResponse = await fetchRenderedArticle(renderingUrl)
 
-    const editionsRenderedHtml =
-        replaceImagePaths === 'true'
-            ? replaceImageUrls(responseBody, imageSize)
-            : responseBody
+    const response = getRenderResponse(renderResponse.body, imageSize)
 
-    if (response.statusText == 'OK') {
-        res.setHeader('Content-Type', 'text/html')
-        res.send(editionsRenderedHtml)
+    if (renderResponse.success) {
+        res.setHeader('Content-Type', response.contentType)
+        res.send(response.responseBody)
     } else {
-        const message = `Failed to fetch story from ${renderingUrl}. Response: ${responseBody}`
+        const message = `Failed to fetch story from ${renderingUrl}. Response: ${renderResponse.body}`
         console.error(`${message}`)
-        res.status(response.status).send(message)
+        res.status(renderResponse.status).send(message)
     }
 }

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -1,21 +1,35 @@
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
 
+const replaceImageUrls = (html: string): string => {
+    return html.replace(/https:\/\/i.guim.co.uk\/img\//g, '../../')
+}
+
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
+    const replaceImagePaths = req.query.replaceImagePaths
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}`
-    console.log(`Fetching ${renderingUrl} from apps rendering`)
+    console.log(
+        `Fetching ${renderingUrl} from apps rendering. replaceImagePaths: ${replaceImagePaths}`,
+    )
     const response = await fetch(renderingUrl, {
         headers: {
             Accept:
                 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
         },
     })
-    const text = await response.text()
-    if (response.status === 200) {
-        res.send(text)
+    const responseBody = await response.text()
+
+    const editionsRenderedHtml =
+        replaceImagePaths === 'true'
+            ? replaceImageUrls(responseBody)
+            : responseBody
+
+    if (response.statusText == 'OK') {
+        res.setHeader('Content-Type', 'text/html')
+        res.send(editionsRenderedHtml)
     } else {
-        const message = `Failed to fetch story from ${renderingUrl}. Response: ${text}`
+        const message = `Failed to fetch story from ${renderingUrl}. Response: ${responseBody}`
         console.error(`${message}`)
         res.status(response.status).send(message)
     }

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -27,9 +27,8 @@ export const renderController = async (req: Request, res: Response) => {
     console.log(`Fetching ${renderingUrl} from apps rendering`)
     const renderResponse = await fetchRenderedArticle(renderingUrl)
 
-    const htmlWithImagesReplaced = replaceImageUrls(renderResponse.body)
-
     if (renderResponse.success) {
+        const htmlWithImagesReplaced = replaceImageUrls(renderResponse.body)
         res.setHeader('Content-Type', 'text/html')
         res.send(htmlWithImagesReplaced)
     } else {

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -4,8 +4,19 @@ import fetch from 'node-fetch'
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}`
-    console.log(`fetching ${renderingUrl}`)
-    const response = await fetch(renderingUrl)
+    console.log(`Fetching ${renderingUrl} from apps rendering`)
+    const response = await fetch(renderingUrl, {
+        headers: {
+            Accept:
+                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        },
+    })
     const text = await response.text()
-    res.send(text)
+    if (response.status === 200) {
+        res.send(text)
+    } else {
+        const message = `Failed to fetch story from ${renderingUrl}. Response: ${text}`
+        console.error(`${message}`)
+        res.status(response.status).send(message)
+    }
 }

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express'
+import fetch from 'node-fetch'
+
+export const renderController = async (req: Request, res: Response) => {
+    const path = req.params.path
+    const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}`
+    console.log(`fetching ${renderingUrl}`)
+    const response = await fetch(renderingUrl)
+    const text = await response.text()
+    res.send(text)
+}

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -23,11 +23,8 @@ const replaceImageUrls = (html: string): string => {
 
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
-    const imageSize = req.query.imageSize
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
-    console.log(
-        `Fetching ${renderingUrl} from apps rendering. imageSize: ${imageSize}`,
-    )
+    console.log(`Fetching ${renderingUrl} from apps rendering`)
     const renderResponse = await fetchRenderedArticle(renderingUrl)
 
     const htmlWithImagesReplaced = replaceImageUrls(renderResponse.body)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -1,13 +1,19 @@
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
+import { ImageSize } from '../../Apps/common/src'
 
-const replaceImageUrls = (html: string): string => {
-    return html.replace(/https:\/\/i.guim.co.uk\/img\//g, '../../')
+// TODO: this needs a test once we're happy with the correct format for the paths
+const replaceImageUrls = (html: string, imageSize: ImageSize): string => {
+    return html.replace(
+        /https:\/\/i.guim.co.uk\/img\//g,
+        `../../media/${imageSize}/`,
+    )
 }
 
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
     const replaceImagePaths = req.query.replaceImagePaths
+    const imageSize = req.query.imageSize as ImageSize
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}`
     console.log(
         `Fetching ${renderingUrl} from apps rendering. replaceImagePaths: ${replaceImagePaths}`,
@@ -22,7 +28,7 @@ export const renderController = async (req: Request, res: Response) => {
 
     const editionsRenderedHtml =
         replaceImagePaths === 'true'
-            ? replaceImageUrls(responseBody)
+            ? replaceImageUrls(responseBody, imageSize)
             : responseBody
 
     if (response.statusText == 'OK') {


### PR DESCRIPTION
## Summary

This is a very basic controller which simply calls out to apps renderinig and returns the response. We'll need to think about what headers to add and whether we want to gzip the response, but this is a starting point. 

## Test Plan
The backend is only accessible via preview so I am confident this won't pose any problems for users. It's just a building block so that the archiver can start including html in the bundle
