### PR TITLE
Turned off schedule beta from github action

### DIFF
--- a/.github/workflows/scheduled-ios-beta.yml
+++ b/.github/workflows/scheduled-ios-beta.yml
@@ -3,9 +3,9 @@ name: scheduled-ios-beta
 on:
     workflow_dispatch:
     deployment:
-    schedule:
-        # * is a special character in YAML so you have to quote this string
-        - cron: '0 14 * * 1-5' # every day at 2pm
+    # schedule:
+    # * is a special character in YAML so you have to quote this string
+    # - cron: '0 14 * * 1-5' # every day at 2pm
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Why are you doing this?
To facilitate ER testing (mega-pr) with internal beta users we are turning off automatic internal beta release from github action that build and deploy from `master` branch. 

