### PR TITLE
Handle ER incompatible downloaded issues

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -34,7 +34,10 @@ import { pushDownloadFailsafe } from './helpers/push-download-failsafe';
 import { isInBeta } from './helpers/release-stream';
 import { newMobileProdStack } from './helpers/settings/defaults';
 import { setApiUrl } from './helpers/settings/setters';
-import { hasERMigrationOperationDone, newApiUrlSetForBetaUsers } from './helpers/storage';
+import {
+	hasERMigrationOperationDone,
+	newApiUrlSetForBetaUsers,
+} from './helpers/storage';
 import { EditionProvider } from './hooks/use-edition-provider';
 import { SettingsOverlayProvider } from './hooks/use-settings-overlay';
 import { ToastProvider } from './hooks/use-toast';
@@ -105,32 +108,30 @@ const deleteIssuesForERMigration = async (): Promise<boolean> => {
 	// TODO
 	// This is a migration function - can be safely removed once user migrated to
 	// the new version of the app.
-	if(await hasERMigrationOperationDone.get()) {
+	if (await hasERMigrationOperationDone.get()) {
 		console.log('ER migration operation already done.');
 		return false;
-	}
-	else {
+	} else {
 		await cleanNonERCompatibleDownloadedIssues();
 		await hasERMigrationOperationDone.set(true);
 		console.log('ER migration operation completed.');
 		return true;
 	}
-}
+};
 
 export default class App extends React.Component {
-	
 	componentDidMount() {
 		SplashScreen.hide();
 		prepareAndDownloadTodaysIssue(apolloClient);
 		shouldHavePushFailsafe(apolloClient);
 		forceUpdateApiUrlIfBeta();
-		deleteIssuesForERMigration()
+		deleteIssuesForERMigration();
 		loggingService.postLogs();
 
 		AppState.addEventListener('change', async (appState) => {
 			if (appState === 'active') {
 				prepareAndDownloadTodaysIssue(apolloClient);
-				loggingService.postLogs();				
+				loggingService.postLogs();
 			}
 		});
 

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -122,7 +122,7 @@ export const isIssueOnDevice = async (
 const withPathPrefix = (prefix: string) => (str: string) => `${prefix}/${str}`;
 
 export const getLocalIssues = async (editionSlug: string) => {
-	const editionDirectory = await FSPaths.editionDir(editionSlug);
+	const editionDirectory = FSPaths.editionDir(editionSlug);
 	return RNFS.readdir(editionDirectory).then((files) =>
 		files.map(withPathPrefix(editionSlug)),
 	);
@@ -142,8 +142,10 @@ export const getIssuesCountStrings = async () => {
 	return result;
 };
 
-export const getIssuesToDelete = async (files: string[]) => {
-	const maxAvailableEditions = await getSetting('maxAvailableEditions');
+export const getIssuesToDelete = async (
+	files: string[],
+	maxAvailableEditions: number,
+) => {
 	const totalIssues = files.length;
 
 	if (totalIssues <= maxAvailableEditions) {

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -129,10 +129,6 @@ const storeDetails = {
 	ios: 'itms-apps://itunes.apple.com/app/id452707806',
 	android: 'market://details?id=com.guardian.editions',
 };
-const appsRenderingService = {
-	prod: 'https://mobile.guardianapis.com/rendered-items/',
-	code: 'http://mobile.code.dev-guardianapis.com/rendered-items/',
-};
 
 export const defaultSettings: Settings = {
 	apiUrl,

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -100,6 +100,10 @@ const newApiUrlSetForBetaUsers = createAsyncCache<boolean>(
 	'newApiUrlSetForBeta',
 );
 
+const hasERMigrationOperationDone = createAsyncCache<boolean>(
+	'hasERMigrationOperationDone',
+);
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -169,6 +173,7 @@ export {
 	pushRegisteredTokens,
 	notificationsEnabledCache,
 	newApiUrlSetForBetaUsers,
+	hasERMigrationOperationDone,
 	showAllEditionsCache,
 	seenEditionsCache,
 };


### PR DESCRIPTION
## Why are you doing this?
This PR removes already downloaded issues that are incompatible with the ER and the new webview implementation. It does it silently at the moment. We need a bit more UI work to surface this to the users so they understand why and what to do.

Corresponding ticket: https://theguardian.atlassian.net/browse/LIVE-2584

## Changes

- Remove all the downloaded issues on update to the new version of the app, do it just once

## Screenshots
No UI changes