### PR TITLE
Turned off iOS schedule beta

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -3,9 +3,9 @@ name: scheduled-ios-beta
 on:
     workflow_dispatch:
     deployment:
-    schedule:
-        # * is a special character in YAML so you have to quote this string
-        - cron: '0 14 * * 1-5' # every day at 2pm
+    # schedule:
+    #     # * is a special character in YAML so you have to quote this string
+    #     - cron: '0 14 * * 1-5' # every day at 2pm
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Why are you doing this?

To test build from non-default branch which has new Nav work we are turning off the iOS schedule beta.