### PR TITLE
LIVE-2583: adjust breakpoints

### DIFF
--- a/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
+++ b/projects/Mallard/src/screens/article/slider/SliderTitle.tsx
@@ -54,7 +54,7 @@ const styles = (color: string, location: string) => {
 	return StyleSheet.create({
 		container: {
 			paddingLeft: location === 'front' ? 10 : 0,
-			maxWidth: location === 'article' ? 800 : undefined,
+			maxWidth: location === 'article' ? 740 : undefined,
 			width: '100%',
 			alignSelf: 'center',
 		},

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.spec.tsx.snap
@@ -93,7 +93,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -182,7 +182,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -258,7 +258,7 @@ exports[`SliderTitle - iOS - Mobile should display an Article SliderTitle with t
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -511,7 +511,7 @@ exports[`SliderTitle - iOS - Mobile should display an default SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -599,7 +599,7 @@ exports[`SliderTitle - iOS - Mobile should display no dots when numOfItems is 1 
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }

--- a/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.tablet.spec.tsx.snap
+++ b/projects/Mallard/src/screens/article/slider/__tests__/__snapshots__/SliderTitle.tablet.spec.tsx.snap
@@ -23,8 +23,8 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 38,
-          "lineHeight": 42,
+          "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -35,8 +35,8 @@ exports[`SliderTitle - iOS - Tablet should display a Front SliderTitle with the 
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 38,
-          "lineHeight": 42,
+          "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -93,7 +93,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -111,8 +111,8 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -123,8 +123,8 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -182,7 +182,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -200,8 +200,8 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -258,7 +258,7 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -276,8 +276,8 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -288,8 +288,8 @@ exports[`SliderTitle - iOS - Tablet should display an Article SliderTitle with t
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -364,8 +364,8 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 38,
-          "lineHeight": 42,
+          "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -376,8 +376,8 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 38,
-          "lineHeight": 42,
+          "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -453,8 +453,8 @@ exports[`SliderTitle - iOS - Tablet should display an Front SliderTitle with a s
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 38,
-          "lineHeight": 42,
+          "fontSize": 28,
+          "lineHeight": 32,
         }
       }
     >
@@ -511,7 +511,7 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -529,8 +529,8 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -541,8 +541,8 @@ exports[`SliderTitle - iOS - Tablet should display an default SliderTitle with a
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -599,7 +599,7 @@ exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 
   style={
     Object {
       "alignSelf": "center",
-      "maxWidth": 800,
+      "maxWidth": 740,
       "paddingLeft": 0,
       "width": "100%",
     }
@@ -617,8 +617,8 @@ exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 
         Object {
           "color": "#000000",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >
@@ -629,8 +629,8 @@ exports[`SliderTitle - iOS - Tablet should display no dots when numOfItems is 1 
         Object {
           "color": "grey",
           "fontFamily": "GTGuardianTitlepiece-Bold",
-          "fontSize": 30,
-          "lineHeight": 33,
+          "fontSize": 20,
+          "lineHeight": 22,
         }
       }
     >

--- a/projects/Mallard/src/theme/breakpoints.ts
+++ b/projects/Mallard/src/theme/breakpoints.ts
@@ -1,7 +1,7 @@
 export enum Breakpoints {
 	SmallPhone = 0,
 	Phone = 375,
-	TabletVertical = 690,
+	TabletVertical = 740,
 	TabletLandscape = 1000,
 }
 

--- a/projects/Mallard/src/theme/spacing.ts
+++ b/projects/Mallard/src/theme/spacing.ts
@@ -36,7 +36,7 @@ export const metrics = {
 	radius: 10,
 	article: {
 		sides,
-		maxWidth: 800,
+		maxWidth: 740,
 		rightRail: 180 + sides,
 		railPaddingLeft: sides * 1.5,
 		standfirstBottom: basicMetrics.vertical * 1.5,


### PR DESCRIPTION
## Why are you doing this?

On iPad Air, showcase header images had an incorrect left margin, which caused sports scores components to render off the left hand side of the window.

This PR moves the tablet breakpoint in line with Source (from 800px down to 740px) and changes the article max-width to fit with this. Old iPad Airs should now be classed as tablets.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/121897626-7cb4ce80-cd1a-11eb-855b-9385326136d9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/121897765-9d7d2400-cd1a-11eb-8747-58d91ea31de1.png" width="300px" /> |
| --- | --- |
| <img  src="https://user-images.githubusercontent.com/77005274/121898542-65c2ac00-cd1b-11eb-9f01-bbe5e05e3e03.png"  width="300px" /> | <img  src="https://user-images.githubusercontent.com/77005274/121898463-4f1c5500-cd1b-11eb-8cae-646a730a59ce.png" width="300px"  /> |


