### PR TITLE
Chore update yarnlock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,11 @@
     archiver "^3.0.0"
     aws-sdk "^2.481.0"
 
+"@guardian/prettier@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
+  integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
+
 "@mojotech/json-type-validation@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mojotech/json-type-validation/-/json-type-validation-3.1.0.tgz#13357741bce0e0d7e63369bf384fd92956cc7c99"


### PR DESCRIPTION
## Why are you doing this?
During upgrading, the yarn.lock has fallen out of sync. This PR updates the yarn.lock which adds @guardian/prettier into the projects tools. 