### PR TITLE
Live 2140 :  Add loading indicator to issue picker screen

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -409,7 +409,12 @@ const IssueListFetchContainer = () => {
 	}, []);
 
 	const resp = useIssueResponse(issueId);
-	if (!isShown) return <View style={styles.listPlaceholder} />;
+	if (!isShown)
+		return (
+			<FlexCenter>
+				<Spinner />
+			</FlexCenter>
+		);
 
 	return resp({
 		error: (error: {}) => (

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -8,7 +8,14 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import { Animated, FlatList, Platform, StyleSheet, View } from 'react-native';
+import {
+	Animated,
+	Dimensions,
+	FlatList,
+	Platform,
+	StyleSheet,
+	View,
+} from 'react-native';
 import { isTablet } from 'react-native-device-info';
 import type { IssueSummary } from 'src/common';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
@@ -66,9 +73,12 @@ const styles = StyleSheet.create({
 		paddingTop: 0,
 		backgroundColor: color.dimBackground,
 	},
-	listPlaceholder: {
-		backgroundColor: color.dimmerBackground,
-		height: '100%',
+	loadingScreen: {
+		height: Dimensions.get('window').height,
+		width: Dimensions.get('window').width,
+		backgroundColor: 'white',
+		alignItems: 'center',
+		justifyContent: 'center',
 	},
 	overlay: {
 		position: 'absolute',
@@ -411,9 +421,9 @@ const IssueListFetchContainer = () => {
 	const resp = useIssueResponse(issueId);
 	if (!isShown)
 		return (
-			<FlexCenter>
+			<View style={styles.loadingScreen}>
 				<Spinner />
-			</FlexCenter>
+			</View>
 		);
 
 	return resp({


### PR DESCRIPTION
## Why are you doing this?
On Android, there is tiny delay as the issue picker menu slides in. 

Normally, the "loading" screen is only visible very briefly (<0.5 second) so this isn't an issue. However, if this is longer for any reason (eg poor connection) it leaves the user temporarily with a grey panel(tablet) / screen (mobile).

Updating the background colour to white, adding the editions loading dots, and fixing the header makes the transition a little smoother and provides a loading context to the user if they have bad connectivity. 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/113740157-5e1dd000-96f8-11eb-9d78-2b27353a270d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/113740223-6bd35580-96f8-11eb-9a16-92de0fa85bf9.png" width="300px" /> |
| --- | --- |
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/113740101-51997780-96f8-11eb-92a2-409c6e5bbf88.png" width="300px" /> |
