### PR TITLE
Added displayHint field to Article

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -186,6 +186,7 @@ export interface Article extends Content {
     starRating?: number
     sportScore?: string
     mainMedia?: MediaAtomElement
+    displayHint?: string
 }
 
 export interface CrosswordArticle extends Content {

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -107,6 +107,8 @@ const parseArticleResult = async (
 
     const headerType = headerTypePicker(result)
 
+    const displayHint = (result.fields && result.fields.displayHint) || ''
+
     const trail = result.fields && result.fields.trailText
 
     const byline = result.fields && result.fields.byline
@@ -146,6 +148,7 @@ const parseArticleResult = async (
                     kicker,
                     articleType,
                     headerType,
+                    displayHint,
                     trail,
                     ...images,
                     byline: byline || '',


### PR DESCRIPTION
## Summary
We need `displayHint` field in `Article` object to treat some image captions differently. This PR add this field so client can use it.
 

[**Trello Card ->**](https://trello.com/c/HnJ4aNrR/1067-caption-repeated-in-body-text)

## Test Plan
Check this works in CODE first