### PR TITLE
Live 2181 :  crosswords

### DIFF
--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -1,3 +1,4 @@
+import { neutral } from '@guardian/src-foundations';
 import { NavigationContainer } from '@react-navigation/native';
 import type { StackCardInterpolationProps } from '@react-navigation/stack';
 import {
@@ -175,6 +176,7 @@ const MainStack = () => {
 		<Main.Navigator
 			initialRouteName={RouteNames.Home}
 			screenOptions={{
+				cardStyle: { backgroundColor: neutral[100] },
 				gestureEnabled: false,
 				headerShown: false,
 			}}

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -1,4 +1,3 @@
-import { neutral } from '@guardian/src-foundations';
 import { NavigationContainer } from '@react-navigation/native';
 import type { StackCardInterpolationProps } from '@react-navigation/stack';
 import {
@@ -44,6 +43,7 @@ import {
 import { SubscriptionDetailsScreen } from './screens/settings/subscription-details-screen';
 import { TermsAndConditionsScreen } from './screens/settings/terms-and-conditions-screen';
 import { WeatherGeolocationConsentScreen } from './screens/weather-geolocation-consent-screen';
+import { color } from './theme/color';
 
 const { multiply } = Animated;
 
@@ -176,7 +176,7 @@ const MainStack = () => {
 		<Main.Navigator
 			initialRouteName={RouteNames.Home}
 			screenOptions={{
-				cardStyle: { backgroundColor: neutral[100] },
+				cardStyle: { backgroundColor: color.background },
 				gestureEnabled: false,
 				headerShown: false,
 			}}

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -3,6 +3,7 @@ import type { StackCardInterpolationProps } from '@react-navigation/stack';
 import {
 	CardStyleInterpolators,
 	createStackNavigator,
+	TransitionPresets,
 } from '@react-navigation/stack';
 import React from 'react';
 import { Animated } from 'react-native';
@@ -182,6 +183,13 @@ const MainStack = () => {
 				name={RouteNames.Issue}
 				component={IssueScreen}
 				options={{}}
+			/>
+			<Main.Screen
+				name={RouteNames.Crossword}
+				component={ArticleWrapper}
+				options={{
+					...TransitionPresets.ModalSlideFromBottomIOS,
+				}}
 			/>
 			<Main.Screen
 				name={RouteNames.IssueList}

--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -12,7 +12,10 @@ import {
 } from 'react-native';
 import type { CAPIArticle, Issue, ItemSizes } from 'src/common';
 import { ariaHidden } from 'src/helpers/a11y';
-import type { MainStackParamList } from 'src/navigation/NavigationModels';
+import type {
+	CompositeNavigationStackProps,
+	MainStackParamList,
+} from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator } from 'src/screens/article-screen';
@@ -94,19 +97,23 @@ const ItemTappable = ({
 		return unsubscribe;
 	}, [navigation]);
 
+	const handlePress = () => {
+		fade(opacity, 'out');
+		article.type === 'crossword'
+			? navigation.navigate(RouteNames.Crossword, {
+					path,
+					articleNavigator,
+					prefersFullScreen: true,
+			  })
+			: navigation.navigate(RouteNames.Article, {
+					path,
+					articleNavigator,
+			  });
+	};
+
 	return (
 		<Animated.View style={[style]}>
-			<TouchableHighlight
-				onPress={() => {
-					fade(opacity, 'out');
-					navigation.navigate(RouteNames.Article, {
-						path,
-						articleNavigator,
-						prefersFullScreen: article.type === 'crossword',
-					});
-				}}
-				activeOpacity={0.95}
-			>
+			<TouchableHighlight onPress={handlePress} activeOpacity={0.95}>
 				<View
 					style={[
 						tappableStyles.root,

--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -12,10 +12,7 @@ import {
 } from 'react-native';
 import type { CAPIArticle, Issue, ItemSizes } from 'src/common';
 import { ariaHidden } from 'src/helpers/a11y';
-import type {
-	CompositeNavigationStackProps,
-	MainStackParamList,
-} from 'src/navigation/NavigationModels';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator } from 'src/screens/article-screen';

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -43,6 +43,7 @@ export type MainStackParamList = {
 	SignIn: undefined;
 	EditionsMenu: undefined;
 	Lightbox: LightboxNavigationProps;
+	Crossword: ArticleNavigationProps;
 };
 
 // This is used on pages which include both main and root stacks
@@ -77,4 +78,5 @@ export enum RouteNames {
 	OnboardingConsent = 'OnboardingConsent',
 	PrivacyPolicyInline = 'PrivacyPolicyInline',
 	OnboardingConsentInline = 'OnboardingConsentInline',
+	Crossword = 'Crossword',
 }

--- a/projects/Mallard/src/navigation/navigators/article.tsx
+++ b/projects/Mallard/src/navigation/navigators/article.tsx
@@ -1,59 +1,42 @@
+import { useNavigation } from '@react-navigation/core';
 import type { RouteProp } from '@react-navigation/native';
 import { useRoute } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
-import { Animated, StyleSheet } from 'react-native';
-import { safeInterpolation } from 'src/helpers/math';
+import { Button, ButtonAppearance } from 'src/components/Button/Button';
+import { Header } from 'src/components/layout/header/header';
 import { ArticleScreen } from 'src/screens/article-screen';
-import { color } from 'src/theme/color';
-import { metrics } from 'src/theme/spacing';
 import { SlideCard } from '../../components/layout/slide-card/index';
 import type { MainStackParamList } from '../NavigationModels';
 
-const styles = StyleSheet.create({
-	root: {
-		...StyleSheet.absoluteFillObject,
-	},
-	inner: {
-		...StyleSheet.absoluteFillObject,
-		backgroundColor: color.background,
-		height: '100%',
-		flexGrow: 1,
-		overflow: 'hidden',
-		marginBottom: metrics.slideCardSpacing,
-	},
-	basicCard: { backgroundColor: color.background, overflow: 'hidden' },
-});
+const FullScreenArticle = () => {
+	const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
+	return (
+		<>
+			<Header
+				theme="light"
+				leftAction={
+					<Button
+						appearance={ButtonAppearance.Skeleton}
+						icon={'\uE00A'}
+						alt="Back"
+						onPress={() => navigation.goBack()}
+					></Button>
+				}
+				layout="center"
+			>
+				{null}
+			</Header>
+			<ArticleScreen />
+		</>
+	);
+};
 
 export const ArticleWrapper = () => {
 	const route = useRoute<RouteProp<MainStackParamList, 'Article'>>();
-	const position = new Animated.Value(0);
-	if (route.params.prefersFullScreen) {
-		return (
-			<Animated.View
-				style={[
-					StyleSheet.absoluteFillObject,
-					styles.basicCard,
-					{
-						transform: [
-							{
-								translateY: position.interpolate({
-									inputRange: safeInterpolation([0, 1]),
-									outputRange: safeInterpolation([200, 0]),
-								}),
-							},
-						],
-					},
-					{
-						opacity: position.interpolate({
-							inputRange: safeInterpolation([0, 0.5]),
-							outputRange: safeInterpolation([0, 1]),
-						}),
-					},
-				]}
-			></Animated.View>
-		);
-	}
-	return (
+	return route.params.prefersFullScreen ? (
+		<FullScreenArticle />
+	) : (
 		<SlideCard>
 			<ArticleScreen />
 		</SlideCard>

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -203,7 +203,7 @@ const IssueListFooter = () => {
 				</Button>
 			</GridRowSplit>
 			{isUsingProdDevtools ? (
-				<GridRowSplit>
+				<GridRowSplit style={styles.issueListFooterGrid}>
 					<Button
 						accessibilityLabel="Go to the latest edition button"
 						accessibilityHint="Navigates to the latest edition"

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -24,42 +24,42 @@ put that in the <Spinner /> component.
 
 export const color = {
 	/*
-    Backgrounds
-    */
-	background: background.primary,
+	Backgrounds
+	*/
+	background: neutral[100],
 	text: text.primary,
 	dimBackground: neutral[93],
 	dimmerBackground: neutral[86],
 	dimText: neutral[20],
 	darkBackground: neutral[20],
 	photoBackground: neutral[7],
-	textOverPhotoBackground: background.primary,
-	textOverDarkBackground: background.primary,
+	textOverPhotoBackground: neutral[100],
+	textOverDarkBackground: neutral[100],
 	artboardBackground: neutral[7],
 	skeleton: neutral[60],
 
 	/*
-    Brand (our blue)
-    */
+	Brand (our blue)
+	*/
 	textOverPrimary: brandText.primary,
 	primary: brandBackground.primary,
 	primaryDarker: brand[300],
 
 	/*
-    Border colors
-    */
+	Border colors
+	*/
 	line: border.primary,
 	dimLine: border.secondary,
 	lineOverPrimary: brandBorder.primary,
 
 	/*
-    Error messages and icons.
-    */
+	Error messages and icons.
+	*/
 	error: text.error,
 
 	/*
-    Onboarding & button UI.
-    */
+	Onboarding & button UI.
+	*/
 	ui: {
 		tomato: news[500],
 		apricot: opinion[500],
@@ -69,7 +69,7 @@ export const color = {
 	},
 
 	/*
-    The palette is available to use, but prefer using the name.
-    */
+	The palette is available to use, but prefer using the name.
+	*/
 	palette,
 };

--- a/projects/Mallard/src/theme/color.ts
+++ b/projects/Mallard/src/theme/color.ts
@@ -1,6 +1,5 @@
 import { palette } from '@guardian/pasteup/palette';
 import {
-	background,
 	border,
 	brand,
 	brandBackground,


### PR DESCRIPTION
## Why are you doing this?

Reintroduces crosswords after they were lost during the react navigation 5 upgrade. 

Instead of using custom animation, it now uses out of the box transition to expand to full screen in a modal style, transitioning vertically

## Changes
- render crosswords in a full screen modal
- add default white background to all cards
- add styling to dev button in the issue picker


## Screenshots

| Mobile | Tablet |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/114021973-31d59100-9869-11eb-8b77-2440ffe263aa.png" width="300px" /> | <img src="" width="300px" /> |
