### PR TITLE
Migrate From `capi-ts` To `content-api-models`

### DIFF
--- a/projects/backend/capi/__tests__/articleImgPicker.spec.ts
+++ b/projects/backend/capi/__tests__/articleImgPicker.spec.ts
@@ -3,33 +3,31 @@ import {
     ImageAndTrailImage,
     getImageRole,
 } from '../articleImgPicker'
-import {
-    IContent,
-    IBlocks,
-    IBlockElement,
-    ElementType,
-    IAsset,
-    AssetType,
-    ContentType,
-} from '@guardian/capi-ts'
+import { Asset } from '@guardian/content-api-models/v1/asset'
+import { AssetType } from '@guardian/content-api-models/v1/assetType'
+import { BlockElement } from '@guardian/content-api-models/v1/blockElement'
+import { Content } from '@guardian/content-api-models/v1/content'
+import { Blocks } from '@guardian/content-api-models/v1/blocks'
+import { ElementType } from '@guardian/content-api-models/v1/elementType'
+import { ContentType } from '@guardian/content-api-models/v1/contentType'
 import { articleTypePicker } from '../articleTypePicker'
 import { ArticleType } from '../../../Apps/common/src'
 
-const masterAsset: IAsset = {
+const masterAsset: Asset = {
     type: AssetType.IMAGE,
     typeData: { isMaster: true },
     file: 'https://test/master/asset.com',
 }
-const thumbnailAsset: IAsset = {
+const thumbnailAsset: Asset = {
     type: AssetType.IMAGE,
     file: 'https://test/thumbnail/asset.com',
 }
-const blockImgEleme: IBlockElement = {
+const blockImgEleme: BlockElement = {
     type: ElementType.IMAGE,
     assets: [masterAsset],
 }
 
-const blocks: IBlocks = {
+const blocks: Blocks = {
     main: {
         id: '1',
         bodyHtml: '',
@@ -77,7 +75,7 @@ const articleType = articleTypePicker(sharedGiven)
 
 describe('articleImgPicker.getImages', () => {
     it('should extract both images', () => {
-        const given: IContent = {
+        const given: Content = {
             ...sharedGiven,
             blocks: blocks,
             elements: [thumbnailElem],
@@ -101,7 +99,7 @@ describe('articleImgPicker.getImages', () => {
     })
 
     it('should extract only trail image', () => {
-        const given: IContent = {
+        const given: Content = {
             ...sharedGiven,
             elements: [thumbnailElem],
         }
@@ -124,7 +122,7 @@ describe('articleImgPicker.getImages', () => {
     })
 
     it('should extract only main image', () => {
-        const given: IContent = {
+        const given: Content = {
             ...sharedGiven,
             blocks: blocks,
         }
@@ -140,7 +138,7 @@ describe('articleImgPicker.getImages', () => {
     })
 
     it('should extract no images', () => {
-        const given: IContent = {
+        const given: Content = {
             ...sharedGiven,
         }
 

--- a/projects/backend/capi/__tests__/byline.spec.ts
+++ b/projects/backend/capi/__tests__/byline.spec.ts
@@ -1,5 +1,7 @@
 import { getBylineImages } from '../byline'
-import { TagType, IContent, ContentType } from '@guardian/capi-ts'
+import { TagType } from '@guardian/content-api-models/v1/tagType'
+import { Content } from '@guardian/content-api-models/v1/content'
+import { ContentType } from '@guardian/content-api-models/v1/contentType'
 interface TagSpec {
     id: string
     type: TagType
@@ -25,7 +27,7 @@ const createTag = ({
     bylineLargeImageUrl,
 })
 
-const createArticleLike = (tagSpecs: TagSpec[], byline: string): IContent => ({
+const createArticleLike = (tagSpecs: TagSpec[], byline: string): Content => ({
     id: 'id',
     type: ContentType.ARTICLE,
     fields: {

--- a/projects/backend/capi/__tests__/imageParser.spec.ts
+++ b/projects/backend/capi/__tests__/imageParser.spec.ts
@@ -1,23 +1,24 @@
 import { parseImageElement } from '../elements'
+import { ElementType } from '@guardian/content-api-models/v1/elementType'
+import { ImageElementFields } from '@guardian/content-api-models/v1/imageElementFields'
+import { Asset } from '@guardian/content-api-models/v1/asset'
+import { AssetType } from '@guardian/content-api-models/v1/assetType'
+import { BlockElement } from '@guardian/content-api-models/v1/blockElement'
 import {
-    ElementType,
-    AssetType,
-    IBlockElement,
-    IAsset,
-    IImageElementFields,
-} from '@guardian/capi-ts'
-import { BlockElement, ImageElement } from '../../../Apps/common/src'
+    BlockElement as EditionsBlockElement,
+    ImageElement,
+} from '../../../Apps/common/src'
 
-const createImageAssetLike: IAsset = {
+const createImageAssetLike: Asset = {
     type: AssetType.IMAGE,
     mimeType: 'image/jpeg',
     file: 'https://test/image/asset.comg',
 }
 
-const createImageElementFields: IImageElementFields = {
+const createImageElementFields: ImageElementFields = {
     caption: `£price <a href"http://gallerylink.com"> guardian.com</a>"`,
 }
-const createImageBlockElementLike: IBlockElement = {
+const createImageBlockElementLike: BlockElement = {
     type: ElementType.IMAGE,
     assets: [createImageAssetLike],
     imageTypeData: createImageElementFields,
@@ -25,7 +26,7 @@ const createImageBlockElementLike: IBlockElement = {
 
 describe('imageParser', () => {
     it('the parsed image element contains a href link', () => {
-        const parsed: BlockElement | undefined = parseImageElement(
+        const parsed: EditionsBlockElement | undefined = parseImageElement(
             createImageBlockElementLike,
         )
         expect((parsed as ImageElement).caption).toContain(

--- a/projects/backend/capi/__tests__/kickerPicker.spec.ts
+++ b/projects/backend/capi/__tests__/kickerPicker.spec.ts
@@ -1,5 +1,6 @@
 import { kickerPicker } from '../kickerPicker'
-import { TagType, ContentType } from '@guardian/capi-ts'
+import { TagType } from '@guardian/content-api-models/v1/tagType'
+import { ContentType } from '@guardian/content-api-models/v1/contentType'
 
 type Spec = [TagType, string, string]
 

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -1,4 +1,4 @@
-import { IContent } from '@guardian/capi-ts'
+import { Content } from '@guardian/content-api-models/v1/content'
 import {
     CreditedImage,
     TrailImage,
@@ -8,7 +8,7 @@ import {
 import { oc } from 'ts-optchain'
 import { getImage, getCreditedImage } from './assets'
 import { ArticleType } from '../../Apps/common/src'
-import { ContentType } from '@guardian/capi-ts'
+import { ContentType } from '@guardian/content-api-models/v1/contentType'
 
 /**
  * This function exploits the 'role'field that is passed to the backend when generating image urls
@@ -35,7 +35,7 @@ export const getImageRole = (
 }
 
 const getMainImage = (
-    result: IContent,
+    result: Content,
     articleType: ArticleType,
 ): CreditedImage | undefined => {
     const maybeMainElement = oc(result).blocks.main.elements[0]()
@@ -61,7 +61,7 @@ const getMainImage = (
 }
 
 const getTrailImage = (
-    result: IContent,
+    result: Content,
     articleType: ArticleType,
 ): TrailImage | undefined => {
     const maybeThumbnailElement =
@@ -95,7 +95,7 @@ interface ImageAndTrailImage {
 }
 
 const getImages = (
-    result: IContent,
+    result: Content,
     articleType: ArticleType,
 ): ImageAndTrailImage => {
     const images = {

--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -1,16 +1,18 @@
-import { IContent } from '@guardian/capi-ts/dist/Content'
+import { Content } from '@guardian/content-api-models/v1/content'
 import { ArticleType, HeaderType } from '../../Apps/common/src/index'
-import { TagType, IElement, ElementType } from '@guardian/capi-ts'
+import { ElementType } from '@guardian/content-api-models/v1/elementType'
+import { Element } from '@guardian/content-api-models/v1/element'
+import { TagType } from '@guardian/content-api-models/v1/tagType'
 
-const doesTagExist = (article: IContent, tagId: string): boolean => {
+const doesTagExist = (article: Content, tagId: string): boolean => {
     return article.tags.find(tag => tag.id === tagId) != undefined
 }
 
-const doesTypeExist = (article: IContent, tagType: TagType): boolean => {
+const doesTypeExist = (article: Content, tagType: TagType): boolean => {
     return article.tags.find(tag => tag.type === tagType) != undefined
 }
 
-const showCaseMainMedia = (elements: IElement[]): boolean => {
+const showCaseMainMedia = (elements: Element[]): boolean => {
     const mainImage = elements.find(
         e => e.relation === 'main' && e.type === ElementType.IMAGE,
     )
@@ -21,7 +23,7 @@ const showCaseMainMedia = (elements: IElement[]): boolean => {
         : false
 }
 
-const articleTypePicker = (article: IContent): ArticleType => {
+const articleTypePicker = (article: Content): ArticleType => {
     const isTagPresent = (tagId: string): boolean =>
         doesTagExist(article, tagId)
 
@@ -137,7 +139,7 @@ const articleTypePicker = (article: IContent): ArticleType => {
     }
 }
 
-const headerTypePicker = (article: IContent): HeaderType => {
+const headerTypePicker = (article: Content): HeaderType => {
     const isTagPresent = (tagId: string): boolean =>
         doesTagExist(article, tagId)
 

--- a/projects/backend/capi/assets.ts
+++ b/projects/backend/capi/assets.ts
@@ -1,12 +1,11 @@
-import { IAsset, IBlockElement } from '@guardian/capi-ts'
+import { BlockElement } from '@guardian/content-api-models/v1/blockElement'
+import { Asset } from '@guardian/content-api-models/v1/asset'
 import { Image } from '../common'
 import { getImageFromURL } from '../image'
 import { CreditedImage } from '../../Apps/common/src'
 import { oc } from 'ts-optchain'
 
-const extractImage: (
-    assetArray: IAsset[],
-) => IAsset | undefined = assetArray => {
+const extractImage: (assetArray: Asset[]) => Asset | undefined = assetArray => {
     if (assetArray.length === 0) {
         console.warn('No assets found in asset array: ' + assetArray)
         return undefined
@@ -28,7 +27,7 @@ const extractImage: (
     })
 }
 
-export const getImage = (assetArray: IAsset[]): Image | undefined => {
+export const getImage = (assetArray: Asset[]): Image | undefined => {
     const asset = extractImage(assetArray)
     if (!(asset && asset.file)) {
         console.warn('Image asset potentially invalid.', JSON.stringify(asset))
@@ -38,7 +37,7 @@ export const getImage = (assetArray: IAsset[]): Image | undefined => {
 }
 
 export const getCreditedImage: (
-    element: IBlockElement,
+    element: BlockElement,
 ) => CreditedImage | undefined = element => {
     const asset = extractImage(element.assets)
     if (!(asset && asset.file)) {

--- a/projects/backend/capi/atoms.ts
+++ b/projects/backend/capi/atoms.ts
@@ -1,8 +1,9 @@
 import { Lambda, SharedIniFileCredentials } from 'aws-sdk'
 import { awsToString } from '../parser'
-import { IAtoms, IContentAtomElementFields } from '@guardian/capi-ts'
+import { Atoms } from '@guardian/content-api-models/v1/atoms'
+import { Atom } from '@guardian/content-atom-model/atom'
+import { ContentAtomElementFields } from '@guardian/content-api-models/v1/contentAtomElementFields'
 import { BlockElement } from '../../Apps/common/src'
-import { IAtom } from '@guardian/capi-ts/dist/com/gu/contentatom/thrift/Atom'
 import { attempt, hasFailed } from '../utils/try'
 
 import { oc } from 'ts-optchain'
@@ -20,7 +21,7 @@ const lambda = new Lambda({
     region: 'eu-west-1',
     ...creds,
 })
-export const rationaliseAtoms = (atoms?: IAtoms) => ({
+export const rationaliseAtoms = (atoms?: Atoms) => ({
     audio: (atoms && atoms.audios) || [],
     chart: (atoms && atoms.charts) || [],
     commonsdivision: (atoms && atoms.commonsdivisions) || [],
@@ -34,7 +35,6 @@ export const rationaliseAtoms = (atoms?: IAtoms) => ({
     quiz: (atoms && atoms.quizzes) || [],
     recipe: (atoms && atoms.recipes) || [],
     review: (atoms && atoms.reviews) || [],
-    storyquestions: (atoms && atoms.storyquestions) || [],
     timeline: (atoms && atoms.timelines) || [],
     viewpoint: (atoms && atoms.viewpoints) || [],
 })
@@ -63,8 +63,8 @@ const renderAtom = async (
 }
 
 export const renderAtomElement = async (
-    data: IContentAtomElementFields | undefined,
-    atoms: { [key: string]: IAtom[] },
+    data: ContentAtomElementFields | undefined,
+    atoms: { [key: string]: Atom[] },
 ): Promise<BlockElement> => {
     if (data == null) {
         console.error('No atom data found in element.')
@@ -78,17 +78,17 @@ export const renderAtomElement = async (
         console.error('Atom not found in CAPI response.')
         throw new Error('Atom not found in CAPI response.')
     }
-    if (atomType === 'media' && atom !== null) {
-        const imageURL = oc(atom).data.media.posterImage.master.file()
+    if (atomType === 'media' && atom !== null && atom.data.kind === 'media') {
+        const imageURL = atom.data.media.posterImage?.master?.file
         const image = getImageFromURL(imageURL)
-        const activeVersion64 = oc(atom).data.media.activeVersion
+        const activeVersion64 = atom.data.media.activeVersion
         const activeVersion =
             (activeVersion64 &&
                 activeVersion64.buffer &&
                 activeVersion64.toNumber()) ||
             -1
-        const latestAsset = oc(atom)
-            .data.media.assets([])
+        const latestAsset = atom
+            .data.media.assets
             .find(_ => _.version.toNumber() === activeVersion)
 
         const platform = getPlatformName(oc(latestAsset).platform())

--- a/projects/backend/capi/byline.ts
+++ b/projects/backend/capi/byline.ts
@@ -1,9 +1,10 @@
-import { IContent, TagType } from '@guardian/capi-ts'
+import { Content } from '@guardian/content-api-models/v1/content'
+import { TagType } from '@guardian/content-api-models/v1/tagType'
 import { getImageFromURL } from '../image'
 import { Image } from '../common'
 
 export const getBylineImages = (
-    article: IContent,
+    article: Content,
 ): { cutout?: Image } | undefined => {
     const byline = article.fields && article.fields.byline
     if (byline == null) return undefined

--- a/projects/backend/capi/decoders.ts
+++ b/projects/backend/capi/decoders.ts
@@ -1,0 +1,42 @@
+// Derived from Apps-Rendering
+// https://github.com/guardian/apps-rendering/blob/986336e5970154754f4f9a294961a4e17569667b/src/server/decoders.ts
+// ----- Imports ----- //
+
+import { TBufferedTransport, TCompactProtocol, TProtocol, TTransport } from 'thrift';
+import { SearchResponseSerde } from '@guardian/content-api-models/v1/searchResponse';
+
+// ----- Types ----- //
+
+interface ThriftDecoder<A> {
+	read(p: TProtocol): A;
+}
+
+// ----- Functions ----- //
+
+async function toTransport(buffer: Buffer): Promise<TTransport> {
+	return new Promise((resolve, _) => {
+		const writer = TBufferedTransport.receiver((transport, _) => {
+			resolve(transport);
+		}, 0);
+		writer(buffer);
+	});
+}
+
+const decodeContent = <A>(decoder: ThriftDecoder<A>) => async (
+	content: Buffer | undefined,
+): Promise<A> => {
+	if (content) {
+		const transport = await toTransport(content);
+		const protocol = new TCompactProtocol(transport);
+
+		return decoder.read(protocol);
+	} else {
+		return Promise.reject('Invalid request');
+	}
+};
+
+const capiSearchDecoder = decodeContent(SearchResponseSerde);
+
+// ----- Exports ----- //
+
+export { capiSearchDecoder };

--- a/projects/backend/capi/decoders.ts
+++ b/projects/backend/capi/decoders.ts
@@ -2,41 +2,46 @@
 // https://github.com/guardian/apps-rendering/blob/986336e5970154754f4f9a294961a4e17569667b/src/server/decoders.ts
 // ----- Imports ----- //
 
-import { TBufferedTransport, TCompactProtocol, TProtocol, TTransport } from 'thrift';
-import { SearchResponseSerde } from '@guardian/content-api-models/v1/searchResponse';
+import {
+    TBufferedTransport,
+    TCompactProtocol,
+    TProtocol,
+    TTransport,
+} from 'thrift'
+import { SearchResponseSerde } from '@guardian/content-api-models/v1/searchResponse'
 
 // ----- Types ----- //
 
 interface ThriftDecoder<A> {
-	read(p: TProtocol): A;
+    read(p: TProtocol): A
 }
 
 // ----- Functions ----- //
 
 async function toTransport(buffer: Buffer): Promise<TTransport> {
-	return new Promise((resolve, _) => {
-		const writer = TBufferedTransport.receiver((transport, _) => {
-			resolve(transport);
-		}, 0);
-		writer(buffer);
-	});
+    return new Promise(resolve => {
+        const writer = TBufferedTransport.receiver(transport => {
+            resolve(transport)
+        }, 0)
+        writer(buffer)
+    })
 }
 
 const decodeContent = <A>(decoder: ThriftDecoder<A>) => async (
-	content: Buffer | undefined,
+    content: Buffer | undefined,
 ): Promise<A> => {
-	if (content) {
-		const transport = await toTransport(content);
-		const protocol = new TCompactProtocol(transport);
+    if (content) {
+        const transport = await toTransport(content)
+        const protocol = new TCompactProtocol(transport)
 
-		return decoder.read(protocol);
-	} else {
-		return Promise.reject('Invalid request');
-	}
-};
+        return decoder.read(protocol)
+    } else {
+        return Promise.reject('Invalid request')
+    }
+}
 
-const capiSearchDecoder = decodeContent(SearchResponseSerde);
+const capiSearchDecoder = decodeContent(SearchResponseSerde)
 
 // ----- Exports ----- //
 
-export { capiSearchDecoder };
+export { capiSearchDecoder }

--- a/projects/backend/capi/elements.ts
+++ b/projects/backend/capi/elements.ts
@@ -1,12 +1,13 @@
-import { IBlockElement, ElementType } from '@guardian/capi-ts'
-import { BlockElement } from '../common'
+import { BlockElement } from '@guardian/content-api-models/v1/blockElement'
+import { ElementType } from '@guardian/content-api-models/v1/elementType'
+import { Atom } from '@guardian/content-atom-model/atom'
+import { BlockElement as EditionsBlockElement } from '../common'
 import { getImage } from './assets'
 import { renderAtomElement } from './atoms'
-import { IAtom } from '@guardian/capi-ts/dist/com/gu/contentatom/thrift/Atom'
 
 const parseImageElement = (
-    element: IBlockElement,
-): BlockElement | undefined => {
+    element: BlockElement,
+): EditionsBlockElement | undefined => {
     const image = getImage(element.assets)
     if (element.imageTypeData && image) {
         return {
@@ -22,9 +23,9 @@ const parseImageElement = (
     }
 }
 
-const elementParser = (id: string, atoms: { [key: string]: IAtom[] }) => async (
-    element: IBlockElement,
-): Promise<BlockElement> => {
+const elementParser = (id: string, atoms: { [key: string]: Atom[] }) => async (
+    element: BlockElement,
+): Promise<EditionsBlockElement> => {
     switch (element.type) {
         case ElementType.TEXT:
             if (element.textTypeData && element.textTypeData.html) {

--- a/projects/backend/capi/kickerPicker.ts
+++ b/projects/backend/capi/kickerPicker.ts
@@ -1,8 +1,8 @@
-import { TagType } from '@guardian/capi-ts'
-import { IContent } from '@guardian/capi-ts/dist/Content'
-import { ITag } from '@guardian/capi-ts/dist/Tag'
+import { TagType } from '@guardian/content-api-models/v1/tagType'
+import { Content } from '@guardian/content-api-models/v1/content'
+import { Tag } from '@guardian/content-api-models/v1/tag'
 
-const tagTitleIsAlreadyInHeadline = (tag: ITag, headline: string) =>
+const tagTitleIsAlreadyInHeadline = (tag: Tag, headline: string) =>
     headline.toLowerCase().includes(tag.webTitle.toLowerCase())
 
 /*
@@ -14,7 +14,7 @@ const tagTitleIsAlreadyInHeadline = (tag: ITag, headline: string) =>
  - Use second tag if top tag features in the headline
  - Otherwise use top tag
  */
-const kickerPicker = (article: IContent, headline: string) => {
+const kickerPicker = (article: Content, headline: string) => {
     const byline = article.fields && article.fields.byline
     const seriesTag = article.tags.find(tag => tag.type === TagType.SERIES)
     const toneTag = article.tags.find(tag => tag.type === TagType.TONE)
@@ -40,8 +40,8 @@ const kickerPicker = (article: IContent, headline: string) => {
         if (toneTag.id === 'tone/comment') return byline
     }
 
-    const topTag: ITag | undefined = article.tags[0]
-    const secondTag: ITag | undefined = article.tags[1]
+    const topTag: Tag | undefined = article.tags[0]
+    const secondTag: Tag | undefined = article.tags[1]
 
     if (!topTag) return
 

--- a/projects/backend/image.ts
+++ b/projects/backend/image.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'crypto'
 import { ImageUse, imageUseSizes } from '../Apps/common/src'
 import { Image, ImageSize, ImageRole, imageRoles } from './common'
-import { IAssetFields } from '@guardian/capi-ts'
+import { AssetFields } from '@guardian/content-api-models/v1/assetFields'
 
 const salt = process.env.IMAGE_SALT
 
 export const getImageFromURL = (
     url?: string,
-    typeData?: IAssetFields,
+    typeData?: AssetFields,
 ): Image | undefined => {
     if (url === undefined) return undefined
     try {

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -17,7 +17,7 @@
         "ts-jest": "^24.0.2",
         "ts-node": "^8.3.0",
         "ts-node-dev": "^1.0.0-pre.63",
-        "typescript": "^3.7.5"
+        "typescript": "^3.5.3"
     },
     "scripts": {
         "build": "ncc build backend.ts -o dist -m -e aws-sdk",

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -17,7 +17,7 @@
         "ts-jest": "^24.0.2",
         "ts-node": "^8.3.0",
         "ts-node-dev": "^1.0.0-pre.63",
-        "typescript": "^3.5.3"
+        "typescript": "^3.7.5"
     },
     "scripts": {
         "build": "ncc build backend.ts -o dist -m -e aws-sdk",
@@ -29,8 +29,8 @@
         "test:watch": "jest --watch"
     },
     "dependencies": {
-        "@creditkarma/thrift-server-core": "^0.14.1",
-        "@guardian/capi-ts": "^0.2.0",
+        "@guardian/content-api-models": "^15.9.6",
+        "@guardian/content-atom-model": "^3.2.4",
         "@types/aws-lambda": "^8.10.31",
         "@types/aws4": "^1.5.1",
         "@types/jest": "^24.0.17",
@@ -49,6 +49,7 @@
         "ramda": "^0.26.1",
         "react-native-inappbrowser-reborn": "^3.0.1",
         "striptags": "^3.1.1",
+        "thrift": "^0.12.0",
         "ts-optchain": "^0.1.8",
         "utility-types": "^3.7.0"
     },

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -4519,10 +4519,10 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^3.7.5:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.6.0"

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -139,18 +139,49 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@creditkarma/thrift-server-core@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@creditkarma/thrift-server-core/-/thrift-server-core-0.14.1.tgz#30705a03d6a6164b1c17bfc9f2513640b5b2238f"
-  integrity sha512-N0knWvGFx6i3X3vQ/OFOypAD1TV4xGMJeF0SDA+dL8q6H/fdac4nb2TtkdOYM4ppMWVYgXrQq5h0Jh8rdUDZ2Q==
+"@guardian/content-api-models@^15.9.6":
+  version "15.9.6"
+  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-15.9.6.tgz#ebe3b51cb636f22118fda2196491c4d1b8c8a440"
+  integrity sha512-TpeMPgUSBI/jaKpgzVm0Spzm7p8+t7AxXn4UkpH8cgH4V3vF7o4q+SChPq7cgtr50MnZD9Ej8UGbq7rAKqchUA==
   dependencies:
-    "@types/lodash" "^4.14.136"
-    lodash "^4.17.15"
+    "@guardian/content-atom-model" "^3.2.4"
+    "@guardian/content-entity-model" "^2.0.6"
+    "@guardian/story-packages-model" "^2.0.4"
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.9"
+    node-int64 "^0.4.0"
+    thrift "^0.12.0"
 
-"@guardian/capi-ts@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/capi-ts/-/capi-ts-0.2.0.tgz#d701143615db78e48b5fe19ea59c1c051f8db4b7"
-  integrity sha512-UA+2YPuFVf7WvS4mV69G0cz+cRwyNIeH0wKTKPnMbhzVvcuSqBNVHIVk50+b7YUKZsH3o7wgFXhMv6q4dTmizg==
+"@guardian/content-atom-model@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@guardian/content-atom-model/-/content-atom-model-3.2.4.tgz#5ba9db208b3acb8a30f67e284696f20fa8f69393"
+  integrity sha512-XJ1jleNm5et+1tVxHwDOz94ODn1MLrchwAQKb3XXEX6jnguLLTKKcHPP5UQ4WqgJuuEoEo5ZLpgOXcCDE0HN5A==
+  dependencies:
+    "@guardian/content-entity-model" "^2.0.6"
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.9"
+    node-int64 "^0.4.0"
+    thrift "^0.12.0"
+
+"@guardian/content-entity-model@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@guardian/content-entity-model/-/content-entity-model-2.0.6.tgz#5a5a3dec91f6f4744a2c04843eb0272424e54f81"
+  integrity sha512-mcRxXqJY9jAJWjv/xANQ6wuwwN76IV8WYLDWhCB0dQB/BpQm9VZIs81el4nWGOUTTOw/7Ls5TdERWvBDzadvwQ==
+  dependencies:
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.9"
+    node-int64 "^0.4.0"
+    thrift "^0.12.0"
+
+"@guardian/story-packages-model@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/story-packages-model/-/story-packages-model-2.0.4.tgz#f05f73c5c0e1eb6d6658f5d3c29cf30260e63328"
+  integrity sha512-i16vtZqYkNYGIr3VUdnpcIDphMRqfWhHzEKaB//idEPUlFJuSqhDoJIo2CkBQYWQYN9XmEJInkcUZSNhJz7CcA==
+  dependencies:
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.9"
+    node-int64 "^0.4.0"
+    thrift "^0.12.0"
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -436,11 +467,6 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/lodash@^4.14.136":
-  version "4.14.136"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
-  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
-
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -453,10 +479,22 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-int64@*", "@types/node-int64@^0.4.29":
+  version "0.4.29"
+  resolved "https://registry.yarnpkg.com/@types/node-int64/-/node-int64-0.4.29.tgz#8c7c16a7c1195ae4f8beaa903b0018ac66291d16"
+  integrity sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "12.6.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.3.tgz#44d507c5634f85e7164707ca36bba21b5213d487"
   integrity sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA==
+
+"@types/q@*":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
+  integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
 "@types/ramda@^0.26.19":
   version "0.26.19"
@@ -500,6 +538,15 @@
   dependencies:
     "@types/cookiejar" "*"
     "@types/node" "*"
+
+"@types/thrift@^0.10.9":
+  version "0.10.10"
+  resolved "https://registry.yarnpkg.com/@types/thrift/-/thrift-0.10.10.tgz#f90f6c84c8b003c79f54463f909b0a12a993029d"
+  integrity sha512-sEhRbmmQgiTn+JdophEPiuTFkc9QRl7R/Kxs/le5GXZAc2K1/VCHauW734nCwpu1cFI8jL1niyrqk7E4tGL92w==
+  dependencies:
+    "@types/node" "*"
+    "@types/node-int64" "*"
+    "@types/q" "*"
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"
@@ -2813,11 +2860,6 @@ lodash@^4.17.11, lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3576,6 +3618,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+q@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -4267,6 +4314,15 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+thrift@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.12.0.tgz#67678beba655ca40dd30744b65455f2b9f8e9912"
+  integrity sha512-qE9PZi4XSbSQLz/sNxj6+ZiiFQYgbM4GmlO3CS/EVJBjCVfd46Zw0aiVIqOvVn74M7XUGyjOs2chAOwK4d4/hQ==
+  dependencies:
+    node-int64 "^0.4.0"
+    q "^1.5.0"
+    ws "^5.0.0"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -4463,10 +4519,10 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.5:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -4674,7 +4730,7 @@ write-file-atomic@2.4.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-ws@^5.2.0:
+ws@^5.0.0, ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -4519,7 +4519,7 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.5.3:
+typescript@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==


### PR DESCRIPTION
## Summary

We're attempting to make requests from the Editions backend directly to Apps-Rendering, so that we can leverage Apps-Rendering's functionality to build HTML documents for the articles. The Editions backend currently makes requests to CAPI's Thrift endpoint to get the data for an article, and fortunately Apps-Rendering can accept this CAPI data directly to build an article.

Unfortunately Apps-Rendering and Editions use different techniques to generate the CAPI types and encoders/decoders from the Thrift models:

- Editions uses the [`typescript-capi-thrift`](https://github.com/guardian/typescript-capi-thrift) project for the TypeScript models, and leverages CreditKarma's `thrift-server-core` library to decode them
- Apps-Rendering uses the TypeScript models generated by the [`content-api-models`](https://github.com/guardian/content-api-models) project, and decodes them using the `thrift` Node.js library

One way to solve this problem is to migrate Editions over to using the `content-api-models` and `content-atom-model` packages that come from the `content-api-models` repository. There are a few advantages to doing this:

- The models and decoders match what Apps-Rendering is using
- The packages are built and maintained by the CAPI team, and are published automatically whenever the models change
- The TypeScript models are generated by Scrooge
- They can be decoded using the main `thrift` package for Node.js

**Note:** The packages that come from `content-api-models` weren't available when Editions and Apps-Rendering first started. They were added six months ago by @alexduf to solve some problems we were having with the CreditKarma library: https://github.com/guardian/content-api-models/pull/179 (I _think_ - @alexduf please correct me if I've misremembered that).

### Why a Draft?

I've opened this as a **Draft** for now for a few reasons:

- I'd like to gather some feedback
- I haven't been able to test this properly yet; it compiles but I don't know if it runs correctly
- ~I need to update ESLint to handle the new version of TypeScript (that's why CI is failing)~

## Changes

- Migrated type imports to `content-api-models` and `content-atom-model`
- Replaced `@creditkarma/thrift-server-core` decoders with `thrift`
- Re-used decoder code from Apps-Rendering for `SearchResponse`
- Used `Object.entries` to fix compiler error
