### PR TITLE
Simple Apps Rendering Proxy

### DIFF
--- a/projects/backend/.gitignore
+++ b/projects/backend/.gitignore
@@ -2,3 +2,4 @@
 !types/*.d.ts
 coverage
 yarn-error.log
+.env

--- a/projects/backend/README.md
+++ b/projects/backend/README.md
@@ -29,4 +29,4 @@ yarn preview
 
 You can now access the backend on `https://localhost:3131/`
 
-The routing is done in `index.ts` - go and find some routes to hit!
+The routing is done in `application.ts` - go and find some routes to hit!

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -26,6 +26,7 @@ const testStubControllers: EditionsBackendControllers = {
     frontController: stub,
     imageController: stub,
     renderController: stub,
+    appsRenderingController: stub,
     editionsController: stubEditionController,
 }
 

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -15,6 +15,7 @@ export interface EditionsBackendControllers {
     frontController: (req: Request, res: Response) => void
     imageController: (req: Request, res: Response) => void
     renderController: (req: Request, res: Response) => void
+    appsRenderingController: (req: Request, res: Response) => void
     editionsController: {
         GET: (req: Request, res: Response) => void
         POST: (req: Request, res: Response) => void
@@ -60,6 +61,8 @@ export const createApp = (
     )
 
     app.get('/render/:path(*)', controllers.renderController)
+
+    app.get('/rendered-items/:path(*)', controllers.appsRenderingController)
 
     app.get(
         '/' +

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -6,6 +6,7 @@ import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController } from './controllers/image'
 import { renderController } from './controllers/render'
+import { appsRenderingController } from './controllers/appsRendering'
 import {
     editionsControllerGet,
     editionsControllerPost,
@@ -19,6 +20,7 @@ const runtimeControllers: EditionsBackendControllers = {
     frontController,
     imageController,
     renderController,
+    appsRenderingController,
     editionsController: {
         GET: editionsControllerGet,
         POST: editionsControllerPost,

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -3,14 +3,11 @@ import fetch from 'node-fetch'
 
 const fetchRenderedArticle = async (url: string) => {
     const response = await fetch(url, {
-        headers: {
-            Accept:
-                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        },
+        headers: {Accept: 'text/html',},
     })
     const responseBody = await response.text()
     return {
-        success: response.statusText === 'OK',
+        success: response.ok,
         status: response.status,
         body: responseBody,
     }

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch'
 export const appsRenderingController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
+    
     console.log(`Fetching HTML from AppsRendering URL: ${renderingUrl}`)
     const renderResponse = await fetch(renderingUrl, {
         headers: { Accept: 'text/html' },

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -1,29 +1,19 @@
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
 
-const fetchRenderedArticle = async (url: string) => {
-    const response = await fetch(url, {
-        headers: {Accept: 'text/html',},
-    })
-    const responseBody = await response.text()
-    return {
-        success: response.ok,
-        status: response.status,
-        body: responseBody,
-    }
-}
-
 export const appsRenderingController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
     console.log(`Fetching HTML from AppsRendering URL: ${renderingUrl}`)
-    const renderResponse = await fetchRenderedArticle(renderingUrl)
+    const renderResponse = await fetch(renderingUrl, {
+        headers: { Accept: 'text/html' },
+    })
 
-    if (renderResponse.success) {
+    if (renderResponse.ok) {
         res.setHeader('Content-Type', 'text/html')
-        res.send(renderResponse.body)
+        renderResponse.body.pipe(res)
     } else {
-        const message = `Failed to fetch AppsRendered HTML from ${renderingUrl}. Response: ${renderResponse.body}`
+        const message = `Failed to fetch AppsRendered HTML from ${renderingUrl}. Response: ${renderResponse.statusText}`
         console.error(`${message}`)
         res.status(renderResponse.status).send(message)
     }

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from 'express'
+import fetch from 'node-fetch'
+
+const fetchRenderedArticle = async (url: string) => {
+    const response = await fetch(url, {
+        headers: {
+            Accept:
+                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        },
+    })
+    const responseBody = await response.text()
+    return {
+        success: response.statusText === 'OK',
+        status: response.status,
+        body: responseBody,
+    }
+}
+
+export const appsRenderingController = async (req: Request, res: Response) => {
+    const path = req.params.path
+    const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
+    console.log(`Fetching rendered HTML from AppsRendering URL: ${renderingUrl}`)
+    const renderResponse = await fetchRenderedArticle(renderingUrl)
+
+    if (renderResponse.success) {
+        res.setHeader('Content-Type', 'text/html')
+        res.send(renderResponse.body)
+    } else {
+        const message = `Failed to fetch AppsRendered HTML from ${renderingUrl}. Response: ${renderResponse.body}`
+        console.error(`${message}`)
+        res.status(renderResponse.status).send(message)
+    }
+}

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -19,7 +19,7 @@ const fetchRenderedArticle = async (url: string) => {
 export const appsRenderingController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
-    console.log(`Fetching rendered HTML from AppsRendering URL: ${renderingUrl}`)
+    console.log(`Fetching HTML from AppsRendering URL: ${renderingUrl}`)
     const renderResponse = await fetchRenderedArticle(renderingUrl)
 
     if (renderResponse.success) {

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -9,12 +9,13 @@ export const appsRenderingController = async (req: Request, res: Response) => {
         headers: { Accept: 'text/html' },
     })
 
-    if (renderResponse.ok) {
-        res.setHeader('Content-Type', 'text/html')
-        renderResponse.body.pipe(res)
-    } else {
+    if (!renderResponse.ok) {
         const message = `Failed to fetch AppsRendered HTML from ${renderingUrl}. Response: ${renderResponse.statusText}`
         console.error(`${message}`)
         res.status(renderResponse.status).send(message)
+        return
     }
+
+    res.setHeader('Content-Type', 'text/html')
+    renderResponse.body.pipe(res)
 }

--- a/projects/backend/controllers/appsRendering.ts
+++ b/projects/backend/controllers/appsRendering.ts
@@ -4,7 +4,6 @@ import fetch from 'node-fetch'
 export const appsRenderingController = async (req: Request, res: Response) => {
     const path = req.params.path
     const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
-    
     console.log(`Fetching HTML from AppsRendering URL: ${renderingUrl}`)
     const renderResponse = await fetch(renderingUrl, {
         headers: { Accept: 'text/html' },


### PR DESCRIPTION
## Summary

Simple Apps Rendering proxy to allow Editions app to quickly and painlessly test Apps Rendered HTML content via a simple editions endpoint. This has been optimised for delete-ability, as it may very well be an interim solution.

App -> Editions Backend -> AR PROD*

*The AR endpoint is configured in the .env file

Example Request:

```
https://editions.guardianapis.com/rendered-items/travel/2020/jan/27/rail-sail-how-to-book-perfect-holiday-without-flying
```

will be proxied to:

```
https://mobile.guardianapis.com/rendered-items/travel/2020/jan/27/rail-sail-how-to-book-perfect-holiday-without-flying?editions
```

[**JIRA Ticket | Wire-up Editions backend AR for rendered article requests**](https://theguardian.atlassian.net/browse/LIVE-1446)
