### PR TITLE
Updated Ophan events storage directory

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/ophan/RNOphanModule.java
@@ -37,7 +37,7 @@ class RNOphanModule extends ReactContextBaseJavaModule {
 
     public RNOphanModule(@Nonnull ReactApplicationContext reactContext) {
         super(reactContext);
-        recordStoreDir = new File(reactContext.getCacheDir(), "ophan");
+        recordStoreDir = new File(reactContext.getFilesDir(), "ophan");
         if (reactContext.getResources().getBoolean(R.bool.is_tablet)) {
             deviceClass = DeviceClass.TABLET;
         } else {


### PR DESCRIPTION
## Summary
There are reported issues of low page view count for the android app. There is apparently no issue with the implementation but there is a potential issue with how android stores the events in the file system to send it later. On android, it stores all the events inside the `cache` folder which is a target for the OS to clear when storage space running low and as a result ophan stored events in the file system that are waiting to be sent can be deleted.

This PR updates the storage location, instead of the `cache` folder it usages the app's normal directory to store events. 

This should also solve a recurring crash that we see in Firebase [crashlytics](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/android:com.guardian.editions/issues/05f91b73a87871b32a7694011a0649b2?time=last-thirty-days&sessionEventKey=603CACD602BD000148DAFA7554FB671E_1513468110149855102)

[**Jira Card ->**](https://theguardian.atlassian.net/browse/LIVE-1761)

## Test Plan
Release this change to open beta users and verify that ophan data collection improved/fixed