### PR TITLE
Live 2254 :  Fastlane Signing

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -53,13 +53,16 @@ platform :ios do
       readonly: true,
       git_url: "https://github.com/guardian/code-signing.git",
       keychain_name: "CI",
-      keychain_password: ENV["FASTLANE_PASSWORD"]
+      keychain_password: ENV["FASTLANE_PASSWORD"],
+      skip_provisioning_profiles: true
     )
 
     update_code_signing_settings(
       use_automatic_signing: false,
       path: "ios/Mallard.xcodeproj",
     )
+
+    get_provisioning_profile(app_identifier: "uk.co.guardian.gce", readonly: true, api_key: appstore_api_key)
 
     currentNumber = latest_testflight_build_number(api_key: appstore_api_key)
 


### PR DESCRIPTION
## Why are you doing this?

After renewing the distribution certificate on iOS, the Editions build started to fail as it was still referencing the outdated provisioning profile. This is because it was relying on the code signing repo for its profile, which had a copy/reference to the outdated profile. 

To fix this, @jacobwinch suggested 2 options:  
1. Delete the 'old' profiles from the code-signing repo and allow Fastlane to create a new profile for Editions automatically.

2. Follow the `ios-live` path: manually create a profile and link it to the new cert. Tell Fastlane to download it explicitly using get_provisioning_profile as part of the build process and set skip_provisioning_profiles: true at the sync_code_signing call site. (Optionally) delete the profiles stuff from the code-signing repo to tidy up. For context, `ios-live` use this method as they have multiple provisioning profiles. 


Whilst option 1 is theoretically simpler, this PR follows option 2 in order to make Editions and the Live App consistent and create a standardised approach. There is also the added benefit that the provisioning profile is already available and has been updated with the new distribution certificate. Also, when the distribution certificate on iOS is updated each year, Editions will just work as they share the same provisioning profile, reducing the annual task of renewing certificates.  

Alongside this, the profile folder from the code-signing repo has been removed as this is no longer used.

## Changes

- Tell Fastlane to download it explicitly using get_provisioning_profile as part of the build process 
- Set skip_provisioning_profiles: true at the sync_code_signing call site
