### PR TITLE
Fix:  add patch to podfile for images in iOS 14

### DIFF
--- a/projects/Mallard/ios/Podfile
+++ b/projects/Mallard/ios/Podfile
@@ -44,6 +44,25 @@ target 'Mallard' do
 
     pod 'RNSentry', :path => '../node_modules/@sentry/react-native'
 
+    # A known bug in current RN (61.5) with ios14 - https://github.com/facebook/react-native/issues/29279
+    post_install do |installer|
+      find_and_replace("../node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m",
+      "_currentFrame.CGImage;","_currentFrame.CGImage ;} else { [super displayLayer:layer];")
+    end
+    
+    def find_and_replace(dir, findstr, replacestr)
+      Dir[dir].each do |name|
+          text = File.read(name)
+          replace = text.gsub(findstr,replacestr)
+          if text != replace
+              puts "Fix: " + name
+              File.open(name, "w") { |file| file.puts replace }
+              STDOUT.flush
+          end
+      end
+      Dir[dir + '*/'].each(&method(:find_and_replace))
+    end
+    
   # permisions
   permissions_path = '../node_modules/react-native-permissions/ios'
   pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse.podspec"


### PR DESCRIPTION
## Why are you doing this?

This PR re-implements a patch previously introduced [here](https://github.com/guardian/editions/pull/1755) to show images when using React-Native@0.61.5 and iOS 14 sdk with Xcode 12 