### PR TITLE
Live 2114 : Manage Editions button

### DIFF
--- a/projects/Mallard/index.js
+++ b/projects/Mallard/index.js
@@ -1,12 +1,12 @@
-import { AppRegistry, YellowBox, Text } from 'react-native'
-import { name as appName } from './app.json'
-import App from './src/App'
+import { AppRegistry, YellowBox, Text } from 'react-native';
+import { name as appName } from './app.json';
+import App from './src/App';
 
 // In lieu of a wrapper component (i.e. <UnscaledText />), this quickly opts us out of scaled text globally.
-Text.defaultProps = Text.defaultProps || {}
-Text.defaultProps.allowFontScaling = false
+Text.defaultProps = Text.defaultProps || {};
+Text.defaultProps.allowFontScaling = false;
 
 // Supress Could Not Find Image warnings as a result of our approach to find the image locally
-YellowBox.ignoreWarnings([])
+YellowBox.ignoreWarnings([]);
 
-AppRegistry.registerComponent(appName, () => App)
+AppRegistry.registerComponent(appName, () => App);

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -18,7 +18,7 @@ export type OnboardingStackParamList = {
 };
 
 export type SettingsStackParamList = {
-	Settings: undefined;
+	Settings: { screen: RouteNames };
 	Endpoints: undefined;
 	Edition: undefined;
 	GdprConsent: undefined;

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -151,7 +151,9 @@ const IssueRowContainer = React.memo(
 				issue={issue}
 				issueDetails={issueDetails}
 				onGoToSettings={() =>
-					navigation.navigate(RouteNames.ManageEditions)
+					navigation.navigate(RouteNames.Settings, {
+						screen: RouteNames.ManageEditions,
+					})
 				}
 			/>
 		);
@@ -171,7 +173,9 @@ const IssueListFooter = () => {
 					accessibilityHint="Navigates to the manage downloads screen"
 					appearance={ButtonAppearance.Skeleton}
 					onPress={() => {
-						navigation.navigate(RouteNames.ManageEditions);
+						navigation.navigate(RouteNames.Settings, {
+							screen: RouteNames.ManageEditions,
+						});
 					}}
 				>
 					{Copy.issueListFooter.manageDownloads}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -164,7 +164,6 @@ const IssueListFooter = () => {
 	const navigation = useNavigation<CompositeNavigationStackProps>();
 	const isUsingProdDevtools = useIsUsingProdDevtools();
 	const { setIssueId } = useIssueSummary();
-
 	return (
 		<View style={styles.issueListFooter}>
 			<GridRowSplit style={styles.issueListFooterGrid}>


### PR DESCRIPTION
## Why are you doing this?
Upgrading react-navigation broke the `Manage Editions` route. This PR fixes that route by navigating to the nested settings  navigator. 

