### PR TITLE
Edition backend post thrift Content to AR backend to receive rendered article

### DIFF
--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -60,7 +60,7 @@ export const createApp = (
         controllers.frontController,
     )
 
-    app.get('/render/:path(*)', controllers.renderController)
+    app.get('/render/:internalPageCode', controllers.renderController)
 
     app.get('/rendered-items/:path(*)', controllers.appsRenderingController)
 

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -21,9 +21,12 @@ import { getBylineImages } from './byline'
 import { rationaliseAtoms } from './atoms'
 import { articleTypePicker, headerTypePicker } from './articleTypePicker'
 import { getImages } from './articleImgPicker'
-import { RequestSigner } from 'aws4'
-import { SharedIniFileCredentials, STS } from 'aws-sdk'
 import { capiSearchDecoder } from './decoders'
+import {
+    CAPIEndpoint,
+    generateCapiEndpoint,
+    getPreviewHeaders,
+} from '../utils/article'
 
 type NotInCAPI =
     | 'key'
@@ -287,90 +290,6 @@ const parseArticleResult = async (
     }
 }
 
-type CAPIEndpoint = 'preview' | 'printsent' | 'live'
-
-const getStsCreds = async (role: string) => {
-    const sts = new STS({ apiVersion: '2011-06-15' })
-    const creds = await sts
-        .assumeRole({
-            RoleArn: role as string,
-            RoleSessionName: 'capi-assume-role-access2',
-        })
-        .promise()
-        .catch(err => console.error('assume role failed', err))
-
-    if (creds && creds.Credentials) {
-        return {
-            secretAccessKey: creds.Credentials.SecretAccessKey,
-            accessKeyId: creds.Credentials.AccessKeyId,
-            sessionToken: creds.Credentials.SessionToken,
-        }
-    } else {
-        const errorMessage = `Could not generate credentials using STS role ${role}`
-        console.error(errorMessage)
-        throw new Error(errorMessage)
-    }
-}
-
-const getProfileCreds = async () => {
-    const credentials = new SharedIniFileCredentials({ profile: 'capi' })
-    return {
-        secretAccessKey: credentials.secretAccessKey,
-        accessKeyId: credentials.accessKeyId,
-        sessionToken: credentials.sessionToken,
-    }
-}
-
-/**
- * To access the capi Preview endpoint we need to sign requests (as it is a private api gateway endpoint)
- * This function generates the necessary headers.
- * @param endpoint
- */
-export async function sign(endpoint: string) {
-    const url = new URL(endpoint)
-
-    const opts = {
-        region: 'eu-west-1',
-        service: 'execute-api',
-        host: url.hostname,
-        path: url.pathname + url.search,
-    }
-
-    const credentials = process.env.capiAccessArn
-        ? await getStsCreds(process.env.capiAccessArn)
-        : await getProfileCreds()
-
-    const { headers } = new RequestSigner(opts, credentials).sign()
-
-    console.log(`Signed request, generated headers: ${JSON.stringify(headers)}`)
-
-    return headers
-}
-
-const getEndpoint = (capi: CAPIEndpoint, paths: string[]): string => {
-    const queryString = `?ids=${paths.join(',')}&api-key=${
-        process.env.CAPI_KEY
-    }&format=thrift&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&page-size=100`
-
-    switch (capi) {
-        case 'printsent':
-            return `${process.env.psurl}/search${queryString}`
-        case 'live':
-            return `https://content.guardianapis.com/search${queryString}`
-        case 'preview':
-            return `${process.env.capiPreviewUrl}/search${queryString}`
-        default:
-            return ''
-    }
-}
-
-const getPreviewHeaders = async (endpoint: string) => {
-    return {
-        Accept: 'application/json',
-        ...(await sign(endpoint)),
-    }
-}
-
 const isScheduledInNext30Days = (dateiso8601: string): boolean => {
     const date = new Date(dateiso8601)
     const oneMonthAway = new Date(new Date().setDate(date.getDate() + 30))
@@ -390,15 +309,14 @@ export const getArticles = async (
     ids: number[],
     capi: CAPIEndpoint,
 ): Promise<{ [key: string]: CAPIContent }> => {
-    const paths = ids.map(_ => `internal-code/page/${_}`)
     const isFromPrint = capi === 'printsent'
-    const endpoint = getEndpoint(capi, paths)
+    const endpoint = generateCapiEndpoint(ids, capi)
     const headers = capi === 'preview' ? await getPreviewHeaders(endpoint) : {}
 
     if (endpoint.length > 1000) {
         console.warn(
             `Unusually long CAPI request of ${endpoint.length}, splitting`,
-            paths,
+            ids,
         )
         const midpoint = ~~(ids.length / 2) //Coerece into int, even though apparently you can slice on a float
         const firstRequest = attempt(getArticles(ids.slice(0, midpoint), capi))

--- a/projects/backend/capi/encoders.ts
+++ b/projects/backend/capi/encoders.ts
@@ -1,0 +1,25 @@
+import { Content, ContentSerde } from '@guardian/content-api-models/v1/content'
+import { TBufferedTransport, TCompactProtocol } from 'thrift'
+
+const encodeContent = async (data: Content): Promise<Buffer> => {
+    try {
+        var buffer = Buffer.from([])
+        var transport = new TBufferedTransport(buffer, outBuffer => {
+            if (outBuffer) {
+                buffer = Buffer.concat([buffer, outBuffer])
+            } else {
+                return Promise.reject('Failed to write Content to buffer')
+            }
+        })
+
+        var protocol = new TCompactProtocol(transport)
+        ContentSerde.write(protocol, data)
+        protocol.flush()
+        transport.flush()
+        return buffer
+    } catch (error) {
+        return Promise.reject(error)
+    }
+}
+
+export { encodeContent }

--- a/projects/backend/capi/encoders.ts
+++ b/projects/backend/capi/encoders.ts
@@ -3,8 +3,8 @@ import { TBufferedTransport, TCompactProtocol } from 'thrift'
 
 const encodeContent = async (data: Content): Promise<Buffer> => {
     try {
-        var buffer = Buffer.from([])
-        var transport = new TBufferedTransport(buffer, outBuffer => {
+        let buffer = Buffer.from([])
+        const transport = new TBufferedTransport(buffer, outBuffer => {
             if (outBuffer) {
                 buffer = Buffer.concat([buffer, outBuffer])
             } else {
@@ -12,7 +12,7 @@ const encodeContent = async (data: Content): Promise<Buffer> => {
             }
         })
 
-        var protocol = new TCompactProtocol(transport)
+        const protocol = new TCompactProtocol(transport)
         ContentSerde.write(protocol, data)
         protocol.flush()
         transport.flush()

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -1,12 +1,30 @@
+import { Content } from '@guardian/content-api-models/v1/content'
+import { SearchResponse } from '@guardian/content-api-models/v1/searchResponse'
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
+import { capiSearchDecoder } from '../capi/decoders'
+import { encodeContent } from '../capi/encoders'
+import {
+    CAPIEndpoint,
+    generateCapiEndpoint,
+    getPreviewHeaders,
+} from '../utils/article'
+import { attempt, hasFailed } from '../utils/try'
 
-const fetchRenderedArticle = async (url: string) => {
+interface RenderedArticle {
+    success: boolean
+    status: number
+    body: string
+}
+
+const fetchRenderedArticle = async (
+    url: string,
+    buffer: Buffer,
+): Promise<RenderedArticle> => {
     const response = await fetch(url, {
-        headers: {
-            Accept:
-                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        },
+        method: 'post',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: buffer,
     })
     const responseBody = await response.text()
     return {
@@ -16,24 +34,88 @@ const fetchRenderedArticle = async (url: string) => {
     }
 }
 
-// TODO: this needs a test once we're happy with the correct format for the paths
-const replaceImageUrls = (html: string): string => {
-    return html.replace(/https:\/\/i.guim.co.uk\/img\//g, `../media/`)
+const fetchSingleCapiContent = async (
+    internalPageCode: number,
+    capi: CAPIEndpoint,
+): Promise<SearchResponse> => {
+    try {
+        const endpoint = generateCapiEndpoint([internalPageCode], capi)
+        const headers =
+            capi === 'preview' ? await getPreviewHeaders(endpoint) : {}
+        console.log('Debug link:', endpoint.replace(/thrift/g, 'json'))
+        const resp = await attempt(fetch(endpoint, { headers }))
+
+        if (hasFailed(resp)) throw new Error('Could not connect to CAPI.')
+
+        if (resp.status != 200) {
+            console.warn(
+                `Non 200 status code: ${resp.status} ${resp.statusText}`,
+            )
+        }
+
+        const buffer = await resp.buffer()
+        const data = await capiSearchDecoder(buffer)
+        const results: Content[] = data.results
+        if (results) return data
+        return Promise.reject('Invalid capi response')
+    } catch (error) {
+        return Promise.reject(error)
+    }
+}
+
+const fetchCapiContent = async (
+    internalPageCode: number,
+): Promise<SearchResponse> => {
+    return (
+        (await fetchSingleCapiContent(internalPageCode, 'live')) ||
+        (await fetchSingleCapiContent(internalPageCode, 'printsent')) ||
+        (await fetchSingleCapiContent(internalPageCode, 'preview')) ||
+        Promise.reject(
+            `Failed to fetch article:${internalPageCode} from live, printsent or preview`,
+        )
+    )
+}
+
+const sendError = (message: string, errCode: number, res: Response) => {
+    console.error(`${message}`)
+    res.status(errCode).send(message)
 }
 
 export const renderController = async (req: Request, res: Response) => {
-    const path = req.params.path
-    const renderingUrl = `${process.env.APPS_RENDERING_URL}${path}?editions`
-    console.log(`Fetching ${renderingUrl} from apps rendering`)
-    const renderResponse = await fetchRenderedArticle(renderingUrl)
+    const internalPageCode: number = req.params.internalPageCode
+    try {
+        const searchResponse = await fetchCapiContent(internalPageCode)
+        if (searchResponse.results.length < 1) {
+            const msg = `Failed to fetch content for internalPageCode: ${internalPageCode}`
+            sendError(msg, 400, res)
+            return
+        }
 
-    if (renderResponse.success) {
-        const htmlWithImagesReplaced = replaceImageUrls(renderResponse.body)
-        res.setHeader('Content-Type', 'text/html')
-        res.send(htmlWithImagesReplaced)
-    } else {
-        const message = `Failed to fetch story from ${renderingUrl}. Response: ${renderResponse.body}`
-        console.error(`${message}`)
-        res.status(renderResponse.status).send(message)
+        const stage = process.env.stage || 'dev'
+        const renderingUrl =
+            stage == 'dev'
+                ? 'http://localhost:8080/editions-article'
+                : `${process.env.APPS_RENDERING_URL}`
+
+        // TODO modify the 'content' if required before re-encode
+        // we may need to modify the pillar based on 'front'
+        const content = searchResponse.results[0]
+
+        // re-encode the response to send to AR backend
+        const bufferData = await encodeContent(content)
+        const renderedArticle = await fetchRenderedArticle(
+            renderingUrl,
+            bufferData,
+        )
+        if (renderedArticle.success) {
+            res.setHeader('Content-Type', 'text/html')
+            res.send(renderedArticle.body)
+        } else {
+            const message = `Failed to fetch story from ${renderingUrl}. Response: ${renderedArticle.body}`
+            sendError(message, renderedArticle.status, res)
+        }
+    } catch (error) {
+        const message = `Failed to fetch story for internalPageCode ${internalPageCode}.`
+        sendError(message, 400, res)
     }
 }

--- a/projects/backend/utils/article.ts
+++ b/projects/backend/utils/article.ts
@@ -1,4 +1,8 @@
 import { ArticleType, BlockElement, HTMLElement } from '../../Apps/common/src'
+import { SharedIniFileCredentials, STS } from 'aws-sdk'
+import { RequestSigner } from 'aws4'
+
+type CAPIEndpoint = 'preview' | 'printsent' | 'live'
 
 const DROP_CAP_ARTICLE_TYPES: ArticleType[] = [
     ArticleType.Immersive,
@@ -15,4 +19,95 @@ const articleShouldHaveDropCap = ({
 const isHTMLElement = (el?: BlockElement): el is HTMLElement =>
     !!el && el.id === 'html'
 
-export { articleShouldHaveDropCap, isHTMLElement }
+const getEndpoint = (capi: CAPIEndpoint, paths: string[]): string => {
+    const queryString = `?ids=${paths.join(',')}&api-key=${
+        process.env.CAPI_KEY
+    }&format=thrift&show-elements=all&show-atoms=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all&page-size=100`
+
+    switch (capi) {
+        case 'printsent':
+            return `${process.env.psurl}/search${queryString}`
+        case 'live':
+            return `https://content.guardianapis.com/search${queryString}`
+        case 'preview':
+            return `${process.env.capiPreviewUrl}/search${queryString}`
+        default:
+            return ''
+    }
+}
+
+const getStsCreds = async (role: string) => {
+    const sts = new STS({ apiVersion: '2011-06-15' })
+    const creds = await sts
+        .assumeRole({
+            RoleArn: role as string,
+            RoleSessionName: 'capi-assume-role-access2',
+        })
+        .promise()
+        .catch(err => console.error('assume role failed', err))
+
+    if (creds && creds.Credentials) {
+        return {
+            secretAccessKey: creds.Credentials.SecretAccessKey,
+            accessKeyId: creds.Credentials.AccessKeyId,
+            sessionToken: creds.Credentials.SessionToken,
+        }
+    } else {
+        const errorMessage = `Could not generate credentials using STS role ${role}`
+        console.error(errorMessage)
+        throw new Error(errorMessage)
+    }
+}
+
+const getProfileCreds = async () => {
+    const credentials = new SharedIniFileCredentials({ profile: 'capi' })
+    return {
+        secretAccessKey: credentials.secretAccessKey,
+        accessKeyId: credentials.accessKeyId,
+        sessionToken: credentials.sessionToken,
+    }
+}
+
+/**
+ * To access the capi Preview endpoint we need to sign requests (as it is a private api gateway endpoint)
+ * This function generates the necessary headers.
+ * @param endpoint
+ */
+async function sign(endpoint: string) {
+    const url = new URL(endpoint)
+
+    const opts = {
+        region: 'eu-west-1',
+        service: 'execute-api',
+        host: url.hostname,
+        path: url.pathname + url.search,
+    }
+
+    const credentials = process.env.capiAccessArn
+        ? await getStsCreds(process.env.capiAccessArn)
+        : await getProfileCreds()
+
+    const { headers } = new RequestSigner(opts, credentials).sign()
+
+    return headers
+}
+
+const getPreviewHeaders = async (endpoint: string) => {
+    return {
+        Accept: 'application/json',
+        ...(await sign(endpoint)),
+    }
+}
+
+const generateCapiEndpoint = (ids: number[], capi: CAPIEndpoint): string => {
+    const paths = ids.map(_ => `internal-code/page/${_}`)
+    return getEndpoint(capi, paths)
+}
+
+export {
+    articleShouldHaveDropCap,
+    isHTMLElement,
+    CAPIEndpoint,
+    generateCapiEndpoint,
+    getPreviewHeaders,
+}


### PR DESCRIPTION
## Summary
Our backend needs to communicate with `apps-rendering` service using `internalPageCode` rather than the article `path`. To do that we needed to make some changes in the edition `backend` as well as `apps-rendering` service. This PR makes the following changes:

1. New `/render` endpoint now receives an `internalPageCode`
2. Edition backend fetch the article for the given page code from capi (it looks at all three environments, printsent, live and preview)
3. Edition backend sends the capi blob (`Content` obj) to `apps-rendering` backend and  receives a rendered html

Relavent `apps-rendering` [PR is here](https://github.com/guardian/apps-rendering/pull/1008)