### PR TITLE
Live 1788 :  Onboarding stack

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -4,7 +4,6 @@
 
 import { ApolloProvider } from '@apollo/react-hooks';
 import AsyncStorage from '@react-native-community/async-storage';
-import { NavigationContainer } from '@react-navigation/native';
 import type ApolloClient from 'apollo-client';
 import React from 'react';
 import { AppState, StatusBar, StyleSheet, View } from 'react-native';
@@ -17,7 +16,7 @@ import {
 } from 'src/hooks/use-config-provider';
 import { NavPositionProvider } from 'src/hooks/use-nav-position';
 import { setUserId } from 'src/services/ophan';
-import { RootStack } from './AppNavigation';
+import { AppNavigation } from './AppNavigation';
 import { AccessProvider } from './authentication/AccessContext';
 import type { IdentityAuthData } from './authentication/authorizers/IdentityAuthorizer';
 import type { AnyAttempt } from './authentication/lib/Attempt';
@@ -137,9 +136,7 @@ export default class App extends React.Component {
                                             onNavigationStateChange
                                         }
                                     /> */}
-									<NavigationContainer>
-										<RootStack />
-									</NavigationContainer>
+									<AppNavigation />
 									<NetInfoAutoToast />
 								</View>
 								<ModalRenderer />

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -81,7 +81,10 @@ const Onboarding = createStackNavigator<OnboardingStackParamList>();
 
 const OnboardingStack = () => {
 	return (
-		<Onboarding.Navigator>
+		<Onboarding.Navigator
+			initialRouteName={RouteNames.OnboardingConsent}
+			screenOptions={{ gestureEnabled: false, headerShown: false }}
+		>
 			<Onboarding.Screen
 				name={RouteNames.OnboardingConsent}
 				component={OnboardingConsentScreen}
@@ -241,7 +244,6 @@ const AppNavigation = () => {
 			setIsOnboarded(false);
 		} else {
 			setIsOnboarded(true);
-			console.log(isOnboarded, 'onboarded');
 		}
 	});
 	return (

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -42,8 +42,6 @@ import { SubscriptionDetailsScreen } from './screens/settings/subscription-detai
 import { TermsAndConditionsScreen } from './screens/settings/terms-and-conditions-screen';
 import { WeatherGeolocationConsentScreen } from './screens/weather-geolocation-consent-screen';
 
-const Stack = createStackNavigator<RootStackParamList>();
-
 const { multiply } = Animated;
 
 const cardStyleInterpolator = (props: any) => {
@@ -101,18 +99,20 @@ const OnboardingStack = () => {
 	);
 };
 
+const Root = createStackNavigator<RootStackParamList>();
+
 const RootStack = () => {
 	return (
-		<Stack.Navigator
+		<Root.Navigator
 			initialRouteName={RouteNames.Home}
 			screenOptions={{ gestureEnabled: false, headerShown: false }}
 		>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.Issue}
 				component={IssueScreen}
 				options={{}}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.IssueList}
 				component={HomeScreen}
 				options={{
@@ -122,7 +122,7 @@ const RootStack = () => {
 					cardStyleInterpolator,
 				}}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.EditionsMenu}
 				component={EditionsMenuScreen}
 				options={{
@@ -132,7 +132,7 @@ const RootStack = () => {
 					cardStyleInterpolator,
 				}}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.Article}
 				component={ArticleWrapper}
 				options={{
@@ -142,71 +142,68 @@ const RootStack = () => {
 					gestureDirection: 'vertical',
 				}}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.Settings}
 				component={SettingsScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.SignIn}
 				component={AuthSwitcherScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.AlreadySubscribed}
 				component={AlreadySubscribedScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.CasSignIn}
 				component={CasSignInScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.ManageEditionsSettings}
 				component={ManageEditionsScreenWithHeader}
 			/>
 			{/** @TODO Fix the enable all button */}
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.GdprConsent}
 				component={GdprConsentScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.PrivacyPolicy}
 				component={PrivacyPolicyScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.Lightbox}
 				component={LightboxScreen}
 			/>
 			{/* ==== Inspect from here === */}
-			<Stack.Screen
-				name={RouteNames.Edition}
-				component={EditionsScreen}
-			/>
-			<Stack.Screen
+			<Root.Screen name={RouteNames.Edition} component={EditionsScreen} />
+			<Root.Screen
 				name={RouteNames.TermsAndConditions}
 				component={TermsAndConditionsScreen}
 			/>
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.BetaProgrammeFAQs}
 				component={BetaProgrammeFAQsScreen}
 			/>
-			<Stack.Screen name={RouteNames.Help} component={HelpScreen} />
-			<Stack.Screen name={RouteNames.Credits} component={CreditsScreen} />
-			<Stack.Screen name={RouteNames.FAQ} component={FAQScreen} />
-			<Stack.Screen
+			<Root.Screen name={RouteNames.Help} component={HelpScreen} />
+			<Root.Screen name={RouteNames.Credits} component={CreditsScreen} />
+			<Root.Screen name={RouteNames.FAQ} component={FAQScreen} />
+			<Root.Screen
 				name={RouteNames.SubscriptionDetails}
 				component={SubscriptionDetailsScreen}
 			/>
-			<Stack.Screen name={RouteNames.Endpoints} component={ApiScreen} />
+			<Root.Screen name={RouteNames.Endpoints} component={ApiScreen} />
 			{/* Turned off to remove Promise rejection error on Android */}
-			{/* <Stack.Screen
+			{/* <Root.Screen
                 name={RouteNames.Storybook}
                 component={StorybookScreen}
             /> */}
 
-			<Stack.Screen
+			<Root.Screen
 				name={RouteNames.WeatherGeolocationConsent}
 				component={WeatherGeolocationConsentScreen}
 			/>
-		</Stack.Navigator>
+		</Root.Navigator>
 	);
 };
 

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -4,7 +4,10 @@ import {
 } from '@react-navigation/stack';
 import React from 'react';
 import { Animated } from 'react-native';
-import type { RootStackParamList } from './navigation/NavigationModels';
+import type {
+	OnboardingStackParamList,
+	RootStackParamList,
+} from './navigation/NavigationModels';
 import { RouteNames } from './navigation/NavigationModels';
 import { ArticleWrapper } from './navigation/navigators/article';
 import { EditionsMenuScreen } from './screens/editions-menu-screen';
@@ -68,6 +71,27 @@ const cardStyleInterpolator = (props: any) => {
 			}),
 		},
 	};
+};
+
+const Onboarding = createStackNavigator<OnboardingStackParamList>();
+
+const OnboardingStack = () => {
+	return (
+		<Onboarding.Navigator>
+			<Onboarding.Screen
+				name={RouteNames.OnboardingConsent}
+				component={OnboardingConsentScreen}
+			/>
+			<Onboarding.Screen
+				name={RouteNames.OnboardingConsentInline}
+				component={GdprConsentScreenForOnboarding}
+			/>
+			<Onboarding.Screen
+				name={RouteNames.PrivacyPolicyInline}
+				component={PrivacyPolicyScreenForOnboarding}
+			/>
+		</Onboarding.Navigator>
+	);
 };
 
 const RootStack = () => {

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -143,21 +143,6 @@ const RootStack = () => {
 				name={RouteNames.SignIn}
 				component={AuthSwitcherScreen}
 			/>
-			{/* <Stack.Screen
-                name={RouteNames.OnboardingStart}
-            /> */}
-			<Stack.Screen
-				name={RouteNames.OnboardingConsent}
-				component={OnboardingConsentScreen}
-			/>
-			<Stack.Screen
-				name={RouteNames.OnboardingConsentInline}
-				component={GdprConsentScreenForOnboarding}
-			/>
-			<Stack.Screen
-				name={RouteNames.PrivacyPolicyInline}
-				component={PrivacyPolicyScreenForOnboarding}
-			/>
 			<Stack.Screen
 				name={RouteNames.AlreadySubscribed}
 				component={AlreadySubscribedScreen}

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -162,7 +162,6 @@ const RootStack = () => {
 				name={RouteNames.ManageEditionsSettings}
 				component={ManageEditionsScreenWithHeader}
 			/>
-			{/** @TODO Fix the enable all button */}
 			<Root.Screen
 				name={RouteNames.GdprConsent}
 				component={GdprConsentScreen}

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -29,6 +29,9 @@ export type RootStackParamList = {
 	Lightbox: LightboxNavigationProps;
 	Storybook: undefined;
 	EditionsMenu: undefined;
+};
+
+export type OnboardingStackParamList = {
 	OnboardingConsent: undefined;
 	PrivacyPolicyInline: undefined;
 	OnboardingConsentInline: undefined;

--- a/projects/Mallard/src/screens/onboarding-screen.tsx
+++ b/projects/Mallard/src/screens/onboarding-screen.tsx
@@ -26,27 +26,10 @@ const Frame = ({ children }: { children: ReactNode }) => (
 	</SafeAreaView>
 );
 
-const OnboardingConsentScreen = ({
-	onOpenGdprConsent,
-	onContinue,
-	onOpenPrivacyPolicy,
-}: {
-	onOpenGdprConsent: () => void;
-	onContinue: () => void;
-	onOpenPrivacyPolicy: () => void;
-}) => {
+const OnboardingConsentScreen = () => {
 	return (
 		<Frame>
-			<OnboardingConsent
-				{...{
-					onOpenGdprConsent,
-					onOpenPrivacyPolicy,
-				}}
-				onContinue={() => {
-					onOpenGdprConsent();
-					onContinue();
-				}}
-			/>
+			<OnboardingConsent />
 		</Frame>
 	);
 };

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import gql from 'graphql-tag';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -19,6 +20,7 @@ import {
 } from 'src/helpers/settings/setters';
 import { Copy } from 'src/helpers/words';
 import { useQuery } from 'src/hooks/apollo';
+import { RouteNames } from 'src/navigation/NavigationModels';
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
 	<View
@@ -43,15 +45,8 @@ const styles = StyleSheet.create({
 
 const QUERY = gql(`{ ${GDPR_SETTINGS_FRAGMENT} }`);
 
-const OnboardingConsent = ({
-	onOpenGdprConsent,
-	onContinue,
-	onOpenPrivacyPolicy,
-}: {
-	onOpenGdprConsent: () => void;
-	onContinue: () => void;
-	onOpenPrivacyPolicy: () => void;
-}) => {
+const OnboardingConsent = () => {
+	const navigation = useNavigation();
 	const query = useQuery<Record<string, boolean | null>>(QUERY);
 	if (query.loading) return null;
 	const { client } = query;
@@ -75,7 +70,9 @@ const OnboardingConsent = ({
 							<View>
 								<ModalButton
 									onPress={() => {
-										onOpenGdprConsent();
+										navigation.navigate(
+											RouteNames.OnboardingConsentInline,
+										);
 									}}
 									buttonAppearance={
 										ButtonAppearance.SkeletonBlue
@@ -88,7 +85,6 @@ const OnboardingConsent = ({
 								<ModalButton
 									onPress={() => {
 										enableNulls();
-										onContinue();
 									}}
 									buttonAppearance={ButtonAppearance.Dark}
 								>
@@ -105,7 +101,13 @@ const OnboardingConsent = ({
 						technology) is used by the Guardian to improve your
 						experience and our level of service to you. By
 						continuing, you agree with the Guardian&apos;s{' '}
-						<LinkNav onPress={onOpenPrivacyPolicy}>
+						<LinkNav
+							onPress={() => {
+								navigation.navigate(
+									RouteNames.PrivacyPolicyInline,
+								);
+							}}
+						>
 							privacy policy
 						</LinkNav>
 						.

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -154,12 +154,13 @@ const GdprConsent = ({
 		navigation.navigate('App');
 	};
 
+	const hasSetGdpr = () =>
+		gdprData.gdprAllowFunctionality != null &&
+		gdprData.gdprAllowPerformance != null &&
+		gdprData.gdprCurrentVersion === CURRENT_CONSENT_VERSION;
+
 	const onDismiss = () => {
-		if (
-			gdprData.gdprAllowFunctionality != null &&
-			gdprData.gdprAllowPerformance != null &&
-			gdprData.gdprCurrentVersion === CURRENT_CONSENT_VERSION
-		) {
+		if (hasSetGdpr()) {
 			showToast(PREFS_SAVED_MSG);
 			navigation.navigate('App');
 		} else {

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -202,96 +202,134 @@ const GdprConsent = ({
 			);
 		}
 	};
-
 	return (
-		<View style={{ flex: 1 }}>
+		<View style={{ flex: 1, backgroundColor: 'white' }}>
 			{shouldShowDismissableHeader && (
 				<LoginHeader onDismiss={() => onDismiss(route, client)}>
 					{PRIVACY_SETTINGS_HEADER_TITLE}
 				</LoginHeader>
 			)}
-			<ScrollView>
-				<TallRow
-					title={''}
-					explainer={
-						<Text>
-							Below you can manage your privacy settings for
-							cookies and similar technologies for this service.
-							These technologies are provided by us and by our
-							third-party partners. To find out more, read our{' '}
-							<LinkNav
-								onPress={() =>
-									navigation.navigate(
-										RouteNames.PrivacyPolicyInline,
-									)
-								}
-							>
-								privacy policy
-							</LinkNav>
-							. If you disable a category, you may need to restart
-							the app for your changes to fully take effect.
-						</Text>
-					}
-					proxy={
-						<Button
-							appearance={ButtonAppearance.Skeleton}
-							onPress={() =>
-								onEnableAllAndContinue(route, client)
-							}
-						>
-							{continueText}
-						</Button>
-					}
-				></TallRow>
-				<Separator></Separator>
-				<TallRow
-					title={essentials.name}
-					subtitle={essentials.services}
-					explainer={essentials.description}
-				></TallRow>
-
-				<FlatList
-					ItemSeparatorComponent={Separator}
-					ListFooterComponent={Separator}
-					ListHeaderComponent={Separator}
-					data={Object.values(switches)}
-					keyExtractor={({ key }) => key}
-					renderItem={({ item }) => (
+			<FlatList
+				ListHeaderComponent={() => (
+					<>
 						<TallRow
-							title={item.name}
-							subtitle={item.services}
-							explainer={item.description}
+							title={''}
+							explainer={
+								<Text>
+									Below you can manage your privacy settings
+									for cookies and similar technologies for
+									this service. These technologies are
+									provided by us and by our third-party
+									partners. To find out more, read our{' '}
+									<LinkNav
+										onPress={() =>
+											navigation.navigate(
+												RouteNames.PrivacyPolicyInline,
+											)
+										}
+									>
+										privacy policy
+									</LinkNav>
+									. If you disable a category, you may need to
+									restart the app for your changes to fully
+									take effect.
+								</Text>
+							}
 							proxy={
-								<ThreeWaySwitch
-									onValueChange={(value) => {
-										setConsentAndUpdate(item.key, value);
-										showToast(PREFS_SAVED_MSG);
-									}}
-									value={
-										gdprData.gdprCurrentVersion !==
-										CURRENT_CONSENT_VERSION
-											? null
-											: gdprData[item.key]
+								<Button
+									appearance={ButtonAppearance.Skeleton}
+									onPress={() =>
+										onEnableAllAndContinue(route, client)
 									}
-								/>
+								>
+									{continueText}
+								</Button>
 							}
 						></TallRow>
-					)}
-				/>
-				<Footer>
-					<UiBodyCopy weight="bold" style={{ fontSize: 14 }}>
-						You can change the above settings any time by selecting
-						Privacy Settings from the Settings menu.
-					</UiBodyCopy>
-				</Footer>
-				{__DEV__ ? (
-					<Footer>
-						<Button onPress={resetAllAndUpdate.bind(undefined)}>
-							Reset
-						</Button>
-					</Footer>
-				) : null}
-			</ScrollView>
+						<Separator></Separator>
+						<TallRow
+							title={essentials.name}
+							subtitle={essentials.services}
+							explainer={essentials.description}
+						></TallRow>
+					</>
+				)}
+				ListFooterComponent={() => (
+					<>
+						<FlatList
+							ItemSeparatorComponent={Separator}
+							ListFooterComponent={Separator}
+							ListHeaderComponent={Separator}
+							data={Object.values(switches)}
+							keyExtractor={({ key }) => key}
+							renderItem={({ item }) => (
+								<TallRow
+									title={item.name}
+									subtitle={item.services}
+									explainer={item.description}
+									proxy={
+										<ThreeWaySwitch
+											onValueChange={(value) => {
+												setConsentAndUpdate(
+													item.key,
+													value,
+												);
+												showToast(PREFS_SAVED_MSG);
+											}}
+											value={
+												gdprData.gdprCurrentVersion !==
+												CURRENT_CONSENT_VERSION
+													? null
+													: gdprData[item.key]
+											}
+										/>
+									}
+								></TallRow>
+							)}
+						/>
+						<Footer>
+							<UiBodyCopy weight="bold" style={{ fontSize: 14 }}>
+								You can change the above settings any time by
+								selecting Privacy Settings from the Settings
+								menu.
+							</UiBodyCopy>
+						</Footer>
+						{__DEV__ ? (
+							<Footer>
+								<Button
+									onPress={resetAllAndUpdate.bind(undefined)}
+								>
+									Reset
+								</Button>
+							</Footer>
+						) : null}
+					</>
+				)}
+				ItemSeparatorComponent={Separator}
+				data={Object.values(switches)}
+				keyExtractor={({ key }) => key}
+				renderItem={({ item }) => (
+					<TallRow
+						title={item.name}
+						subtitle={item.services}
+						explainer={item.description}
+						proxy={
+							<ThreeWaySwitch
+								onValueChange={(value) => {
+									setConsentAndUpdate(item.key, value);
+									showToast(PREFS_SAVED_MSG);
+								}}
+								value={
+									gdprData.gdprCurrentVersion !==
+									CURRENT_CONSENT_VERSION
+										? null
+										: gdprData[item.key]
+								}
+							/>
+						}
+					></TallRow>
+				)}
+			/>
 		</View>
 	);
 };
@@ -302,9 +340,7 @@ const GdprConsentScreen = () => (
 		actionLeft={true}
 	>
 		<WithAppAppearance value={'settings'}>
-			<ScrollContainer>
-				<GdprConsent continueText={'Enable all'}></GdprConsent>
-			</ScrollContainer>
+			<GdprConsent continueText={'Enable all'}></GdprConsent>
 		</WithAppAppearance>
 	</HeaderScreenContainer>
 );

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -1,10 +1,11 @@
+import type { ParamListBase, RouteProp } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
+import type ApolloClient from 'apollo-client';
 import gql from 'graphql-tag';
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, ScrollView, Text, View } from 'react-native';
+import { Alert, FlatList, Text, View } from 'react-native';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
 import { HeaderScreenContainer } from 'src/components/Header/Header';
-import { ScrollContainer } from 'src/components/layout/ui/container';
 import { Footer, Separator, TallRow } from 'src/components/layout/ui/row';
 import type { ThreeWaySwitchValue } from 'src/components/layout/ui/switch';
 import { ThreeWaySwitch } from 'src/components/layout/ui/switch';
@@ -111,7 +112,7 @@ const GdprConsent = ({
 	if (query.loading) return null;
 	const { client } = query;
 
-	const enableNulls = (client: any) => {
+	const enableNulls = (client: ApolloClient<object>) => {
 		gdprSwitchSettings.map((sw) => {
 			setGdprFlag(client, sw, true);
 		});
@@ -168,7 +169,10 @@ const GdprConsent = ({
 		},
 	};
 
-	const onEnableAllAndContinue = (route: any, client: any) => {
+	const onEnableAllAndContinue = (
+		route: RouteProp<ParamListBase, string>,
+		client: ApolloClient<object>,
+	) => {
 		if (route.name === 'OnboardingConsentInline') {
 			enableNulls(client);
 		} else {
@@ -183,7 +187,10 @@ const GdprConsent = ({
 		gdprData.gdprAllowPerformance != null &&
 		gdprData.gdprCurrentVersion === CURRENT_CONSENT_VERSION;
 
-	const onDismiss = (route: any, client: any) => {
+	const onDismiss = (
+		route: RouteProp<ParamListBase, string>,
+		client: ApolloClient<object>,
+	) => {
 		if (hasSetGdpr()) {
 			showToast(PREFS_SAVED_MSG);
 			navigation.navigate(RouteNames.Issue);

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -151,7 +151,7 @@ const GdprConsent = ({
 	const onEnableAllAndContinue = () => {
 		consentAllAndUpdate();
 		showToast(PREFS_SAVED_MSG);
-		navigation.navigate('App');
+		navigation.navigate(RouteNames.Issue);
 	};
 
 	const hasSetGdpr = () =>
@@ -162,7 +162,7 @@ const GdprConsent = ({
 	const onDismiss = () => {
 		if (hasSetGdpr()) {
 			showToast(PREFS_SAVED_MSG);
-			navigation.navigate('App');
+			navigation.navigate(RouteNames.Issue);
 		} else {
 			Alert.alert(
 				'Before you go',


### PR DESCRIPTION
## Why are you doing this?
If a user hasn't been onboarded and consented yes/no to gdpr consent permissions, they should hit the onboarding screen before the main app. This PR adds the onboarding route back into the app as a separate stack with a switch on initial render to show user either the onboarding stack or the root stack. 

The GDPR consent screen was a nested virtualized list. This PR removes the unnecessary scrollview wrapper