### PR TITLE
Live 2092 consent duck menu

### DIFF
--- a/projects/Mallard/README.md
+++ b/projects/Mallard/README.md
@@ -96,7 +96,7 @@ To test the iPad version, run `yarn run-ipad`. To test responsive layouts, you c
 
 ### Storybook
 
-Within the dev menu, there is a link to Storybook. [Storybook](https://storybook.js.org/) allows us to view components in isolation and helps to define a component library whilst looking at all potential edge cases. A useful tool for both FE developers and the UX/UI team. Storybook will automatically open in a browser when running `run-ios`, `run-android` or `run-ipad`. This browser window allows the user to the control what is happening in the Storybook window of the app.
+[Storybook](https://storybook.js.org/) allows us to view components in isolation and helps to define a component library whilst looking at all potential edge cases. A useful tool for both FE developers and the UX/UI team. Storybook will automatically open in a browser when running `run-ios`, `run-android` or `run-ipad`. This browser window allows the user to the control what is happening in the Storybook window of the app.
 
 ### Upgrading React Native
 

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -32,7 +32,6 @@ export type SettingsStackParamList = {
 	AlreadySubscribed: undefined;
 	SubscriptionDetails: undefined;
 	CasSignIn: undefined;
-	Storybook: undefined;
 	WeatherGeolocationConsent: undefined;
 };
 
@@ -74,7 +73,6 @@ export enum RouteNames {
 	CasSignIn = 'CasSignIn',
 	WeatherGeolocationConsent = 'WeatherGeolocationConsent',
 	Lightbox = 'Lightbox',
-	Storybook = 'Storybook',
 	EditionsMenu = 'EditionsMenu',
 	OnboardingConsent = 'OnboardingConsent',
 	PrivacyPolicyInline = 'PrivacyPolicyInline',

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -142,13 +142,6 @@ const DevZone = () => {
 			<ButtonList>
 				<Button
 					onPress={() => {
-						navigation.navigate(RouteNames.Storybook);
-					}}
-				>
-					Storybook
-				</Button>
-				<Button
-					onPress={() => {
 						navigation.navigate(RouteNames.OnboardingConsent);
 					}}
 				>

--- a/projects/Mallard/src/screens/storybook-screen.tsx
+++ b/projects/Mallard/src/screens/storybook-screen.tsx
@@ -1,3 +1,0 @@
-import Storybook from '../../storybook';
-
-export default Storybook;


### PR DESCRIPTION
## Why are you doing this?
The consent menu button is no longer needed for development and doesn't provide a correct representation of the consent flow so it is being removed.