### PR TITLE
New special edition bubble - Removing full stop for grammatical consistency

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -168,7 +168,7 @@ export const ManageDownloads = {
 
 export const NewEditionWords = {
     title: `A new special edition is available`,
-    bodyText: `Tap on the edition icon above to access it.`,
+    bodyText: `Tap on the edition icon above to access it`,
     dismissButtonText: 'Got it',
 }
 


### PR DESCRIPTION
## Summary
In order to maintain grammatical consistency across the app, we need to remove the full stop. 