### PR TITLE
Fix: android 5 webview crash

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainActivity.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainActivity.java
@@ -2,6 +2,8 @@ package com.guardian.editions;
 
 import android.annotation.SuppressLint;
 import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivityDelegate;
@@ -45,5 +47,16 @@ public class MainActivity extends ReactFragmentActivity {
                 return new RNGestureHandlerEnabledRootView(MainActivity.this);
             }
         };
+    }
+
+    // There is a known issue with androix 1.1.0 which cause webview to crash
+    // This is a workaround for this bug (https://github.com/react-native-webview/react-native-webview/issues/858)
+    // androidX bug: https://issuetracker.google.com/issues/141132133
+    @Override
+    public void applyOverrideConfiguration(Configuration overrideConfiguration) {
+        if(Build.VERSION.SDK_INT >= 21 && Build.VERSION.SDK_INT <= 25) {
+            return;
+        }
+        super.applyOverrideConfiguration(overrideConfiguration);
     }
 }


### PR DESCRIPTION
## Summary
The app is crashing on android 5, and it was due a bug underlying androidX library. This PR introduces a workaround to avoid that crash. Here is an example [stack-track](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/android:com.guardian.editions/issues/cbae13a9e468c10d20194a6a0f04a2ce?time=last-seven-days&sessionEventKey=5F9CA930015100012F8C960133A32140_1468013240195708960) of the crash.

Workaround details are here: https://github.com/react-native-webview/react-native-webview/issues/858

[**Trello Card ->**](https://trello.com/c/g99yyG5j/1641-android-app-is-failing-to-start-on-android-os-5)

## Test Plan
Release it to internal android beta