### PR TITLE
Live 2049 fronts card vanishing

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import type { ReactNode } from 'react';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import {
 	Animated,
@@ -85,6 +85,15 @@ const ItemTappable = ({
 } & TappablePropTypes) => {
 	const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 	const [opacity] = useState(() => new Animated.Value(1));
+
+	React.useEffect(() => {
+		const unsubscribe = navigation.addListener('focus', () => {
+			fade(opacity, 'in');
+		});
+
+		return unsubscribe;
+	}, [navigation]);
+
 	return (
 		<Animated.View style={[style]}>
 			<TouchableHighlight
@@ -108,7 +117,6 @@ const ItemTappable = ({
 					{children}
 				</View>
 			</TouchableHighlight>
-
 			<Animated.View
 				{...ariaHidden}
 				pointerEvents="none"


### PR DESCRIPTION
## Why are you doing this?

Fronts cards were appearing blank when a user opened an article and closed it again. We realised this was due to the card opacity fading out as the article opened.

To fix we reinstated the mising event listener in order to fade the front card back in as the article closed.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/112477178-9cb3a200-8d6a-11eb-975f-ecdaad2ebe9c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/112477230-ab9a5480-8d6a-11eb-8684-eb9232c17186.png" width="300px" /> |
