### PR TITLE
Live 2141 rounded edges

### DIFF
--- a/projects/Mallard/src/components/Header/Header.tsx
+++ b/projects/Mallard/src/components/Header/Header.tsx
@@ -21,9 +21,10 @@ const ModalStyles = StyleSheet.create({
 	container: {
 		height: isTablet() ? 600 : height,
 		width: isTablet() ? 400 : width,
-		borderRadius: 15,
+		borderRadius: isTablet() ? 15 : 0,
 		overflow: 'hidden',
 		backgroundColor: color.background,
+		flex: isTablet() ? 0 : 1,
 	},
 });
 


### PR DESCRIPTION
## Why are you doing this?

On Android mobile the modal wasn't picking up the correct sizing and had rounded edges.

This PR uses `flex: 1` to make it full height and removes the `borderRadius` value on mobile.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/113304746-3c88a700-92fa-11eb-916e-96ff04ad02ac.png" width="300px" />| <img src="https://user-images.githubusercontent.com/77005274/113304828-4f02e080-92fa-11eb-8982-cdbc95930915.png" width="300px" /> |
