### PR TITLE
Special-edition-onboarding for awareness

### DIFF
--- a/projects/Mallard/src/screens/onboarding/special-edition-onboarding.tsx
+++ b/projects/Mallard/src/screens/onboarding/special-edition-onboarding.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import {
+    OnboardingCard,
+    CardAppearance,
+} from 'src/components/onboarding/onboarding-card'
+import { ButtonAppearance } from 'src/components/Button/Button'
+import { ModalButton } from 'src/components/Button/ModalButton'
+import { LinkNav } from 'src/components/link'
+import {
+    gdprSwitchSettings,
+    CURRENT_CONSENT_VERSION,
+} from 'src/helpers/settings'
+import { GDPR_SETTINGS_FRAGMENT } from 'src/helpers/settings/resolvers'
+import {
+    setGdprFlag,
+    setGdprConsentVersion,
+} from 'src/helpers/settings/setters'
+import { useQuery } from 'src/hooks/apollo'
+import gql from 'graphql-tag'
+import { Copy } from 'src/helpers/words'
+import { TitlepieceText } from 'src/components/styled-text'
+
+const styles = StyleSheet.create({
+    consentButtonContainer: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+})
+
+const OnboardingSpecialEdition = ({}: {}) => {
+    return (
+        <View>
+            <TitlepieceText>Gal-dem-takeover</TitlepieceText>
+        </View>
+    )
+}
+
+export { OnboardingSpecialEdition }


### PR DESCRIPTION
Creating a branch and submitting Pip's code for the awareness balloon about special editions.

## Summary
Why are we doing this?
We are planning to launch an end of the year edition. This work will help users know that there's a new edition available and how to access it. 

[**Trello Card ->**](https://trello.com/c/snUrRRLs/1695-special-edition-awareness-balloon)

## Test Plan
Check list:
- Copy and background colour
- Does the CTA closes the balloon?
- Does it appear when users open the app after a new special edition is available?
