### PR TITLE
Live 2717 map trailtext to standfirst

### DIFF
--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -131,6 +131,8 @@ const mapFurnitureToContent = (
     const byline = furniture.showByline
         ? oc(furniture).bylineOverride() || oc(content).fields.byline()
         : ''
+    const standfirst =
+        oc(furniture).trailTextOverride() || oc(content).fields.standfirst()
     return {
         ...content,
         tags: furniture.kicker ? getTags(furniture.kicker) : content.tags,
@@ -138,7 +140,7 @@ const mapFurnitureToContent = (
             ...content.fields,
             headline,
             byline,
-            trailText: oc(furniture).trailTextOverride() || '',
+            standfirst,
         },
     }
 }


### PR DESCRIPTION
## Why are you doing this?

Currently `trailtext` overrides from the Fronts too are not being displayed in Editions Rendering. To resolve this we map the `trailtextOverride` field to `content.fields.standfirst`. If `trailTextOverride` is empty then we render the standfirst as usual.


## Screenshots

No UI changes.