### PR TITLE
Live 2000 chore fix await thenable

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -122,7 +122,7 @@ export const isIssueOnDevice = async (
 const withPathPrefix = (prefix: string) => (str: string) => `${prefix}/${str}`;
 
 export const getLocalIssues = async (editionSlug: string) => {
-	const editionDirectory = await FSPaths.editionDir(editionSlug);
+	const editionDirectory = FSPaths.editionDir(editionSlug);
 	return RNFS.readdir(editionDirectory).then((files) =>
 		files.map(withPathPrefix(editionSlug)),
 	);
@@ -185,7 +185,7 @@ export const findIssueSummaryByKey = (
 
 export const readIssueSummary = async (): Promise<IssueSummary[]> => {
 	const editionSlug = await getSelectedEditionSlug();
-	const editionDirectory = await FSPaths.editionDir(editionSlug);
+	const editionDirectory = FSPaths.editionDir(editionSlug);
 	return RNFS.readFile(editionDirectory + defaultSettings.issuesPath, 'utf8')
 		.then((data) => {
 			try {
@@ -205,7 +205,7 @@ export const readIssueSummary = async (): Promise<IssueSummary[]> => {
 export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
 	const apiUrl = await getSetting('apiUrl');
 	const edition = await getSelectedEditionSlug();
-	const editionDirectory = await FSPaths.editionDir(edition);
+	const editionDirectory = FSPaths.editionDir(edition);
 
 	const fetchIssueSummaryUrl = `${apiUrl}${edition}/issues`;
 
@@ -245,7 +245,7 @@ const cleanFileDisplay = (stat: RNFS.ReadDirItem | RNFS.StatResult) => ({
 export const getFileList = async () => {
 	const imageFolders: RNFS.ReadDirItem[] = [];
 	const editionSlug = await getSelectedEditionSlug();
-	const editionDirectory = await FSPaths.editionDir(editionSlug);
+	const editionDirectory = FSPaths.editionDir(editionSlug);
 	const files = await RNFS.readDir(editionDirectory);
 
 	const subfolders = await Promise.all(

--- a/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
@@ -113,7 +113,7 @@ describe('use-net-info', () => {
 			await resolve(null, null, { client });
 
 			NetInfo.fetch.mockResolvedValue(cellularState);
-			await NetInfo.emit(cellularState);
+			NetInfo.emit(cellularState);
 
 			const state = await resolve(null, null, { client });
 			expect(state).toEqual({
@@ -144,7 +144,7 @@ describe('use-net-info', () => {
 			`;
 
 			NetInfo.fetch.mockResolvedValue(cellularState);
-			await NetInfo.emit(cellularState);
+			NetInfo.emit(cellularState);
 			await Promise.resolve();
 
 			const res = client.cache.readQuery<any>({
@@ -161,7 +161,7 @@ describe('use-net-info', () => {
 			NetInfo.fetch.mockResolvedValue(wifiState);
 			let state = await resolve(null, null, { client });
 
-			await state.setIsForcedOffline(true);
+			state.setIsForcedOffline(true);
 
 			state = await resolve(null, null, { client });
 			expect(state).toEqual({

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -150,7 +150,7 @@ const ManageEditionsScreen = () => {
 												n === data.maxAvailableEditions
 											}
 											onPress={async (n) => {
-												await setMaxAvailableEditions(
+												setMaxAvailableEditions(
 													client,
 													n,
 												);


### PR DESCRIPTION
## Why are you doing this?
Linting fix - remove unnecessary awaits.