### PR TITLE
Tighten the interview headline

### DIFF
--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -731,8 +731,6 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
             ArticleType.Interview
         }"] span h1 .header-top-headline {
             line-height: 50px;
-            padding-top: 5px;
-            padding-bottom: 5px;
         }
         
 

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -730,9 +730,9 @@ export const headerStyles = ({ colors, theme }: CssProps) => css`
         .header-container[data-type="${
             ArticleType.Interview
         }"] span h1 .header-top-headline {
-            line-height: 62px;
-            padding-top: 6px;
-            padding-bottom: 10px;
+            line-height: 50px;
+            padding-top: 5px;
+            padding-bottom: 5px;
         }
         
 


### PR DESCRIPTION
## Summary

This PR tightens the headline on interviews in line with design. 

Example:
![Simulator Screen Shot - iPad (7th generation) - 2020-12-11 at 16 11 31](https://user-images.githubusercontent.com/20416599/101927034-ed442c80-3bcb-11eb-9504-82952ef194f1.png)
