### PR TITLE
Live 2075 : Invisible Back Button 

### DIFF
--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -1,8 +1,9 @@
 import { useNavigation } from '@react-navigation/native';
 import type { ReactElement } from 'react';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Dimensions, StyleSheet, View } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
+import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import { EditionsMenu } from 'src/components/EditionsMenu/EditionsMenu';
 import { EditionsMenuScreenHeader } from 'src/components/ScreenHeader/EditionMenuScreenHeader';
 import { useEditions } from 'src/hooks/use-edition-provider';
@@ -13,6 +14,15 @@ import { ApiState } from './settings/api-screen';
 const sidebarWidth = 360;
 
 const styles = StyleSheet.create({
+	container: {
+		display: 'flex',
+		flexDirection: 'row-reverse',
+	},
+	touchable: {
+		backgroundColor: 'transparent',
+		height: Dimensions.get('window').height,
+		width: Dimensions.get('window').width - sidebarWidth,
+	},
 	screenFiller: {
 		flex: 1,
 		backgroundColor: 'white',
@@ -26,16 +36,33 @@ export const ScreenFiller = ({
 }: {
 	direction?: string;
 	children: ReactElement;
-}) => (
-	<View
-		style={[
-			styles.screenFiller,
-			direction === 'end' && { alignSelf: 'flex-end' },
-		]}
-	>
-		{children}
-	</View>
-);
+}) => {
+	const navigation = useNavigation();
+	return (
+		<View
+			style={[
+				styles.container,
+				{ flexDirection: direction === 'end' ? 'row' : 'row-reverse' },
+			]}
+		>
+			{DeviceInfo.isTablet() && (
+				<TouchableWithoutFeedback
+					onPress={navigation.goBack}
+					style={styles.touchable}
+				/>
+			)}
+
+			<View
+				style={[
+					styles.screenFiller,
+					direction === 'end' && { alignSelf: 'flex-end' },
+				]}
+			>
+				{children}
+			</View>
+		</View>
+	);
+};
 
 export const EditionsMenuScreen = () => {
 	const {


### PR DESCRIPTION
## Why are you doing this?

The area next to the Edition and Issue menu should be tappable so the user can return to the issue. This PR adds a transparent button next to the menu to tap back if the device is a tablet.
