### PR TITLE
Updated default apiUrl

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -121,6 +121,10 @@ export const getSetting = <S extends keyof Settings>(
 	setting: S,
 ): Promise<Settings[S]> => {
 	return AsyncStorage.getItem(SETTINGS_KEY_PREFIX + setting).then((item) => {
+		// TODO - remove this force apiUrl logic before ER work goes production users
+		if (setting == 'apiUrl') {
+			return newMobileProdStack as Settings[S];
+		}
 		if (!item) {
 			return defaultSettings[setting];
 		}

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import { isInBeta } from './release-stream';
 import { defaultSettings, newMobileProdStack } from './settings/defaults';
 
 /**
@@ -81,8 +80,6 @@ export interface DevSettings {
 	issuesPath: string;
 	senderId: string;
 	logging: string;
-	appsRenderingService: string;
-	isAppsRendering: boolean;
 }
 
 interface UserSettings {

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -156,14 +156,11 @@ export const defaultSettings: Settings = {
 	senderId: __DEV__ ? senderId.code : senderId.prod,
 	isWeatherShown: true,
 	wifiOnlyDownloads: false,
-	isAppsRendering: false,
 	maxAvailableEditions: 7,
 	websiteUrl: 'https://www.theguardian.com/',
 	logging: __DEV__
 		? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
 		: 'https://editions-logging.guardianapis.com/log/mallard',
-	// this currently points exclusively to PROD so that we don't require a VPN to access the endpoint.
-	appsRenderingService: appsRenderingService.prod,
 };
 
 export const editionsEndpoint = (apiUrl: Settings['apiUrl']): string =>

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -10,6 +10,11 @@ This is a bit of a mess
 */
 export const backends = [
 	{
+		title: 'PROD published (mobile)',
+		value: newMobileProdStack,
+		preview: false,
+	},
+	{
 		title: 'PROD published',
 		value: 'https://editions.guardianapis.com/',
 		preview: false,
@@ -48,11 +53,6 @@ export const backends = [
 		title: 'CODE preview',
 		value: 'https://preview.editions.code.dev-guardianapis.com/',
 		preview: true,
-	},
-	{
-		title: 'PROD published (mobile)',
-		value: 'https://editions-published-prod.s3-eu-west-1.amazonaws.com/',
-		preview: false,
 	},
 	{
 		title: 'CODE proofed (mobile)',

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -151,7 +151,6 @@ export const Settings = {
 	termsAndConditions: 'Terms and conditions',
 	version: 'Version',
 	betaProgrammeFAQs: 'Beta Programme FAQs',
-	isAppsRendering: 'Show Articles from Editions Rendering',
 };
 
 export const ManageDownloads = {

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -1,13 +1,11 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Dimensions, Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
-import { getSetting, storeSetting } from 'src/helpers/settings';
 import { notificationsEnabledCache } from 'src/helpers/storage';
 import { errorService } from 'src/services/errors';
 import { Breakpoints } from 'src/theme/breakpoints';
 
 const oneGB = 1073741824;
-const IS_APPS_RENDERING = 'isAppsRendering';
 
 interface ConfigState {
 	largeDeviceMemeory: boolean;
@@ -58,12 +56,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	const [notificationsEnabled, setNotificationsEnabled] = useState(
 		notificationInitialState(),
 	);
-	const [isAppsRendering, setIsAppsRendering] = useState(false);
-
-	const storeisAppsRendering = async (setting: boolean) => {
-		await storeSetting(IS_APPS_RENDERING, setting);
-		setIsAppsRendering(setting);
-	};
 
 	const setNotifications = async (setting: boolean) => {
 		try {
@@ -118,12 +110,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 		};
 	}, []);
 
-	useEffect(() => {
-		getSetting(IS_APPS_RENDERING).then((result) => {
-			setIsAppsRendering(result);
-		});
-	}, []);
-
 	return (
 		<ConfigContext.Provider
 			value={{
@@ -131,8 +117,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 				dimensions,
 				notificationsEnabled,
 				setNotifications,
-				isAppsRendering,
-				storeisAppsRendering,
 			}}
 		>
 			{children}

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -19,8 +19,6 @@ interface ConfigState {
 	};
 	notificationsEnabled: boolean;
 	setNotifications: (setting: boolean) => Promise<void>;
-	isAppsRendering: boolean;
-	storeisAppsRendering: (setting: boolean) => void;
 }
 
 const notificationInitialState = () =>
@@ -36,8 +34,6 @@ const initialState: ConfigState = {
 	},
 	notificationsEnabled: notificationInitialState(),
 	setNotifications: () => Promise.resolve(),
-	isAppsRendering: false,
-	storeisAppsRendering: () => {},
 };
 
 const ConfigContext = createContext(initialState);
@@ -152,9 +148,4 @@ export const useDimensions = () => useContext(ConfigContext).dimensions;
 export const useNotificationsEnabled = () => ({
 	notificationsEnabled: useContext(ConfigContext).notificationsEnabled,
 	setNotifications: useContext(ConfigContext).setNotifications,
-});
-
-export const useIsAppsRendering = () => ({
-	isAppsRendering: useContext(ConfigContext).isAppsRendering,
-	setIsAppsRendering: useContext(ConfigContext).storeisAppsRendering,
 });

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -12,7 +12,6 @@ import {
 } from 'src/hooks/use-article';
 import { useArticleResponse } from 'src/hooks/use-issue';
 import { useIsPreview } from 'src/hooks/use-settings';
-import { useToast } from 'src/hooks/use-toast';
 import type { PathToArticle } from 'src/paths';
 import { color } from 'src/theme/color';
 
@@ -51,7 +50,6 @@ const ArticleScreenBody = React.memo<
 			[onIsAtTopChange],
 		);
 
-		const { showToast } = useToast();
 		// First time it's mounted, we make sure to report we're at the top.
 		useEffect(() => handleIsAtTopChange(true), []);
 		return (

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -10,7 +10,6 @@ import {
 	getCollectionPillarOverride,
 	WithArticle,
 } from 'src/hooks/use-article';
-import { useIsAppsRendering } from 'src/hooks/use-config-provider';
 import { useArticleResponse } from 'src/hooks/use-issue';
 import { useIsPreview } from 'src/hooks/use-settings';
 import { useToast } from 'src/hooks/use-toast';
@@ -52,13 +51,11 @@ const ArticleScreenBody = React.memo<
 			[onIsAtTopChange],
 		);
 
-		const { isAppsRendering } = useIsAppsRendering();
 		const { showToast } = useToast();
 		// First time it's mounted, we make sure to report we're at the top.
 		useEffect(() => handleIsAtTopChange(true), []);
 		return (
 			<View style={[styles.container, { width }]}>
-				{isAppsRendering && showToast('EDITIONS RENDERED CONTENT')}
 				{articleResponse({
 					error: ({ message }) => (
 						<FlexErrorMessage

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -24,9 +24,7 @@ import {
 	pushRegisteredTokens,
 	showAllEditionsCache,
 } from 'src/helpers/storage';
-import { Copy } from 'src/helpers/words';
 import { useQuery } from 'src/hooks/apollo';
-import { useIsAppsRendering } from 'src/hooks/use-config-provider';
 import { useEditions } from 'src/hooks/use-edition-provider';
 import { useNetInfo } from 'src/hooks/use-net-info';
 import { useToast } from 'src/hooks/use-toast';
@@ -84,7 +82,6 @@ const DevZone = () => {
 	const [imageSize, setImageSize] = useState('fetching...');
 	const [pushTokens, setPushTokens] = useState('fetching...');
 	const [downloadedIssues, setDownloadedIssues] = useState('fetching...');
-	const { isAppsRendering, setIsAppsRendering } = useIsAppsRendering();
 
 	// initialise local showAllEditions property
 	useEffect(() => {
@@ -215,21 +212,6 @@ const DevZone = () => {
 			</ButtonList>
 			<List
 				data={[
-					{
-						key: 'isAppsRendering',
-						title: Copy.settings.isAppsRendering,
-						proxy: (
-							<Switch
-								accessible={true}
-								accessibilityLabel={
-									Copy.settings.isAppsRendering
-								}
-								accessibilityRole="switch"
-								value={isAppsRendering}
-								onValueChange={setIsAppsRendering}
-							/>
-						),
-					},
 					{
 						key: 'Endpoints',
 						title: 'API Endpoint',


### PR DESCRIPTION
## Why are you doing this?
To make testing easier we are changing the default apiUrl so it points new stack and also a first option in the duck menu.

Also, removed some custom logic that determined where an article using ER or not because all article now use ER going forward.
