### PR TITLE
Issue list is 100% of height

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -68,6 +68,7 @@ const styles = StyleSheet.create({
 		marginTop: metrics.vertical * 2,
 	},
 	issueList: {
+		height: Dimensions.get('window').height,
 		paddingTop: 0,
 		backgroundColor: color.dimBackground,
 	},


### PR DESCRIPTION
## Why are you doing this?

Make issue picker have full height of device screen. 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/118457432-a665e000-b6f1-11eb-840c-28133a6aca4b.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/118457436-a6fe7680-b6f1-11eb-9246-42906ab26214.png" width="300px" /> |
