### PR TITLE
Update words.ts to remove full stop in special edition bubble copy

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -167,8 +167,8 @@ export const ManageDownloads = {
 }
 
 export const NewEditionWords = {
-    title: `A new special edition is available`,
-    bodyText: `Tap on the edition icon above to access it.`,
+    title: 'A new special edition is available',
+    bodyText: 'Tap on the edition icon above to access it',
     dismissButtonText: 'Got it',
 }
 


### PR DESCRIPTION
Maintain consistency with Editions and remove full stop in the new Special Editions pop-up bubble copy
Remove unnecessary backticks