### PR TITLE
LIVE-1880 & LIVE-1892 :  Lightbox and Share Functionality

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,7 +37,7 @@
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
-        "@guardian/renditions": "^0.1.3",
+        "@guardian/renditions": "^0.1.4",
         "@guardian/src-foundations": "^2.5.0-rc.1",
         "@invertase/react-native-apple-authentication": "^1.0.0",
         "@react-native-community/async-storage": "^1.5.0",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,6 +37,7 @@
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
+        "@guardian/renditions": "^0.1.2",
         "@guardian/src-foundations": "^2.5.0-rc.1",
         "@invertase/react-native-apple-authentication": "^1.0.0",
         "@react-native-community/async-storage": "^1.5.0",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -37,7 +37,7 @@
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
-        "@guardian/renditions": "^0.1.2",
+        "@guardian/renditions": "^0.1.3",
         "@guardian/src-foundations": "^2.5.0-rc.1",
         "@invertase/react-native-apple-authentication": "^1.0.0",
         "@react-native-community/async-storage": "^1.5.0",

--- a/projects/Mallard/src/components/article/html/components/header.ts
+++ b/projects/Mallard/src/components/article/html/components/header.ts
@@ -994,7 +994,7 @@ const MainMediaImage = ({
                 data-preserve-ratio="${preserveRatio || 'false'}"
                 style="background-image: url(${path}), url(${remotePath}); "
                 ${!isGallery &&
-                    `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${0}, isMainImage: 'true'}))"`}
+                    `onclick="window.ReactNativeWebView.postMessage(JSON.stringify({kind: 'Lightbox', index: ${0}, isMainImage: true}))"`}
                 data-open="false"
             >
                 ${preserveRatio &&
@@ -1133,7 +1133,7 @@ const getByLine = (
         <button
             name="Share button"
             class="share-touch-zone"
-            onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'share'}))"
+            onclick="window.ReactNativeWebView.postMessage(JSON.stringify({kind: 'Share'}))"
         >
             <div class="share-button">
                 <div class="share-icon">

--- a/projects/Mallard/src/components/article/html/components/images.ts
+++ b/projects/Mallard/src/components/article/html/components/images.ts
@@ -216,7 +216,7 @@ const ImageBase = ({
         <figure class="image" data-role="${role || 'inline'}">
             <img
                 src="${path}"
-                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
+                onclick="window.ReactNativeWebView.postMessage(JSON.stringify({kind: 'Lightbox', index: ${index}, isMainImage: false}))"
                 alt="${alt}"
                 id="img-${index}"
                 onerror="this.src='${remotePath}'"
@@ -236,7 +236,7 @@ const ImageBase = ({
                         ${showViewMore &&
                             html`
                                 <span
-                                    onclick="window.ReactNativeWebView.postMessage(JSON.stringify({type: 'openLightbox', index: ${index}, isMainImage: 'false'}))"
+                                    onclick="window.ReactNativeWebView.postMessage(JSON.stringify({kind: 'Lightbox', index: ${index}, isMainImage: false}))"
                                 >
                                     view more
                                 </span>

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -32,7 +32,7 @@ import {
     PlatformMessage,
     LightboxMessage,
     pingEditionsRenderingJsString,
-    MessageKind
+    MessageKind,
 } from '@guardian/renditions'
 
 const styles = StyleSheet.create({

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -278,7 +278,10 @@ const Article = ({
 
     const handleLightbox = (parsed: LightboxMessage) => {
         let index = parsed.index
+
+        //following if statement can be removed once ER is in production
         if (
+            !isAppsRendering &&
             article.type !== 'gallery' &&
             article.image &&
             parsed.isMainImage === false &&

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -281,7 +281,7 @@ const Article = ({
         if (
             article.type !== 'gallery' &&
             article.image &&
-            !parsed.isMainImage &&
+            parsed.isMainImage === false &&
             lightboxImages &&
             lightboxImages.length > 1
         ) {

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -32,6 +32,7 @@ import {
     PlatformMessage,
     LightboxMessage,
     pingEditionsRenderingJsString,
+    MessageKind
 } from '@guardian/renditions'
 
 const styles = StyleSheet.create({
@@ -303,7 +304,7 @@ const Article = ({
 
     const handlePing = (event: string) => {
         const parsed = parsePing(event)
-        if (parsed.kind === 'Share' && shareUrl) {
+        if (parsed.kind === MessageKind.Share && shareUrl) {
             handleShare(shareUrl)
         }
         if (parsed.kind === 'shouldShowHeaderChange') {
@@ -314,7 +315,7 @@ const Article = ({
         if (parsed.kind === 'isAtTopChange') {
             onIsAtTopChange(parsed.isAtTop)
         }
-        if (lightboxEnabled && parsed.kind === 'Lightbox') {
+        if (lightboxEnabled && parsed.kind === MessageKind.Lightbox) {
             handleLightbox(parsed)
         }
     }
@@ -322,7 +323,7 @@ const Article = ({
     const getPlatform = (): PlatformMessage => {
         const value =
             Platform.OS === 'ios' ? PlatformType.IOS : PlatformType.Android
-        return { kind: 'Platform', value }
+        return { kind: MessageKind.Platform, value }
     }
     const platform = getPlatform()
 

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -10,9 +10,9 @@ import {
 import { LightboxMessage, ShareMessage } from '@guardian/renditions'
 export type WebViewPing =
     | {
-        kind: 'shouldShowHeaderChange'
-        shouldShowHeader: boolean
-    }
+          kind: 'shouldShowHeaderChange'
+          shouldShowHeader: boolean
+      }
     | { kind: 'isAtTopChange'; isAtTop: boolean }
     | ShareMessage
     | LightboxMessage
@@ -86,7 +86,7 @@ export const generateAssetsFontCss = ({
             src: url("${fileName}")
         }
         ${variant &&
-        css`@font-face {
+            css`@font-face {
                 font-family: '${variant.showsAsFamily}';
                 font-weight: ${variant.weight};
                 font-style: ${variant.style};
@@ -103,8 +103,8 @@ export const getBundleUri = (
         dev:
             (Platform.OS === 'android'
                 ? // 10.0.2.2 is a special IP directing to the host dev machine
-                // from within the emulator
-                'http://10.0.2.2:'
+                  // from within the emulator
+                  'http://10.0.2.2:'
                 : 'http://localhost:') + bundles[key].watchPort,
         prod:
             (Platform.OS === 'android' ? 'file:///android_asset/' : '') +
@@ -118,7 +118,6 @@ export const getBundleUri = (
 }
 
 export const parsePing = (data: string) => JSON.parse(data) as WebViewPing
-
 
 const makeJavaScript = (topPadding: number) => html`
     <script>

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -7,21 +7,15 @@ import {
     getScaledFont,
     getFont,
 } from 'src/theme/typography'
-import {Message} from '@guardian/renditions'
+import { LightboxMessage, ShareMessage } from '@guardian/renditions'
 export type WebViewPing =
     | {
-          type: 'shouldShowHeaderChange'
-          shouldShowHeader: boolean
-      }
-    | { type: 'isAtTopChange'; isAtTop: boolean }
-    | {
-          type: 'share'
-      }
-    | {
-          type: 'openLightbox'
-          index: number
-          isMainImage: string
-      }
+        kind: 'shouldShowHeaderChange'
+        shouldShowHeader: boolean
+    }
+    | { kind: 'isAtTopChange'; isAtTop: boolean }
+    | ShareMessage
+    | LightboxMessage
 
 /*
 this tricks vs code into thinking
@@ -92,7 +86,7 @@ export const generateAssetsFontCss = ({
             src: url("${fileName}")
         }
         ${variant &&
-            css`@font-face {
+        css`@font-face {
                 font-family: '${variant.showsAsFamily}';
                 font-weight: ${variant.weight};
                 font-style: ${variant.style};
@@ -109,8 +103,8 @@ export const getBundleUri = (
         dev:
             (Platform.OS === 'android'
                 ? // 10.0.2.2 is a special IP directing to the host dev machine
-                  // from within the emulator
-                  'http://10.0.2.2:'
+                // from within the emulator
+                'http://10.0.2.2:'
                 : 'http://localhost:') + bundles[key].watchPort,
         prod:
             (Platform.OS === 'android' ? 'file:///android_asset/' : '') +
@@ -124,7 +118,7 @@ export const getBundleUri = (
 }
 
 export const parsePing = (data: string) => JSON.parse(data) as WebViewPing
-export const parseAppsRenderingPing = (data: string) => JSON.parse(data) as Message
+
 
 const makeJavaScript = (topPadding: number) => html`
     <script>
@@ -199,7 +193,7 @@ const makeJavaScript = (topPadding: number) => html`
                 // though a message.
                 window.ReactNativeWebView.postMessage(
                     JSON.stringify({
-                        type: 'shouldShowHeaderChange',
+                        kind: 'shouldShowHeaderChange',
                         shouldShowHeader: window.shouldShowHeader,
                     }),
                 )
@@ -211,7 +205,7 @@ const makeJavaScript = (topPadding: number) => html`
 
                 window.ReactNativeWebView.postMessage(
                     JSON.stringify({
-                        type: 'isAtTopChange',
+                        kind: 'isAtTopChange',
                         isAtTop: window.isAtTop,
                     }),
                 )

--- a/projects/Mallard/src/helpers/webview.ts
+++ b/projects/Mallard/src/helpers/webview.ts
@@ -7,7 +7,7 @@ import {
     getScaledFont,
     getFont,
 } from 'src/theme/typography'
-
+import {Message} from '@guardian/renditions'
 export type WebViewPing =
     | {
           type: 'shouldShowHeaderChange'
@@ -124,6 +124,7 @@ export const getBundleUri = (
 }
 
 export const parsePing = (data: string) => JSON.parse(data) as WebViewPing
+export const parseAppsRenderingPing = (data: string) => JSON.parse(data) as Message
 
 const makeJavaScript = (topPadding: number) => html`
     <script>

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1883,10 +1883,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.11.tgz#a1e442b6dba4540fce1273eff74abb74c0652f2d"
   integrity sha512-MLzUhb0+oaMS1g9FQ8nL3G3cdEsQTzC8/Hq1vdrIV/ufbu/6u7sult/AXXk602WodE4ugRZoJMZ5N90Z0WCfBg==
 
-"@guardian/renditions@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@guardian/renditions/-/renditions-0.1.3.tgz#eab7a88e0ac5afaad19fd2893113cb98546089fa"
-  integrity sha512-WQj/Vi2XqvUDBWfURYD8pOm3A7LmAIg5uPigQsRhh+QCj0a50E4BBLnW0DhDIB5lMB+gKr84BDcIXOJt3ggi2Q==
+"@guardian/renditions@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/renditions/-/renditions-0.1.4.tgz#1e0e53e28cb0fb33a71930c8ec5c31f85669b143"
+  integrity sha512-OPg0ShKPlSBccIXEZBjHRt4W+f6qeGELLevpaE2qaqNG+5U2MoermC0e7YjLwXKDdMsCCpemuvqtm0XMJ1sCCw==
   dependencies:
     typescript "^4.1.3"
 

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1883,6 +1883,13 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.11.tgz#a1e442b6dba4540fce1273eff74abb74c0652f2d"
   integrity sha512-MLzUhb0+oaMS1g9FQ8nL3G3cdEsQTzC8/Hq1vdrIV/ufbu/6u7sult/AXXk602WodE4ugRZoJMZ5N90Z0WCfBg==
 
+"@guardian/renditions@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/renditions/-/renditions-0.1.3.tgz#eab7a88e0ac5afaad19fd2893113cb98546089fa"
+  integrity sha512-WQj/Vi2XqvUDBWfURYD8pOm3A7LmAIg5uPigQsRhh+QCj0a50E4BBLnW0DhDIB5lMB+gKr84BDcIXOJt3ggi2Q==
+  dependencies:
+    typescript "^4.1.3"
+
 "@guardian/src-foundations@^2.5.0-rc.1":
   version "2.5.0-rc.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.5.0-rc.1.tgz#e21869dac88f848241ea8f3da8205b1da808ee1d"


### PR DESCRIPTION
## Summary
In order to trigger the lightbox and share functionality we need to send and receive messages between the client and the webview. This PR updates the types used when handling these messages to match the Renditions package to support the AR served content as well as the current implementation. 

[**Jira Card (Lightbox) ->**](https://theguardian.atlassian.net/browse/LIVE-1880)
[**Jira Card (Share) ->**](https://theguardian.atlassian.net/browse/LIVE-1892)


## Testing
Testing steps are as follows and need to be done for content rendered traditionally and from apps rendering:

- [ ] main image expands into lightbox at the correct image
- [ ] body images expand into lightbox at the correct image
- [ ] share button opens to share screen
- [ ] share button logo reflects the OS