### PR TITLE
LIVE-2205: fix sign in route and remove animations

### DIFF
--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -75,40 +75,6 @@ const cardStyleInterpolator = (props: StackCardInterpolationProps) => {
 	};
 };
 
-const settingsInterpolater = (props: StackCardInterpolationProps) => {
-	const translateX = multiply(
-		props.current.progress.interpolate({
-			inputRange: [0, 1],
-			outputRange: [200, 0],
-			extrapolate: 'clamp',
-		}),
-		props.inverted,
-	);
-
-	return {
-		cardStyle: {
-			backgroundColor: 'transparent',
-			opacity: props.current.progress.interpolate({
-				inputRange: [0, 1, 4],
-				outputRange: [0, 1, 0],
-			}),
-			transform: [
-				// Translation for the animation of the current card
-				{
-					translateX,
-				},
-			],
-		},
-		overlayStyle: {
-			opacity: props.current.progress.interpolate({
-				inputRange: [0, 1, 2],
-				outputRange: [0, 1, 0],
-			}),
-			backgroundColor: 'transparent',
-		},
-	};
-};
-
 const modalInterpolater = (props: StackCardInterpolationProps) => {
 	const translateY = multiply(
 		props.current.progress.interpolate({
@@ -213,10 +179,7 @@ const MainStack = () => {
 					gestureDirection: 'vertical',
 				}}
 			/>
-			<Main.Screen
-				name={RouteNames.SignIn}
-				component={AuthSwitcherScreen}
-			/>
+
 			<Main.Screen
 				name={RouteNames.Lightbox}
 				component={LightboxScreen}
@@ -229,13 +192,12 @@ const SettingsStack = () => {
 	return (
 		<Settings.Navigator
 			initialRouteName={RouteNames.Settings}
-			mode="modal"
 			screenOptions={{
 				gestureEnabled: false,
 				headerShown: false,
 				cardStyle: { backgroundColor: 'transparent' },
 				cardOverlayEnabled: true,
-				cardStyleInterpolator: settingsInterpolater,
+				animationEnabled: false,
 			}}
 		>
 			<Settings.Screen
@@ -292,6 +254,10 @@ const SettingsStack = () => {
 			<Settings.Screen
 				name={RouteNames.WeatherGeolocationConsent}
 				component={WeatherGeolocationConsentScreen}
+			/>
+			<Settings.Screen
+				name={RouteNames.SignIn}
+				component={AuthSwitcherScreen}
 			/>
 			<Settings.Screen name={RouteNames.Help} component={HelpScreen} />
 			<Settings.Screen name={RouteNames.FAQ} component={FAQScreen} />

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -3,6 +3,7 @@ import type { StackCardInterpolationProps } from '@react-navigation/stack';
 import {
 	CardStyleInterpolators,
 	createStackNavigator,
+	TransitionPresets,
 } from '@react-navigation/stack';
 import React from 'react';
 import { Animated } from 'react-native';
@@ -71,39 +72,6 @@ const cardStyleInterpolator = (props: StackCardInterpolationProps) => {
 				outputRange: [0, 0.5],
 				extrapolate: 'clamp',
 			}),
-		},
-	};
-};
-
-const modalInterpolater = (props: StackCardInterpolationProps) => {
-	const translateY = multiply(
-		props.current.progress.interpolate({
-			inputRange: [0, 1],
-			outputRange: [200, 0],
-			extrapolate: 'clamp',
-		}),
-		props.inverted,
-	);
-
-	return {
-		cardStyle: {
-			backgroundColor: 'transparent',
-			opacity: props.current.progress.interpolate({
-				inputRange: [0, 1, 4],
-				outputRange: [0, 1, 0],
-			}),
-			transform: [
-				{
-					translateY,
-				},
-			],
-		},
-		overlayStyle: {
-			opacity: props.current.progress.interpolate({
-				inputRange: [0, 1, 2],
-				outputRange: [0, 1, 0],
-			}),
-			backgroundColor: 'transparent',
 		},
 	};
 };
@@ -273,7 +241,7 @@ const RootStack = () => {
 				headerShown: false,
 				cardStyle: { backgroundColor: 'transparent' },
 				cardOverlayEnabled: true,
-				cardStyleInterpolator: modalInterpolater,
+				...TransitionPresets.ModalSlideFromBottomIOS,
 			}}
 		>
 			<Root.Screen

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -32,6 +32,7 @@ export type SettingsStackParamList = {
 	AlreadySubscribed: undefined;
 	SubscriptionDetails: undefined;
 	CasSignIn: undefined;
+	SignIn: undefined;
 	WeatherGeolocationConsent: undefined;
 };
 
@@ -40,7 +41,6 @@ export type MainStackParamList = {
 	Issue: IssueNavigationProps;
 	Article: ArticleNavigationProps;
 	IssueList: undefined;
-	SignIn: undefined;
 	EditionsMenu: undefined;
 	Lightbox: LightboxNavigationProps;
 };


### PR DESCRIPTION
## Why are you doing this?

We decided to remove the existing the animations for the settings modal until we can work out how to replicate the old Editions animations correctly with the new API. This PR also fixes a bug where the close button on the sign-in screen was going back to the home page rather than the settings screen.
