### PR TITLE
Edition Picker Menu Style Updates

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/__tests__/__snapshots__/EditionsButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/__tests__/__snapshots__/EditionsButton.spec.tsx.snap
@@ -27,8 +27,8 @@ exports[`RegionButton should display a default RegionButton with correct styling
   <View
     style={
       Object {
-        "paddingHorizontal": 12,
-        "width": 96,
+        "marginRight": 13,
+        "width": 75,
       }
     }
   />
@@ -113,8 +113,8 @@ exports[`RegionButton should display a selected RegionButton with correct stylin
   <View
     style={
       Object {
-        "paddingHorizontal": 12,
-        "width": 96,
+        "marginRight": 13,
+        "width": 75,
       }
     }
   />
@@ -193,15 +193,15 @@ Monthly - Edition Button"
       "borderWidth": 1,
       "flexDirection": "row",
       "paddingBottom": 32,
-      "paddingTop": 10,
+      "paddingTop": 14,
     }
   }
 >
   <View
     style={
       Object {
-        "paddingHorizontal": 12,
-        "width": 96,
+        "marginRight": 13,
+        "width": 75,
       }
     }
   />
@@ -223,7 +223,7 @@ Monthly - Edition Button"
           },
           Object {
             "color": "#FEEEF7",
-            "fontFamily": "GHGuardianHeadline-Regular",
+            "fontFamily": "GHGuardianHeadline-Medium",
             "fontSize": 32,
             "lineHeight": 34,
             "marginBottom": 5,
@@ -304,15 +304,15 @@ Monthly - Edition Button"
       "borderWidth": 4,
       "flexDirection": "row",
       "paddingBottom": 32,
-      "paddingTop": 10,
+      "paddingTop": 14,
     }
   }
 >
   <View
     style={
       Object {
-        "paddingHorizontal": 12,
-        "width": 96,
+        "marginRight": 13,
+        "width": 75,
       }
     }
   />
@@ -334,7 +334,7 @@ Monthly - Edition Button"
           },
           Object {
             "color": "#FEEEF7",
-            "fontFamily": "GHGuardianHeadline-Regular",
+            "fontFamily": "GHGuardianHeadline-Medium",
             "fontSize": 32,
             "lineHeight": 34,
             "marginBottom": 5,

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
@@ -27,7 +27,7 @@ const styles = (selected: boolean, special: boolean, titleColor: string) => {
             fontSize: special ? 32 : 20,
             lineHeight: special ? 34 : 20,
             fontFamily: special
-                ? families.headline.regular
+                ? families.headline.medium
                 : families.titlepiece.regular,
             marginBottom: 5,
             color: titleColor,

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
@@ -18,7 +18,7 @@ const styles = (selected: boolean, special: boolean, titleColor: string) => {
         },
         imageContainer: {
             width: EDITIONS_MENU_TEXT_LEFT_PADDING,
-            paddingHorizontal: 12,
+            marginRight: 13,
         },
         textContainer: {
             flex: 1,

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
@@ -2,9 +2,9 @@ import { brand, neutral } from '@guardian/src-foundations'
 import { StyleSheet } from 'react-native'
 import { families } from 'src/theme/typography'
 
-export const EDITIONS_MENU_TEXT_LEFT_PADDING = 96
-const imageWidth = 67
-const imageHeight = 134
+export const EDITIONS_MENU_TEXT_LEFT_PADDING = 75
+const imageWidth = 75
+const imageHeight = 150
 
 const styles = (selected: boolean, special: boolean, titleColor: string) => {
     return StyleSheet.create({

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
@@ -13,7 +13,7 @@ const styles = (selected: boolean, special: boolean, titleColor: string) => {
             borderWidth: selected ? 4 : 1,
             borderRadius: 3,
             paddingBottom: 32,
-            paddingTop: 10,
+            paddingTop: special ? 14 : 10,
             flexDirection: 'row',
         },
         imageContainer: {

--- a/projects/Mallard/src/components/ScreenHeader/EditionMenuScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/EditionMenuScreenHeader.tsx
@@ -5,7 +5,7 @@ import { IssueTitle } from 'src/components/issue/issue-title'
 import { StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({
-    title: { paddingLeft: 110, alignSelf: 'flex-start' },
+    title: { paddingLeft: 100, alignSelf: 'flex-start' },
 })
 
 export const EditionsMenuScreenHeader = ({

--- a/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/EditionMenuScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/__tests__/__snapshots__/EditionMenuScreenHeader.spec.tsx.snap
@@ -111,7 +111,7 @@ exports[`Edition Menu Screen Header Edition menu screen Header should render wit
           style={
             Object {
               "alignSelf": "flex-start",
-              "paddingLeft": 110,
+              "paddingLeft": 100,
             }
           }
         >


### PR DESCRIPTION
## Summary
This PR adds some styling tweaks to the edition picker button and header in preparation for the next special Edition in line with new designs, specifically the positioning of the thumbnail picture.

## Changes

- Remove padding from button image and add marginRight
- Adjust the size of the image in line with new thumbnail
- Update special title font weight from regular to medium
- Reduce header padding to 100

## Screenshots
| phone | tablet|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/109203669-5cc5c300-779c-11eb-8e54-ca83a4a7c265.png" width="300" /> | <img src="https://user-images.githubusercontent.com/20416599/109203690-63543a80-779c-11eb-8bbf-6d7a5ff99cb2.png" width="300" /> |
| --- | --- |

