### PR TITLE
Live 2180 manage downloads

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -61,13 +61,11 @@ import { ApiState } from './settings/api-screen';
 
 const styles = StyleSheet.create({
 	issueListFooter: {
-		padding: metrics.horizontal,
-		paddingTop: metrics.vertical * 2,
-		paddingBottom: metrics.vertical * 8,
-		paddingLeft: 90,
+		marginBottom: 160,
 	},
 	issueListFooterGrid: {
-		marginBottom: metrics.vertical,
+		paddingLeft: 90,
+		marginTop: metrics.vertical * 2,
 	},
 	issueList: {
 		paddingTop: 0,
@@ -189,7 +187,7 @@ const IssueListFooter = () => {
 	const isUsingProdDevtools = useIsUsingProdDevtools();
 	const { setIssueId } = useIssueSummary();
 	return (
-		<View style={styles.issueListFooter}>
+		<>
 			<GridRowSplit style={styles.issueListFooterGrid}>
 				<Button
 					accessibilityLabel="Manage downloads button"
@@ -224,7 +222,7 @@ const IssueListFooter = () => {
 					</Button>
 				</GridRowSplit>
 			) : null}
-		</View>
+		</>
 	);
 };
 
@@ -335,6 +333,7 @@ const IssueListView = React.memo(
 				// space on the screen. This improves performance.
 				initialNumToRender={4}
 				ItemSeparatorComponent={Separator}
+				ListFooterComponentStyle={styles.issueListFooter}
 				ListFooterComponent={footer}
 				style={styles.issueList}
 				data={issueList}


### PR DESCRIPTION
## Why are you doing this?
The `manage downloads` button in the issue picker footer is being pushed below the screen. This PR adds footer styling to bring it back into view on scroll. 

## Changes
Add list footer styling with padding 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/113885055-6d178780-97b7-11eb-96f8-f6facafd84d5.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/113884044-94218980-97b6-11eb-97bc-82abcc00e69d.png" width="300px" /> |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/113885136-7ef92a80-97b7-11eb-85e1-87230c99b600.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/113884080-9c79c480-97b6-11eb-8e95-90edf89850a1.png" width="300px" /> |