### PR TITLE
Fix: empty url loading bug

### DIFF
--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -277,13 +277,18 @@ export const EditionProvider = ({
     useEffect(() => {
         // Get the api url and then make network request to fetch edition list
         getSetting('apiUrl').then(async url => {
-            setApiUrl(editionsEndpoint(url))
-            const ed = await getEditions(apiUrl)
+            const fullUrl = editionsEndpoint(url)
+            setApiUrl(fullUrl)
+
+            // Avoid calling getEditions below by passing `apiUrl` state variable because that
+            // doesn't get updated immediately, it only updates in next render.
+            // Details can be found here: https://stackoverflow.com/questions/54069253/usestate-set-method-not-reflecting-change-immediately
+            const ed = await getEditions(fullUrl)
             if (ed) {
                 setEditionsList(ed)
             }
         })
-    }, [apiUrl])
+    }, [])
 
     /**
      * If a chosen edition is regional, then we mark that as default for future reference


### PR DESCRIPTION
## Summary

Due to the nature of how the state variable gets updated, we were seeing lots of network calls being made with empty url. This PR fix that problem. A sample crashlytics log can be seen [here](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/ios:uk.co.guardian.gce/issues/478416e472734656cae0512d4a570620?time=last-seven-days&versions=7.2%20(861)&sessionEventKey=cf0db3de7e2c40869249df2600e5f5b6_1469667662878755913)

