### PR TITLE
Feature Flag To Serve From Apps-Rendering CODE

### DIFF
--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -13,7 +13,7 @@ import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { defaultSettings } from 'src/helpers/settings/defaults'
-import { useIsSSR } from 'src/hooks/use-config-provider'
+import { useisAppsRendering } from 'src/hooks/use-config-provider'
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
     {
@@ -48,7 +48,7 @@ const WebviewWithArticle = ({
     const [isConnected] = useState(
         data != null ? data.netInfo.isConnected : false,
     )
-    const { isSSR } = useIsSSR()
+    const { isAppsRendering } = useisAppsRendering()
 
     // FIXME: pass this as article data instead so it's never out-of-sync?
     const [, { pillar }] = useArticle()
@@ -107,7 +107,7 @@ const WebviewWithArticle = ({
         uri: `${defaultSettings.appsRenderingService}${article.key}?editions`,
     }
 
-    const source = isSSR ? serverRenderedSource : clientRenderedSource
+    const source = isAppsRendering ? serverRenderedSource : clientRenderedSource
 
     return (
         <WebView

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -13,7 +13,7 @@ import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { defaultSettings } from 'src/helpers/settings/defaults'
-import {useIsSSR} from 'src/hooks/use-config-provider'
+import { useIsSSR } from 'src/hooks/use-config-provider'
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
     {
@@ -96,7 +96,7 @@ const WebviewWithArticle = ({
         getImagePath,
     })
 
-    const {isSSR} = useIsSSR()
+    const { isSSR } = useIsSSR()
     const source = {
         html,
         baseUrl:

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -96,7 +96,7 @@ const WebviewWithArticle = ({
         getImagePath,
     })
 
-    const isSSR = useIsSSR()
+    const {isSSR} = useIsSSR()
     const source = {
         html,
         baseUrl:

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -12,7 +12,8 @@ import { FSPaths, APIPaths, PathToArticle } from 'src/paths'
 import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
-
+import { defaultSettings } from 'src/helpers/settings/defaults'
+import {useIsSSR} from 'src/hooks/use-config-provider'
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
     {
@@ -95,17 +96,24 @@ const WebviewWithArticle = ({
         getImagePath,
     })
 
+    const isSSR = useIsSSR()
+    const source = {
+        html,
+        baseUrl:
+            '' /* required as per https://stackoverflow.com/a/51931187/609907 */,
+    }
+
+    const editions_rendered_source = {
+        uri: `${defaultSettings.appsRenderingService}${article.key}?editions`,
+    }
+
     return (
         <WebView
             {...webViewProps}
             bounces={largeDeviceMemory ? true : false}
             originWhitelist={['*']}
             scrollEnabled={true}
-            source={{
-                html,
-                baseUrl:
-                    '' /* required as per https://stackoverflow.com/a/51931187/609907 */,
-            }}
+            source={isSSR ? editions_rendered_source : source}
             ref={_ref}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
             allowFileAccess={true}

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -48,6 +48,7 @@ const WebviewWithArticle = ({
     const [isConnected] = useState(
         data != null ? data.netInfo.isConnected : false,
     )
+    const { isSSR } = useIsSSR()
 
     // FIXME: pass this as article data instead so it's never out-of-sync?
     const [, { pillar }] = useArticle()
@@ -96,16 +97,17 @@ const WebviewWithArticle = ({
         getImagePath,
     })
 
-    const { isSSR } = useIsSSR()
-    const source = {
+    const clientRenderedSource = {
         html,
         baseUrl:
             '' /* required as per https://stackoverflow.com/a/51931187/609907 */,
     }
 
-    const editions_rendered_source = {
+    const serverRenderedSource = {
         uri: `${defaultSettings.appsRenderingService}${article.key}?editions`,
     }
+
+    const source = isSSR ? serverRenderedSource : clientRenderedSource
 
     return (
         <WebView
@@ -113,7 +115,7 @@ const WebviewWithArticle = ({
             bounces={largeDeviceMemory ? true : false}
             originWhitelist={['*']}
             scrollEnabled={true}
-            source={isSSR ? editions_rendered_source : source}
+            source={source}
             ref={_ref}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
             allowFileAccess={true}

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -13,7 +13,7 @@ import { Platform } from 'react-native'
 import { Image, ImageUse, IssueOrigin } from 'src/common'
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider'
 import { defaultSettings } from 'src/helpers/settings/defaults'
-import { useisAppsRendering } from 'src/hooks/use-config-provider'
+import { useIsAppsRendering } from 'src/hooks/use-config-provider'
 type QueryValue = { imageSize: ImageSize; apiUrl: string }
 const QUERY = gql`
     {
@@ -48,7 +48,7 @@ const WebviewWithArticle = ({
     const [isConnected] = useState(
         data != null ? data.netInfo.isConnected : false,
     )
-    const { isAppsRendering } = useisAppsRendering()
+    const { isAppsRendering } = useIsAppsRendering()
 
     // FIXME: pass this as article data instead so it's never out-of-sync?
     const [, { pillar }] = useArticle()
@@ -97,17 +97,17 @@ const WebviewWithArticle = ({
         getImagePath,
     })
 
-    const clientRenderedSource = {
+    const clientRenderingSource = {
         html,
         baseUrl:
             '' /* required as per https://stackoverflow.com/a/51931187/609907 */,
     }
 
-    const serverRenderedSource = {
+    const appsRenderingSource = {
         uri: `${defaultSettings.appsRenderingService}${article.key}?editions`,
     }
 
-    const source = isAppsRendering ? serverRenderedSource : clientRenderedSource
+    const source = isAppsRendering ? appsRenderingSource : clientRenderingSource
 
     return (
         <WebView

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -80,7 +80,8 @@ export interface DevSettings {
     issuesPath: string
     senderId: string
     logging: string,
-    appsRenderingService: string
+    appsRenderingService: string,
+    isSSR: boolean
 }
 
 interface UserSettings {

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -79,8 +79,8 @@ export interface DevSettings {
     websiteUrl: string
     issuesPath: string
     senderId: string
-    logging: string,
-    appsRenderingService: string,
+    logging: string
+    appsRenderingService: string
     isSSR: boolean
 }
 

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -81,7 +81,7 @@ export interface DevSettings {
     senderId: string
     logging: string
     appsRenderingService: string
-    isSSR: boolean
+    isAppsRendering: boolean
 }
 
 interface UserSettings {

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -79,7 +79,8 @@ export interface DevSettings {
     websiteUrl: string
     issuesPath: string
     senderId: string
-    logging: string
+    logging: string,
+    appsRenderingService: string
 }
 
 interface UserSettings {

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -134,7 +134,8 @@ export const defaultSettings: Settings = {
     logging: __DEV__
         ? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
         : 'https://editions-logging.guardianapis.com/log/mallard',
-    appsRenderingService: appsRenderingService.code,
+    // this currently points exclusively to PROD so that we don't require a VPN to access the endpoint.
+    appsRenderingService: appsRenderingService.prod,
 }
 
 export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -134,9 +134,7 @@ export const defaultSettings: Settings = {
     logging: __DEV__
         ? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
         : 'https://editions-logging.guardianapis.com/log/mallard',
-    appsRenderingService: __DEV__
-        ? appsRenderingService.code
-        : appsRenderingService.prod,
+    appsRenderingService: appsRenderingService.code
 }
 
 export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -128,7 +128,7 @@ export const defaultSettings: Settings = {
     senderId: __DEV__ ? senderId.code : senderId.prod,
     isWeatherShown: true,
     wifiOnlyDownloads: false,
-    isSSR: false,
+    isAppsRendering: false,
     maxAvailableEditions: 7,
     websiteUrl: 'https://www.theguardian.com/',
     logging: __DEV__

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -134,7 +134,7 @@ export const defaultSettings: Settings = {
     logging: __DEV__
         ? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
         : 'https://editions-logging.guardianapis.com/log/mallard',
-    appsRenderingService: appsRenderingService.code
+    appsRenderingService: appsRenderingService.code,
 }
 
 export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -101,6 +101,10 @@ const storeDetails = {
     ios: 'itms-apps://itunes.apple.com/app/id452707806',
     android: 'market://details?id=com.guardian.editions',
 }
+const appsRenderingService = {
+    prod: 'https://mobile.guardianapis.com/rendered-items/',
+    code: 'http://mobile.code.dev-guardianapis.com/rendered-items/',
+}
 
 export const defaultSettings: Settings = {
     apiUrl,
@@ -129,6 +133,9 @@ export const defaultSettings: Settings = {
     logging: __DEV__
         ? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
         : 'https://editions-logging.guardianapis.com/log/mallard',
+    appsRenderingService: __DEV__
+        ? appsRenderingService.code
+        : appsRenderingService.prod,
 }
 
 export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -128,6 +128,7 @@ export const defaultSettings: Settings = {
     senderId: __DEV__ ? senderId.code : senderId.prod,
     isWeatherShown: true,
     wifiOnlyDownloads: false,
+    isSSR: false,
     maxAvailableEditions: 7,
     websiteUrl: 'https://www.theguardian.com/',
     logging: __DEV__

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -150,7 +150,7 @@ export const Settings = {
     termsAndConditions: 'Terms and conditions',
     version: 'Version',
     betaProgrammeFAQs: 'Beta Programme FAQs',
-    isSSR: 'Show Articles from Editions Rendering',
+    isAppsRendering: 'Show Articles from Editions Rendering',
 }
 
 export const ManageDownloads = {

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -150,7 +150,7 @@ export const Settings = {
     termsAndConditions: 'Terms and conditions',
     version: 'Version',
     betaProgrammeFAQs: 'Beta Programme FAQs',
-    useSSR: 'Show Articles from Editions Rendering',
+    isSSR: 'Show Articles from Editions Rendering',
 
 }
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -151,7 +151,6 @@ export const Settings = {
     version: 'Version',
     betaProgrammeFAQs: 'Beta Programme FAQs',
     isSSR: 'Show Articles from Editions Rendering',
-
 }
 
 export const ManageDownloads = {

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -150,6 +150,8 @@ export const Settings = {
     termsAndConditions: 'Terms and conditions',
     version: 'Version',
     betaProgrammeFAQs: 'Beta Programme FAQs',
+    useSSR: 'Show Articles from Editions Rendering',
+
 }
 
 export const ManageDownloads = {

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -62,11 +62,11 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     const [notificationsEnabled, setNotificationsEnabled] = useState(
         notificationInitialState(),
     )
-    const [isAppsRendering, setisAppsRendering] = useState(false)
+    const [isAppsRendering, setIsAppsRendering] = useState(false)
 
     const storeisAppsRendering = async (setting: boolean) => {
         await storeSetting(IS_APPS_RENDERING, setting)
-        setisAppsRendering(setting)
+        setIsAppsRendering(setting)
     }
 
     const setNotifications = async (setting: boolean) => {
@@ -124,7 +124,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 
     useEffect(() => {
         getSetting(IS_APPS_RENDERING).then(result => {
-            setisAppsRendering(result)
+            setIsAppsRendering(result)
         })
     }, [])
 
@@ -154,7 +154,7 @@ export const useNotificationsEnabled = () => ({
     setNotifications: useContext(ConfigContext).setNotifications,
 })
 
-export const useisAppsRendering = () => ({
+export const useIsAppsRendering = () => ({
     isAppsRendering: useContext(ConfigContext).isAppsRendering,
-    setisAppsRendering: useContext(ConfigContext).storeisAppsRendering,
+    setIsAppsRendering: useContext(ConfigContext).storeisAppsRendering,
 })

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -7,7 +7,7 @@ import { errorService } from 'src/services/errors'
 import AsyncStorage from '@react-native-community/async-storage'
 
 const oneGB = 1073741824
-const IS_SSR_KEY = '@isAppsRendering'
+const IS_APPS_RENDERING = 'isAppsRendering'
 interface ConfigState {
     largeDeviceMemeory: boolean
     dimensions: {

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -4,10 +4,11 @@ import DeviceInfo from 'react-native-device-info'
 import { Breakpoints } from 'src/theme/breakpoints'
 import { notificationsEnabledCache } from 'src/helpers/storage'
 import { errorService } from 'src/services/errors'
-import AsyncStorage from '@react-native-community/async-storage'
+import { getSetting, storeSetting } from 'src/helpers/settings'
 
 const oneGB = 1073741824
 const IS_APPS_RENDERING = 'isAppsRendering'
+
 interface ConfigState {
     largeDeviceMemeory: boolean
     dimensions: {
@@ -63,9 +64,9 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     )
     const [isAppsRendering, setisAppsRendering] = useState(false)
 
-    const storeisAppsRendering = (setting: boolean) => {
+    const storeisAppsRendering = async (setting: boolean) => {
+        await storeSetting(IS_APPS_RENDERING, setting)
         setisAppsRendering(setting)
-        AsyncStorage.setItem(IS_SSR_KEY, JSON.stringify(setting))
     }
 
     const setNotifications = async (setting: boolean) => {
@@ -122,11 +123,9 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     }, [])
 
     useEffect(() => {
-        async function getisAppsRendering() {
-            const result = await AsyncStorage.getItem(IS_SSR_KEY)
-            if (result) setisAppsRendering(JSON.parse(result))
-        }
-        getisAppsRendering()
+        getSetting(IS_APPS_RENDERING).then(result => {
+            setisAppsRendering(result)
+        })
     }, [])
 
     return (

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -155,4 +155,7 @@ export const useNotificationsEnabled = () => ({
     setNotifications: useContext(ConfigContext).setNotifications,
 })
 
-export const useIsSSR = () => useContext(ConfigContext).isSSR
+export const useIsSSR = () => ({
+    isSSR: useContext(ConfigContext).isSSR,
+    setIsSSR: useContext(ConfigContext).storeIsSSR
+})

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -157,5 +157,5 @@ export const useNotificationsEnabled = () => ({
 
 export const useIsSSR = () => ({
     isSSR: useContext(ConfigContext).isSSR,
-    setIsSSR: useContext(ConfigContext).storeIsSSR
+    setIsSSR: useContext(ConfigContext).storeIsSSR,
 })

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -154,3 +154,5 @@ export const useNotificationsEnabled = () => ({
     notificationsEnabled: useContext(ConfigContext).notificationsEnabled,
     setNotifications: useContext(ConfigContext).setNotifications,
 })
+
+export const useIsSSR = () => useContext(ConfigContext).isSSR

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -7,7 +7,7 @@ import { errorService } from 'src/services/errors'
 import AsyncStorage from '@react-native-community/async-storage'
 
 const oneGB = 1073741824
-const IS_SSR_KEY = '@isSSR'
+const IS_SSR_KEY = '@isAppsRendering'
 interface ConfigState {
     largeDeviceMemeory: boolean
     dimensions: {
@@ -18,8 +18,8 @@ interface ConfigState {
     }
     notificationsEnabled: boolean
     setNotifications: (setting: boolean) => Promise<void>
-    isSSR: boolean
-    storeIsSSR: (setting: boolean) => void
+    isAppsRendering: boolean
+    storeisAppsRendering: (setting: boolean) => void
 }
 
 const notificationInitialState = () =>
@@ -35,8 +35,8 @@ const initialState: ConfigState = {
     },
     notificationsEnabled: notificationInitialState(),
     setNotifications: () => Promise.resolve(),
-    isSSR: false,
-    storeIsSSR: () => {},
+    isAppsRendering: false,
+    storeisAppsRendering: () => {},
 }
 
 const ConfigContext = createContext(initialState)
@@ -61,10 +61,10 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     const [notificationsEnabled, setNotificationsEnabled] = useState(
         notificationInitialState(),
     )
-    const [isSSR, setIsSSR] = useState(false)
+    const [isAppsRendering, setisAppsRendering] = useState(false)
 
-    const storeIsSSR = (setting: boolean) => {
-        setIsSSR(setting)
+    const storeisAppsRendering = (setting: boolean) => {
+        setisAppsRendering(setting)
         AsyncStorage.setItem(IS_SSR_KEY, JSON.stringify(setting))
     }
 
@@ -122,11 +122,11 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
     }, [])
 
     useEffect(() => {
-        async function getIsSSR() {
+        async function getisAppsRendering() {
             const result = await AsyncStorage.getItem(IS_SSR_KEY)
-            if (result) setIsSSR(JSON.parse(result))
+            if (result) setisAppsRendering(JSON.parse(result))
         }
-        getIsSSR()
+        getisAppsRendering()
     }, [])
 
     return (
@@ -136,8 +136,8 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
                 dimensions,
                 notificationsEnabled,
                 setNotifications,
-                isSSR,
-                storeIsSSR,
+                isAppsRendering,
+                storeisAppsRendering,
             }}
         >
             {children}
@@ -155,7 +155,7 @@ export const useNotificationsEnabled = () => ({
     setNotifications: useContext(ConfigContext).setNotifications,
 })
 
-export const useIsSSR = () => ({
-    isSSR: useContext(ConfigContext).isSSR,
-    setIsSSR: useContext(ConfigContext).storeIsSSR,
+export const useisAppsRendering = () => ({
+    isAppsRendering: useContext(ConfigContext).isAppsRendering,
+    setisAppsRendering: useContext(ConfigContext).storeisAppsRendering,
 })

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -11,7 +11,7 @@ import { PathToArticle } from 'src/paths'
 import { color } from 'src/theme/color'
 import { HeaderControlInnerProps } from 'src/components/article/types/article'
 import { NavigationScreenProp } from 'react-navigation'
-import { useIsSSR } from 'src/hooks/use-config-provider'
+import { useisAppsRendering } from 'src/hooks/use-config-provider'
 
 const styles = StyleSheet.create({
     flex: { flexGrow: 1 },
@@ -58,7 +58,7 @@ const ArticleScreenBody = React.memo<
             // eslint-disable-next-line react-hooks/exhaustive-deps
             [onIsAtTopChange],
         )
-        const { isSSR } = useIsSSR()
+        const { isAppsRendering } = useisAppsRendering()
         // First time it's mounted, we make sure to report we're at the top.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         useEffect(() => handleIsAtTopChange(true), [])
@@ -83,7 +83,7 @@ const ArticleScreenBody = React.memo<
                                 <UiBodyCopy>{previewNotice}</UiBodyCopy>
                             )}
 
-                            {isSSR && (
+                            {isAppsRendering && (
                                 <UiBodyCopy style={styles.ssrBanner}>
                                     EDITIONS RENDERED CONTENT:{' '}
                                     {article.article.articleType ||

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
         marginTop: 40,
         backgroundColor: 'aqua',
         textAlign: 'center',
-    }
+    },
 })
 
 export type OnIsAtTopChange = (isAtTop: boolean, articleKey: string) => void
@@ -84,11 +84,10 @@ const ArticleScreenBody = React.memo<
                             )}
 
                             {isSSR && (
-                                <UiBodyCopy
-                                    style={styles.ssrBanner}
-                                >
+                                <UiBodyCopy style={styles.ssrBanner}>
                                     EDITIONS RENDERED CONTENT:{' '}
-                                    {article.article.articleType || "TYPE UNKNOWN"}
+                                    {article.article.articleType ||
+                                        'TYPE UNKNOWN'}
                                 </UiBodyCopy>
                             )}
 

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -11,10 +11,18 @@ import { PathToArticle } from 'src/paths'
 import { color } from 'src/theme/color'
 import { HeaderControlInnerProps } from 'src/components/article/types/article'
 import { NavigationScreenProp } from 'react-navigation'
+import { useIsSSR } from 'src/hooks/use-config-provider'
 
 const styles = StyleSheet.create({
     flex: { flexGrow: 1 },
     container: { height: '100%' },
+    ssrBanner: {
+        width: '100%',
+        padding: 10,
+        marginTop: 40,
+        backgroundColor: 'aqua',
+        textAlign: 'center',
+    }
 })
 
 export type OnIsAtTopChange = (isAtTop: boolean, articleKey: string) => void
@@ -50,10 +58,10 @@ const ArticleScreenBody = React.memo<
             // eslint-disable-next-line react-hooks/exhaustive-deps
             [onIsAtTopChange],
         )
+        const { isSSR } = useIsSSR()
         // First time it's mounted, we make sure to report we're at the top.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         useEffect(() => handleIsAtTopChange(true), [])
-
         return (
             <View style={[styles.container, { width }]}>
                 {articleResponse({
@@ -74,6 +82,16 @@ const ArticleScreenBody = React.memo<
                             {previewNotice && (
                                 <UiBodyCopy>{previewNotice}</UiBodyCopy>
                             )}
+
+                            {isSSR && (
+                                <UiBodyCopy
+                                    style={styles.ssrBanner}
+                                >
+                                    EDITIONS RENDERED CONTENT:{' '}
+                                    {article.article.articleType || "TYPE UNKNOWN"}
+                                </UiBodyCopy>
+                            )}
+
                             <WithArticle
                                 type={
                                     article.article.articleType ||

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -11,7 +11,7 @@ import { PathToArticle } from 'src/paths'
 import { color } from 'src/theme/color'
 import { HeaderControlInnerProps } from 'src/components/article/types/article'
 import { NavigationScreenProp } from 'react-navigation'
-import { useisAppsRendering } from 'src/hooks/use-config-provider'
+import { useIsAppsRendering } from 'src/hooks/use-config-provider'
 
 const styles = StyleSheet.create({
     flex: { flexGrow: 1 },
@@ -58,7 +58,7 @@ const ArticleScreenBody = React.memo<
             // eslint-disable-next-line react-hooks/exhaustive-deps
             [onIsAtTopChange],
         )
-        const { isAppsRendering } = useisAppsRendering()
+        const { isAppsRendering } = useIsAppsRendering()
         // First time it's mounted, we make sure to report we're at the top.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         useEffect(() => handleIsAtTopChange(true), [])

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -32,7 +32,7 @@ import { metrics } from 'src/theme/spacing'
 import { useEditions } from 'src/hooks/use-edition-provider'
 import { pushRegisteredTokens, showAllEditionsCache } from 'src/helpers/storage'
 import { Copy } from 'src/helpers/words'
-import { useisAppsRendering } from 'src/hooks/use-config-provider'
+import { useIsAppsRendering } from 'src/hooks/use-config-provider'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -78,7 +78,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [imageSize, setImageSize] = useState('fetching...')
     const [pushTokens, setPushTokens] = useState('fetching...')
     const [downloadedIssues, setDownloadedIssues] = useState('fetching...')
-    const { isAppsRendering, setisAppsRendering } = useisAppsRendering()
+    const { isAppsRendering, setIsAppsRendering } = useIsAppsRendering()
     // initialise local showAllEditions property
     useEffect(() => {
         showAllEditionsCache.get().then(v => v != null && setShowAllEditions(v))
@@ -225,7 +225,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                                 accessibilityLabel={Copy.settings.isAppsRendering}
                                 accessibilityRole="switch"
                                 value={isAppsRendering}
-                                onValueChange={setisAppsRendering}
+                                onValueChange={setIsAppsRendering}
                             />
                         ),
                     },

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -32,7 +32,7 @@ import { metrics } from 'src/theme/spacing'
 import { useEditions } from 'src/hooks/use-edition-provider'
 import { pushRegisteredTokens, showAllEditionsCache } from 'src/helpers/storage'
 import { Copy } from 'src/helpers/words'
-import { useIsSSR } from 'src/hooks/use-config-provider'
+import { useisAppsRendering } from 'src/hooks/use-config-provider'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -78,7 +78,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [imageSize, setImageSize] = useState('fetching...')
     const [pushTokens, setPushTokens] = useState('fetching...')
     const [downloadedIssues, setDownloadedIssues] = useState('fetching...')
-    const { isSSR, setIsSSR } = useIsSSR()
+    const { isAppsRendering, setisAppsRendering } = useisAppsRendering()
     // initialise local showAllEditions property
     useEffect(() => {
         showAllEditionsCache.get().then(v => v != null && setShowAllEditions(v))
@@ -217,15 +217,15 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
             <List
                 data={[
                     {
-                        key: 'isSSR',
-                        title: Copy.settings.isSSR,
+                        key: 'isAppsRendering',
+                        title: Copy.settings.isAppsRendering,
                         proxy: (
                             <Switch
                                 accessible={true}
-                                accessibilityLabel={Copy.settings.isSSR}
+                                accessibilityLabel={Copy.settings.isAppsRendering}
                                 accessibilityRole="switch"
-                                value={isSSR}
-                                onValueChange={setIsSSR}
+                                value={isAppsRendering}
+                                onValueChange={setisAppsRendering}
                             />
                         ),
                     },

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -31,6 +31,8 @@ import {
 import { metrics } from 'src/theme/spacing'
 import { useEditions } from 'src/hooks/use-edition-provider'
 import { pushRegisteredTokens, showAllEditionsCache } from 'src/helpers/storage'
+import { Copy } from 'src/helpers/words'
+import { useIsSSR } from 'src/hooks/use-config-provider'
 
 const ButtonList = ({ children }: { children: ReactNode }) => {
     return (
@@ -76,7 +78,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
     const [imageSize, setImageSize] = useState('fetching...')
     const [pushTokens, setPushTokens] = useState('fetching...')
     const [downloadedIssues, setDownloadedIssues] = useState('fetching...')
-
+    const { isSSR, setIsSSR } = useIsSSR()
     // initialise local showAllEditions property
     useEffect(() => {
         showAllEditionsCache.get().then(v => v != null && setShowAllEditions(v))
@@ -211,8 +213,24 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                     Clear caches
                 </Button>
             </ButtonList>
+
             <List
                 data={[
+                    {
+                        key: 'isSSR',
+                        title: Copy.settings.isSSR,
+                        proxy: (
+                            <Switch
+                                accessible={true}
+                                accessibilityLabel={
+                                    Copy.settings.isSSR
+                                }
+                                accessibilityRole="switch"
+                                value={isSSR}
+                                onValueChange={setIsSSR}
+                            />
+                        ),
+                    },
                     {
                         key: 'Endpoints',
                         title: 'API Endpoint',

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -222,9 +222,7 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         proxy: (
                             <Switch
                                 accessible={true}
-                                accessibilityLabel={
-                                    Copy.settings.isSSR
-                                }
+                                accessibilityLabel={Copy.settings.isSSR}
                                 accessibilityRole="switch"
                                 value={isSSR}
                                 onValueChange={setIsSSR}

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -222,7 +222,9 @@ const DevZone = withNavigation(({ navigation }: NavigationInjectedProps) => {
                         proxy: (
                             <Switch
                                 accessible={true}
-                                accessibilityLabel={Copy.settings.isAppsRendering}
+                                accessibilityLabel={
+                                    Copy.settings.isAppsRendering
+                                }
                                 accessibilityRole="switch"
                                 value={isAppsRendering}
                                 onValueChange={setIsAppsRendering}


### PR DESCRIPTION
## Summary
This PR  adds a feature flag to display articles in the app using apps-rendering CODE as the backend for online articles. 
This will allow all team members to view editions rendering work in the editions app, allowing us to spot UI bugs and tweaks early.

NB - this feature flag will only work for online articles. Any offline content will not be rendered when the flag is set.

[**Trello Card ->**](https://trello.com/c/NsArA49Y/1674-article-scaffolding-for-editions-to-view-er-templates)

