### PR TITLE
LIVE-1893-Add-Sound-To-Video

### DIFF
--- a/projects/Mallard/ios/Mallard/AppDelegate.m
+++ b/projects/Mallard/ios/Mallard/AppDelegate.m
@@ -14,6 +14,7 @@
 #import <React/RCTLinkingManager.h>
 #import <RNCPushNotificationIOS.h>
 #import "RNSplashScreen.h"
+#import <AVFoundation/AVFoundation.h>
 
 @implementation AppDelegate
 
@@ -35,6 +36,8 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   [RNSplashScreen show];
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+
   return YES;
 }
 


### PR DESCRIPTION
## Why are you doing this?
If an iOS device is on silent, videos have no sound in the app. This differs from the behaviour of Editions on Android and of The Guardian live app on Android and iOS. This PR amends the AppDelegate so that we override the silent setting and play sound from videos. 
