### PR TITLE
Fix: 'view more' button appearing on wrong article type

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -67,6 +67,7 @@ const cleanupBullets = (html: string) => {
 const renderArticleContent = (
     elements: BlockElement[],
     { showMedia, publishedId, getImagePath, displayHint }: ArticleContentProps,
+    articleType: string,
 ) => {
     const imagePaths = getLightboxImages(elements).map(i => i.src.path)
     return elements
@@ -92,11 +93,12 @@ const renderArticleContent = (
                     const displayCaptionAndCredit = displayHint != 'photoEssay'
                     return publishedId
                         ? Image({
-                              imageElement: el,
-                              path,
-                              index,
-                              displayCaptionAndCredit,
-                          })
+                            imageElement: el,
+                            path,
+                            index,
+                            displayCaptionAndCredit,
+                            articleType,
+                        })
                         : ''
                 }
                 case 'pullquote':
@@ -174,39 +176,39 @@ export const renderArticle = (
                 publishedId,
                 imageSize,
                 getImagePath,
-            })
+            }, article.type)
             break
         default:
             header =
                 type === ArticleType.Showcase
                     ? HeaderShowcase({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
+                        ...article,
+                        type,
+                        headerType,
+                        publishedId,
+                        showMedia,
+                        pillar,
+                        getImagePath,
+                    })
                     : type === ArticleType.Interview
-                    ? HeaderInterview({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
-                    : Header({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
+                        ? HeaderInterview({
+                            ...article,
+                            type,
+                            headerType,
+                            publishedId,
+                            showMedia,
+                            pillar,
+                            getImagePath,
+                        })
+                        : Header({
+                            ...article,
+                            type,
+                            headerType,
+                            publishedId,
+                            showMedia,
+                            pillar,
+                            getImagePath,
+                        })
             const displayHint = article.displayHint
             content = renderArticleContent(elements, {
                 showMedia,
@@ -214,7 +216,7 @@ export const renderArticle = (
                 imageSize,
                 getImagePath,
                 displayHint,
-            })
+            }, article.type)
             break
     }
 

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -93,12 +93,12 @@ const renderArticleContent = (
                     const displayCaptionAndCredit = displayHint != 'photoEssay'
                     return publishedId
                         ? Image({
-                            imageElement: el,
-                            path,
-                            index,
-                            displayCaptionAndCredit,
-                            articleType,
-                        })
+                              imageElement: el,
+                              path,
+                              index,
+                              displayCaptionAndCredit,
+                              articleType,
+                          })
                         : ''
                 }
                 case 'pullquote':
@@ -171,52 +171,60 @@ export const renderArticle = (
                 getImagePath,
                 pillar,
             })
-            content = renderArticleContent(elements, {
-                showMedia,
-                publishedId,
-                imageSize,
-                getImagePath,
-            }, article.type)
+            content = renderArticleContent(
+                elements,
+                {
+                    showMedia,
+                    publishedId,
+                    imageSize,
+                    getImagePath,
+                },
+                article.type,
+            )
             break
         default:
             header =
                 type === ArticleType.Showcase
                     ? HeaderShowcase({
-                        ...article,
-                        type,
-                        headerType,
-                        publishedId,
-                        showMedia,
-                        pillar,
-                        getImagePath,
-                    })
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
                     : type === ArticleType.Interview
-                        ? HeaderInterview({
-                            ...article,
-                            type,
-                            headerType,
-                            publishedId,
-                            showMedia,
-                            pillar,
-                            getImagePath,
-                        })
-                        : Header({
-                            ...article,
-                            type,
-                            headerType,
-                            publishedId,
-                            showMedia,
-                            pillar,
-                            getImagePath,
-                        })
+                    ? HeaderInterview({
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
+                    : Header({
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
             const displayHint = article.displayHint
-            content = renderArticleContent(elements, {
-                showMedia,
-                publishedId,
-                imageSize,
-                getImagePath,
-                displayHint,
-            }, article.type)
+            content = renderArticleContent(
+                elements,
+                {
+                    showMedia,
+                    publishedId,
+                    imageSize,
+                    getImagePath,
+                    displayHint,
+                },
+                article.type,
+            )
             break
     }
 

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -203,6 +203,7 @@ const ImageBase = ({
     role,
     remotePath,
     displayCaptionAndCredit,
+    articleType,
 }: {
     path: string
     index?: number
@@ -213,9 +214,11 @@ const ImageBase = ({
     role?: ImageElement['role']
     remotePath?: string
     displayCaptionAndCredit?: boolean
+    articleType?: string,
 }) => {
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
     const isInlineTablet = !role && isTablet
+    const showViewMore = isInlineTablet && articleType === ArticleType.Gallery
     const figcaption =
         displayCaptionAndCredit &&
         renderCaption({ caption, credit, displayCredit })
@@ -240,7 +243,7 @@ const ImageBase = ({
                             )}
                             ${figcaption}
                         </figcaption>
-                        ${isInlineTablet &&
+                        ${showViewMore &&
                             html`
                                 <span
                                     onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
@@ -260,12 +263,14 @@ const Image = ({
     index,
     remotePath,
     displayCaptionAndCredit,
+    articleType,
 }: {
     imageElement: ImageElement
     path: string | undefined
     index?: number | undefined
     remotePath?: string
     displayCaptionAndCredit?: boolean
+    articleType?: string,
 }) => {
     if (path) {
         return ImageBase({
@@ -273,6 +278,7 @@ const Image = ({
             index,
             remotePath,
             displayCaptionAndCredit,
+            articleType,
             ...imageElement,
         })
     }

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -214,7 +214,7 @@ const ImageBase = ({
     role?: ImageElement['role']
     remotePath?: string
     displayCaptionAndCredit?: boolean
-    articleType?: string,
+    articleType?: string
 }) => {
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
     const isInlineTablet = !role && isTablet
@@ -270,7 +270,7 @@ const Image = ({
     index?: number | undefined
     remotePath?: string
     displayCaptionAndCredit?: boolean
-    articleType?: string,
+    articleType?: string
 }) => {
     if (path) {
         return ImageBase({


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in https://github.com/guardian/editions/pull/1604, whereby the view more button appears below *all* inline photo captions, rather than just on gallery. In this PR, we pass down the article type as a prop and only render the view more button below captions if it is a gallery article. 

[**Trello Card ->**](https://trello.com/c/t66sqEVh/1706-view-more-button-captions-appearing-on-inline-photos-on-ipads-and-tablets)

## Test Plan

Before: 
![Simulator Screen Shot - iPad (7th generation) - 2020-12-22 at 10 05 52](https://user-images.githubusercontent.com/20416599/102877664-04daab00-443f-11eb-9446-4755c632390d.png)
![Simulator Screen Shot - iPad (7th generation) - 2020-12-22 at 10 07 07](https://user-images.githubusercontent.com/20416599/102877669-073d0500-443f-11eb-9b6a-f2cb1073a94c.png)

After:
![Simulator Screen Shot - iPad (7th generation) - 2020-12-22 at 10 12 14](https://user-images.githubusercontent.com/20416599/102877684-0c9a4f80-443f-11eb-9f34-ff9063ed504f.png)
![Simulator Screen Shot - iPad (7th generation) - 2020-12-22 at 10 12 24](https://user-images.githubusercontent.com/20416599/102877691-0efca980-443f-11eb-9ac2-63a5d8edb347.png)


*articles used for screen shots are from Edition 21/12/20 and are National > The Weekend's Best Photos & World > Greece "Zak's an icon"



