### PR TITLE
fix: Force beta users to use new stack

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -121,12 +121,14 @@ export const getSetting = <S extends keyof Settings>(
 	setting: S,
 ): Promise<Settings[S]> => {
 	return AsyncStorage.getItem(SETTINGS_KEY_PREFIX + setting).then((item) => {
-		if (!item) {
-			return defaultSettings[setting];
-		}
-
+		// TODO - to test our new edition stack we are forcing beta users to use
+		// the new stack. Need to remove this once new stack is fully in operation
+		// and fastly config change has been made so it points to the new mobile stack
 		if (isInBeta() && setting == 'apiUrl') {
 			return newMobileProdStack as Settings[S];
+		}
+		if (!item) {
+			return defaultSettings[setting];
 		}
 		return unsanitize(item) as Settings[S];
 	});


### PR DESCRIPTION
## Why are you doing this?
A small change was removed by one of the PR related to the ios14 upgrade. This PR brings it back which just change the order of logic to make sure beta users always use the new backend stack
