### PR TITLE
Article overrides implementation

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -258,6 +258,13 @@ Don't really want to run this all the time, so it's calculated below.
     thumb: { phone: 158, tablet: 185, tabletL: 245, tabletXL: 285 },
     'thumb-large': { phone: 225, tablet: 385, tabletL: 510, tabletXL: 605 },
 }
+
+export interface RenderedArticle {
+    success: boolean
+    message: string
+    internalPageCode: number
+    body: string
+}
 export interface IssueIdentifier {
     edition: EditionId
     issueDate: string

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -129,10 +129,6 @@ const storeDetails = {
 	ios: 'itms-apps://itunes.apple.com/app/id452707806',
 	android: 'market://details?id=com.guardian.editions',
 };
-const appsRenderingService = {
-	prod: 'https://mobile.guardianapis.com/rendered-items/',
-	code: 'http://mobile.code.dev-guardianapis.com/rendered-items/',
-};
 
 export const defaultSettings: Settings = {
 	apiUrl,

--- a/projects/archiver/src/tasks/front/helpers/render.ts
+++ b/projects/archiver/src/tasks/front/helpers/render.ts
@@ -1,6 +1,3 @@
-import { unnest } from 'ramda'
-import { Front } from '../../../../common'
-import { getRenderedContent } from '../../../utils/backend-client'
 import { getBucket, ONE_MONTH, upload } from '../../../utils/s3'
 
 // call render function in backend client, store result
@@ -8,27 +5,4 @@ import { getBucket, ONE_MONTH, upload } from '../../../utils/s3'
 export const uploadRenderedArticle = async (path: string, html: string) => {
     const Bucket = getBucket('proof')
     return upload(path, html, Bucket, 'text/html', ONE_MONTH)
-}
-
-/**
- * Loop through all the articles of Front object and fetch
- * server-side-redering (SSR) article content for each article
- * @param front
- */
-export const getSSRArticlesFromFront = async (front: Front) => {
-    const allCards = unnest(front.collections.map(_ => _.cards))
-    const content = unnest(allCards.map(_ => Object.values(_.articles)))
-    const renderedContent = await Promise.all(
-        content.map(async c => {
-            return {
-                internalPageCode: c.internalPageCode,
-                content: await getRenderedContent(
-                    c.internalPageCode,
-                    front.key,
-                ),
-            }
-        }),
-    )
-
-    return renderedContent
 }

--- a/projects/archiver/src/utils/backend-client.ts
+++ b/projects/archiver/src/utils/backend-client.ts
@@ -16,6 +16,7 @@ import {
     hasFailed,
     withFailureMessage,
 } from '../../../backend/utils/try'
+import { RenderedArticle } from '../../../Apps/common/src'
 
 export const URL =
     process.env.backend !== undefined
@@ -86,18 +87,17 @@ export const getEditions = async (): Promise<Attempt<EditionsList>> => {
     return maybeEditionsList
 }
 
-export const getRenderedContent = async (
-    internalPageCode: number,
-    frontName: string,
-): Promise<Attempt<string>> => {
-    const path = `${URL}render/${internalPageCode}?frontName=${frontName}`
-    console.log(`Attempting to fetch rendered html for ${path}`)
+export const getRenderedFront = async (
+    publishedId: string,
+    front: string,
+): Promise<Attempt<RenderedArticle[]>> => {
+    const path = `${URL}render/${frontPath(publishedId, front)}`
     const response = await fetch(path)
-    const maybeRenderedContent = await attempt(response.text())
-    if (hasFailed(maybeRenderedContent)) {
-        const failureMessage = `Failed to fetch html for ${path}`
-        console.error(failureMessage)
-        return withFailureMessage(maybeRenderedContent, failureMessage)
+    const renderedFront = await attempt(response.json() as Promise<
+        RenderedArticle[]
+    >)
+    if (hasFailed(renderedFront)) {
+        return renderedFront
     }
-    return maybeRenderedContent
+    return renderedFront
 }

--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -25,7 +25,7 @@ const testStubControllers: EditionsBackendControllers = {
     issueController: stub,
     frontController: stub,
     imageController: stub,
-    renderController: stub,
+    renderFrontController: stub,
     appsRenderingController: stub,
     editionsController: stubEditionController,
 }

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -14,7 +14,7 @@ export interface EditionsBackendControllers {
     issueController: (req: Request, res: Response) => void
     frontController: (req: Request, res: Response) => void
     imageController: (req: Request, res: Response) => void
-    renderController: (req: Request, res: Response) => void
+    renderFrontController: (req: Request, res: Response) => void
     appsRenderingController: (req: Request, res: Response) => void
     editionsController: {
         GET: (req: Request, res: Response) => void
@@ -60,7 +60,10 @@ export const createApp = (
         controllers.frontController,
     )
 
-    app.get('/render/:internalPageCode', controllers.renderController)
+    app.get(
+        '/render/' + frontPath(issuePathSegments, '*?'),
+        controllers.renderFrontController,
+    )
 
     app.get('/rendered-items/:path(*)', controllers.appsRenderingController)
 

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -5,7 +5,7 @@ import { Handler } from 'aws-lambda'
 import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController } from './controllers/image'
-import { renderController } from './controllers/render'
+import { renderFrontController } from './controllers/render'
 import { appsRenderingController } from './controllers/appsRendering'
 import {
     editionsControllerGet,
@@ -19,7 +19,7 @@ const runtimeControllers: EditionsBackendControllers = {
     issueController,
     frontController,
     imageController,
-    renderController,
+    renderFrontController,
     appsRenderingController,
     editionsController: {
         GET: editionsControllerGet,

--- a/projects/backend/fronts.ts
+++ b/projects/backend/fronts.ts
@@ -292,7 +292,7 @@ const getDisplayName = (front: string) => {
     return split.charAt(0).toUpperCase() + split.slice(1)
 }
 
-const fetchPublishedIssue = async (
+export const fetchPublishedIssue = async (
     issue: IssuePublicationIdentifier,
     frontId: string,
     lastModifiedUpdater: LastModifiedUpdater,


### PR DESCRIPTION
Implemented rendered front where backend returns a fully rendered version of a front to archiver.

## Why are you doing this?
Currently, when we render an article using ER it does not take into account any overrides in the fronts tool. This PR introduces a new endpoint in the backend that takes front metadata as input and returns a fully rendered version of each and every article within the front. This helps archiver lambda to process them in one go rather than making an individual request for every single article.


