### PR TITLE
Beta app points to new backend stack

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import { defaultSettings } from './settings/defaults';
+import { isInBeta } from './release-stream';
+import { defaultSettings, newMobileProdStack } from './settings/defaults';
 
 /**
  * History of Consent Management
@@ -118,13 +119,18 @@ const unsanitize = (value: string): UnsanitizedSetting => {
 
 export const getSetting = <S extends keyof Settings>(
 	setting: S,
-): Promise<Settings[S]> =>
-	AsyncStorage.getItem(SETTINGS_KEY_PREFIX + setting).then((item) => {
+): Promise<Settings[S]> => {
+	return AsyncStorage.getItem(SETTINGS_KEY_PREFIX + setting).then((item) => {
 		if (!item) {
 			return defaultSettings[setting];
 		}
+
+		if (isInBeta() && setting == 'apiUrl') {
+			return newMobileProdStack as Settings[S];
+		}
 		return unsanitize(item) as Settings[S];
 	});
+};
 
 export const storeSetting = (
 	setting: keyof Settings,

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -1,6 +1,9 @@
 import { Platform } from 'react-native';
 import type { Settings } from '../settings';
 
+export const newMobileProdStack =
+	'https://editions-published-prod.s3-eu-west-1.amazonaws.com/';
+
 /*
 Default settings.
 This is a bit of a mess
@@ -43,7 +46,7 @@ export const backends = [
 	},
 	{
 		title: '(MOBILE) PROD published',
-		value: 'https://editions-published-prod.s3-eu-west-1.amazonaws.com/',
+		value: newMobileProdStack,
 		preview: false,
 	},
 	{


### PR DESCRIPTION
## Why are you doing this?
The new backend stack (under mobile aws account) is running in parallel to the current stack. To test the backward compatibility properly against the new stack with the wider audience we can use our beta users who will use the new backend stack with existing apps. This PR just does that.

## Testing Plan
We can push this change to the beta users for the backward compatibility test, meaning they will have app as it it but will use new backend stack. If something goes wrong we can roll back this change and release another beta. If all goes well we will still roll back this change so that it does not go to prod users. For prod users we will make the api url change by `fastly` config.

## Changes

- Change the apiUrl if a user is in beta

