### PR TITLE
Force beta users to use new stack but respect changes from the duck menu

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -30,6 +30,10 @@ import { prepareAndDownloadTodaysIssue } from './download-edition/prepare-and-do
 import { prepFileSystem } from './helpers/files';
 import { nestProviders } from './helpers/provider';
 import { pushDownloadFailsafe } from './helpers/push-download-failsafe';
+import { isInBeta } from './helpers/release-stream';
+import { newMobileProdStack } from './helpers/settings/defaults';
+import { setApiUrl } from './helpers/settings/setters';
+import { newApiUrlSetForBetaUsers } from './helpers/storage';
 import { EditionProvider } from './hooks/use-edition-provider';
 import { SettingsOverlayProvider } from './hooks/use-settings-overlay';
 import { ToastProvider } from './hooks/use-toast';
@@ -82,6 +86,20 @@ const shouldHavePushFailsafe = async (client: ApolloClient<object>) => {
 	}
 };
 
+const forceUpdateApiUrlIfBeta = async () => {
+	if (isInBeta()) {
+		const betaApiHasSetAlready = await newApiUrlSetForBetaUsers.get()
+		if(!betaApiHasSetAlready) {
+			setApiUrl(apolloClient, newMobileProdStack)
+			console.log('*** Beta: updated api url for BETA Users ***')
+			await newApiUrlSetForBetaUsers.set(true)
+		}
+		else {
+			console.log('*** Beta: api url for Beta users already updated ***')
+		}
+	}
+}
+
 export default class App extends React.Component {
 	componentDidMount() {
 		SplashScreen.hide();
@@ -93,6 +111,7 @@ export default class App extends React.Component {
 			if (appState === 'active') {
 				prepareAndDownloadTodaysIssue(apolloClient);
 				loggingService.postLogs();
+				forceUpdateApiUrlIfBeta();
 			}
 		});
 

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -87,6 +87,8 @@ const shouldHavePushFailsafe = async (client: ApolloClient<object>) => {
 };
 
 const forceUpdateApiUrlIfBeta = async () => {
+	// TODO - to test our new edition stack we are forcing beta users to use
+	// the new stack. Need to remove this once new stack is fully in operation.
 	if (isInBeta()) {
 		const betaApiHasSetAlready = await newApiUrlSetForBetaUsers.get()
 		if(!betaApiHasSetAlready) {

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -121,12 +121,6 @@ export const getSetting = <S extends keyof Settings>(
 	setting: S,
 ): Promise<Settings[S]> => {
 	return AsyncStorage.getItem(SETTINGS_KEY_PREFIX + setting).then((item) => {
-		// TODO - to test our new edition stack we are forcing beta users to use
-		// the new stack. Need to remove this once new stack is fully in operation
-		// and fastly config change has been made so it points to the new mobile stack
-		if (isInBeta() && setting == 'apiUrl') {
-			return newMobileProdStack as Settings[S];
-		}
 		if (!item) {
 			return defaultSettings[setting];
 		}

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -96,6 +96,10 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
 	'notificationsEnabled',
 );
 
+const newApiUrlSetForBetaUsers = createAsyncCache<boolean>(
+	'newApiUrlSetForBeta',
+);
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -164,6 +168,7 @@ export {
 	editionsListCache,
 	pushRegisteredTokens,
 	notificationsEnabledCache,
+	newApiUrlSetForBetaUsers,
 	showAllEditionsCache,
 	seenEditionsCache,
 };


### PR DESCRIPTION
## Why are you doing this?
As it says on the tin. Our production team needs to work with multiple api environment and those changes needs to persist. Previously it was always forcing beta users to use new stack and this PR fixed that issue.

