### PR TITLE
LIVE-2053: fix width

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -556,8 +556,8 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 859918905322e8816d2b5ab7fe54bf5a0c84d21c
   FirebaseInstallations: 466c7b4d1f58fe16707693091da253726a731ed2
   FirebaseRemoteConfig: 35a729305f254fb15a2e541d4b36f3a379da7fdc
-  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  Folly: 183c8dae43723c50ebd669140abc6258bbb6e95a
+  glog: 0af464288b7fbaf913986b419dc492c787bfdffe
   GoogleDataTransport: 672fb0ce96fe7f7f31d43672fca62ad2c9c86f7b
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -45,6 +45,7 @@ import { WithAppAppearance } from 'src/theme/appearance';
 import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 import type { IssueWithFronts } from '../../../Apps/common/src';
+import { ScreenFiller } from './editions-menu-screen';
 import { ApiState } from './settings/api-screen';
 
 const styles = StyleSheet.create({
@@ -435,26 +436,30 @@ export const HomeScreen = () => {
 
 	return (
 		<WithAppAppearance value={'tertiary'}>
-			<IssuePickerHeader
-				title={issueHeaderData.title}
-				subTitle={issueHeaderData.subTitle}
-				headerStyles={specialEditionProps?.headerStyle}
-			/>
-			{issueSummary ? (
-				<IssueListFetchContainer />
-			) : error ? (
-				<FlexErrorMessage
-					style={styles.issueList}
-					debugMessage={error}
-					title={CONNECTION_FAILED_ERROR}
-					message={CONNECTION_FAILED_AUTO_RETRY}
-				/>
-			) : (
-				<FlexCenter>
-					<Spinner></Spinner>
-				</FlexCenter>
-			)}
-			<ApiState />
+			<ScreenFiller direction="end">
+				<>
+					<IssuePickerHeader
+						title={issueHeaderData.title}
+						subTitle={issueHeaderData.subTitle}
+						headerStyles={specialEditionProps?.headerStyle}
+					/>
+					{issueSummary ? (
+						<IssueListFetchContainer />
+					) : error ? (
+						<FlexErrorMessage
+							style={styles.issueList}
+							debugMessage={error}
+							title={CONNECTION_FAILED_ERROR}
+							message={CONNECTION_FAILED_AUTO_RETRY}
+						/>
+					) : (
+						<FlexCenter>
+							<Spinner></Spinner>
+						</FlexCenter>
+					)}
+					<ApiState />
+				</>
+			</ScreenFiller>
 		</WithAppAppearance>
 	);
 };


### PR DESCRIPTION
## Why are you doing this?

The issue list was broken, this fixes that issue.

A bug still exists where the `SettingsScreen` has lost its modal styling, that can be done as a separate PR.

## Changes

- Add `ScreenFiller` component 


## Screenshots



 <img src="https://user-images.githubusercontent.com/77005274/112348050-5ce3b080-8cbf-11eb-8d3c-1ef003905fdf.png" width="300px" /> 
