### PR TITLE
Live 2176 : Remove  IAP Dev Button on Android

### DIFF
--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -3,7 +3,7 @@ import { useNavigation } from '@react-navigation/native';
 import gql from 'graphql-tag';
 import type { ReactNode } from 'react';
 import React, { useContext, useEffect, useState } from 'react';
-import { Alert, Clipboard, View } from 'react-native';
+import { Alert, Clipboard, Platform, View } from 'react-native';
 import { Switch } from 'react-native-gesture-handler';
 import { AccessContext } from 'src/authentication/AccessContext';
 import { isValid } from 'src/authentication/lib/Attempt';
@@ -178,7 +178,7 @@ const DevZone = () => {
 				>
 					Pop a toast
 				</Button>
-				{isInBeta() && (
+				{isInBeta() && Platform.OS === 'ios' && (
 					<Button onPress={() => DEV_getLegacyIAPReceipt()}>
 						Add legacy IAP receipt
 					</Button>


### PR DESCRIPTION
## Why are you doing this?
IAP is specific to iOS so we are hiding this dev button on Android
