### PR TITLE
Update style of the new edition popup bubble 

### DIFF
--- a/projects/Mallard/src/components/onboarding/new-edition.tsx
+++ b/projects/Mallard/src/components/onboarding/new-edition.tsx
@@ -9,11 +9,6 @@ import { ModalButton } from '../Button/ModalButton'
 import DeviceInfo from 'react-native-device-info'
 import { lifestyle } from '@guardian/src-foundations/palette'
 
-export enum CardAppearance {
-    apricot,
-    blue,
-}
-
 const isTablet = DeviceInfo.isTablet()
 
 const modalStyles = (backgroundColor: string, textColor: string) =>

--- a/projects/Mallard/src/components/onboarding/new-edition.tsx
+++ b/projects/Mallard/src/components/onboarding/new-edition.tsx
@@ -7,7 +7,7 @@ import { ButtonAppearance } from '../Button/Button'
 import { SpecialEditionHeaderStyles } from '../../../../Apps/common/src'
 import { ModalButton } from '../Button/ModalButton'
 import DeviceInfo from 'react-native-device-info'
-import { lifestyle } from '@guardian/src-foundations/palette'
+import { brand } from '@guardian/src-foundations/palette'
 
 const isTablet = DeviceInfo.isTablet()
 
@@ -28,7 +28,7 @@ const modalStyles = (backgroundColor: string, textColor: string) =>
         },
         container: {
             flex: 1,
-            backgroundColor: lifestyle[300],
+            backgroundColor: backgroundColor,
             overflow: 'hidden',
             padding: 12,
             borderRadius: 5,
@@ -44,7 +44,7 @@ const modalStyles = (backgroundColor: string, textColor: string) =>
             borderStyle: 'solid',
             borderLeftColor: 'transparent',
             borderRightColor: 'transparent',
-            borderBottomColor: lifestyle[300],
+            borderBottomColor: backgroundColor,
         },
         buttonWrapper: {
             width: '40%',
@@ -68,7 +68,7 @@ const NewEditionCard = ({
               headerStyle.backgroundColor,
               headerStyle.textColorPrimary || 'white',
           )
-        : modalStyles(color.ui.sea, color.background)
+        : modalStyles(brand[800], color.text)
     return (
         <View style={styles.wrapper}>
             <View style={[styles.bubblePointer]} />

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -168,7 +168,7 @@ export const ManageDownloads = {
 
 export const NewEditionWords = {
     title: `A new special edition is available`,
-    bodyText: `Tap on the edition menu icon on the top left to read it.`,
+    bodyText: `Tap on the edition icon above to access it.`,
     dismissButtonText: 'Got it',
 }
 


### PR DESCRIPTION
## Summary
This PR updates the colour and copy of the new edition popup inline with new designs.

[**Trello Card ->**](https://trello.com/c/snUrRRLs/1695-special-edition-awareness-balloon#comment-5fd0bcf4fe5e6b1169e2ccbc)

Before:
![edition bubble - ipad air - portrait](https://user-images.githubusercontent.com/20416599/101634176-3bb4c800-3a20-11eb-9049-695a011ad331.png)

After:
![Simulator Screen Shot - ipad mini 4 - 2020-12-09 at 13 08 33](https://user-images.githubusercontent.com/20416599/101634145-2fc90600-3a20-11eb-875c-9f321241877c.png)

