### PR TITLE
Reduce height of mobile cards.

### DIFF
--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -41,7 +41,7 @@ export const metrics = {
     fronts: {
         sides: basicMetrics.horizontal * 1.5,
         marginBottom: basicMetrics.horizontal * 2,
-        cardSize: toSize(540, 520), // height should really be 500
+        cardSize: toSize(540, 510),
         cardSizeTablet: toSize(650, 646),
         circleButtonDiameter: 36,
     },


### PR DESCRIPTION
## Summary
In discussions with @pradasa a loong time ago we agreed mobile cards should be a bit shorter. This PR shaves 10 pixels off the height of mobile cards, thus solving the slim border seen on iPhone SE/iPhone 5 devices.

[**Trello Card ->**](https://trello.com/c/nC1cJfBX/1300-cover-cards-image-doesnt-fit-the-full-card)

## Test Plan
I've tested this in the simulator for an iphone 11. The worst thing I saw was this - otherwise no cropped text or dodgy borders. I think this would be fine to push to beta, but we should make sure we tell the production team to update their apps as it is a slight change to the layout.

<img width="377" alt="Screenshot 2020-11-06 at 17 37 30" src="https://user-images.githubusercontent.com/3606555/98397257-fbe07680-2056-11eb-8543-81af8bdf9e02.png">

