### PR TITLE
Keychain updated to latest version

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -321,7 +321,7 @@ PODS:
     - React
   - RNInAppBrowser (3.3.3):
     - React
-  - RNKeychain (5.0.1):
+  - RNKeychain (6.2.0):
     - React
   - RNLocalize (1.4.0):
     - React
@@ -595,7 +595,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
   RNIap: 89befcc43b4077663968b1e3d0c1e3fbd0a1eaca
   RNInAppBrowser: 0800f17fd7ed9fc503eb68e427befebb41ee719b
-  RNKeychain: a5623de13ec5378bfb8035422e3dee4fa538660d
+  RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNPermissions: 9e437a90de84a5402ff689d4da233730b81556c2
   RNSentry: 0a70359ddacbfb9b1cbbb0971e54065b9f70ac57

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -78,7 +78,7 @@
         "react-native-image-zoom-viewer": "^3.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",
-        "react-native-keychain": "5.0.1",
+        "react-native-keychain": "6.2.0",
         "react-native-localize": "^1.4.0",
         "react-native-permissions": "^2.0.3",
         "react-native-progress-circle": "^2.1.0",

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -98,15 +98,12 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
  */
 const createServiceTokenStore = (service: string) => ({
     get: () =>
-        Keychain.getGenericPassword({ service })
-            .then(val => {
-                return val ? val : null
-            })
-            .catch(e => {
-                console.log(`KEYCHAIN GET ERROR: ` + e)
-            }),
-    set: async ({ username, token }: { username: string; token: string }) =>
-        await Keychain.setGenericPassword(username, token, { service }),
+        Keychain.getGenericPassword({ service }).then(val =>
+            val ? val : null,
+        ),
+    set: async ({ username, token }: { username: string; token: string }) => {
+        await Keychain.setGenericPassword(username, token, { service })
+    },
     reset: async (): Promise<void> => {
         await Keychain.resetGenericPassword({ service })
     },

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -97,13 +97,15 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
  * This is keyed off the given service.
  */
 const createServiceTokenStore = (service: string) => ({
-    get: () =>
-        Keychain.getGenericPassword({ service }).then(val =>
-            val ? val : null,
-        ),
-    set: async ({ username, token }: { username: string; token: string }) => {
+    get: () => 
+        Keychain.getGenericPassword({ service }).then(val => {
+            return val ? val : null
+        }).catch(e => {
+            console.log(`KEYCHAIN GET ERROR: ` + e)
+        }),
+    set: async ({ username, token }: { username: string; token: string }) => (
         await Keychain.setGenericPassword(username, token, { service })
-    },
+    ),
     reset: async (): Promise<void> => {
         await Keychain.resetGenericPassword({ service })
     },

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -97,15 +97,16 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
  * This is keyed off the given service.
  */
 const createServiceTokenStore = (service: string) => ({
-    get: () => 
-        Keychain.getGenericPassword({ service }).then(val => {
-            return val ? val : null
-        }).catch(e => {
-            console.log(`KEYCHAIN GET ERROR: ` + e)
-        }),
-    set: async ({ username, token }: { username: string; token: string }) => (
-        await Keychain.setGenericPassword(username, token, { service })
-    ),
+    get: () =>
+        Keychain.getGenericPassword({ service })
+            .then(val => {
+                return val ? val : null
+            })
+            .catch(e => {
+                console.log(`KEYCHAIN GET ERROR: ` + e)
+            }),
+    set: async ({ username, token }: { username: string; token: string }) =>
+        await Keychain.setGenericPassword(username, token, { service }),
     reset: async (): Promise<void> => {
         await Keychain.resetGenericPassword({ service })
     },

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -11208,10 +11208,10 @@ react-native-inappbrowser-reborn@^3.3.3:
     invariant "^2.2.4"
     opencollective-postinstall "^2.0.2"
 
-react-native-keychain@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-5.0.1.tgz#2751de436f017c87b8aabb32533bee88657d643e"
-  integrity sha512-CLIPNexPBufPpNqgF7/smZNAiv6x0SCsztfEi/hWPCQ7yHxNwdRUyUzOLGrw1lPe/6fQE+TC3iS1+cbDTaRJag==
+react-native-keychain@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-6.2.0.tgz#8f4cff503aad367141db5aea0189ead9240c28ff"
+  integrity sha512-U6fnOQRJPq+c0Abl+FoYy9v0H3kQU587tMamU/o+MoBSUScFLE3DQpkyT1PW4NF5IObgiGuqQdmjC2KgtBpjGA==
 
 react-native-localize@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary
The current `react-native-keychain` is failing to read/write large values for some android devices and as a side effect (I think), it triggers fingerprint dialog.

This PR updated the library to the latest version of the library (6.2.0) which resolves that problem.

Note: The new library does prevent showing fingerprint to new install but it still seems to be an issue for those users who experienced fingerprint issues before. 

[**Trello Card ->**](https://trello.com/c/qMwpMhcR/1654-fingerprint-message-android-2620-14001378)

## Test Plan
Roll out to beta users and validate the sign-in still works as expected.