### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Derived from the docs here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates
+# Details on configuration here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for npm (including Yarn)
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary

Dependabot will automatically open update PRs for you! For now I think this will only look at the `package.json` and `yarn.lock` files in the top-level directory. I expect we can configure it to handle all the sub-projects in future too. [Here](https://github.com/guardian/apps-rendering/pulls?q=is%3Apr+label%3Adependencies+is%3Aclosed) are some examples of dependabot PRs on Apps-Rendering.
