### PR TITLE
Added internalId to edition api respose

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -177,6 +177,7 @@ export interface Content extends WithKey {
     isFromPrint: boolean
     webUrl?: string
     displayHint?: string
+    internalId: number
 }
 export interface Article extends Content {
     type: 'article'

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -177,7 +177,7 @@ export interface Content extends WithKey {
     isFromPrint: boolean
     webUrl?: string
     displayHint?: string
-    internalId: number
+    internalPageCode: number
 }
 export interface Article extends Content {
     type: 'article'

--- a/projects/archiver/test/tasks/front/helpers/media.spec.ts
+++ b/projects/archiver/test/tasks/front/helpers/media.spec.ts
@@ -21,6 +21,7 @@ test('getImage', () => {
         mediaType: 'Image',
         elements: [],
         isFromPrint: true,
+        internalId: 1,
     }
     expect(getImagesFromArticle(article)).toContain(image)
 })
@@ -46,6 +47,7 @@ test('getImageUse', () => {
         elements: [],
         isFromPrint: false,
         bylineHtml: '<a>🧬</<a> Senior person',
+        internalId: 1,
     }
     expect(getImagesFromArticle(article)).toContain(image)
 })

--- a/projects/archiver/test/tasks/front/helpers/media.spec.ts
+++ b/projects/archiver/test/tasks/front/helpers/media.spec.ts
@@ -21,7 +21,7 @@ test('getImage', () => {
         mediaType: 'Image',
         elements: [],
         isFromPrint: true,
-        internalId: 1,
+        internalPageCode: 1,
     }
     expect(getImagesFromArticle(article)).toContain(image)
 })
@@ -47,7 +47,7 @@ test('getImageUse', () => {
         elements: [],
         isFromPrint: false,
         bylineHtml: '<a>🧬</<a> Senior person',
-        internalId: 1,
+        internalPageCode: 1,
     }
     expect(getImagesFromArticle(article)).toContain(image)
 })

--- a/projects/backend/__tests__/helpers/fixtures.ts
+++ b/projects/backend/__tests__/helpers/fixtures.ts
@@ -39,6 +39,7 @@ const Content = <T extends string>(
     mediaType,
     sportScore,
     isFromPrint: false,
+    internalId: 1,
 })
 
 const Article = ({

--- a/projects/backend/__tests__/helpers/fixtures.ts
+++ b/projects/backend/__tests__/helpers/fixtures.ts
@@ -39,7 +39,7 @@ const Content = <T extends string>(
     mediaType,
     sportScore,
     isFromPrint: false,
-    internalId: 1,
+    internalPageCode: 1,
 })
 
 const Article = ({

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -137,7 +137,6 @@ const parseArticleResult = async (
 
     const webUrl = !isFromPrint ? result.webUrl : undefined
 
-    console.log('internalid: ' + internalid)
     switch (result.type) {
         case ContentType.ARTICLE:
             const article: [number, CArticle] = [

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -92,9 +92,9 @@ const parseArticleResult = async (
 ): Promise<[number, CAPIContent]> => {
     const path = result.id
     console.log(`Parsing CAPI response for ${path}`)
-    const internalid = result.fields && result.fields.internalPageCode
-    if (internalid == null)
-        throw new Error(`internalid was undefined in ${path}!`)
+    const internalPageCode = result.fields && result.fields.internalPageCode
+    if (internalPageCode == null)
+        throw new Error(`internalPageCode was undefined in ${path}!`)
 
     const title = (result.fields && result.fields.headline) || result.webTitle
 
@@ -140,7 +140,7 @@ const parseArticleResult = async (
     switch (result.type) {
         case ContentType.ARTICLE:
             const article: [number, CArticle] = [
-                internalid,
+                internalPageCode,
                 {
                     type: 'article',
                     path: path,
@@ -160,14 +160,14 @@ const parseArticleResult = async (
                     mainMedia: getMainMediaAtom(result.blocks),
                     isFromPrint,
                     webUrl,
-                    internalId: internalid,
+                    internalPageCode,
                 },
             ]
             return article
 
         case ContentType.GALLERY:
             const galleryArticle: [number, CGallery] = [
-                internalid,
+                internalPageCode,
                 {
                     type: 'gallery',
                     path: path,
@@ -183,7 +183,7 @@ const parseArticleResult = async (
                     elements,
                     isFromPrint,
                     webUrl,
-                    internalId: internalid,
+                    internalPageCode,
                 },
             ]
 
@@ -191,7 +191,7 @@ const parseArticleResult = async (
 
         case ContentType.PICTURE:
             const pictureArticle: [number, CPicture] = [
-                internalid,
+                internalPageCode,
                 {
                     type: 'picture',
                     path: path,
@@ -207,7 +207,7 @@ const parseArticleResult = async (
                     elements,
                     isFromPrint,
                     webUrl,
-                    internalId: internalid,
+                    internalPageCode,
                 },
             ]
 
@@ -239,7 +239,7 @@ const parseArticleResult = async (
             }
 
             const crosswordArticle: [number, CAPIContent] = [
-                internalid,
+                internalPageCode,
                 {
                     type: 'crossword',
                     trail,
@@ -253,7 +253,7 @@ const parseArticleResult = async (
                     crossword,
                     isFromPrint,
                     webUrl,
-                    internalId: internalid,
+                    internalPageCode,
                 },
             ]
 
@@ -261,7 +261,7 @@ const parseArticleResult = async (
 
         default:
             return [
-                internalid,
+                internalPageCode,
                 {
                     type: 'article',
                     path: path,
@@ -287,7 +287,7 @@ const parseArticleResult = async (
                     ],
                     isFromPrint,
                     webUrl,
-                    internalId: internalid,
+                    internalPageCode,
                 },
             ]
     }

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -137,6 +137,7 @@ const parseArticleResult = async (
 
     const webUrl = !isFromPrint ? result.webUrl : undefined
 
+    console.log('internalid: ' + internalid)
     switch (result.type) {
         case ContentType.ARTICLE:
             const article: [number, CArticle] = [
@@ -160,6 +161,7 @@ const parseArticleResult = async (
                     mainMedia: getMainMediaAtom(result.blocks),
                     isFromPrint,
                     webUrl,
+                    internalId: internalid,
                 },
             ]
             return article
@@ -182,6 +184,7 @@ const parseArticleResult = async (
                     elements,
                     isFromPrint,
                     webUrl,
+                    internalId: internalid,
                 },
             ]
 
@@ -205,6 +208,7 @@ const parseArticleResult = async (
                     elements,
                     isFromPrint,
                     webUrl,
+                    internalId: internalid,
                 },
             ]
 
@@ -250,6 +254,7 @@ const parseArticleResult = async (
                     crossword,
                     isFromPrint,
                     webUrl,
+                    internalId: internalid,
                 },
             ]
 
@@ -283,6 +288,7 @@ const parseArticleResult = async (
                     ],
                     isFromPrint,
                     webUrl,
+                    internalId: internalid,
                 },
             ]
     }


### PR DESCRIPTION
## Summary
In order to help with some article rendering work, we need to include a unique id to each article object. This PR just does that.

This will add this new field as a child of the article object.
<img width="705" alt="Screen Shot 2020-11-04 at 15 01 41" src="https://user-images.githubusercontent.com/6583174/98122929-85eeda80-1eb1-11eb-8bed-0530ae2e8b59.png">
