### PR TITLE
Generate new sets of image bundles with flat directory structures

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -292,7 +292,7 @@ export interface IssueSummary extends WithKey, IssueCompositeKey {
     } & { data: string }
     assetsSSR?: {
         [P in ImageSize]?: string
-    } & { data: string }
+    } & { html: string }
 }
 
 export interface Issue extends IssueSummary, WithKey {
@@ -464,6 +464,9 @@ export const issuePath = (issue: string) => `${issueDir(issue)}/issue`
 // const issuePath = (issueId: string) => `${issueDir(issueId)}issue`
 export const frontPath = (issue: string, frontId: string) =>
     `${issueDir(issue)}/front/${frontId}`
+
+export const htmlPath = (issue: string, frontId: string) =>
+    `${issueDir(issue)}/html`
 
 // These have issueids in the path, but you'll need to change the archiver if you want to use them.
 

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -285,6 +285,9 @@ export interface IssueSummary extends WithKey, IssueCompositeKey {
     assets?: {
         [P in ImageSize]?: string
     } & { data: string }
+    assetsSSR?: {
+        [P in ImageSize]?: string
+    } & { data: string }
 }
 
 export interface Issue extends IssueSummary, WithKey {

--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -465,8 +465,7 @@ export const issuePath = (issue: string) => `${issueDir(issue)}/issue`
 export const frontPath = (issue: string, frontId: string) =>
     `${issueDir(issue)}/front/${frontId}`
 
-export const htmlPath = (issue: string, frontId: string) =>
-    `${issueDir(issue)}/html`
+export const htmlDirPath = (issue: string) => `${issueDir(issue)}/html`
 
 // These have issueids in the path, but you'll need to change the archiver if you want to use them.
 

--- a/projects/archiver/src/tasks/zip/helpers/zipper.ts
+++ b/projects/archiver/src/tasks/zip/helpers/zipper.ts
@@ -6,7 +6,7 @@ import { getMatchingObjects } from './lister'
 export const zip = async (
     name: string,
     prefixes: string[],
-    options: { removeFromOutputPath: string[]; replaceWith?: string },
+    options: { removeFromOutputPath?: string; replaceImageSize?: string },
     bucket: Bucket,
 ) => {
     const output = new PassThrough()
@@ -35,16 +35,16 @@ export const zip = async (
 
     await Promise.all(
         files.map(async file => {
-            let zipPath = ''
-            if (options.removeFromOutputPath) {
-                options.removeFromOutputPath.forEach(str => {
-                    if (file.includes(str)) {
-                        zipPath = file.replace(str, options.replaceWith || '')
-                    }
-                })
-            } else {
-                zipPath = file
-            }
+            const path = options.removeFromOutputPath
+                ? file.replace(`${options.removeFromOutputPath}`, '')
+                : file
+
+            // Remove the image size from the path and replace with a static `images`
+            // It is currently needed for server side rendering html bundle
+            const zipPath = options.replaceImageSize
+                ? path.replace(`/${options.replaceImageSize}/`, '/images/')
+                : path
+
             console.log(`getting ${file}`)
             const s3response = await s3
                 .getObject({ Bucket: bucket.name, Key: file })

--- a/projects/archiver/src/tasks/zip/helpers/zipper.ts
+++ b/projects/archiver/src/tasks/zip/helpers/zipper.ts
@@ -6,7 +6,7 @@ import { getMatchingObjects } from './lister'
 export const zip = async (
     name: string,
     prefixes: string[],
-    options: { removeFromOutputPath?: string },
+    options: { removeFromOutputPath: string[]; replaceWith?: string },
     bucket: Bucket,
 ) => {
     const output = new PassThrough()
@@ -35,9 +35,16 @@ export const zip = async (
 
     await Promise.all(
         files.map(async file => {
-            const zipPath = options.removeFromOutputPath
-                ? file.replace(`${options.removeFromOutputPath}`, '')
-                : file
+            let zipPath = ''
+            if (options.removeFromOutputPath) {
+                options.removeFromOutputPath.forEach(str => {
+                    if (file.includes(str)) {
+                        zipPath = file.replace(str, options.replaceWith || '')
+                    }
+                })
+            } else {
+                zipPath = file
+            }
             console.log(`getting ${file}`)
             const s3response = await s3
                 .getObject({ Bucket: bucket.name, Key: file })

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -30,7 +30,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
             `${publishedId}/data`,
             [issuePath(publishedId), frontPath(publishedId, '')],
             {
-                removeFromOutputPath: [`${version}/`],
+                removeFromOutputPath: `${version}/`,
             },
             bucket,
         )
@@ -47,8 +47,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
                             mediaDir(publishedId, size),
                         ],
                         {
-                            removeFromOutputPath: [`${version}/`],
-                            replaceWith: '',
+                            removeFromOutputPath: `${version}/`,
                         },
                         bucket,
                     )
@@ -71,11 +70,8 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
                             mediaDir(publishedId, size),
                         ],
                         {
-                            removeFromOutputPath: [
-                                `${version}/media/${size}`,
-                                `${version}/thumbs/${size}`,
-                            ],
-                            replaceWith: 'images',
+                            removeFromOutputPath: `${version}/`,
+                            replaceImageSize: size,
                         },
                         bucket,
                     )

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -9,7 +9,7 @@ import {
 import { zip } from './helpers/zipper'
 import { UploadTaskOutput } from '../upload'
 import { handleAndNotify } from '../../services/task-handler'
-import { htmlPath, thumbsDir } from '../../../../Apps/common/src'
+import { htmlDirPath, thumbsDir } from '../../../../Apps/common/src'
 import { getBucket } from '../../utils/s3'
 import { sleep } from '../../utils/sleep'
 
@@ -86,7 +86,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
         // SSR - generate 'html' bundle for new app client
         await zip(
             `${publishedId}/ssr/html`,
-            [htmlPath(publishedId, '')],
+            [htmlDirPath(publishedId)],
             {
                 removeFromOutputPath: `${version}/`,
             },

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -62,32 +62,42 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
 
         // Generate image bundle with simpler structure, without imageSize
         await Promise.all(
-            imageSizes
-                .filter(f => f == 'phone')
-                .map(
-                    async (size): Promise<[ImageSize, string]> => {
-                        const imgUpload = await zip(
-                            `${publishedId}/ssr/${size}`,
-                            [
-                                thumbsDir(publishedId, size),
-                                mediaDir(publishedId, size),
+            imageSizes.map(
+                async (size): Promise<[ImageSize, string]> => {
+                    const imgUpload = await zip(
+                        `${publishedId}/ssr/${size}`,
+                        [
+                            thumbsDir(publishedId, size),
+                            mediaDir(publishedId, size),
+                        ],
+                        {
+                            removeFromOutputPath: [
+                                `${version}/media/${size}`,
+                                `${version}/thumbs/${size}`,
                             ],
-                            {
-                                removeFromOutputPath: [
-                                    `${version}/media/${size}`,
-                                    `${version}/thumbs/${size}`,
-                                ],
-                                replaceWith: 'images',
-                            },
-                            bucket,
-                        )
+                            replaceWith: 'images',
+                        },
+                        bucket,
+                    )
 
-                        console.log(` ${size}   media zip uploaded`)
-                        return [size, imgUpload.Key]
-                    },
-                ),
+                    console.log(` ${size}   media zip uploaded`)
+                    return [size, imgUpload.Key]
+                },
+            ),
         )
         console.log('Media zips uploaded.')
+
+        // TODO zip upload with SSR article htmls
+        // await zip(
+        //     `${publishedId}/data`,
+        //     [issuePath(publishedId), frontPath(publishedId, '')],
+        //     {
+        //         removeFromOutputPath: [`${version}/`],
+        //     },
+        //     bucket,
+        // )
+        // console.log(`data zip uploaded to: s3://${bucket.name}/${publishedId}`)
+
         return {
             issuePublication,
             issue,

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -9,7 +9,7 @@ import {
 import { zip } from './helpers/zipper'
 import { UploadTaskOutput } from '../upload'
 import { handleAndNotify } from '../../services/task-handler'
-import { thumbsDir } from '../../../../Apps/common/src'
+import { htmlPath, thumbsDir } from '../../../../Apps/common/src'
 import { getBucket } from '../../utils/s3'
 import { sleep } from '../../utils/sleep'
 
@@ -59,7 +59,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
         )
         console.log('Media zips uploaded.')
 
-        // Generate image bundle with simpler structure, without imageSize
+        // SSR - generate image bundle with simpler structure, without imageSize
         await Promise.all(
             imageSizes.map(
                 async (size): Promise<[ImageSize, string]> => {
@@ -83,16 +83,16 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
         )
         console.log('Media zips uploaded.')
 
-        // TODO zip upload with SSR article htmls
-        // await zip(
-        //     `${publishedId}/data`,
-        //     [issuePath(publishedId), frontPath(publishedId, '')],
-        //     {
-        //         removeFromOutputPath: [`${version}/`],
-        //     },
-        //     bucket,
-        // )
-        // console.log(`data zip uploaded to: s3://${bucket.name}/${publishedId}`)
+        // SSR - generate 'html' bundle for new app client
+        await zip(
+            `${publishedId}/ssr/html`,
+            [htmlPath(publishedId, '')],
+            {
+                removeFromOutputPath: `${version}/`,
+            },
+            bucket,
+        )
+        console.log(`html zip uploaded to: s3://${bucket.name}/${publishedId}`)
 
         return {
             issuePublication,

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -30,7 +30,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
             `${publishedId}/data`,
             [issuePath(publishedId), frontPath(publishedId, '')],
             {
-                removeFromOutputPath: `${version}/`,
+                removeFromOutputPath: [`${version}/`],
             },
             bucket,
         )
@@ -47,7 +47,8 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
                             mediaDir(publishedId, size),
                         ],
                         {
-                            removeFromOutputPath: `${version}/`,
+                            removeFromOutputPath: [`${version}/`],
+                            replaceWith: '',
                         },
                         bucket,
                     )
@@ -56,6 +57,35 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
                     return [size, imgUpload.Key]
                 },
             ),
+        )
+        console.log('Media zips uploaded.')
+
+        // Generate image bundle with simpler structure, without imageSize
+        await Promise.all(
+            imageSizes
+                .filter(f => f == 'phone')
+                .map(
+                    async (size): Promise<[ImageSize, string]> => {
+                        const imgUpload = await zip(
+                            `${publishedId}/ssr/${size}`,
+                            [
+                                thumbsDir(publishedId, size),
+                                mediaDir(publishedId, size),
+                            ],
+                            {
+                                removeFromOutputPath: [
+                                    `${version}/media/${size}`,
+                                    `${version}/thumbs/${size}`,
+                                ],
+                                replaceWith: 'images',
+                            },
+                            bucket,
+                        )
+
+                        console.log(` ${size}   media zip uploaded`)
+                        return [size, imgUpload.Key]
+                    },
+                ),
         )
         console.log('Media zips uploaded.')
         return {

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -1,5 +1,6 @@
 import { IssuePublicationIdentifier, IssueSummary } from '../../../../common'
 import { getIssueSummaryInternal } from '../../../../src/tasks/indexer/helpers/get-issue-summary'
+import { Bucket } from '../../../../src/utils/s3'
 
 describe('getIssueSummaryInternal', () => {
     const assetKeys = [
@@ -10,6 +11,8 @@ describe('getIssueSummaryInternal', () => {
         'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
     ]
 
+    const bucket: Bucket = { name: 'test', context: 'default' }
+
     it('should return IssueSummary', async () => {
         const issue: IssuePublicationIdentifier = {
             edition: 'american-edition',
@@ -17,9 +20,9 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-10-09',
         }
 
-        const actual = getIssueSummaryInternal(
+        const actual = await getIssueSummaryInternal(
             issue,
-            assetKeys,
+            bucket,
             'American Edition',
         )
 
@@ -53,9 +56,9 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-1011-09',
         }
 
-        const actual = getIssueSummaryInternal(
+        const actual = await getIssueSummaryInternal(
             issueWithIncorrectDate,
-            assetKeys,
+            bucket,
             'American Edition',
         )
 
@@ -69,9 +72,9 @@ describe('getIssueSummaryInternal', () => {
             issueDate: '2019-10-09',
         }
 
-        const actual = getIssueSummaryInternal(
+        const actual = await getIssueSummaryInternal(
             issueWithIncorrectDate,
-            [],
+            bucket,
             'American Edition',
         )
 

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -11,6 +11,14 @@ describe('getIssueSummaryInternal', () => {
         'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
     ]
 
+    const assetKeysSSR = [
+        'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/html.zip',
+        'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/phone.zip',
+        'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tablet.zip',
+        'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletL.zip',
+        'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
+    ]
+
     const bucket: Bucket = { name: 'test', context: 'default' }
 
     it('should return IssueSummary', async () => {
@@ -22,7 +30,8 @@ describe('getIssueSummaryInternal', () => {
 
         const actual = await getIssueSummaryInternal(
             issue,
-            bucket,
+            assetKeys,
+            assetKeysSSR,
             'American Edition',
         )
 
@@ -35,6 +44,18 @@ describe('getIssueSummaryInternal', () => {
             assets: {
                 data:
                     'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/data.zip',
+                phone:
+                    'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/phone.zip',
+                tablet:
+                    'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tablet.zip',
+                tabletL:
+                    'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletL.zip',
+                tabletXL:
+                    'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
+            },
+            assetsSSR: {
+                html:
+                    'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/html.zip',
                 phone:
                     'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/phone.zip',
                 tablet:
@@ -58,7 +79,8 @@ describe('getIssueSummaryInternal', () => {
 
         const actual = await getIssueSummaryInternal(
             issueWithIncorrectDate,
-            bucket,
+            assetKeys,
+            assetKeysSSR,
             'American Edition',
         )
 
@@ -74,7 +96,8 @@ describe('getIssueSummaryInternal', () => {
 
         const actual = await getIssueSummaryInternal(
             issueWithIncorrectDate,
-            bucket,
+            [],
+            [],
             'American Edition',
         )
 


### PR DESCRIPTION
## Summary

To avoid duplicate `html` bundles we need a clean image directory structure without an image size prefix in it (i.e. without phone, tablet etc). This PR is for that purpose

The outcome of the PR is having a simpler folder structure, something like this:
<img width="513" alt="Screen Shot 2020-11-10 at 15 08 05" src="https://user-images.githubusercontent.com/6583174/98684541-9649fe00-2366-11eb-98e0-9231163e5d0c.png">


And a new assets item in the issue summary api called `assetsSSR`, look like this:
<img width="961" alt="Screen Shot 2020-11-10 at 12 29 48" src="https://user-images.githubusercontent.com/6583174/98671503-a822a580-2354-11eb-9498-a7dc01a3723a.png">
