### PR TITLE
Handled error while reading file stats

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -304,8 +304,8 @@ PODS:
     - React
   - RNCPushNotificationIOS (1.2.2):
     - React
-  - RNDeviceInfo (5.3.1):
-    - React
+  - RNDeviceInfo (8.1.3):
+    - React-Core
   - RNFBApp (10.8.1):
     - Firebase/CoreOnly (~> 7.6.0)
     - React-Core
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 2e2e3feb9bdadc752a026703d8c4065ca912e75a
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: 4c97a36dbec42dba411cc35e6dac25e34a805fde
-  RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
+  RNDeviceInfo: 8d3a29207835f972bce883723882980143270d55
   RNFBApp: 02bde3edecf2e9694b908a5d3504e03449980f20
   RNFBCrashlytics: 0e6347d4e2251c6656b43ce8544662d1bac7deff
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -304,8 +304,8 @@ PODS:
     - React
   - RNCPushNotificationIOS (1.2.2):
     - React
-  - RNDeviceInfo (8.1.3):
-    - React-Core
+  - RNDeviceInfo (5.3.1):
+    - React
   - RNFBApp (10.8.1):
     - Firebase/CoreOnly (~> 7.6.0)
     - React-Core
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 2e2e3feb9bdadc752a026703d8c4065ca912e75a
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: 4c97a36dbec42dba411cc35e6dac25e34a805fde
-  RNDeviceInfo: 8d3a29207835f972bce883723882980143270d55
+  RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
   RNFBApp: 02bde3edecf2e9694b908a5d3504e03449980f20
   RNFBCrashlytics: 0e6347d4e2251c6656b43ce8544662d1bac7deff
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -279,11 +279,15 @@ export const getFileList = async () => {
 				file.name === 'media'
 					? `${file.path}/${imageSize}/media`
 					: `${file.path}/${imageSize}/thumb/media`,
-			).then((filestat) =>
-				filestat
-					.map((deepfile) => cleanFileDisplay(deepfile))
-					.slice(0, 1),
-			);
+			)
+				.then((filestat) =>
+					filestat
+						.map((deepfile) => cleanFileDisplay(deepfile))
+						.slice(0, 1),
+				)
+				.catch((e) => {
+					console.error(e);
+				});
 		}),
 	);
 


### PR DESCRIPTION
## Why are you doing this?

Clipboard copy functionality stopped working for some users because we had an incorrect image folder structure for some Issues. The bug has been rectified on the server-side and users (in beta) who downloaded those Issues with incorrect image folder structure having issues with copying diagnostic info. This is because diagnostic info tries to create stats from the image folders. This is a temp solution for those users, it now handles the error gracefully when the folder is missing or does not match the path.
