### PR TITLE
LIVE-2087: add animation hooks

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -31,6 +31,7 @@ import { prepFileSystem } from './helpers/files';
 import { nestProviders } from './helpers/provider';
 import { pushDownloadFailsafe } from './helpers/push-download-failsafe';
 import { EditionProvider } from './hooks/use-edition-provider';
+import { SettingsOverlayProvider } from './hooks/use-settings-overlay';
 import { ToastProvider } from './hooks/use-toast';
 import { pushNotificationRegistration } from './notifications/push-notifications';
 import { DeprecateVersionModal } from './screens/deprecate-screen';
@@ -68,6 +69,7 @@ const WithProviders = nestProviders(
 	NavPositionProvider,
 	ConfigProvider,
 	EditionProvider,
+	SettingsOverlayProvider,
 );
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>

--- a/projects/Mallard/src/__mocks__/@react-navigation.tsx
+++ b/projects/Mallard/src/__mocks__/@react-navigation.tsx
@@ -1,21 +1,24 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
+import { SettingsOverlayProvider } from '../hooks/use-settings-overlay';
 
 // https://medium.com/@dariaruckaolszaska/testing-your-react-navigation-5-hooks-b8b8f745e5b6
 const Stack = createStackNavigator();
 const MockedNavigator = ({ component, params = {}, props }: any) => {
 	return (
-		<NavigationContainer>
-			<Stack.Navigator>
-				<Stack.Screen
-					name="MockedScreen"
-					component={component}
-					initialParams={params}
-					{...props}
-				/>
-			</Stack.Navigator>
-		</NavigationContainer>
+		<SettingsOverlayProvider>
+			<NavigationContainer>
+				<Stack.Navigator>
+					<Stack.Screen
+						name="MockedScreen"
+						component={component}
+						initialParams={params}
+						{...props}
+					/>
+				</Stack.Navigator>
+			</NavigationContainer>
+		</SettingsOverlayProvider>
 	);
 };
 

--- a/projects/Mallard/src/components/Header/Header.tsx
+++ b/projects/Mallard/src/components/Header/Header.tsx
@@ -1,7 +1,10 @@
-import { useNavigation } from '@react-navigation/native';
-import React from 'react';
+import { useNavigation, useNavigationState } from '@react-navigation/native';
+import React, { useContext } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { isTablet } from 'react-native-device-info';
+import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
+import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
+import { RouteNames } from 'src/navigation/NavigationModels';
 import { color } from 'src/theme/color';
 import { Button } from '../Button/Button';
 import { CloseButton } from '../Button/CloseButton';
@@ -39,6 +42,13 @@ const HeaderScreenContainer = ({
 	title: string;
 }) => {
 	const navigation = useNavigation();
+	const { setSettingsModalOpen } = useContext(
+		SettingsOverlayContext,
+	) as SettingsOverlayInterface;
+	const screenName = useNavigationState(
+		(state) => state.routes[state.index].name,
+	);
+
 	return (
 		<View style={ModalStyles.wrapper}>
 			<View style={ModalStyles.container}>
@@ -48,7 +58,12 @@ const HeaderScreenContainer = ({
 							<Button
 								icon={'\uE00A'}
 								alt="Back"
-								onPress={() => navigation.goBack()}
+								onPress={() => {
+									if (screenName === RouteNames.Settings) {
+										setSettingsModalOpen(false);
+									}
+									navigation.goBack();
+								}}
 							></Button>
 						) : null
 					}

--- a/projects/Mallard/src/components/Header/Header.tsx
+++ b/projects/Mallard/src/components/Header/Header.tsx
@@ -1,10 +1,7 @@
-import { useNavigation, useNavigationState } from '@react-navigation/native';
-import React, { useContext } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { isTablet } from 'react-native-device-info';
-import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
-import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
-import { RouteNames } from 'src/navigation/NavigationModels';
 import { color } from 'src/theme/color';
 import { Button } from '../Button/Button';
 import { CloseButton } from '../Button/CloseButton';
@@ -42,12 +39,6 @@ const HeaderScreenContainer = ({
 	title: string;
 }) => {
 	const navigation = useNavigation();
-	const { setSettingsModalOpen } = useContext(
-		SettingsOverlayContext,
-	) as SettingsOverlayInterface;
-	const screenName = useNavigationState(
-		(state) => state.routes[state.index].name,
-	);
 
 	return (
 		<View style={ModalStyles.wrapper}>
@@ -59,9 +50,6 @@ const HeaderScreenContainer = ({
 								icon={'\uE00A'}
 								alt="Back"
 								onPress={() => {
-									if (screenName === RouteNames.Settings) {
-										setSettingsModalOpen(false);
-									}
 									navigation.goBack();
 								}}
 							></Button>

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -1,11 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
-import React from 'react';
+import React, { useContext } from 'react';
 import type { SpecialEditionHeaderStyles } from 'src/common';
 import { CloseButton } from 'src/components/Button/CloseButton';
 import { SettingsButton } from 'src/components/Button/SettingsButton';
 import { IssueTitle } from 'src/components/issue/issue-title';
 import { Header } from 'src/components/layout/header/header';
 import { styles } from 'src/components/styled-text';
+import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
+import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
 import { RouteNames } from 'src/navigation/NavigationModels';
 
 const IssuePickerHeader = ({
@@ -18,6 +20,10 @@ const IssuePickerHeader = ({
 	title: string;
 }) => {
 	const navigation = useNavigation();
+	const { setSettingsModalOpen } = useContext(
+		SettingsOverlayContext,
+	) as SettingsOverlayInterface;
+
 	return (
 		<Header
 			alignment={'drawer'}
@@ -32,6 +38,7 @@ const IssuePickerHeader = ({
 			leftAction={
 				<SettingsButton
 					onPress={() => {
+						setSettingsModalOpen(true);
 						navigation.navigate(RouteNames.Settings);
 					}}
 				/>

--- a/projects/Mallard/src/hooks/use-overlay-animation.tsx
+++ b/projects/Mallard/src/hooks/use-overlay-animation.tsx
@@ -1,0 +1,29 @@
+import React, { useRef, useState } from 'react';
+import { Animated } from 'react-native';
+
+const useOverlayAnimation = (shouldAnimate: boolean) => {
+	const fadeAnim = useRef(new Animated.Value(0)).current;
+
+	const [showOverlay, setShowOverlay] = useState(false);
+
+	React.useEffect(() => {
+		if (shouldAnimate) {
+			setShowOverlay(true);
+			Animated.timing(fadeAnim, {
+				toValue: 0.5,
+				duration: 400,
+				delay: 0,
+			}).start();
+		} else {
+			Animated.timing(fadeAnim, {
+				toValue: 0,
+				duration: 400,
+				delay: 250,
+			}).start(() => setShowOverlay(false));
+		}
+	}, [shouldAnimate]);
+
+	return { showOverlay, fadeAnim };
+};
+
+export default useOverlayAnimation;

--- a/projects/Mallard/src/hooks/use-overlay-animation.tsx
+++ b/projects/Mallard/src/hooks/use-overlay-animation.tsx
@@ -11,14 +11,13 @@ const useOverlayAnimation = (shouldAnimate: boolean) => {
 			setShowOverlay(true);
 			Animated.timing(fadeAnim, {
 				toValue: 0.5,
-				duration: 400,
-				delay: 0,
+				duration: 300,
+				delay: 200,
 			}).start();
 		} else {
 			Animated.timing(fadeAnim, {
 				toValue: 0,
-				duration: 400,
-				delay: 250,
+				duration: 200,
 			}).start(() => setShowOverlay(false));
 		}
 	}, [shouldAnimate]);

--- a/projects/Mallard/src/hooks/use-settings-overlay.tsx
+++ b/projects/Mallard/src/hooks/use-settings-overlay.tsx
@@ -1,0 +1,33 @@
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import React, { createContext, useState } from 'react';
+
+interface Props {
+	children: ReactNode;
+}
+
+interface SettingsOverlayInterface {
+	settingsModalOpen: boolean;
+	setSettingsModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const SettingsOverlayContext = createContext<SettingsOverlayInterface | null>(
+	null,
+);
+
+const SettingsOverlayProvider = ({ children }: Props) => {
+	const [settingsModalOpen, setSettingsModalOpen] = useState<boolean>(false);
+
+	return (
+		<SettingsOverlayContext.Provider
+			value={{ settingsModalOpen, setSettingsModalOpen }}
+		>
+			{children}
+		</SettingsOverlayContext.Provider>
+	);
+};
+
+export {
+	SettingsOverlayProvider,
+	SettingsOverlayContext,
+	SettingsOverlayInterface,
+};

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native';
+import { useIsFocused, useNavigation } from '@react-navigation/native';
 import type { Dispatch } from 'react';
 import React, {
 	useCallback,
@@ -440,10 +440,19 @@ export const HomeScreen = () => {
 	const { issueSummary, error } = useIssueSummary();
 	const { selectedEdition } = useEditions();
 	const specialEditionProps = getSpecialEditionProps(selectedEdition);
-	const { settingsModalOpen } = useContext(
+	const { settingsModalOpen, setSettingsModalOpen } = useContext(
 		SettingsOverlayContext,
 	) as SettingsOverlayInterface;
 	const { showOverlay, fadeAnim } = useOverlayAnimation(settingsModalOpen);
+	const isFocused = useIsFocused();
+
+	useEffect(() => {
+		if (isFocused) {
+			setSettingsModalOpen(false);
+		} else {
+			setSettingsModalOpen(true);
+		}
+	}, [isFocused]);
 
 	const issueHeaderData =
 		selectedEdition.editionType === 'Special'

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -2,12 +2,14 @@ import { useNavigation } from '@react-navigation/native';
 import type { Dispatch } from 'react';
 import React, {
 	useCallback,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
 	useState,
 } from 'react';
-import { FlatList, Platform, StyleSheet, View } from 'react-native';
+import { Animated, FlatList, Platform, StyleSheet, View } from 'react-native';
+import { isTablet } from 'react-native-device-info';
 import type { IssueSummary } from 'src/common';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
 import {
@@ -35,7 +37,10 @@ import {
 import { useIssueResponse } from 'src/hooks/use-issue';
 import { useIssueSummary } from 'src/hooks/use-issue-summary';
 import { useSetNavPosition } from 'src/hooks/use-nav-position';
+import useOverlayAnimation from 'src/hooks/use-overlay-animation';
 import { useIsUsingProdDevtools } from 'src/hooks/use-settings';
+import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
+import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
 import { navigateToIssue } from 'src/navigation/helpers/base';
 import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
@@ -64,6 +69,15 @@ const styles = StyleSheet.create({
 	listPlaceholder: {
 		backgroundColor: color.dimmerBackground,
 		height: '100%',
+	},
+	overlay: {
+		position: 'absolute',
+		backgroundColor: color.darkBackground,
+		top: 0,
+		bottom: 0,
+		left: 0,
+		right: 0,
+		zIndex: 2,
 	},
 });
 
@@ -426,6 +440,11 @@ export const HomeScreen = () => {
 	const { issueSummary, error } = useIssueSummary();
 	const { selectedEdition } = useEditions();
 	const specialEditionProps = getSpecialEditionProps(selectedEdition);
+	const { settingsModalOpen } = useContext(
+		SettingsOverlayContext,
+	) as SettingsOverlayInterface;
+	const { showOverlay, fadeAnim } = useOverlayAnimation(settingsModalOpen);
+
 	const issueHeaderData =
 		selectedEdition.editionType === 'Special'
 			? { title: '', subTitle: '' }
@@ -433,6 +452,11 @@ export const HomeScreen = () => {
 
 	return (
 		<WithAppAppearance value={'tertiary'}>
+			{isTablet() && showOverlay && (
+				<Animated.View
+					style={[styles.overlay, { opacity: fadeAnim }]}
+				></Animated.View>
+			)}
 			<ScreenFiller direction="end">
 				<>
 					<IssuePickerHeader

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -17,6 +17,8 @@ import { SubFoundModalCard } from 'src/components/sub-found-modal-card';
 import { withConsent } from 'src/helpers/settings';
 import { Copy } from 'src/helpers/words';
 import { useFormField } from 'src/hooks/use-form-field';
+import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
+import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
 import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import isEmail from 'validator/lib/isEmail';
@@ -50,6 +52,9 @@ const AuthSwitcherScreen = () => {
 
 	const { authIdentity } = useContext(AccessContext);
 	const { open } = useModal();
+	const { setSettingsModalOpen } = useContext(
+		SettingsOverlayContext,
+	) as SettingsOverlayInterface;
 
 	const handleAuthClick = async (
 		runGetIdentityAuthParams: () => Promise<AuthParams>,
@@ -77,7 +82,10 @@ const AuthSwitcherScreen = () => {
 											attempt.data.userDetails
 												.primaryEmailAddress
 										}
-										onDismiss={() => navigation.popToTop()}
+										onDismiss={() => {
+											setSettingsModalOpen(false);
+											navigation.popToTop();
+										}}
 										onOpenCASLogin={() =>
 											navigation.navigate(
 												RouteNames.CasSignIn,
@@ -136,7 +144,10 @@ const AuthSwitcherScreen = () => {
 			email={email}
 			password={password}
 			isLoading={isLoading}
-			onDismiss={() => navigation.goBack()}
+			onDismiss={() => {
+				setSettingsModalOpen(false);
+				navigation.popToTop();
+			}}
 			onHelpPress={() =>
 				navigation.navigate(RouteNames.AlreadySubscribed)
 			}

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -17,8 +17,6 @@ import { SubFoundModalCard } from 'src/components/sub-found-modal-card';
 import { withConsent } from 'src/helpers/settings';
 import { Copy } from 'src/helpers/words';
 import { useFormField } from 'src/hooks/use-form-field';
-import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
-import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
 import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import isEmail from 'validator/lib/isEmail';
@@ -52,9 +50,6 @@ const AuthSwitcherScreen = () => {
 
 	const { authIdentity } = useContext(AccessContext);
 	const { open } = useModal();
-	const { setSettingsModalOpen } = useContext(
-		SettingsOverlayContext,
-	) as SettingsOverlayInterface;
 
 	const handleAuthClick = async (
 		runGetIdentityAuthParams: () => Promise<AuthParams>,
@@ -82,10 +77,7 @@ const AuthSwitcherScreen = () => {
 											attempt.data.userDetails
 												.primaryEmailAddress
 										}
-										onDismiss={() => {
-											setSettingsModalOpen(false);
-											navigation.popToTop();
-										}}
+										onDismiss={() => navigation.popToTop()}
 										onOpenCASLogin={() =>
 											navigation.navigate(
 												RouteNames.CasSignIn,
@@ -144,10 +136,7 @@ const AuthSwitcherScreen = () => {
 			email={email}
 			password={password}
 			isLoading={isLoading}
-			onDismiss={() => {
-				setSettingsModalOpen(false);
-				navigation.popToTop();
-			}}
+			onDismiss={() => navigation.popToTop()}
 			onHelpPress={() =>
 				navigation.navigate(RouteNames.AlreadySubscribed)
 			}


### PR DESCRIPTION
## Why are you doing this?

The new Modal (implemented via React-Navigation v5) doesn't add an opacity layer over the `Issue Picker` menu.

This PR adds a `SettingsOverlayContext` so allow us to activate an opacity overlay on the `Home Screen` whenever the settings menu modal is opened.

I've also added a `use-overlay-animation` hook which returns both a boolean to control whether then overlay is rendered, and a `Animation` value which can be used to control the opacity of the overlay. We need both as otherwise we're left with a transparent overlay which blocks the use of any buttons on the components below it.

## Changes

- add `SettingsOverlayProvider` context
- add `use-overlay-animation` hook
- add overlay to home screen
- add `setSettingsModalOpen()` instructions to header buttons 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/113161881-b3f50280-9236-11eb-8549-b5517e49de6e.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/113161992-c96a2c80-9236-11eb-95e2-b1f745958ba6.png" width="300px" /> |
