### PR TITLE
Books Special Edition - Style Changes

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/EditionButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/EditionButton.tsx
@@ -56,7 +56,7 @@ const EditionButton: React.FC<Props> = ({
                         {subTitle}
                     </UiExplainerCopy>
                     {expiry && (
-                        <UiExplainerCopy style={defaultStyles.subTitle}>
+                        <UiExplainerCopy style={defaultStyles.expiry}>
                             Available until {localDate(expiry)}
                         </UiExplainerCopy>
                     )}

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/__tests__/__snapshots__/EditionsButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/__tests__/__snapshots__/EditionsButton.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`RegionButton should display a default RegionButton with correct styling
       "borderRadius": 3,
       "borderWidth": 1,
       "flexDirection": "row",
-      "paddingBottom": 32,
+      "paddingBottom": 30,
       "paddingTop": 10,
     }
   }
@@ -105,7 +105,7 @@ exports[`RegionButton should display a selected RegionButton with correct stylin
       "borderRadius": 3,
       "borderWidth": 4,
       "flexDirection": "row",
-      "paddingBottom": 32,
+      "paddingBottom": 30,
       "paddingTop": 10,
     }
   }
@@ -192,7 +192,7 @@ Monthly - Edition Button"
       "borderRadius": 3,
       "borderWidth": 1,
       "flexDirection": "row",
-      "paddingBottom": 32,
+      "paddingBottom": 8,
       "paddingTop": 14,
     }
   }
@@ -269,7 +269,7 @@ Monthly
             "color": "#333333",
           },
           Object {
-            "color": "#121212",
+            "color": "#767676",
             "flexWrap": "wrap",
             "paddingRight": 20,
           },
@@ -303,7 +303,7 @@ Monthly - Edition Button"
       "borderRadius": 3,
       "borderWidth": 4,
       "flexDirection": "row",
-      "paddingBottom": 32,
+      "paddingBottom": 8,
       "paddingTop": 14,
     }
   }
@@ -380,7 +380,7 @@ Monthly
             "color": "#333333",
           },
           Object {
-            "color": "#121212",
+            "color": "#767676",
             "flexWrap": "wrap",
             "paddingRight": 20,
           },

--- a/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionButton/styles.tsx
@@ -12,7 +12,7 @@ const styles = (selected: boolean, special: boolean, titleColor: string) => {
             borderColor: selected ? brand[400] : neutral[86],
             borderWidth: selected ? 4 : 1,
             borderRadius: 3,
-            paddingBottom: 32,
+            paddingBottom: special ? 8 : 30,
             paddingTop: special ? 14 : 10,
             flexDirection: 'row',
         },
@@ -36,6 +36,11 @@ const styles = (selected: boolean, special: boolean, titleColor: string) => {
             flexWrap: 'wrap',
             paddingRight: 20,
             color: neutral[7],
+        },
+        expiry: {
+            flexWrap: 'wrap',
+            paddingRight: 20,
+            color: neutral[46],
         },
         image: {
             width: imageWidth,


### PR DESCRIPTION
## Summary
This PR includes two last minute UI tweaks to the edition selector button from Design to be included in time for the new special editions.

## Changes
- Use neutral.46 for expiry copy
- Reduce vertical padding

## Screenshots

| mobile | tablet|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/109495875-c806e200-7a87-11eb-9e88-d99f8c1bd13d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/20416599/109496214-4499c080-7a88-11eb-8467-84041d13a1ed.png" width="300" /> |
| --- | --- |
