### PR TITLE
Fix 2FA issue for iOS github action using latest version of Fastlane

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -51,6 +51,7 @@ platform :ios do
       build_number: latest_testflight_build_number.to_i + 1
     )
 
+    ENV["SPACESHIP_SKIP_2FA_UPGRADE"] = "1"
     ENV["FASTLANE_DISABLE_OUTPUT_FORMAT"] = "true"
     ENV["FASTLANE_HIDE_TIMESTAMP"] = "true"
     puts("::set-output name=buildnumber::#{latest_testflight_build_number.to_i + 1}")

--- a/projects/Mallard/ios/Gemfile.lock
+++ b/projects/Mallard/ios/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.0)
-    fastlane (2.169.0)
+    fastlane (2.175.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       aws-sdk-s3 (~> 1.0)


### PR DESCRIPTION
## Summary
The full details are summarized in this [doc](https://docs.google.com/document/d/1nIgFJlgcnvVDg_jfzumoloauPJ7OoYE7ZB-FaNu5FfU/edit)

TLDR;
Due to some changes in the apple publishing process 2FA process has enforced upon deployment and hence Fastlane is failing to upload the ios bundle.

This PR took the simpler approach to bypass 2FA for the time being.
