### PR TITLE
Editions Mallard : TypeScript upgrade

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -124,7 +124,7 @@
         "mockdate": "^2.0.5",
         "react-native-storybook-loader": "^1.8.1",
         "react-test-renderer": "16.9.0",
-        "typescript": "^3.5.3"
+        "typescript": "^4.1.3"
     },
     "resolutions": {
         "@types/react": "16.9.1",

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -150,7 +150,6 @@ export const Front = React.memo(
                     showsHorizontalScrollIndicator={false}
                     // These three props are responsible for the majority of
                     // performance improvements
-                    initialNumToRender={2}
                     {...flatListOptimisationProps}
                     showsVerticalScrollIndicator={false}
                     scrollEventThrottle={1}

--- a/projects/Mallard/src/components/lists/styles.ts
+++ b/projects/Mallard/src/components/lists/styles.ts
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
         justifyContent: 'space-between',
     },
     buttonPrimary: {
-        maxWidth: DeviceInfo.isTablet
+        maxWidth: DeviceInfo.isTablet()
             ? 300
             : Dimensions.get('screen').width * 0.75,
     },

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -1,19 +1,14 @@
 import { isInBeta } from './release-stream'
 import { Platform } from 'react-native'
 
-export const REQUEST_INVALID_RESPONSE_STATE = 'Request failed'
-export const REQUEST_INVALID_RESPONSE_VALIDATION = 'Failed to parse data'
-export const LOCAL_JSON_INVALID_RESPONSE_VALIDATION =
-    'Failed to parse local data'
 
-export const COOKIE_LINK = 'https://www.theguardian.com/info/cookies'
-export const PRIVACY_LINK = 'https://www.theguardian.com/info/privacy'
 export const IOS_BETA_EMAIL = 'editions.ios.beta@theguardian.com'
 export const ANDROID_BETA_EMAIL = 'editions.android.beta@theguardian.com'
 export const ISSUE_EMAIL = 'editions.feedback@theguardian.com'
 export const SUBSCRIPTION_EMAIL = 'subscriptions@theguardian.com'
 export const READERS_EMAIL = 'guardian.readers@theguardian.com'
 export const APPS_FEEDBACK_EMAIL = 'editions.feedback@theguardian.com'
+export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
 
 export const CONNECTION_FAILED_ERROR = `Connection failed`
 export const CONNECTION_FAILED_SUB_ERROR = `Let's try and get your issue`
@@ -50,7 +45,6 @@ export const PRIVACY_POLICY_HEADER_TITLE = 'Privacy Policy'
 export const BETA_PROGRAMME_FAQ_HEADER_TITLE = 'Beta Programme FAQ'
 export const REFRESH_BUTTON_TEXT = 'Refresh'
 export const DOWNLOAD_ISSUE_MESSAGE_OFFLINE = `You're currently offline. You can download it when you go online`
-export const CUSTOMER_HELP_EMAIL = 'customer.help@theguardian.com'
 
 export const USER_EMAIL_BODY_INTRO = `\n \nThanks for taking the time to send us feedback or report an issue.\n \nIf you are reporting a bug in the app, it will be very helpful if you could describe what you were doing in the app and let us know which screen you were on when the issue occurred. Is this an issue you have seen previously? The more detail you can provide the better and screenshots of these issues are always appreciated.\n \nIf you need a hand with taking a screenshot on your device, you can use this guide: http://www.take-a-screenshot.org/ \n \nThe Guardian Editions team`
 

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -1,7 +1,6 @@
 import { isInBeta } from './release-stream'
 import { Platform } from 'react-native'
 
-
 export const IOS_BETA_EMAIL = 'editions.ios.beta@theguardian.com'
 export const ANDROID_BETA_EMAIL = 'editions.android.beta@theguardian.com'
 export const ISSUE_EMAIL = 'editions.feedback@theguardian.com'

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -53,7 +53,8 @@ type CommonState = {
 }
 
 const __typename = 'NetInfo'
-export type NetInfo = CommonState & {
+
+type NetInfo = CommonState & {
     __typename: 'NetInfo'
     type: NetInfoStateType
     isConnected: boolean
@@ -247,4 +248,4 @@ const useNetInfo = (() => {
     }
 })()
 
-export { useNetInfo }
+export { useNetInfo, NetInfo }

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -13290,10 +13290,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
## Summary
In order to use the Renditions module, the Mallard project within Editions needs to upgrade TypeScript from 3.5.1 to 4.2.1.


This PR only bumps TypeScript for the Mallard project, not the whole Editions monorepo as is beyond the scope of this ticket and will require dedicated health time.