### PR TITLE
Fix: Caption Overlap and caption arrow misdirected

### DIFF
--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -7,6 +7,7 @@ import { metrics } from 'src/theme/spacing'
 import { Arrow } from './arrow'
 import { CssProps, themeColors } from '../helpers/css'
 import { ArticleType } from '../../../../../../Apps/common/src'
+import { ArticleTheme } from '../article'
 export const renderCaption = ({
     caption,
     credit,
@@ -18,7 +19,7 @@ export const renderCaption = ({
         : caption
 }
 
-const breakoutCaption = (role: ImageElement['role']) => css`
+const breakoutCaption = (role: ImageElement['role'], theme: ArticleTheme) => css`
     .image[data-role='${role}'] div {
         position: absolute;
         right: ${px(
@@ -37,22 +38,20 @@ const breakoutCaption = (role: ImageElement['role']) => css`
         overflow: hidden;
     }
 
-    .image[data-role='${role}'] strong {
+    .image[data-role='${role}'] span {
         font-family: 'GuardianTextSans-Regular';
+        color: ${themeColors(theme).dimText};
         ${getFontCss('sans', 0.9)}
-
+        font-weight: bold;
     }
 
-    .image[data-role='${role}'] figcaption svg {
-        transform: rotate(-90deg);
-    }
 `
 
 const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
     const galleryStyles = css`
         /*INLINE*/
         @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            ${breakoutCaption('inline')}
+            ${breakoutCaption('inline', theme)}
         }
     `
     const defaultStyles = css`
@@ -153,7 +152,7 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
     )}
                 );
             }
-            ${breakoutCaption('showcase')}
+            ${breakoutCaption('showcase', theme)}
         }
 
         /*IMMERSIVE*/
@@ -214,6 +213,7 @@ const ImageBase = ({
     displayCaptionAndCredit?: boolean
 }) => {
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
+    const isInlineTablet = !role && isTablet
     const figcaption =
         displayCaptionAndCredit &&
         renderCaption({ caption, credit, displayCredit })
@@ -231,15 +231,15 @@ const ImageBase = ({
         html`
                 <div>
                     <figcaption>
-                        ${Arrow({ direction: Direction.top })} ${figcaption} 
+                        ${Arrow(isInlineTablet ? { direction: Direction.left } : { direction: Direction.top })} ${figcaption} 
                     </figcaption>
                     
-                  ${isTablet && 
-                    html`
-                    <strong
+                  ${isInlineTablet &&
+            html`
+                    <span
                     onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
-                    >view more</strong>`
-                }
+                    >view more</span>
+                    `}
                  </div>
                     
                 `}

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -13,18 +13,20 @@ export const renderCaption = ({
     credit,
     displayCredit,
 }: Pick<ImageElement, 'caption' | 'credit' | 'displayCredit'>) => {
-
     return displayCredit === true
         ? [caption, credit].filter(s => !!s).join(' ')
         : caption
 }
 
-const breakoutCaption = (role: ImageElement['role'], theme: ArticleTheme) => css`
+const breakoutCaption = (
+    role: ImageElement['role'],
+    theme: ArticleTheme,
+) => css`
     .image[data-role='${role}'] div {
         position: absolute;
         right: ${px(
-    (metrics.article.rightRail + metrics.article.sides * 1.5) * -1,
-)};
+            (metrics.article.rightRail + metrics.article.sides * 1.5) * -1,
+        )};
         top: -0.5em;
         display:block;
         width: ${px(metrics.article.rightRail)};
@@ -110,8 +112,8 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
                 width: 500px;
                 margin-left: ${px(metrics.article.sides)};
                 margin-right: ${px(
-        (metrics.article.rightRail + metrics.article.sides) * -1,
-    )};
+                    (metrics.article.rightRail + metrics.article.sides) * -1,
+                )};
             }
 
             .image[data-role='supporting'] figcaption {
@@ -123,12 +125,12 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
 
         /*SHOWCASE*/
         @media (min-width: ${px(
-        Breakpoints.tabletVertical,
-    )}) and (max-width: ${px(Breakpoints.tabletLandscape)}) {
+                Breakpoints.tabletVertical,
+            )}) and (max-width: ${px(Breakpoints.tabletLandscape)}) {
             .image[data-role='showcase'] {
                 margin-right: ${px(
-        (metrics.article.rightRail + metrics.article.sides) * -1,
-    )};
+                    (metrics.article.rightRail + metrics.article.sides) * -1,
+                )};
             }
 
             .image[data-role='showcase'] figcaption {
@@ -139,17 +141,17 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
             .image[data-role='showcase'] img {
                 margin-left: ${px(
-        ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-            2) *
-        -1,
-    )};
+                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
+                        2) *
+                        -1,
+                )};
                 width: calc(
                     100% +
                         ${px(
-        (Breakpoints.tabletLandscape -
-            metrics.article.maxWidth) /
-        2,
-    )}
+                            (Breakpoints.tabletLandscape -
+                                metrics.article.maxWidth) /
+                                2,
+                        )}
                 );
             }
             ${breakoutCaption('showcase', theme)}
@@ -159,8 +161,8 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         @media (min-width: ${px(Breakpoints.tabletVertical)}) {
             .image[data-role='immersive'] {
                 margin-right: ${px(
-        (metrics.article.rightRail + metrics.article.sides) * -1,
-    )};
+                    (metrics.article.rightRail + metrics.article.sides) * -1,
+                )};
             }
             .image[data-role='immersive'] figcaption {
                 width: ${px(metrics.article.rightRail)};
@@ -172,17 +174,17 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
                 width: calc(
                     100% +
                         ${px(
-        Breakpoints.tabletLandscape -
-        metrics.article.maxWidth,
-    )}
+                            Breakpoints.tabletLandscape -
+                                metrics.article.maxWidth,
+                        )}
                 );
                 display: block;
                 background: 'red';
                 margin-left: ${px(
-        ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-            2) *
-        -1,
-    )};
+                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
+                        2) *
+                        -1,
+                )};
             }
         }
     `
@@ -228,20 +230,25 @@ const ImageBase = ({
             />
 
             ${figcaption &&
-        html`
-                <div>
-                    <figcaption>
-                        ${Arrow(isInlineTablet ? { direction: Direction.left } : { direction: Direction.top })} ${figcaption} 
-                    </figcaption>
-                    
-                  ${isInlineTablet &&
-            html`
-                    <span
-                    onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
-                    >view more</span>
-                    `}
-                 </div>
-                    
+                html`
+                    <div>
+                        <figcaption>
+                            ${Arrow(
+                                isInlineTablet
+                                    ? { direction: Direction.left }
+                                    : { direction: Direction.top },
+                            )}
+                            ${figcaption}
+                        </figcaption>
+                        ${isInlineTablet &&
+                            html`
+                                <span
+                                    onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
+                                >
+                                    view more
+                                </span>
+                            `}
+                    </div>
                 `}
         </figure>
     `

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -1,31 +1,46 @@
 import { ImageElement } from 'src/common'
 import { Direction } from 'src/common'
+import { useMediaQuery } from 'src/hooks/use-screen'
 import { css, getFontCss, html, px } from 'src/helpers/webview'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { metrics } from 'src/theme/spacing'
 import { Arrow } from './arrow'
 import { CssProps, themeColors } from '../helpers/css'
 import { ArticleType } from '../../../../../../Apps/common/src'
-
 export const renderCaption = ({
     caption,
     credit,
     displayCredit,
 }: Pick<ImageElement, 'caption' | 'credit' | 'displayCredit'>) => {
+
     return displayCredit === true
         ? [caption, credit].filter(s => !!s).join(' ')
         : caption
 }
 
 const breakoutCaption = (role: ImageElement['role']) => css`
-    .image[data-role='${role}'] figcaption {
+    .image[data-role='${role}'] div {
         position: absolute;
         right: ${px(
-            (metrics.article.rightRail + metrics.article.sides * 1.5) * -1,
-        )};
+    (metrics.article.rightRail + metrics.article.sides * 1.5) * -1,
+)};
         top: -0.5em;
-        display: block;
+        display:block;
         width: ${px(metrics.article.rightRail)};
+    }
+
+    .image[data-role='${role}'] figcaption {
+        position:relative;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 15;
+        overflow: hidden;
+    }
+
+    .image[data-role='${role}'] strong {
+        font-family: 'GuardianTextSans-Regular';
+        ${getFontCss('sans', 0.9)}
+
     }
 
     .image[data-role='${role}'] figcaption svg {
@@ -96,8 +111,8 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
                 width: 500px;
                 margin-left: ${px(metrics.article.sides)};
                 margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
+        (metrics.article.rightRail + metrics.article.sides) * -1,
+    )};
             }
 
             .image[data-role='supporting'] figcaption {
@@ -109,12 +124,12 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
 
         /*SHOWCASE*/
         @media (min-width: ${px(
-                Breakpoints.tabletVertical,
-            )}) and (max-width: ${px(Breakpoints.tabletLandscape)}) {
+        Breakpoints.tabletVertical,
+    )}) and (max-width: ${px(Breakpoints.tabletLandscape)}) {
             .image[data-role='showcase'] {
                 margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
+        (metrics.article.rightRail + metrics.article.sides) * -1,
+    )};
             }
 
             .image[data-role='showcase'] figcaption {
@@ -125,17 +140,17 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
             .image[data-role='showcase'] img {
                 margin-left: ${px(
-                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-                        2) *
-                        -1,
-                )};
+        ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
+            2) *
+        -1,
+    )};
                 width: calc(
                     100% +
                         ${px(
-                            (Breakpoints.tabletLandscape -
-                                metrics.article.maxWidth) /
-                                2,
-                        )}
+        (Breakpoints.tabletLandscape -
+            metrics.article.maxWidth) /
+        2,
+    )}
                 );
             }
             ${breakoutCaption('showcase')}
@@ -145,8 +160,8 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
         @media (min-width: ${px(Breakpoints.tabletVertical)}) {
             .image[data-role='immersive'] {
                 margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
+        (metrics.article.rightRail + metrics.article.sides) * -1,
+    )};
             }
             .image[data-role='immersive'] figcaption {
                 width: ${px(metrics.article.rightRail)};
@@ -158,17 +173,17 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
                 width: calc(
                     100% +
                         ${px(
-                            Breakpoints.tabletLandscape -
-                                metrics.article.maxWidth,
-                        )}
+        Breakpoints.tabletLandscape -
+        metrics.article.maxWidth,
+    )}
                 );
                 display: block;
                 background: 'red';
                 margin-left: ${px(
-                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-                        2) *
-                        -1,
-                )};
+        ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
+            2) *
+        -1,
+    )};
             }
         }
     `
@@ -198,6 +213,7 @@ const ImageBase = ({
     remotePath?: string
     displayCaptionAndCredit?: boolean
 }) => {
+    const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
     const figcaption =
         displayCaptionAndCredit &&
         renderCaption({ caption, credit, displayCredit })
@@ -212,10 +228,20 @@ const ImageBase = ({
             />
 
             ${figcaption &&
-                html`
+        html`
+                <div>
                     <figcaption>
-                        ${Arrow({ direction: Direction.top })} ${figcaption}
+                        ${Arrow({ direction: Direction.top })} ${figcaption} 
                     </figcaption>
+                    
+                  ${isTablet && 
+                    html`
+                    <strong
+                    onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
+                    >view more</strong>`
+                }
+                 </div>
+                    
                 `}
         </figure>
     `


### PR DESCRIPTION
## Summary

This PR fixes 2 UI bugs:

1. Inline captions overlap on small tablet devices (namely iPad Mini). In this PR, any inline caption greater than 15 lines is truncated and an ellipsis is added. The user can click a newly added view more button below to expand to lightbox view and read the full caption. 

2. Caption arrows don't rotate to point at image. This is now resolved by checking if the image is inline on tablet. 

[**Trello Card ->**](https://trello.com/c/xoMKO1Y7)
[**Trello Card ->**](https://trello.com/c/iZV7Q7kA)

## Test Plan
Before:

![Simulator Screen Shot - ipad mini 4 - 2020-11-30 at 12 15 35](https://user-images.githubusercontent.com/20416599/100609344-c3eeeb00-3305-11eb-9e99-d35066b72e80.png)

After:
![Simulator Screen Shot - ipad mini 4 - 2020-11-30 at 12 01 05](https://user-images.githubusercontent.com/20416599/100609362-ca7d6280-3305-11eb-9d54-2c0f6a9e373d.png)
