### PR TITLE
FIX: Gallery captions not always inline

### DIFF
--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -93,12 +93,12 @@ const renderArticleContent = (
                     const displayCaptionAndCredit = displayHint != 'photoEssay'
                     return publishedId
                         ? Image({
-                              imageElement: el,
-                              path,
-                              index,
-                              displayCaptionAndCredit,
-                              articleType,
-                          })
+                            imageElement: el,
+                            path,
+                            index,
+                            displayCaptionAndCredit,
+                            articleType,
+                        })
                         : ''
                 }
                 case 'pullquote':
@@ -186,33 +186,33 @@ export const renderArticle = (
             header =
                 type === ArticleType.Showcase
                     ? HeaderShowcase({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
+                        ...article,
+                        type,
+                        headerType,
+                        publishedId,
+                        showMedia,
+                        pillar,
+                        getImagePath,
+                    })
                     : type === ArticleType.Interview
-                    ? HeaderInterview({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
-                    : Header({
-                          ...article,
-                          type,
-                          headerType,
-                          publishedId,
-                          showMedia,
-                          pillar,
-                          getImagePath,
-                      })
+                        ? HeaderInterview({
+                            ...article,
+                            type,
+                            headerType,
+                            publishedId,
+                            showMedia,
+                            pillar,
+                            getImagePath,
+                        })
+                        : Header({
+                            ...article,
+                            type,
+                            headerType,
+                            publishedId,
+                            showMedia,
+                            pillar,
+                            getImagePath,
+                        })
             const displayHint = article.displayHint
             content = renderArticleContent(
                 elements,
@@ -236,9 +236,7 @@ export const renderArticle = (
         {
             colors: getPillarColors(pillar),
             theme,
-        },
-        type,
-    )
+        })
     const body = html`
         ${showWebHeader && article && header}
         <div class="content-wrap">

--- a/projects/Mallard/src/components/article/html/article.ts
+++ b/projects/Mallard/src/components/article/html/article.ts
@@ -93,12 +93,12 @@ const renderArticleContent = (
                     const displayCaptionAndCredit = displayHint != 'photoEssay'
                     return publishedId
                         ? Image({
-                            imageElement: el,
-                            path,
-                            index,
-                            displayCaptionAndCredit,
-                            articleType,
-                        })
+                              imageElement: el,
+                              path,
+                              index,
+                              displayCaptionAndCredit,
+                              articleType,
+                          })
                         : ''
                 }
                 case 'pullquote':
@@ -186,33 +186,33 @@ export const renderArticle = (
             header =
                 type === ArticleType.Showcase
                     ? HeaderShowcase({
-                        ...article,
-                        type,
-                        headerType,
-                        publishedId,
-                        showMedia,
-                        pillar,
-                        getImagePath,
-                    })
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
                     : type === ArticleType.Interview
-                        ? HeaderInterview({
-                            ...article,
-                            type,
-                            headerType,
-                            publishedId,
-                            showMedia,
-                            pillar,
-                            getImagePath,
-                        })
-                        : Header({
-                            ...article,
-                            type,
-                            headerType,
-                            publishedId,
-                            showMedia,
-                            pillar,
-                            getImagePath,
-                        })
+                    ? HeaderInterview({
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
+                    : Header({
+                          ...article,
+                          type,
+                          headerType,
+                          publishedId,
+                          showMedia,
+                          pillar,
+                          getImagePath,
+                      })
             const displayHint = article.displayHint
             content = renderArticleContent(
                 elements,
@@ -232,11 +232,10 @@ export const renderArticle = (
         ? ArticleTheme.Dark
         : ArticleTheme.Default
 
-    const styles = makeCss(
-        {
-            colors: getPillarColors(pillar),
-            theme,
-        })
+    const styles = makeCss({
+        colors: getPillarColors(pillar),
+        theme,
+    })
     const body = html`
         ${showWebHeader && article && header}
         <div class="content-wrap">

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -49,7 +49,7 @@ const breakoutCaption = (
 
 `
 
-const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
+const imageStyles = ({ colors, theme }: CssProps) => {
     const defaultStyles = css`
         .image {
             position: relative;

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -50,12 +50,6 @@ const breakoutCaption = (
 `
 
 const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
-    const galleryStyles = css`
-        /*INLINE*/
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            ${breakoutCaption('inline', theme)}
-        }
-    `
     const defaultStyles = css`
         .image {
             position: relative;
@@ -187,10 +181,12 @@ const imageStyles = ({ colors, theme }: CssProps, contentType: string) => {
                 )};
             }
         }
+
+        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+            ${breakoutCaption('inline', theme)}
+        }
     `
-    return contentType !== ArticleType.Gallery
-        ? defaultStyles + galleryStyles
-        : defaultStyles
+    return defaultStyles
 }
 
 const ImageBase = ({
@@ -216,8 +212,9 @@ const ImageBase = ({
     displayCaptionAndCredit?: boolean
     articleType?: string
 }) => {
+    console.log(role, path)
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
-    const isInlineTablet = !role && isTablet
+    const isInlineTablet = (!role) && isTablet
     const showViewMore = isInlineTablet && articleType === ArticleType.Gallery
     const figcaption =
         displayCaptionAndCredit &&

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -49,8 +49,7 @@ const breakoutCaption = (
 
 `
 
-const imageStyles = ({ colors, theme }: CssProps) => {
-    const defaultStyles = css`
+const imageStyles = ({ colors, theme }: CssProps) => css`
         .image {
             position: relative;
             clear: right;
@@ -186,8 +185,6 @@ const imageStyles = ({ colors, theme }: CssProps) => {
             ${breakoutCaption('inline', theme)}
         }
     `
-    return defaultStyles
-}
 
 const ImageBase = ({
     path,

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -209,7 +209,6 @@ const ImageBase = ({
     displayCaptionAndCredit?: boolean
     articleType?: string
 }) => {
-    console.log(role, path)
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
     const isInlineTablet = !role && isTablet
     const showViewMore = isInlineTablet && articleType === ArticleType.Gallery

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -50,141 +50,138 @@ const breakoutCaption = (
 `
 
 const imageStyles = ({ colors, theme }: CssProps) => css`
-        .image {
-            position: relative;
-            clear: right;
-            z-index: 10000;
-        }
-        .image img {
-            display: block;
-            width: 100%;
-            height: auto;
-        }
+    .image {
+        position: relative;
+        clear: right;
+        z-index: 10000;
+    }
+    .image img {
+        display: block;
+        width: 100%;
+        height: auto;
+    }
+    .image figcaption {
+        font-family: 'GuardianTextSans-Regular';
+        color: ${themeColors(theme).dimText};
+        ${getFontCss('sans', 0.5)}
+        position: relative;
+        margin-top: 0.5em;
+    }
+    .image figcaption svg {
+        width: 1.2em;
+        position: relative;
+    }
+    .image figcaption svg path {
+        fill: ${theme === 'dark' ? colors.bright : colors.main};
+    }
+
+    /* Tablet captions */
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
         .image figcaption {
-            font-family: 'GuardianTextSans-Regular';
-            color: ${themeColors(theme).dimText};
-            ${getFontCss('sans', 0.5)}
-            position: relative;
-            margin-top: 0.5em;
+            ${getFontCss('sans', 0.9)}
         }
-        .image figcaption svg {
-            width: 1.2em;
-            position: relative;
+    }
+
+    /*THUMBS*/
+    @media (max-width: ${px(Breakpoints.tabletVertical)}) {
+        .image[data-role='thumbnail'] {
+            width: 40%;
+            float: left;
+            margin-right: ${px(metrics.article.sides)};
         }
-        .image figcaption svg path {
-            fill: ${theme === 'dark' ? colors.bright : colors.main};
+    }
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .image[data-role='thumbnail'] {
+            width: ${px(metrics.article.rightRail)};
+            position: absolute;
+            right: 0;
+        }
+    }
+
+    /*SUPPORTING*/
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .image[data-role='supporting'] {
+            float: right;
+            width: 500px;
+            margin-left: ${px(metrics.article.sides)};
+            margin-right: ${px(
+                (metrics.article.rightRail + metrics.article.sides) * -1,
+            )};
         }
 
-        /* Tablet captions */
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            .image figcaption {
-                ${getFontCss('sans', 0.9)}
-            }
+        .image[data-role='supporting'] figcaption {
+            width: ${px(metrics.article.rightRail - metrics.article.sides)};
+            position: absolute;
+            right: 0;
+        }
+    }
+
+    /*SHOWCASE*/
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) and (max-width: ${px(
+            Breakpoints.tabletLandscape,
+        )}) {
+        .image[data-role='showcase'] {
+            margin-right: ${px(
+                (metrics.article.rightRail + metrics.article.sides) * -1,
+            )};
         }
 
-        /*THUMBS*/
-        @media (max-width: ${px(Breakpoints.tabletVertical)}) {
-            .image[data-role='thumbnail'] {
-                width: 40%;
-                float: left;
-                margin-right: ${px(metrics.article.sides)};
-            }
+        .image[data-role='showcase'] figcaption {
+            width: ${px(metrics.article.rightRail)};
+            float: right;
         }
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            .image[data-role='thumbnail'] {
-                width: ${px(metrics.article.rightRail)};
-                position: absolute;
-                right: 0;
-            }
+    }
+    @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
+        .image[data-role='showcase'] img {
+            margin-left: ${px(
+                ((Breakpoints.tabletLandscape - metrics.article.maxWidth) / 2) *
+                    -1,
+            )};
+            width: calc(
+                100% +
+                    ${px(
+                        (Breakpoints.tabletLandscape -
+                            metrics.article.maxWidth) /
+                            2,
+                    )}
+            );
         }
+        ${breakoutCaption('showcase', theme)}
+    }
 
-        /*SUPPORTING*/
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            .image[data-role='supporting'] {
-                float: right;
-                width: 500px;
-                margin-left: ${px(metrics.article.sides)};
-                margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
-            }
+    /*IMMERSIVE*/
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        .image[data-role='immersive'] {
+            margin-right: ${px(
+                (metrics.article.rightRail + metrics.article.sides) * -1,
+            )};
+        }
+        .image[data-role='immersive'] figcaption {
+            width: ${px(metrics.article.rightRail)};
+            float: right;
+        }
+    }
+    @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
+        .image[data-role='immersive'] img {
+            width: calc(
+                100% +
+                    ${px(
+                        Breakpoints.tabletLandscape - metrics.article.maxWidth,
+                    )}
+            );
+            display: block;
+            background: 'red';
+            margin-left: ${px(
+                ((Breakpoints.tabletLandscape - metrics.article.maxWidth) / 2) *
+                    -1,
+            )};
+        }
+    }
 
-            .image[data-role='supporting'] figcaption {
-                width: ${px(metrics.article.rightRail - metrics.article.sides)};
-                position: absolute;
-                right: 0;
-            }
-        }
-
-        /*SHOWCASE*/
-        @media (min-width: ${px(
-                Breakpoints.tabletVertical,
-            )}) and (max-width: ${px(Breakpoints.tabletLandscape)}) {
-            .image[data-role='showcase'] {
-                margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
-            }
-
-            .image[data-role='showcase'] figcaption {
-                width: ${px(metrics.article.rightRail)};
-                float: right;
-            }
-        }
-        @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
-            .image[data-role='showcase'] img {
-                margin-left: ${px(
-                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-                        2) *
-                        -1,
-                )};
-                width: calc(
-                    100% +
-                        ${px(
-                            (Breakpoints.tabletLandscape -
-                                metrics.article.maxWidth) /
-                                2,
-                        )}
-                );
-            }
-            ${breakoutCaption('showcase', theme)}
-        }
-
-        /*IMMERSIVE*/
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            .image[data-role='immersive'] {
-                margin-right: ${px(
-                    (metrics.article.rightRail + metrics.article.sides) * -1,
-                )};
-            }
-            .image[data-role='immersive'] figcaption {
-                width: ${px(metrics.article.rightRail)};
-                float: right;
-            }
-        }
-        @media (min-width: ${px(Breakpoints.tabletLandscape)}) {
-            .image[data-role='immersive'] img {
-                width: calc(
-                    100% +
-                        ${px(
-                            Breakpoints.tabletLandscape -
-                                metrics.article.maxWidth,
-                        )}
-                );
-                display: block;
-                background: 'red';
-                margin-left: ${px(
-                    ((Breakpoints.tabletLandscape - metrics.article.maxWidth) /
-                        2) *
-                        -1,
-                )};
-            }
-        }
-
-        @media (min-width: ${px(Breakpoints.tabletVertical)}) {
-            ${breakoutCaption('inline', theme)}
-        }
-    `
+    @media (min-width: ${px(Breakpoints.tabletVertical)}) {
+        ${breakoutCaption('inline', theme)}
+    }
+`
 
 const ImageBase = ({
     path,

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -214,7 +214,7 @@ const ImageBase = ({
 }) => {
     console.log(role, path)
     const isTablet = useMediaQuery(width => width >= Breakpoints.tabletVertical)
-    const isInlineTablet = (!role) && isTablet
+    const isInlineTablet = !role && isTablet
     const showViewMore = isInlineTablet && articleType === ArticleType.Gallery
     const figcaption =
         displayCaptionAndCredit &&

--- a/projects/Mallard/src/components/article/html/css.ts
+++ b/projects/Mallard/src/components/article/html/css.ts
@@ -79,7 +79,7 @@ const makeFontsCss = () => css`
 const dropCapFontSizeMultiplier = Platform.OS === 'ios' ? 5.25 : 5.75
 const dropCapLineHeightMultiplier = Platform.OS === 'ios' ? 4.1 : 4.6
 
-const makeCss = ({ colors, theme }: CssProps, contentType: ArticleType) => css`
+const makeCss = ({ colors, theme }: CssProps) => css`
     ${makeFontsCss()}
 
     :root {
@@ -221,7 +221,7 @@ const makeCss = ({ colors, theme }: CssProps, contentType: ArticleType) => css`
         colors,
         theme,
     })}
-    ${imageStyles({ colors, theme }, contentType)}
+    ${imageStyles({ colors, theme })}
     ${lineStyles({ colors, theme })}
     ${starRatingStyles({ colors, theme })}
     ${sportScoreStyles({ colors, theme })}


### PR DESCRIPTION
## Summary

This PR reverts changes introduced in  #974. These changes were brought in to move captions underneath images on gallery articles . As we are now truncating longer captions with a view more button, this fix is no longer required and all gallery captions will appear inline on tablet in both landscape and tablet. 


## Point of interest
Whilst this PR resolves this bug, captions only appeared underneath images on *some* gallery articles, as you can see in the before screenshots. This is because some gallery articles have a type field of 'gallery' and some do not (screenshot 1 is type 'article' and screenshot 2 is type 'gallery'). This is being set in Editions in line 63 of use-article.tsx and does not reflect the CAPI article type field. More time needed to understand why this is being done.
[**Trello Card ->**](https://trello.com/c/QXY0CXUj/1711-bug-gallery-caption-placement-on-ipad)

## Test Plan

## Before: 
<img src="https://user-images.githubusercontent.com/20416599/103766397-b1f41c80-5016-11eb-8451-b595316447a9.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103766409-b6b8d080-5016-11eb-95d9-615427280e42.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103766412-b7516700-5016-11eb-9d0b-e07b6e550c21.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103766414-b8829400-5016-11eb-9320-2a228d548ad2.png" width="500" />


## After:
<img src="https://user-images.githubusercontent.com/20416599/103766837-6ee67900-5017-11eb-93e4-1ff13080ae89.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103763052-2fb52980-5011-11eb-8034-c4a2b3899506.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103763055-30e65680-5011-11eb-9d6a-e76d5b7e766b.png" width="500" />
<img src="https://user-images.githubusercontent.com/20416599/103763057-317eed00-5011-11eb-85f5-dcd1520ba1ee.png" width="500" />

Articles used for testing are taken from 03/01/2021 
1. Life > Observer Original Photography
2. Life > We Love... Fashion Fixes For The Week
