### PR TITLE
Move interview headline below main media

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -731,24 +731,10 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             ArticleType.Interview
         }"] span h1 .header-top-headline {
             line-height: 62px;
-            padding-top: 5px;
+            padding-top: 6px;
             padding-bottom: 10px;
         }
         
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            .header-container[data-type="${ArticleType.Interview}"] span h1 {
-                padding-left: ${
-                    Dimensions.get('window').width > metrics.article.maxWidth
-                        ? px(metrics.article.sides * 0.7)
-                        : px(metrics.article.sides * 1.7)
-                };
-            }
-        }
-        @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
-            .header-container[data-type="${ArticleType.Interview}"] span h1 {
-                padding-left: ${px(metrics.article.sides - 5)};
-            }
-        }
 
         .header-container[data-type="${ArticleType.Interview}"] .header-kicker {
             background-color: ${colors.main};
@@ -756,6 +742,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             font-family: ${families.headline.bold};
             margin-left: 0;
             padding: 10px;
+            border: none;
         }
 
         .interview-tablet .header-bottom {
@@ -1329,8 +1316,8 @@ const HeaderInterviewTablet = ({
                 </div>
             </div>
             <div class="header-bottom" data-type="${type}">
-                <div class="header-container-line-wrap">
-                    <div class="header-container wrapper" data-type="${type}">
+                <div>
+                    <div class="header-container wrapper interview-tablet-wrapper" data-type="${type}">
                         <span>
                             ${getHeadline(headerType, type, headerProps)}
                         </span>

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -727,6 +727,14 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: 25px;
         }
 
+        .header-container[data-type="${
+            ArticleType.Interview
+        }"] span h1 .header-top-headline {
+            line-height: 62px;
+            padding-top: 5px;
+            padding-bottom: 10px;
+        }
+
         .header-container[data-type="${ArticleType.Interview}"] .header-kicker {
             background-color: ${colors.main};
             color: ${color.textOverDarkBackground};
@@ -1303,12 +1311,16 @@ const HeaderInterviewTablet = ({
                                 >${headerProps.kicker}</span
                             >
                         `}
-                    <header>
-                        ${getHeadline(headerType, type, headerProps)}
-                    </header>
                 </div>
             </div>
             <div class="header-bottom" data-type="${type}">
+                <div class="header-container-line-wrap">
+                    <div class="header-container wrapper" data-type="${type}">
+                        <span>
+                            ${getHeadline(headerType, type, headerProps)}
+                        </span>
+                    </div>
+                </div>
                 <section
                     class="interview-tablet-standfirst interview-tablet-wrapper"
                 >

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1316,7 +1316,10 @@ const HeaderInterviewTablet = ({
                 </div>
             </div>
             <div class="header-bottom" data-type="${type}">
-                <div class="header-container wrapper interview-tablet-wrapper" data-type="${type}">
+                <div
+                    class="header-container wrapper interview-tablet-wrapper"
+                    data-type="${type}"
+                >
                     <span>
                         ${getHeadline(headerType, type, headerProps)}
                     </span>

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -1316,12 +1316,10 @@ const HeaderInterviewTablet = ({
                 </div>
             </div>
             <div class="header-bottom" data-type="${type}">
-                <div>
-                    <div class="header-container wrapper interview-tablet-wrapper" data-type="${type}">
-                        <span>
-                            ${getHeadline(headerType, type, headerProps)}
-                        </span>
-                    </div>
+                <div class="header-container wrapper interview-tablet-wrapper" data-type="${type}">
+                    <span>
+                        ${getHeadline(headerType, type, headerProps)}
+                    </span>
                 </div>
                 <section
                     class="interview-tablet-standfirst interview-tablet-wrapper"

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -80,20 +80,20 @@ const shareButtonColor = ({ colors, theme }: CssProps) => {
 }
 
 const threeLines = `
-background-image: repeating-linear-gradient(
-    to bottom,
-    ${color.dimLine},
-    ${color.dimLine} 1px,
-    transparent 1px,
-    transparent 4px
-);
-background-repeat: repeat-x;
-background-position: bottom;
-background-size: 1px 16px;
-content: '';
-display: block;
-height: 16px;
-margin: 0;
+    background-image: repeating-linear-gradient(
+        to bottom,
+        ${color.dimLine},
+        ${color.dimLine} 1px,
+        transparent 1px,
+        transparent 4px
+    );
+    background-repeat: repeat-x;
+    background-position: bottom;
+    background-size: 1px 16px;
+    content: '';
+    display: block;
+    height: 16px;
+    margin: 0;
 `
 
 export const headerStyles = ({ colors, theme }: CssProps) => css`
@@ -101,7 +101,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     .header a {
         pointer-events: none;
     }
-
     .header:after, .header-immersive-video:after {
         ${threeLines}
     }
@@ -130,7 +129,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: ${px(metrics.article.sides)};
         }
     }
-
 
     .header-bg {
         left: -50em;
@@ -189,6 +187,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         border-bottom: 1px solid ${color.dimLine};
         display: block;
     }
+
     .header h1, .header-immersive-video h1 {
         font-size: 30px;
         font-family: ${families.headline.regular};
@@ -258,6 +257,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         left: ${px(metrics.article.sides * -1)};
         right: ${px(metrics.article.sides * -1)};
     }
+
     @media (min-width: ${px(Breakpoints.tabletVertical)}) {
         .header-byline:not(:empty):after {
             left: 0;
@@ -483,7 +483,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
 
     /*gallery*/
-    .header-container[data-type='${ArticleType.Gallery
+    .header-container[data-type='${
+        ArticleType.Gallery
     }'] .header-byline  > span > a {
         color: ${themeColors(theme).text};
     }
@@ -565,13 +566,15 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: 10px;
         }
 
-        .header-container[data-type='${ArticleType.Interview
-    }'] .header-byline button{
+        .header-container[data-type='${
+            ArticleType.Interview
+        }'] .header-byline button{
             margin-right: 10px;
         }
 
-        .header-container[data-type='${ArticleType.Interview
-    }'] .header-byline span {
+        .header-container[data-type='${
+            ArticleType.Interview
+        }'] .header-byline span {
             padding-left: 10px;
         }
 
@@ -623,7 +626,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         padding-right: 25px;
         margin-bottom: 12px;
     }
-    .header-container[data-type='${ArticleType.Interview
+    .header-container[data-type='${
+        ArticleType.Interview
     }'] .header h1 .header-top-headline {
         background-color: ${color.palette.neutral[7]};
         box-shadow: 0.5rem 0 0 ${color.palette.neutral[7]},
@@ -638,7 +642,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin-left: 0;
         padding-left: 10px;
     }
-    .header-container[data-type='${ArticleType.Interview
+    .header-container[data-type='${
+        ArticleType.Interview
     }'] .header-byline:before {
         background-image: repeating-linear-gradient(
             to bottom,
@@ -659,12 +664,14 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         padding: 0em 0 1.25em 0em;
         color: ${color.palette.neutral[7]};
     }
-    .header-container[data-type='${ArticleType.Interview
+    .header-container[data-type='${
+        ArticleType.Interview
     }'] .header-byline button{
         margin-right: 20px;
         margin-top: 0px;
     }
-    .header-container[data-type='${ArticleType.Interview
+    .header-container[data-type='${
+        ArticleType.Interview
     }'] .header-byline span {
         margin-top: 4px;
         display: block;
@@ -682,8 +689,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             position: relative;
          }
 
-        .header-image-container--interview .header-container[data-type="${ArticleType.Interview
-    }"] {
+        .header-image-container--interview .header-container[data-type="${
+            ArticleType.Interview
+        }"] {
             position: absolute;
             bottom: 0;
             z-index: 250;
@@ -705,8 +713,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             fill: white;
         }
 
-        .header-container[data-type="${ArticleType.Interview
-    }"] h1 .header-top-headline {
+        .header-container[data-type="${
+            ArticleType.Interview
+        }"] h1 .header-top-headline {
             background-color: ${color.palette.neutral[7]};
             box-shadow: 0.5rem 0 0 ${color.palette.neutral[7]},
                 -10px 0 0 ${color.palette.neutral[7]};
@@ -718,26 +727,29 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: 25px;
         }
 
-        .header-container[data-type="${ArticleType.Interview
-    }"] span h1 .header-top-headline {
+        .header-container[data-type="${
+            ArticleType.Interview
+        }"] span h1 .header-top-headline {
             line-height: 62px;
             padding-top: 5px;
             padding-bottom: 10px;
         }
         
         @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-
-            .header-container[data-type="${ArticleType.Interview
-    }"] span h1 {
-                padding-left: ${Dimensions.get('window').width > metrics.article.maxWidth ? px(metrics.article.sides * 0.7) : px(metrics.article.sides * 1.7)};
+            .header-container[data-type="${ArticleType.Interview}"] span h1 {
+                padding-left: ${
+                    Dimensions.get('window').width > metrics.article.maxWidth
+                        ? px(metrics.article.sides * 0.7)
+                        : px(metrics.article.sides * 1.7)
+                };
             }
-    }
-    @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
-        .header-container[data-type="${ArticleType.Interview
-    }"] span h1 {
-            padding-left: ${px(metrics.article.sides - 5)};
         }
-    }
+        @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
+            .header-container[data-type="${ArticleType.Interview}"] span h1 {
+                padding-left: ${px(metrics.article.sides - 5)};
+            }
+        }
+
         .header-container[data-type="${ArticleType.Interview}"] .header-kicker {
             background-color: ${colors.main};
             color: ${color.textOverDarkBackground};
@@ -768,30 +780,33 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
 
         .app[data-type='${ArticleType.Interview}'] .content-wrap {
-            padding-left: ${Dimensions.get('window').width > metrics.article.maxWidth
-        ? px(metrics.article.sides)
-        : px(metrics.article.sides * 2)
-    }
+            padding-left: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? px(metrics.article.sides)
+                    : px(metrics.article.sides * 2)
+            }
         }
 
         .interview-tablet-wrapper {
-            margin-left: ${Dimensions.get('window').width > metrics.article.maxWidth
-        ? px(
-            (Dimensions.get('window').width -
-                metrics.article.maxWidth) /
-            2,
-        )
-        : px(metrics.article.sides * 2)
-    };
-            margin-right: ${Dimensions.get('window').width > metrics.article.maxWidth
-        ? px(
-            (Dimensions.get('window').width -
-                metrics.article.maxWidth) /
-            2 +
-            metrics.article.rightRail,
-        )
-        : px(metrics.article.rightRail + metrics.article.sides)
-    };
+            margin-left: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? px(
+                          (Dimensions.get('window').width -
+                              metrics.article.maxWidth) /
+                              2,
+                      )
+                    : px(metrics.article.sides * 2)
+            };
+            margin-right: ${
+                Dimensions.get('window').width > metrics.article.maxWidth
+                    ? px(
+                          (Dimensions.get('window').width -
+                              metrics.article.maxWidth) /
+                              2 +
+                              metrics.article.rightRail,
+                      )
+                    : px(metrics.article.rightRail + metrics.article.sides)
+            };
         }
 
         .interview-tablet .standfirst--interview p {
@@ -807,8 +822,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             font-size: 40px;
         }
 
-        .interview-tablet .header-image-container--interview .header-container[data-type="${ArticleType.Interview
-    }"] h1 .header-top-headline {
+        .interview-tablet .header-image-container--interview .header-container[data-type="${
+            ArticleType.Interview
+        }"] h1 .header-top-headline {
             line-height: 50px;
         }
 
@@ -889,8 +905,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         .header-image--showcase {
             margin-right: 0;
             margin-left: ${(Dimensions.get('window').width -
-        metrics.article.maxWidth) /
-    2};
+                metrics.article.maxWidth) /
+                2};
         }
 
         .header-container[data-type='${ArticleType.Showcase}'] .standfirst {
@@ -898,13 +914,15 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             line-height: 25px;
         }
 
-        .header-container[data-type='${ArticleType.Showcase
-    }'] .share-touch-zone {
+        .header-container[data-type='${
+            ArticleType.Showcase
+        }'] .share-touch-zone {
             margin: -8px 0 0 0;
         }
 
-        .header-container[data-type='${ArticleType.Showcase
-    }'] .header-byline:not(:empty):after {
+        .header-container[data-type='${
+            ArticleType.Showcase
+        }'] .header-byline:not(:empty):after {
             right: 4px;
         }
 
@@ -991,11 +1009,11 @@ const MainMediaImage = ({
                 data-preserve-ratio="${preserveRatio || 'false'}"
                 style="background-image: url(${path}), url(${remotePath}); "
                 ${!isGallery &&
-        `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
+                    `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
                 data-open="false"
             >
                 ${preserveRatio &&
-        html`
+                    html`
                         <img
                             class="image-as-bg__img"
                             src="${path}"
@@ -1043,8 +1061,8 @@ const getStandFirstText = ({
     return html`
         <p
             ${type === ArticleType.Interview &&
-        `class=interview-standfirst` &&
-        `style=color:${interviewColor};`}
+                `class=interview-standfirst` &&
+                `style=color:${interviewColor};`}
         >
             ${standfirst}
         </p>
@@ -1069,13 +1087,13 @@ const getStandFirst = (
                 <div class="${cutout && `header-opinion-flex`}">
                     ${getHeadline(articleHeaderType, type, headerProps)}
                     ${publishedId &&
-            cutout &&
-            html`
+                        cutout &&
+                        html`
                             <div>
                                 ${Image({
-                image: cutout,
-                getImagePath,
-            })}
+                                    image: cutout,
+                                    getImagePath,
+                                })}
                             </div>
                         `}
                 </div>
@@ -1086,12 +1104,12 @@ const getStandFirst = (
             <section class="header-top">
                 ${getHeadline(articleHeaderType, type, headerProps)}
                 ${articleHeaderType === HeaderType.RegularByline &&
-            headerProps.standfirst &&
-            getStandFirstText({
-                standfirst: headerProps.standfirst,
-                type,
-                pillar,
-            })}
+                    headerProps.standfirst &&
+                    getStandFirstText({
+                        standfirst: headerProps.standfirst,
+                        type,
+                        pillar,
+                    })}
             </section>
         `
     }
@@ -1177,90 +1195,90 @@ const Header = ({
         type === ArticleType.Article || type === ArticleType.Review
     return html`
         ${immersive &&
-        headerProps.image &&
-        publishedId &&
-        MainMediaImage({
-            image: headerProps.image,
-            isGallery: isGallery,
-            className:
-                type === ArticleType.Interview
-                    ? 'header-image--interview'
-                    : 'header-image--immersive',
-            getImagePath,
-        })}
+            headerProps.image &&
+            publishedId &&
+            MainMediaImage({
+                image: headerProps.image,
+                isGallery: isGallery,
+                className:
+                    type === ArticleType.Interview
+                        ? 'header-image--interview'
+                        : 'header-image--immersive',
+                getImagePath,
+            })}
         ${!immersive &&
-        displayWideImage &&
-        headerProps.image &&
-        publishedId &&
-        MainMediaImage({
-            articleType: type,
-            className: 'header-image--wide',
-            image: headerProps.image,
-            isGallery: isGallery,
-            preserveRatio: true,
-            children: headerProps.starRating
-                ? Rating(headerProps)
-                : headerProps.sportScore
+            displayWideImage &&
+            headerProps.image &&
+            publishedId &&
+            MainMediaImage({
+                articleType: type,
+                className: 'header-image--wide',
+                image: headerProps.image,
+                isGallery: isGallery,
+                preserveRatio: true,
+                children: headerProps.starRating
+                    ? Rating(headerProps)
+                    : headerProps.sportScore
                     ? SportScore({
-                        sportScore: headerProps.sportScore,
-                    })
+                          sportScore: headerProps.sportScore,
+                      })
                     : undefined,
-            getImagePath,
-        })}
+                getImagePath,
+            })}
         <div class="header-container-line-wrap">
             ${type !== ArticleType.Interview && Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
                 ${!immersive &&
-        !displayWideImage &&
-        headerProps.image &&
-        publishedId &&
-        MainMediaImage({
-            articleType: type,
-            className: 'header-image--standard',
-            image: headerProps.image,
-            isGallery: isGallery,
-            preserveRatio: true,
-            children: headerProps.starRating
-                ? Rating(headerProps)
-                : headerProps.sportScore
-                    ? SportScore({
-                        sportScore: headerProps.sportScore,
-                    })
-                    : undefined,
-            getImagePath,
-        })}
+                    !displayWideImage &&
+                    headerProps.image &&
+                    publishedId &&
+                    MainMediaImage({
+                        articleType: type,
+                        className: 'header-image--standard',
+                        image: headerProps.image,
+                        isGallery: isGallery,
+                        preserveRatio: true,
+                        children: headerProps.starRating
+                            ? Rating(headerProps)
+                            : headerProps.sportScore
+                            ? SportScore({
+                                  sportScore: headerProps.sportScore,
+                              })
+                            : undefined,
+                        getImagePath,
+                    })}
                 <header
                     class=${immersive &&
-            headerProps.mainMedia &&
-            headerProps.showMedia
-            ? 'header-immersive-video'
-            : 'header'}
+                    headerProps.mainMedia &&
+                    headerProps.showMedia
+                        ? 'header-immersive-video'
+                        : 'header'}
                 >
                     ${headerProps.mainMedia &&
-        (headerProps.showMedia
-            ? renderMediaAtom(headerProps.mainMedia)
-            : null)}
+                        (headerProps.showMedia
+                            ? renderMediaAtom(headerProps.mainMedia)
+                            : null)}
                     ${headerProps.kicker &&
-        html`
+                        html`
                             <span class="header-kicker"
                                 >${headerProps.kicker}</span
                             >
                         `}
                     ${getStandFirst(
-            headerType,
-            type,
-            headerProps,
-            publishedId,
-            getImagePath,
-            pillar,
-        )}
+                        headerType,
+                        type,
+                        headerProps,
+                        publishedId,
+                        getImagePath,
+                        pillar,
+                    )}
                 </header>
                 ${getByLine(
-            headerType,
-            headerProps as ArticleHeaderProps,
-            type,
-            webUrl,
-        )}
+                    headerType,
+                    headerProps as ArticleHeaderProps,
+                    type,
+                    webUrl,
+                )}
                 <div class="header-bg"></div>
             </div>
         </div>
@@ -1288,22 +1306,22 @@ const HeaderInterviewTablet = ({
         <div class="interview-tablet">
             <div class="header-image-container--interview">
                 ${headerProps.image &&
-        publishedId &&
-        MainMediaImage({
-            image: headerProps.image,
-            className: 'header-image--interview',
-            getImagePath,
-        })}
+                    publishedId &&
+                    MainMediaImage({
+                        image: headerProps.image,
+                        className: 'header-image--interview',
+                        getImagePath,
+                    })}
                 <div
                     class="header-container interview-tablet-wrapper"
                     data-type="${type}"
                 >
                     ${headerProps.mainMedia &&
-        (headerProps.showMedia
-            ? renderMediaAtom(headerProps.mainMedia)
-            : null)}
+                        (headerProps.showMedia
+                            ? renderMediaAtom(headerProps.mainMedia)
+                            : null)}
                     ${headerProps.kicker &&
-        html`
+                        html`
                             <span class="header-kicker"
                                 >${headerProps.kicker}</span
                             >
@@ -1322,22 +1340,22 @@ const HeaderInterviewTablet = ({
                     class="interview-tablet-standfirst interview-tablet-wrapper"
                 >
                     ${headerProps.standfirst &&
-        getStandFirstText({
-            standfirst: headerProps.standfirst,
-            type,
-            pillar,
-        })}
+                        getStandFirstText({
+                            standfirst: headerProps.standfirst,
+                            type,
+                            pillar,
+                        })}
                 </section>
                 <div
                     class="byline-container interview-tablet-wrapper"
                     data-type="${type}"
                 >
                     ${getByLine(
-            headerType,
-            headerProps as ArticleHeaderProps,
-            type,
-            webUrl,
-        )}
+                        headerType,
+                        headerProps as ArticleHeaderProps,
+                        type,
+                        webUrl,
+                    )}
                     <div class="header-bg"></div>
                 </div>
             </div>
@@ -1370,7 +1388,7 @@ const HeaderInterviewMobile = ({
                     image: headerProps.image,
                     className: 'header-image--interview',
                     getImagePath,
-            })}
+                })}
             <div class="header-container-line-wrap">
                 <div class="header-container wrapper" data-type="${type}">
                     <header class="header">

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -483,8 +483,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
     }
 
     /*gallery*/
-    .header-container[data-type='${
-        ArticleType.Gallery
+    .header-container[data-type='${ArticleType.Gallery
     }'] .header-byline  > span > a {
         color: ${themeColors(theme).text};
     }
@@ -566,15 +565,13 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: 10px;
         }
 
-        .header-container[data-type='${
-            ArticleType.Interview
-        }'] .header-byline button{
+        .header-container[data-type='${ArticleType.Interview
+    }'] .header-byline button{
             margin-right: 10px;
         }
 
-        .header-container[data-type='${
-            ArticleType.Interview
-        }'] .header-byline span {
+        .header-container[data-type='${ArticleType.Interview
+    }'] .header-byline span {
             padding-left: 10px;
         }
 
@@ -626,8 +623,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         padding-right: 25px;
         margin-bottom: 12px;
     }
-    .header-container[data-type='${
-        ArticleType.Interview
+    .header-container[data-type='${ArticleType.Interview
     }'] .header h1 .header-top-headline {
         background-color: ${color.palette.neutral[7]};
         box-shadow: 0.5rem 0 0 ${color.palette.neutral[7]},
@@ -642,8 +638,7 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         margin-left: 0;
         padding-left: 10px;
     }
-    .header-container[data-type='${
-        ArticleType.Interview
+    .header-container[data-type='${ArticleType.Interview
     }'] .header-byline:before {
         background-image: repeating-linear-gradient(
             to bottom,
@@ -664,14 +659,12 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         padding: 0em 0 1.25em 0em;
         color: ${color.palette.neutral[7]};
     }
-    .header-container[data-type='${
-        ArticleType.Interview
+    .header-container[data-type='${ArticleType.Interview
     }'] .header-byline button{
         margin-right: 20px;
         margin-top: 0px;
     }
-    .header-container[data-type='${
-        ArticleType.Interview
+    .header-container[data-type='${ArticleType.Interview
     }'] .header-byline span {
         margin-top: 4px;
         display: block;
@@ -689,9 +682,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             position: relative;
          }
 
-        .header-image-container--interview .header-container[data-type="${
-            ArticleType.Interview
-        }"] {
+        .header-image-container--interview .header-container[data-type="${ArticleType.Interview
+    }"] {
             position: absolute;
             bottom: 0;
             z-index: 250;
@@ -713,9 +705,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             fill: white;
         }
 
-        .header-container[data-type="${
-            ArticleType.Interview
-        }"] h1 .header-top-headline {
+        .header-container[data-type="${ArticleType.Interview
+    }"] h1 .header-top-headline {
             background-color: ${color.palette.neutral[7]};
             box-shadow: 0.5rem 0 0 ${color.palette.neutral[7]},
                 -10px 0 0 ${color.palette.neutral[7]};
@@ -727,14 +718,26 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             padding-right: 25px;
         }
 
-        .header-container[data-type="${
-            ArticleType.Interview
-        }"] span h1 .header-top-headline {
+        .header-container[data-type="${ArticleType.Interview
+    }"] span h1 .header-top-headline {
             line-height: 62px;
             padding-top: 5px;
             padding-bottom: 10px;
         }
+        
+        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
 
+            .header-container[data-type="${ArticleType.Interview
+    }"] span h1 {
+                padding-left: ${Dimensions.get('window').width > metrics.article.maxWidth ? px(metrics.article.sides * 0.7) : px(metrics.article.sides * 1.7)};
+            }
+    }
+    @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
+        .header-container[data-type="${ArticleType.Interview
+    }"] span h1 {
+            padding-left: ${px(metrics.article.sides - 5)};
+        }
+    }
         .header-container[data-type="${ArticleType.Interview}"] .header-kicker {
             background-color: ${colors.main};
             color: ${color.textOverDarkBackground};
@@ -765,33 +768,30 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         }
 
         .app[data-type='${ArticleType.Interview}'] .content-wrap {
-            padding-left: ${
-                Dimensions.get('window').width > metrics.article.maxWidth
-                    ? px(metrics.article.sides)
-                    : px(metrics.article.sides * 2)
-            }
+            padding-left: ${Dimensions.get('window').width > metrics.article.maxWidth
+        ? px(metrics.article.sides)
+        : px(metrics.article.sides * 2)
+    }
         }
 
         .interview-tablet-wrapper {
-            margin-left: ${
-                Dimensions.get('window').width > metrics.article.maxWidth
-                    ? px(
-                          (Dimensions.get('window').width -
-                              metrics.article.maxWidth) /
-                              2,
-                      )
-                    : px(metrics.article.sides * 2)
-            };
-            margin-right: ${
-                Dimensions.get('window').width > metrics.article.maxWidth
-                    ? px(
-                          (Dimensions.get('window').width -
-                              metrics.article.maxWidth) /
-                              2 +
-                              metrics.article.rightRail,
-                      )
-                    : px(metrics.article.rightRail + metrics.article.sides)
-            };
+            margin-left: ${Dimensions.get('window').width > metrics.article.maxWidth
+        ? px(
+            (Dimensions.get('window').width -
+                metrics.article.maxWidth) /
+            2,
+        )
+        : px(metrics.article.sides * 2)
+    };
+            margin-right: ${Dimensions.get('window').width > metrics.article.maxWidth
+        ? px(
+            (Dimensions.get('window').width -
+                metrics.article.maxWidth) /
+            2 +
+            metrics.article.rightRail,
+        )
+        : px(metrics.article.rightRail + metrics.article.sides)
+    };
         }
 
         .interview-tablet .standfirst--interview p {
@@ -807,9 +807,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             font-size: 40px;
         }
 
-        .interview-tablet .header-image-container--interview .header-container[data-type="${
-            ArticleType.Interview
-        }"] h1 .header-top-headline {
+        .interview-tablet .header-image-container--interview .header-container[data-type="${ArticleType.Interview
+    }"] h1 .header-top-headline {
             line-height: 50px;
         }
 
@@ -890,8 +889,8 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         .header-image--showcase {
             margin-right: 0;
             margin-left: ${(Dimensions.get('window').width -
-                metrics.article.maxWidth) /
-                2};
+        metrics.article.maxWidth) /
+    2};
         }
 
         .header-container[data-type='${ArticleType.Showcase}'] .standfirst {
@@ -899,15 +898,13 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             line-height: 25px;
         }
 
-        .header-container[data-type='${
-            ArticleType.Showcase
-        }'] .share-touch-zone {
+        .header-container[data-type='${ArticleType.Showcase
+    }'] .share-touch-zone {
             margin: -8px 0 0 0;
         }
 
-        .header-container[data-type='${
-            ArticleType.Showcase
-        }'] .header-byline:not(:empty):after {
+        .header-container[data-type='${ArticleType.Showcase
+    }'] .header-byline:not(:empty):after {
             right: 4px;
         }
 
@@ -994,11 +991,11 @@ const MainMediaImage = ({
                 data-preserve-ratio="${preserveRatio || 'false'}"
                 style="background-image: url(${path}), url(${remotePath}); "
                 ${!isGallery &&
-                    `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
+        `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
                 data-open="false"
             >
                 ${preserveRatio &&
-                    html`
+        html`
                         <img
                             class="image-as-bg__img"
                             src="${path}"
@@ -1046,8 +1043,8 @@ const getStandFirstText = ({
     return html`
         <p
             ${type === ArticleType.Interview &&
-                `class=interview-standfirst` &&
-                `style=color:${interviewColor};`}
+        `class=interview-standfirst` &&
+        `style=color:${interviewColor};`}
         >
             ${standfirst}
         </p>
@@ -1072,13 +1069,13 @@ const getStandFirst = (
                 <div class="${cutout && `header-opinion-flex`}">
                     ${getHeadline(articleHeaderType, type, headerProps)}
                     ${publishedId &&
-                        cutout &&
-                        html`
+            cutout &&
+            html`
                             <div>
                                 ${Image({
-                                    image: cutout,
-                                    getImagePath,
-                                })}
+                image: cutout,
+                getImagePath,
+            })}
                             </div>
                         `}
                 </div>
@@ -1089,12 +1086,12 @@ const getStandFirst = (
             <section class="header-top">
                 ${getHeadline(articleHeaderType, type, headerProps)}
                 ${articleHeaderType === HeaderType.RegularByline &&
-                    headerProps.standfirst &&
-                    getStandFirstText({
-                        standfirst: headerProps.standfirst,
-                        type,
-                        pillar,
-                    })}
+            headerProps.standfirst &&
+            getStandFirstText({
+                standfirst: headerProps.standfirst,
+                type,
+                pillar,
+            })}
             </section>
         `
     }
@@ -1180,90 +1177,90 @@ const Header = ({
         type === ArticleType.Article || type === ArticleType.Review
     return html`
         ${immersive &&
-            headerProps.image &&
-            publishedId &&
-            MainMediaImage({
-                image: headerProps.image,
-                isGallery: isGallery,
-                className:
-                    type === ArticleType.Interview
-                        ? 'header-image--interview'
-                        : 'header-image--immersive',
-                getImagePath,
-            })}
+        headerProps.image &&
+        publishedId &&
+        MainMediaImage({
+            image: headerProps.image,
+            isGallery: isGallery,
+            className:
+                type === ArticleType.Interview
+                    ? 'header-image--interview'
+                    : 'header-image--immersive',
+            getImagePath,
+        })}
         ${!immersive &&
-            displayWideImage &&
-            headerProps.image &&
-            publishedId &&
-            MainMediaImage({
-                articleType: type,
-                className: 'header-image--wide',
-                image: headerProps.image,
-                isGallery: isGallery,
-                preserveRatio: true,
-                children: headerProps.starRating
-                    ? Rating(headerProps)
-                    : headerProps.sportScore
+        displayWideImage &&
+        headerProps.image &&
+        publishedId &&
+        MainMediaImage({
+            articleType: type,
+            className: 'header-image--wide',
+            image: headerProps.image,
+            isGallery: isGallery,
+            preserveRatio: true,
+            children: headerProps.starRating
+                ? Rating(headerProps)
+                : headerProps.sportScore
                     ? SportScore({
-                          sportScore: headerProps.sportScore,
-                      })
+                        sportScore: headerProps.sportScore,
+                    })
                     : undefined,
-                getImagePath,
-            })}
+            getImagePath,
+        })}
         <div class="header-container-line-wrap">
             ${type !== ArticleType.Interview && Line({ zIndex: 10 })}
             <div class="header-container wrapper" data-type="${type}">
                 ${!immersive &&
-                    !displayWideImage &&
-                    headerProps.image &&
-                    publishedId &&
-                    MainMediaImage({
-                        articleType: type,
-                        className: 'header-image--standard',
-                        image: headerProps.image,
-                        isGallery: isGallery,
-                        preserveRatio: true,
-                        children: headerProps.starRating
-                            ? Rating(headerProps)
-                            : headerProps.sportScore
-                            ? SportScore({
-                                  sportScore: headerProps.sportScore,
-                              })
-                            : undefined,
-                        getImagePath,
-                    })}
+        !displayWideImage &&
+        headerProps.image &&
+        publishedId &&
+        MainMediaImage({
+            articleType: type,
+            className: 'header-image--standard',
+            image: headerProps.image,
+            isGallery: isGallery,
+            preserveRatio: true,
+            children: headerProps.starRating
+                ? Rating(headerProps)
+                : headerProps.sportScore
+                    ? SportScore({
+                        sportScore: headerProps.sportScore,
+                    })
+                    : undefined,
+            getImagePath,
+        })}
                 <header
                     class=${immersive &&
-                    headerProps.mainMedia &&
-                    headerProps.showMedia
-                        ? 'header-immersive-video'
-                        : 'header'}
+            headerProps.mainMedia &&
+            headerProps.showMedia
+            ? 'header-immersive-video'
+            : 'header'}
                 >
                     ${headerProps.mainMedia &&
-                        (headerProps.showMedia
-                            ? renderMediaAtom(headerProps.mainMedia)
-                            : null)}
+        (headerProps.showMedia
+            ? renderMediaAtom(headerProps.mainMedia)
+            : null)}
                     ${headerProps.kicker &&
-                        html`
+        html`
                             <span class="header-kicker"
                                 >${headerProps.kicker}</span
                             >
                         `}
                     ${getStandFirst(
-                        headerType,
-                        type,
-                        headerProps,
-                        publishedId,
-                        getImagePath,
-                        pillar,
-                    )}
+            headerType,
+            type,
+            headerProps,
+            publishedId,
+            getImagePath,
+            pillar,
+        )}
                 </header>
                 ${getByLine(
-                    headerType,
-                    headerProps as ArticleHeaderProps,
-                    type,
-                    webUrl,
-                )}
+            headerType,
+            headerProps as ArticleHeaderProps,
+            type,
+            webUrl,
+        )}
                 <div class="header-bg"></div>
             </div>
         </div>
@@ -1291,22 +1288,22 @@ const HeaderInterviewTablet = ({
         <div class="interview-tablet">
             <div class="header-image-container--interview">
                 ${headerProps.image &&
-                    publishedId &&
-                    MainMediaImage({
-                        image: headerProps.image,
-                        className: 'header-image--interview',
-                        getImagePath,
-                    })}
+        publishedId &&
+        MainMediaImage({
+            image: headerProps.image,
+            className: 'header-image--interview',
+            getImagePath,
+        })}
                 <div
                     class="header-container interview-tablet-wrapper"
                     data-type="${type}"
                 >
                     ${headerProps.mainMedia &&
-                        (headerProps.showMedia
-                            ? renderMediaAtom(headerProps.mainMedia)
-                            : null)}
+        (headerProps.showMedia
+            ? renderMediaAtom(headerProps.mainMedia)
+            : null)}
                     ${headerProps.kicker &&
-                        html`
+        html`
                             <span class="header-kicker"
                                 >${headerProps.kicker}</span
                             >
@@ -1325,22 +1322,22 @@ const HeaderInterviewTablet = ({
                     class="interview-tablet-standfirst interview-tablet-wrapper"
                 >
                     ${headerProps.standfirst &&
-                        getStandFirstText({
-                            standfirst: headerProps.standfirst,
-                            type,
-                            pillar,
-                        })}
+        getStandFirstText({
+            standfirst: headerProps.standfirst,
+            type,
+            pillar,
+        })}
                 </section>
                 <div
                     class="byline-container interview-tablet-wrapper"
                     data-type="${type}"
                 >
                     ${getByLine(
-                        headerType,
-                        headerProps as ArticleHeaderProps,
-                        type,
-                        webUrl,
-                    )}
+            headerType,
+            headerProps as ArticleHeaderProps,
+            type,
+            webUrl,
+        )}
                     <div class="header-bg"></div>
                 </div>
             </div>
@@ -1373,7 +1370,7 @@ const HeaderInterviewMobile = ({
                     image: headerProps.image,
                     className: 'header-image--interview',
                     getImagePath,
-                })}
+            })}
             <div class="header-container-line-wrap">
                 <div class="header-container wrapper" data-type="${type}">
                     <header class="header">


### PR DESCRIPTION
## Summary
This PR move the headline from the main media to just below, leaving only the kicker on the image. This is due to headlines overlapping with faces on the image and therefore obscuring the image.

[**Trello Card ->**](https://trello.com/c/fkI1akxC/1693-interview-templates-headline-covers-main-media)

## Screenshots

**Before:**
![ipadmini-portrait-bug](https://user-images.githubusercontent.com/20416599/101613577-d2bf5700-3a03-11eb-86d8-a1a2e6d8fa8d.png)
![ipadmini-landscape-bug](https://user-images.githubusercontent.com/20416599/101613634-e8cd1780-3a03-11eb-8468-defb64abfe3e.png)

**After:**
![ipadmini-portrait-fix](https://user-images.githubusercontent.com/20416599/101613705-fda9ab00-3a03-11eb-86a0-8abd302e4fb5.png)
![ipadmini-landscape-fix](https://user-images.githubusercontent.com/20416599/101613724-039f8c00-3a04-11eb-8693-e3ada2f84c56.png)


*article used is from 15/11/2020 - Life, card 3 - "This much I know" : Jodie Turner-Smith