### PR TITLE
Disabled bitcode compilation

### DIFF
--- a/projects/Mallard/ios/exports-plists/debug.plist
+++ b/projects/Mallard/ios/exports-plists/debug.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>compileBitcode</key>
-	<true/>
+	<false/>
 	<key>method</key>
 	<string>development</string>
 	<key>signingStyle</key>

--- a/projects/Mallard/ios/exports-plists/release.plist
+++ b/projects/Mallard/ios/exports-plists/release.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>compileBitcode</key>
-	<true/>
+	<false/>
 	<key>method</key>
 	<string>development</string>
 	<key>signingStyle</key>


### PR DESCRIPTION
## Why are you doing this?
Currently, iOS Edition app has `bitcode compile` flag enabled as a result Firebase Crahlytics can't decode the crash stack traces (because it does not have the correct dSYMs file). Live iOS app doesn't use `bitcode` feature either, so this PR disabled that flag for the Edition app so we can see a clean text stack trace in Crashlytics.

