### PR TITLE
updated rn-device-info library

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -77,7 +77,7 @@
         "react-native": "0.61.5",
         "react-native-background-fetch": "^2.7.1",
         "react-native-config": "^1.4.2",
-        "react-native-device-info": "^5.3.0",
+        "react-native-device-info": "^8.0.2",
         "react-native-fs": "^2.16.6",
         "react-native-gesture-handler": "^1.9.0",
         "react-native-htmlview": "^0.15.0",

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -125,7 +125,7 @@ Privacy settings: ${gdprEntries
 		.join(' ')}
 Editions Data Folder Size: ${bytes}B / ${kilobytes}KB / ${megabytes}MB / ${gigabytes}GB
 Total Disk Space (Mb): ${bytesToMb(totalDiskCapacity)}
-Available Disk Spce (Mb): ${bytesToMb(freeDiskStorage)}
+Available Disk Space (Mb): ${bytesToMb(freeDiskStorage)}
 Issues on device: ${fileList && JSON.stringify(fileList, null, 2)}
 
 -User / Supporter Info-

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -12417,10 +12417,10 @@ react-native-config@^1.4.2:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.2.tgz#cc39f22ed72c5cb06af1adf0ba70ef01593900b4"
   integrity sha512-iTvCvThvFTH7SdiBcsxYtpLy86zglsh51ZBqFPPZ75tdrQMdlRnDNnb86kNjQf03KT0qs1nCMLRejfPMIim8iA==
 
-react-native-device-info@^5.3.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.3.1.tgz#d764732c4841b6b6c2f42516e8840075717ea88a"
-  integrity sha512-e/fRDoah+HxItscOJTGJY8zyVKmBUdf53VWIDGLGV4VVZ0mfzIQ2uo0ULGri0vjGUYqgyqgnW3jybPSznMxKcA==
+react-native-device-info@^8.0.2:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.1.3.tgz#022fc01372632bf80c0a6d201aab53344efc715f"
+  integrity sha512-73e3wiGFL8DvIXEd8x4Aq+mO8mZvHARwfYorIEu+X0trLHY92bP5Ict8DJHDjCQ0+HtAvpA4Wda2VoUVN1zh6Q==
 
 react-native-fs@^2.16.6:
   version "2.16.6"


### PR DESCRIPTION
## Why are you doing this?
This PR updated `react-native-device-info` library that fixes some issues for android, especially around getting disk statistics

For example, it was reporting these stats for android:
Total Disk Space (Mb): 4556
Available Disk Space (Mb): 85537

Which is now fixed by this latest library
