### PR TITLE
LIVE-2087: fix animations and modal styling

### DIFF
--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -1,4 +1,5 @@
 import { NavigationContainer } from '@react-navigation/native';
+import type { StackCardInterpolationProps } from '@react-navigation/stack';
 import {
 	CardStyleInterpolators,
 	createStackNavigator,
@@ -10,6 +11,7 @@ import type {
 	MainStackParamList,
 	OnboardingStackParamList,
 	RootStackParamList,
+	SettingsStackParamList,
 } from './navigation/NavigationModels';
 import { RouteNames } from './navigation/NavigationModels';
 import { ArticleWrapper } from './navigation/navigators/article';
@@ -43,7 +45,7 @@ import { WeatherGeolocationConsentScreen } from './screens/weather-geolocation-c
 
 const { multiply } = Animated;
 
-const cardStyleInterpolator = (props: any) => {
+const cardStyleInterpolator = (props: StackCardInterpolationProps) => {
 	const translateX = multiply(
 		props.current.progress.interpolate({
 			inputRange: [0, 1],
@@ -54,7 +56,6 @@ const cardStyleInterpolator = (props: any) => {
 	);
 
 	return {
-		// ...CardStyleInterpolators.forHorizontalIOS(props),
 		cardStyle: {
 			overflow: 'hidden',
 			transform: [
@@ -74,8 +75,44 @@ const cardStyleInterpolator = (props: any) => {
 	};
 };
 
+const settingsInterpolater = (props: StackCardInterpolationProps) => {
+	const translateX = multiply(
+		props.current.progress.interpolate({
+			inputRange: [0, 1],
+			outputRange: [200, 0],
+			extrapolate: 'clamp',
+		}),
+		props.inverted,
+	);
+
+	return {
+		cardStyle: {
+			backgroundColor: 'transparent',
+
+			opacity: props.current.progress.interpolate({
+				inputRange: [0, 1, 4],
+				outputRange: [0, 1, 0],
+			}),
+			transform: [
+				// Translation for the animation of the current card
+				{
+					translateX,
+				},
+			],
+		},
+		overlayStyle: {
+			opacity: props.current.progress.interpolate({
+				inputRange: [0, 1, 2],
+				outputRange: [0, 1, 0],
+			}),
+			backgroundColor: 'transparent',
+		},
+	};
+};
+
 const Onboarding = createStackNavigator<OnboardingStackParamList>();
 const Root = createStackNavigator<RootStackParamList>();
+const Settings = createStackNavigator<SettingsStackParamList>();
 const Main = createStackNavigator<MainStackParamList>();
 
 const OnboardingStack = () => {
@@ -145,16 +182,85 @@ const MainStack = () => {
 				name={RouteNames.SignIn}
 				component={AuthSwitcherScreen}
 			/>
-			{/* Turned off to remove Promise rejection error on Android */}
-			{/* <Main.Screen
-                name={RouteNames.Storybook}
-                component={StorybookScreen}
-            /> */}
 			<Main.Screen
 				name={RouteNames.Lightbox}
 				component={LightboxScreen}
 			/>
 		</Main.Navigator>
+	);
+};
+
+const SettingsStack = () => {
+	return (
+		<Settings.Navigator
+			initialRouteName={RouteNames.Settings}
+			mode="modal"
+			screenOptions={{
+				gestureEnabled: false,
+				headerShown: false,
+				cardStyle: { backgroundColor: 'transparent' },
+				cardOverlayEnabled: true,
+				cardStyleInterpolator: settingsInterpolater,
+			}}
+		>
+			<Settings.Screen
+				name={RouteNames.Settings}
+				component={SettingsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.TermsAndConditions}
+				component={TermsAndConditionsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.SubscriptionDetails}
+				component={SubscriptionDetailsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.AlreadySubscribed}
+				component={AlreadySubscribedScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.GdprConsent}
+				component={GdprConsentScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.PrivacyPolicy}
+				component={PrivacyPolicyScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.ManageEditions}
+				component={ManageEditionsScreen}
+				options={{
+					gestureDirection: 'vertical',
+				}}
+			/>
+			<Settings.Screen
+				name={RouteNames.Endpoints}
+				component={ApiScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.Credits}
+				component={CreditsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.BetaProgrammeFAQs}
+				component={BetaProgrammeFAQsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.Edition}
+				component={EditionsScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.CasSignIn}
+				component={CasSignInScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.WeatherGeolocationConsent}
+				component={WeatherGeolocationConsentScreen}
+			/>
+			<Settings.Screen name={RouteNames.Help} component={HelpScreen} />
+			<Settings.Screen name={RouteNames.FAQ} component={FAQScreen} />
+		</Settings.Navigator>
 	);
 };
 
@@ -166,21 +272,6 @@ const RootStack = () => {
 				headerShown: false,
 				cardStyle: { backgroundColor: 'transparent' },
 				cardOverlayEnabled: true,
-				cardStyleInterpolator: ({ current: { progress } }) => ({
-					cardStyle: {
-						opacity: progress.interpolate({
-							inputRange: [0, 0.5, 0.9, 1],
-							outputRange: [0, 0.25, 0.7, 1],
-						}),
-					},
-					overlayStyle: {
-						opacity: progress.interpolate({
-							inputRange: [0, 1],
-							outputRange: [0, 0.5],
-							extrapolate: 'clamp',
-						}),
-					},
-				}),
 			}}
 		>
 			<Root.Screen
@@ -190,51 +281,9 @@ const RootStack = () => {
 			/>
 			<Root.Screen
 				name={RouteNames.Settings}
-				component={SettingsScreen}
+				component={SettingsStack}
 				options={{ headerShown: false }}
 			/>
-			<Root.Screen
-				name={RouteNames.TermsAndConditions}
-				component={TermsAndConditionsScreen}
-				options={{ headerShown: false }}
-			/>
-			<Root.Screen
-				name={RouteNames.SubscriptionDetails}
-				component={SubscriptionDetailsScreen}
-			/>
-			<Root.Screen
-				name={RouteNames.AlreadySubscribed}
-				component={AlreadySubscribedScreen}
-			/>
-			<Root.Screen
-				name={RouteNames.GdprConsent}
-				component={GdprConsentScreen}
-			/>
-			<Root.Screen
-				name={RouteNames.PrivacyPolicy}
-				component={PrivacyPolicyScreen}
-			/>
-			<Root.Screen
-				name={RouteNames.ManageEditions}
-				component={ManageEditionsScreen}
-			/>
-			<Root.Screen name={RouteNames.Endpoints} component={ApiScreen} />
-			<Root.Screen name={RouteNames.Credits} component={CreditsScreen} />
-			<Root.Screen
-				name={RouteNames.BetaProgrammeFAQs}
-				component={BetaProgrammeFAQsScreen}
-			/>
-			<Root.Screen name={RouteNames.Edition} component={EditionsScreen} />
-			<Root.Screen
-				name={RouteNames.CasSignIn}
-				component={CasSignInScreen}
-			/>
-			<Root.Screen
-				name={RouteNames.WeatherGeolocationConsent}
-				component={WeatherGeolocationConsentScreen}
-			/>
-			<Root.Screen name={RouteNames.Help} component={HelpScreen} />
-			<Root.Screen name={RouteNames.FAQ} component={FAQScreen} />
 		</Root.Navigator>
 	);
 };

--- a/projects/Mallard/src/components/Header/Header.tsx
+++ b/projects/Mallard/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { isTablet } from 'react-native-device-info';
+import { color } from 'src/theme/color';
 import { Button } from '../Button/Button';
 import { CloseButton } from '../Button/CloseButton';
 import { IssueTitle } from '../issue/issue-title';
@@ -18,8 +19,11 @@ const ModalStyles = StyleSheet.create({
 		flex: 1,
 	},
 	container: {
-		minHeight: isTablet() ? 600 : height,
+		height: isTablet() ? 600 : height,
 		width: isTablet() ? 400 : width,
+		borderRadius: 15,
+		overflow: 'hidden',
+		backgroundColor: color.background,
 	},
 });
 

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -9,6 +9,16 @@ import type {
 export type RootStackParamList = {
 	Home: undefined;
 	Settings: undefined;
+};
+
+export type OnboardingStackParamList = {
+	OnboardingConsent: undefined;
+	PrivacyPolicyInline: undefined;
+	OnboardingConsentInline: undefined;
+};
+
+export type SettingsStackParamList = {
+	Settings: undefined;
 	Endpoints: undefined;
 	Edition: undefined;
 	GdprConsent: undefined;
@@ -26,12 +36,6 @@ export type RootStackParamList = {
 	WeatherGeolocationConsent: undefined;
 };
 
-export type OnboardingStackParamList = {
-	OnboardingConsent: undefined;
-	PrivacyPolicyInline: undefined;
-	OnboardingConsentInline: undefined;
-};
-
 export type MainStackParamList = {
 	Home: undefined;
 	Issue: IssueNavigationProps;
@@ -44,8 +48,8 @@ export type MainStackParamList = {
 
 // This is used on pages which include both main and root stacks
 export type CompositeNavigationStackProps = CompositeNavigationProp<
-	StackNavigationProp<RootStackParamList>,
-	StackNavigationProp<MainStackParamList>
+	StackNavigationProp<MainStackParamList>,
+	StackNavigationProp<SettingsStackParamList>
 >;
 
 export enum RouteNames {

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -26,7 +26,7 @@ import {
 import { Copy } from 'src/helpers/words';
 import { useQuery } from 'src/hooks/apollo';
 import { useNotificationsEnabled } from 'src/hooks/use-config-provider';
-import type { RootStackParamList } from 'src/navigation/NavigationModels';
+import type { SettingsStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { BetaButtonOption } from 'src/screens/settings/join-beta-button';
 import { WithAppAppearance } from 'src/theme/appearance';
@@ -35,7 +35,7 @@ import { DevZone } from './settings/dev-zone';
 const MiscSettingsList = React.memo(
 	(props: { isWeatherShown: boolean; client: ApolloClient<object> }) => {
 		const navigation = useNavigation<
-			StackNavigationProp<RootStackParamList>
+			StackNavigationProp<SettingsStackParamList>
 		>();
 		const {
 			notificationsEnabled,

--- a/projects/Mallard/src/screens/settings/join-beta-button.tsx
+++ b/projects/Mallard/src/screens/settings/join-beta-button.tsx
@@ -9,7 +9,7 @@ import { UiBodyCopy } from 'src/components/styled-text';
 import { JOIN_BETA_LINK } from 'src/constants';
 import { isInBeta } from 'src/helpers/release-stream';
 import { Copy } from 'src/helpers/words';
-import type { RootStackParamList } from 'src/navigation/NavigationModels';
+import type { SettingsStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { remoteConfigService } from 'src/services/remote-config';
 import { metrics } from 'src/theme/spacing';
@@ -22,7 +22,7 @@ const betaButtonStyle = StyleSheet.create({
 });
 
 const betaProgrammeFAQs = (
-	navigation: StackNavigationProp<RootStackParamList>,
+	navigation: StackNavigationProp<SettingsStackParamList>,
 ) => ({
 	key: 'Beta Programme FAQs',
 	title: Copy.settings.betaProgrammeFAQs,
@@ -33,7 +33,9 @@ const betaProgrammeFAQs = (
 });
 
 const betaThanks = () => {
-	const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
+	const navigation = useNavigation<
+		StackNavigationProp<SettingsStackParamList>
+	>();
 	return (
 		<>
 			<Heading>{``}</Heading>
@@ -47,7 +49,9 @@ const betaThanks = () => {
 };
 
 const joinBetaMenuButton = () => {
-	const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
+	const navigation = useNavigation<
+		StackNavigationProp<SettingsStackParamList>
+	>();
 	return (
 		<>
 			<Heading>{``}</Heading>


### PR DESCRIPTION
## Why are you doing this?

The new implementation of the modal was missing the correct animations and styles. 

This PR moves the settings menu screens to a new `Settings` stack to separate the animation styles and make things easier to read. It also fixes a few minor styling issues.

## Changes

- Fix manage editions menu height and background colour
- Round off modal corners
- Update composite type definition
- Add new animations



## Screenshots

| Before | After |
| --- | --- |
| <img  src="https://user-images.githubusercontent.com/77005274/112977165-a6178280-914d-11eb-87d9-2448a6e5e5e1.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/112977234-b62f6200-914d-11eb-882c-82f89823876e.png" width="300px" /> |
