### PR TITLE
bump version number to 7.9

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -917,7 +917,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				KOTLIN_BUILD_TYPE = DEBUG;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.8;
+				MARKETING_VERSION = 7.9;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = "Guardian Editions";
@@ -949,7 +949,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				KOTLIN_BUILD_TYPE = RELEASE;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.8;
+				MARKETING_VERSION = 7.9;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = "Guardian Editions";


### PR DESCRIPTION
Following the release of iOS version 7.8, bump version number to 7.9