### PR TITLE
Download SSR compatible bundles in parallel

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -304,8 +304,8 @@ PODS:
     - React
   - RNCPushNotificationIOS (1.2.2):
     - React
-  - RNDeviceInfo (5.3.1):
-    - React
+  - RNDeviceInfo (8.1.3):
+    - React-Core
   - RNFBApp (10.8.1):
     - Firebase/CoreOnly (~> 7.6.0)
     - React-Core
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 2e2e3feb9bdadc752a026703d8c4065ca912e75a
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: 4c97a36dbec42dba411cc35e6dac25e34a805fde
-  RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c
+  RNDeviceInfo: 8d3a29207835f972bce883723882980143270d55
   RNFBApp: 02bde3edecf2e9694b908a5d3504e03449980f20
   RNFBCrashlytics: 0e6347d4e2251c6656b43ce8544662d1bac7deff
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba

--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -12,6 +12,7 @@ import { DownloadBlockedStatus } from 'src/hooks/use-net-info';
 import { pushTracking } from 'src/notifications/push-tracking';
 import { FSPaths } from 'src/paths';
 import { errorService } from 'src/services/errors';
+import { remoteConfigService } from 'src/services/remote-config';
 import type { ImageSize, IssueSummary } from '../../../Apps/common/src';
 import { Feature } from '../../../Apps/common/src/logging';
 import { deleteIssue } from './clear-issues-and-editions';
@@ -64,6 +65,49 @@ export const updateListeners = (localId: string, status: DLStatus) => {
 	listeners.forEach((listener) => listener(status));
 };
 
+const downloadSSRBundle = async (issue: IssueSummary, imageSize: ImageSize) => {
+	const { assets, localId } = issue;
+
+	if (assets) {
+		const htmlAssetPath = assets.data.replace('data.zip', 'ssr/html.zip');
+		const htmlDownloadResult = await downloadNamedIssueArchive({
+			localIssueId: localId,
+			assetPath: htmlAssetPath,
+			filename: 'ssr-html.zip',
+			withProgress: false,
+		});
+		console.log(
+			`SSR html.zip download completed with status:${htmlDownloadResult.statusCode}`,
+		);
+		await unzipNamedIssueArchive(
+			`${FSPaths.downloadIssueLocation(localId)}/ssr-html.zip`,
+		);
+		console.log('SSR html unzipped');
+
+		const originalImgAsset = assets[imageSize] as string;
+		const ssrImgPath = originalImgAsset.replace(
+			`${imageSize}.zip`,
+			`ssr/${imageSize}.zip`,
+		);
+		const downloadSSRImgFileName = `ssr-${imageSize}.zip`;
+		const dlSSRImg = await downloadNamedIssueArchive({
+			localIssueId: localId,
+			assetPath: ssrImgPath,
+			filename: downloadSSRImgFileName,
+			withProgress: false,
+		});
+		console.log(
+			`SSR image download completed with status: ${dlSSRImg.statusCode}`,
+		);
+		await unzipNamedIssueArchive(
+			`${FSPaths.downloadIssueLocation(
+				localId,
+			)}/${downloadSSRImgFileName}`,
+		);
+		console.log('SSR image unzipped');
+	}
+};
+
 const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 	const { assets, localId } = issue;
 
@@ -79,13 +123,16 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 			Feature.DOWNLOAD,
 		);
 
+		const ssrBundleDownloadEnabled = remoteConfigService.getBoolean(
+			'download_parallel_ssr_bundle',
+		);
+
 		await retry(
 			async () => {
-				// We are not asking for progress update during Data bundle download (to avoid false visual completion)
-				// So, instead we are artificially triggering a small progress update to render some visual change
+				// To give a artificial visual indication move the progressbar a little
 				updateListeners(localId, {
 					type: 'download',
-					data: 0.5,
+					data: 1.0,
 				});
 				const dataDownloadResult = await downloadNamedIssueArchive({
 					localIssueId: localId,
@@ -94,21 +141,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					withProgress: false,
 				});
 				console.log(
-					`Data download completed with status:${dataDownloadResult.statusCode}`,
-				);
-
-				const htmlAssetPath = assets.data.replace(
-					'data.zip',
-					'ssr/html.zip',
-				);
-				const htmlDownloadResult = await downloadNamedIssueArchive({
-					localIssueId: localId,
-					assetPath: htmlAssetPath,
-					filename: 'ssr-html.zip',
-					withProgress: false,
-				});
-				console.log(
-					`Html download completed with status:${htmlDownloadResult.statusCode}`,
+					`data.zip download completed with status:${dataDownloadResult.statusCode}`,
 				);
 
 				await pushTracking(
@@ -116,6 +149,13 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					'completed',
 					Feature.DOWNLOAD,
 				);
+
+				if (ssrBundleDownloadEnabled) {
+					console.log('Parallel SSR bundle download is ENABLED');
+					await downloadSSRBundle(issue, imageSize);
+				} else {
+					console.log('Parallel SSR bundle download is DISABLED');
+				}
 
 				await pushTracking(
 					'attemptMediaDownload',
@@ -130,23 +170,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					withProgress: true,
 				});
 				console.log(
-					`Image download completed with status: ${dlImg.statusCode}`,
-				);
-
-				const originalImgAsset = assets[imageSize] as string;
-				const ssrImgPath = originalImgAsset.replace(
-					`${imageSize}.zip`,
-					`ssr/${imageSize}.zip`,
-				);
-				const downloadSSRImgFileName = `ssr-${imageSize}.zip`;
-				const dlSSRImg = await downloadNamedIssueArchive({
-					localIssueId: localId,
-					assetPath: ssrImgPath,
-					filename: downloadSSRImgFileName,
-					withProgress: true,
-				});
-				console.log(
-					`SSR Image download completed with status: ${dlSSRImg.statusCode}`,
+					`media.zip download completed with status: ${dlImg.statusCode}`,
 				);
 
 				await pushTracking(
@@ -165,11 +189,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 				await unzipNamedIssueArchive(
 					`${FSPaths.downloadIssueLocation(localId)}/data.zip`,
 				);
-
-				await unzipNamedIssueArchive(
-					`${FSPaths.downloadIssueLocation(localId)}/ssr-html.zip`,
-				);
-				console.log('SSR html unzipped');
+				console.log('data.zip unzipped');
 
 				await pushTracking('unzipData', 'end', Feature.DOWNLOAD);
 
@@ -178,12 +198,7 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 				await unzipNamedIssueArchive(
 					`${FSPaths.downloadIssueLocation(localId)}/media.zip`,
 				);
-				await unzipNamedIssueArchive(
-					`${FSPaths.downloadIssueLocation(
-						localId,
-					)}/${downloadSSRImgFileName}`,
-				);
-				console.log('SSR image unzipped');
+				console.log('media.zip unzipped');
 
 				await pushTracking('unzipImages', 'end', Feature.DOWNLOAD);
 

--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -97,6 +97,20 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					`Data download completed with status:${dataDownloadResult.statusCode}`,
 				);
 
+				const htmlAssetPath = assets.data.replace(
+					'data.zip',
+					'ssr/html.zip',
+				);
+				const htmlDownloadResult = await downloadNamedIssueArchive({
+					localIssueId: localId,
+					assetPath: htmlAssetPath,
+					filename: 'ssr-html.zip',
+					withProgress: false,
+				});
+				console.log(
+					`Html download completed with status:${htmlDownloadResult.statusCode}`,
+				);
+
 				await pushTracking(
 					'attemptDataDownload',
 					'completed',
@@ -119,6 +133,22 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					`Image download completed with status: ${dlImg.statusCode}`,
 				);
 
+				const originalImgAsset = assets[imageSize] as string;
+				const ssrImgPath = originalImgAsset.replace(
+					`${imageSize}.zip`,
+					`ssr/${imageSize}.zip`,
+				);
+				const downloadSSRImgFileName = `ssr-${imageSize}.zip`;
+				const dlSSRImg = await downloadNamedIssueArchive({
+					localIssueId: localId,
+					assetPath: ssrImgPath,
+					filename: downloadSSRImgFileName,
+					withProgress: true,
+				});
+				console.log(
+					`SSR Image download completed with status: ${dlSSRImg.statusCode}`,
+				);
+
 				await pushTracking(
 					'attemptMediaDownload',
 					'completed',
@@ -136,6 +166,11 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 					`${FSPaths.downloadIssueLocation(localId)}/data.zip`,
 				);
 
+				await unzipNamedIssueArchive(
+					`${FSPaths.downloadIssueLocation(localId)}/ssr-html.zip`,
+				);
+				console.log('SSR html unzipped');
+
 				await pushTracking('unzipData', 'end', Feature.DOWNLOAD);
 
 				await pushTracking('unzipImages', 'start', Feature.DOWNLOAD);
@@ -143,6 +178,12 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 				await unzipNamedIssueArchive(
 					`${FSPaths.downloadIssueLocation(localId)}/media.zip`,
 				);
+				await unzipNamedIssueArchive(
+					`${FSPaths.downloadIssueLocation(
+						localId,
+					)}/${downloadSSRImgFileName}`,
+				);
+				console.log('SSR image unzipped');
 
 				await pushTracking('unzipImages', 'end', Feature.DOWNLOAD);
 

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -62,9 +62,7 @@ export const downloadNamedIssueArchive = async ({
 }) => {
 	const apiUrl = await getSetting('apiUrl');
 	const zipUrl = `${apiUrl}${assetPath}`;
-	console.log('Zip url: ' + zipUrl);
 	const downloadFolderLocation = FSPaths.downloadIssueLocation(localIssueId);
-	console.log(`Download Path: ${downloadFolderLocation}/${filename}`);
 	await prepFileSystem();
 	await ensureDirExists(FSPaths.issueRoot(localIssueId));
 	await ensureDirExists(downloadFolderLocation);

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -62,7 +62,9 @@ export const downloadNamedIssueArchive = async ({
 }) => {
 	const apiUrl = await getSetting('apiUrl');
 	const zipUrl = `${apiUrl}${assetPath}`;
+	console.log('Zip url: ' + zipUrl);
 	const downloadFolderLocation = FSPaths.downloadIssueLocation(localIssueId);
+	console.log(`Download Path: ${downloadFolderLocation}/${filename}`);
 	await prepFileSystem();
 	await ensureDirExists(FSPaths.issueRoot(localIssueId));
 	await ensureDirExists(downloadFolderLocation);
@@ -101,6 +103,7 @@ export const unzipNamedIssueArchive = async (zipFilePath: string) => {
 	} catch (e) {
 		e.message = `${e.message} - zipFilePath: ${zipFilePath} - outputPath: ${outputPath}`;
 		errorService.captureException(e);
+		console.log('Unzip Error: ' + JSON.stringify(e));
 	}
 };
 

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -15,6 +15,7 @@ const remoteConfigDefaults = {
 	join_beta_button_enabled: false,
 	lightbox_enabled: true,
 	generate_share_url: true,
+	download_parallel_ssr_bundle: false,
 };
 
 export const RemoteConfigProperties = [
@@ -22,6 +23,7 @@ export const RemoteConfigProperties = [
 	'join_beta_button_enabled',
 	'lightbox_enabled',
 	'generate_share_url',
+	'download_parallel_ssr_bundle',
 ] as const;
 
 export type RemoteConfigProperty = typeof RemoteConfigProperties[number];


### PR DESCRIPTION
## Why are you doing this?
Problem:
The new version of the app that will be released in the future once the ER work is done can only render articles if they are rendered server-side (SSR) and has corresponding changes in the zip bundles (html and images). On the release of this new version of the app, users can download new Issues and read them without any problem. But all the existing downloaded Issues on the user's device will have no SSR content and the structure of the zip bundles will be incompatible with the new version of the app.

Solution:  
The app will download SSR compatible zip bundles in parallel to normal bundles and both versions of the content (html and images) will exist on the user device. As a result, when a user updates their app to the new version the downloaed Issues will work fine. To reduce the amount of duplicate bundle on the user's device and not take too much disk space we will run this parallel download operation just for 7 days before the new version of the app gets released.
  
Testing steps:
- Turn the remote switch on (download_parallel_ssr_bundle)
- Release a build from `master` to internal beta and download few Issues to the device
- Release a build from this PR branch to internal beta and make sure to update the app
- Make sure the device is offline (to be on the safe side) and check downloaded Issues are readable
- Turn the remote switch off once testing is done
