### PR TITLE
Live 2170 : Wire Up Use location Button

### DIFF
--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -212,7 +212,9 @@ const WeatherIconView = ({
 const SetLocationButton = () => {
 	const navigation = useNavigation();
 	const onSetLocation = useCallback(() => {
-		navigation.navigate(RouteNames.WeatherGeolocationConsent);
+		navigation.navigate(RouteNames.Settings, {
+			screen: RouteNames.WeatherGeolocationConsent,
+		});
 	}, [navigation]);
 
 	return (

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Alert, Linking, Platform, StyleSheet, View } from 'react-native';
 import { RESULTS } from 'react-native-permissions';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
+import { HeaderScreenContainer } from 'src/components/Header/Header';
 import { requestLocationPermission } from 'src/helpers/location-permission';
 import { setIsWeatherShown } from 'src/helpers/settings/setters';
 import { getGeolocation } from 'src/helpers/weather';
@@ -70,7 +71,7 @@ const WeatherGeolocationConsentScreen = () => {
 	};
 
 	return (
-		<>
+		<HeaderScreenContainer actionLeft={false} actionRight title={''}>
 			<DefaultInfoTextWebview
 				html={html` ${Copy.weatherConsentHtml.content} `}
 			/>
@@ -90,7 +91,7 @@ const WeatherGeolocationConsentScreen = () => {
 					{Copy.weather.cancelButton}
 				</Button>
 			</View>
-		</>
+		</HeaderScreenContainer>
 	);
 };
 


### PR DESCRIPTION
## Why are you doing this?
The `Use Location` button isn't navigating to the correct screen as it is not being routed through the settings stack. This PR fixes this and additional styling

## Changes

- Navigate to location consent page via settings stack
- Add wrap location consent page in header container for styling

