### PR TITLE
Rendered article html now has full web url for images

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -456,7 +456,6 @@ export const issueDir = (issueId: string) => {
 
 export const issuePath = (issue: string) => `${issueDir(issue)}/issue`
 
-// const issuePath = (issueId: string) => `${issueDir(issueId)}issue`
 export const frontPath = (issue: string, frontId: string) =>
     `${issueDir(issue)}/front/${frontId}`
 

--- a/projects/archiver/src/tasks/zip/helpers/zipper.ts
+++ b/projects/archiver/src/tasks/zip/helpers/zipper.ts
@@ -3,10 +3,20 @@ import archiver = require('archiver')
 import { s3, ONE_WEEK, Bucket } from '../../../utils/s3'
 import { getMatchingObjects } from './lister'
 
+// Replace absolute web url to relative url. This is required when edition app
+// wants to load images from local file system
+const replaceImageUrls = (html: string): string => {
+    return html.replace(/https:\/\/i.guim.co.uk\/img\//g, `../media/images/`)
+}
+
 export const zip = async (
     name: string,
     prefixes: string[],
-    options: { removeFromOutputPath?: string; replaceImageSize?: string },
+    options: {
+        removeFromOutputPath?: string
+        replaceImageSize?: string
+        replaceImagePathInDataBundle?: boolean
+    },
     bucket: Bucket,
 ) => {
     const output = new PassThrough()
@@ -39,19 +49,29 @@ export const zip = async (
                 ? file.replace(`${options.removeFromOutputPath}`, '')
                 : file
 
-            // Remove the image size from the path and replace with a static `images`
-            // It is currently needed for server side rendering html bundle
-            const zipPath = options.replaceImageSize
-                ? path.replace(`/${options.replaceImageSize}/`, '/images/')
-                : path
-
             console.log(`getting ${file}`)
             const s3response = await s3
                 .getObject({ Bucket: bucket.name, Key: file })
                 .promise()
             if (s3response.Body == null) return false
 
-            archive.append(s3response.Body as Buffer, {
+            // Remove the 'image size' from the path and replace with a static `images`
+            // to support new SSR compliant clients. Example: from 'media/phone/img1.png' to 'media/images/img1.png'
+            const zipPath = options.replaceImageSize
+                ? path.replace(`/${options.replaceImageSize}/`, '/images/')
+                : path
+
+            let bufferedData: Buffer
+            if (options.replaceImagePathInDataBundle) {
+                // SSR: inside the 'data' bundle all the image path need to be in
+                // 'relative' path format
+                const articleHtml = s3response.Body.toString('utf-8')
+                const articleWithRelativeImgUrl = replaceImageUrls(articleHtml)
+                bufferedData = Buffer.from(articleWithRelativeImgUrl)
+            } else {
+                bufferedData = s3response.Body as Buffer
+            }
+            archive.append(bufferedData, {
                 name: zipPath,
             })
         }),

--- a/projects/archiver/src/tasks/zip/index.ts
+++ b/projects/archiver/src/tasks/zip/index.ts
@@ -89,6 +89,7 @@ export const handler: Handler<ZipTaskInput, ZipTaskOutput> = handleAndNotify(
             [htmlDirPath(publishedId)],
             {
                 removeFromOutputPath: `${version}/`,
+                replaceImagePathInDataBundle: true,
             },
             bucket,
         )

--- a/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
+++ b/projects/archiver/test/tasks/indexer/helpers/get-issue-summary.spec.ts
@@ -19,8 +19,6 @@ describe('getIssueSummaryInternal', () => {
         'zips/american-edition/2019-10-09/2019-10-08T14:07:37.084Z/tabletXL.zip',
     ]
 
-    const bucket: Bucket = { name: 'test', context: 'default' }
-
     it('should return IssueSummary', async () => {
         const issue: IssuePublicationIdentifier = {
             edition: 'american-edition',

--- a/projects/backend/__tests__/helpers/fixtures.ts
+++ b/projects/backend/__tests__/helpers/fixtures.ts
@@ -20,7 +20,6 @@ const Content = <T extends string>(
         mediaType = 'Image',
         sportScore,
         bylineHtml,
-        internalPageCode = 12345,
     }: Partial<IContent> & WithKey,
 ): IContent & { type: T } => ({
     key,

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -16,11 +16,6 @@ const fetchRenderedArticle = async (url: string) => {
     }
 }
 
-// TODO: this needs a test once we're happy with the correct format for the paths
-const replaceImageUrls = (html: string): string => {
-    return html.replace(/https:\/\/i.guim.co.uk\/img\//g, `../media/images/`)
-}
-
 export const renderController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
@@ -28,9 +23,8 @@ export const renderController = async (req: Request, res: Response) => {
     const renderResponse = await fetchRenderedArticle(renderingUrl)
 
     if (renderResponse.success) {
-        const htmlWithImagesReplaced = replaceImageUrls(renderResponse.body)
         res.setHeader('Content-Type', 'text/html')
-        res.send(htmlWithImagesReplaced)
+        res.send(renderResponse.body)
     } else {
         const message = `Failed to fetch story from ${renderingUrl}. Response: ${renderResponse.body}`
         console.error(`${message}`)


### PR DESCRIPTION
## Summary
To support users when they don't have downloaded issue on their phone we need to allow the app to directly render article with images. To do that our `<article>.html` file needs to have full web url for images. This PR made two changes:

1. Individual `article.html` now has full image path
2. Articles inside `html.zip` contain a relative image path

[**Trello Card ->**](https://trello.com/c/Od0M2r4Y/1698-editions-rendering-article-image-url-handling)

## Test Plan
Deploy to CODE and test it on the app