### PR TITLE
Hiding image caption for photoEssay type

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -176,6 +176,7 @@ export interface Content extends WithKey {
     sportScore?: string
     isFromPrint: boolean
     webUrl?: string
+    displayHint?: string
 }
 export interface Article extends Content {
     type: 'article'

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -30,6 +30,7 @@ interface ArticleContentProps {
     publishedId: Issue['publishedId'] | null
     imageSize: ImageSize
     getImagePath: GetImagePath
+    displayHint?: string
 }
 
 export enum ArticleTheme {
@@ -65,7 +66,7 @@ const cleanupBullets = (html: string) => {
 
 const renderArticleContent = (
     elements: BlockElement[],
-    { showMedia, publishedId, getImagePath }: ArticleContentProps,
+    { showMedia, publishedId, getImagePath, displayHint }: ArticleContentProps,
 ) => {
     const imagePaths = getLightboxImages(elements).map(i => i.src.path)
     return elements
@@ -88,11 +89,13 @@ const renderArticleContent = (
                 case 'image': {
                     const path = getImagePath(el.src)
                     const index = imagePaths.findIndex(e => e === el.src.path)
+                    const displayCaptionAndCredit = displayHint != 'photoEssay'
                     return publishedId
                         ? Image({
                               imageElement: el,
                               path,
                               index,
+                              displayCaptionAndCredit,
                           })
                         : ''
                 }
@@ -204,11 +207,13 @@ export const renderArticle = (
                           pillar,
                           getImagePath,
                       })
+            const displayHint = article.displayHint
             content = renderArticleContent(elements, {
                 showMedia,
                 publishedId,
                 imageSize,
                 getImagePath,
+                displayHint,
             })
             break
     }

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -186,6 +186,7 @@ const ImageBase = ({
     displayCredit,
     role,
     remotePath,
+    displayCaptionAndCredit,
 }: {
     path: string
     index?: number
@@ -195,8 +196,11 @@ const ImageBase = ({
     displayCredit?: boolean
     role?: ImageElement['role']
     remotePath?: string
+    displayCaptionAndCredit?: boolean
 }) => {
-    const figcaption = renderCaption({ caption, credit, displayCredit })
+    const figcaption =
+        displayCaptionAndCredit &&
+        renderCaption({ caption, credit, displayCredit })
     return html`
         <figure class="image" data-role="${role || 'inline'}">
             <img
@@ -222,14 +226,22 @@ const Image = ({
     path,
     index,
     remotePath,
+    displayCaptionAndCredit,
 }: {
     imageElement: ImageElement
     path: string | undefined
     index?: number | undefined
     remotePath?: string
+    displayCaptionAndCredit?: boolean
 }) => {
     if (path) {
-        return ImageBase({ path, index, remotePath, ...imageElement })
+        return ImageBase({
+            path,
+            index,
+            remotePath,
+            displayCaptionAndCredit,
+            ...imageElement,
+        })
     }
     return null
 }


### PR DESCRIPTION
## Summary
In certain articles, with `displayHint=photoEssay` caption appears twice. Once in image caption (which it should be) but also in the body text (due to legacy reason I presume). This PR removes the caption to remove the duplication.


[**Trello Card ->**](https://trello.com/c/HnJ4aNrR/1067-caption-repeated-in-body-text)

## Screenshot
| Before | After |
| ---- | ---|
|![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 55 28](https://user-images.githubusercontent.com/6583174/97328966-d6918280-1876-11eb-85fc-7edc31372835.png)|![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 54 31](https://user-images.githubusercontent.com/6583174/97329010-e0b38100-1876-11eb-9301-3691cf5c1a7b.png)|

