### PR TITLE
Clean api urls

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -92,7 +92,7 @@ const forceUpdateApiUrlIfBeta = async () => {
 		const rollbackedApi = await rollbackedApiUrlForBetaUsers.get();
 		if (!rollbackedApi) {
 			setApiUrl(apolloClient, newMobileProdStack);
-			console.log('*** Beta: fastly config is done, all beta users now rollback to default prod api url, previously it was a custom url ***');
+			console.log('*** Beta: rolling back to default prod api url ***');
 			await rollbackedApiUrlForBetaUsers.set(true);
 		} else {
 			console.log('*** Beta: api url for Beta users already updated ***');

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -88,6 +88,8 @@ const shouldHavePushFailsafe = async (client: ApolloClient<object>) => {
 
 const forceUpdateApiUrlIfBeta = async () => {
 	// TODO - Remove this whole function before release to prod.
+	// Previously we forced beta users to use a tmp url to point to the new stack, now that
+	// we changed the fastly config we can rollback urls and eventually we can remove this full method.
 	if (isInBeta()) {
 		const rollbackedApi = await rollbackedApiUrlForBetaUsers.get();
 		if (!rollbackedApi) {

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -33,7 +33,7 @@ import { pushDownloadFailsafe } from './helpers/push-download-failsafe';
 import { isInBeta } from './helpers/release-stream';
 import { newMobileProdStack } from './helpers/settings/defaults';
 import { setApiUrl } from './helpers/settings/setters';
-import { newApiUrlSetForBetaUsers } from './helpers/storage';
+import { rollbackedApiUrlForBetaUsers } from './helpers/storage';
 import { EditionProvider } from './hooks/use-edition-provider';
 import { SettingsOverlayProvider } from './hooks/use-settings-overlay';
 import { ToastProvider } from './hooks/use-toast';
@@ -87,13 +87,13 @@ const shouldHavePushFailsafe = async (client: ApolloClient<object>) => {
 };
 
 const forceUpdateApiUrlIfBeta = async () => {
-	// TODO - Remove this whole function once new stack is fully in operation.
+	// TODO - Remove this whole function before release to prod.
 	if (isInBeta()) {
-		const betaApiHasSetAlready = await newApiUrlSetForBetaUsers.get();
-		if (!betaApiHasSetAlready) {
+		const rollbackedApi = await rollbackedApiUrlForBetaUsers.get();
+		if (!rollbackedApi) {
 			setApiUrl(apolloClient, newMobileProdStack);
-			console.log('*** Beta: updated api url for BETA Users ***');
-			await newApiUrlSetForBetaUsers.set(true);
+			console.log('*** Beta: fastly config is done, all beta users now rollback to default prod api url, previously it was a custom url ***');
+			await rollbackedApiUrlForBetaUsers.set(true);
 		} else {
 			console.log('*** Beta: api url for Beta users already updated ***');
 		}

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -1,8 +1,7 @@
 import { Platform } from 'react-native';
 import type { Settings } from '../settings';
 
-export const newMobileProdStack =
-	'https://editions-published-prod.s3-eu-west-1.amazonaws.com/';
+export const newMobileProdStack = 'https://editions.guardianapis.com/';
 
 /*
 Default settings.
@@ -10,33 +9,8 @@ This is a bit of a mess
 */
 export const backends = [
 	{
-		title: 'PROD published (new stack)',
-		value: newMobileProdStack,
-		preview: false,
-	},
-	{
-		title: 'PROD proofed (new stack)',
-		value: 'https://editions-proofed-prod.s3-eu-west-1.amazonaws.com/',
-		preview: true,
-	},
-	{
-		title: 'CODE published (new stack)',
-		value: 'https://editions-published-code.s3-eu-west-1.amazonaws.com/',
-		preview: false,
-	},
-	{
-		title: 'CODE proofed (new stack)',
-		value: 'https://editions-proofed-code.s3-eu-west-1.amazonaws.com/',
-		preview: true,
-	},
-	{
-		title: 'CODE preview (new stack)',
-		value: 'https://preview.editions.code.dev-guardianapis.com/',
-		preview: true,
-	},
-	{
 		title: 'PROD published',
-		value: 'https://editions.guardianapis.com/',
+		value: newMobileProdStack,
 		preview: false,
 	},
 	{
@@ -46,7 +20,7 @@ export const backends = [
 	},
 	{
 		title: 'PROD preview',
-		value: 'https://preview.editions.guardianapis.com/',
+		value: 'https://editions-preview.guardianapis.com/',
 		preview: true,
 	},
 	{
@@ -61,7 +35,7 @@ export const backends = [
 	},
 	{
 		title: 'CODE preview',
-		value: 'https://preview.editions.code.dev-guardianapis.com/',
+		value: 'https://editions-preview.code.dev-guardianapis.com/',
 		preview: true,
 	},
 	{

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -96,8 +96,8 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
 	'notificationsEnabled',
 );
 
-const newApiUrlSetForBetaUsers = createAsyncCache<boolean>(
-	'newApiUrlSetForBeta',
+const rollbackedApiUrlForBetaUsers = createAsyncCache<boolean>(
+	'rollbackedApiUrlForBetaUsers',
 );
 
 /**
@@ -168,7 +168,7 @@ export {
 	editionsListCache,
 	pushRegisteredTokens,
 	notificationsEnabledCache,
-	newApiUrlSetForBetaUsers,
+	rollbackedApiUrlForBetaUsers,
 	showAllEditionsCache,
 	seenEditionsCache,
 };


### PR DESCRIPTION
## Why are you doing this?
We did an experiment with the new stack's API URL, now that we made the fastly config change and fastly now pointing to the new stack, we no longer need to keep two sets of API URLs. This PR removes those URLs and also roll back URL change for the beta user that we did for testing.