### PR TITLE
Live 2732 momentum scrolling

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -329,6 +329,7 @@ const Article = ({
 				onMessage={(event) => {
 					handlePing(event.nativeEvent.data);
 				}}
+				decelerationRate={'normal'}
 			/>
 		</Fader>
 	);


### PR DESCRIPTION
## Why are you doing this?
The new webview doesn't have momentum style scrolling out of the box. This PR makes use of the `decelerationRate` prop. This gives the WebView the same "momentum" style scrolling as other iOS views.


| Before |

https://user-images.githubusercontent.com/20416599/124481852-a5bc0280-dda0-11eb-8306-20b7961976a4.mov


| After |

https://user-images.githubusercontent.com/20416599/124487421-9b9d0280-dda6-11eb-9b53-d0eb0860ef70.mov

