### PR TITLE
Handled empty url bug

### DIFF
--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -307,6 +307,7 @@ export const EditionProvider = ({
     useEffect(() => {
         const appChangeEventHandler = async (appState: AppStateStatus) =>
             appState === 'active' &&
+            apiUrl &&
             getEditions(apiUrl).then(ed => ed && setEditionsList(ed))
 
         AppState.addEventListener('change', appChangeEventHandler)


### PR DESCRIPTION
## Summary
This bug still occuring for [android](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/android:com.guardian.editions/issues/8d9427f6f1bee85efaef5c4b31d7f486?time=last-seven-days&versions=2.276.560%20(14001918)&sessionEventKey=5F994840026A0001023EC57F8BE484E0_1467062173322191060) and [ios](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/ios:uk.co.guardian.gce/issues/478416e472734656cae0512d4a570620?time=last-seven-days&versions=7.2%20(854)&sessionEventKey=53d0ccdba85849f9a7c5ff3df405254c_1467055445463754682)

We have fixed it before but there was one more scenario where `empty api url` can occur. This PR fixes that problem.

This happens when the app completes rendering the UI before the async operation (loading url from storage) is done. 