### PR TITLE
Added new api endpoints to access new mobile stack

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -37,6 +37,16 @@ export const backends = [
 		preview: true,
 	},
 	{
+		title: '(MOBILE) CODE published',
+		value: 'https://editions-published-code.s3-eu-west-1.amazonaws.com/',
+		preview: false,
+	},
+	{
+		title: '(MOBILE) PROD published',
+		value: 'https://editions-published-prod.s3-eu-west-1.amazonaws.com/',
+		preview: false,
+	},
+	{
 		title: 'DEV',
 		value: 'http://localhost:3131/',
 		preview: true,


### PR DESCRIPTION
## Why are you doing this?

To test the content/issue/bundle generated by the new mobile aws stack we need to test them in the existing mobile client to make sure it is backward compatible. This PR adds 2 new api endpoints to access content from the mobile stack.
