### PR TITLE
Update sign in route names to

### DIFF
--- a/projects/Mallard/src/screens/article-screen.tsx
+++ b/projects/Mallard/src/screens/article-screen.tsx
@@ -88,8 +88,16 @@ const ArticleScreenLoginOverlay = ({ children }: { children: ReactNode }) => {
 	return (
 		<LoginOverlay
 			isFocused={() => navigation.isFocused()}
-			onLoginPress={() => navigation.navigate(RouteNames.SignIn)}
-			onOpenCASLogin={() => navigation.navigate(RouteNames.CasSignIn)}
+			onLoginPress={() =>
+				navigation.navigate(RouteNames.Settings, {
+					screen: RouteNames.SignIn,
+				})
+			}
+			onOpenCASLogin={() =>
+				navigation.navigate(RouteNames.Settings, {
+					screen: RouteNames.CasSignIn,
+				})
+			}
 			onDismiss={() => navigation.goBack()}
 		>
 			{children}


### PR DESCRIPTION
## Why are you doing this?

Sign in buttons on the sign in modal were not correctly routing to the sign in screen. This PR updates the navigation function to route through the settings stack to the sign in screens