### PR TITLE
LIVE-1900: increase article margin-top

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -261,7 +261,7 @@ const Article = ({
                 mediaPlaybackRequiresUserAction={false}
                 style={[
                     styles.webview,
-                    isAppsRendering ? { marginTop: 40 } : null,
+                    isAppsRendering ? { marginTop: 52 } : null,
                 ]}
                 _ref={r => {
                     ref.current = r


### PR DESCRIPTION
## Summary

We were losing the top of each article below the nav.

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/110347077-26a00300-8028-11eb-9eeb-9259f29edfbf.png" width="300px" /> |

