### PR TITLE
Fix: articles failed to load on android while offline

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -257,7 +257,7 @@ PODS:
     - React
   - react-native-viewpager (4.2.1):
     - React-Core
-  - react-native-webview (11.4.5):
+  - react-native-webview (11.6.5):
     - React-Core
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -585,7 +585,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-viewpager: 40876e00dbd7bcee4c627cf5a9640e6593a019b4
-  react-native-webview: 6d1d368c38edcc0a074bcc51a94ec8de700c241e
+  react-native-webview: 2e8fe70dc32b50d3231c23043f8e8b5a5525d346
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -97,7 +97,7 @@
         "react-native-splash-screen": "^3.2.0",
         "react-native-status-bar-height": "^2.4.0",
         "react-native-svg": "^9.12.0",
-        "react-native-webview": "^11.4.2",
+        "react-native-webview": "^11.6.5",
         "react-native-zip-archive": "5.0.1",
         "validator": "^11.1.0"
     },

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -17,7 +17,7 @@ import type {
 	Image,
 	PictureArticle,
 } from 'src/common';
-import { defaultSettings } from 'src/helpers/settings/defaults';
+import { defaultSettings, htmlEndpoint, isPreview } from 'src/helpers/settings/defaults';
 import { parsePing } from 'src/helpers/webview';
 import { useArticle } from 'src/hooks/use-article';
 import { selectImagePath } from 'src/hooks/use-image-paths';
@@ -186,6 +186,9 @@ const Article = ({
 	const [, { pillar }] = useArticle();
 	const apiUrl = useApiUrl() ?? '';
 	const { issueId } = useIssueSummary();
+	const { front, publishedIssueId } = path;
+	const htmlFolderInS3 = htmlEndpoint(apiUrl, publishedIssueId);
+	const previewParam = isPreview(apiUrl) ? `?frontId=${front}` : '';
 
 	// if webUrl is undefined then we attempt to fetch a url to use for sharing
 	const [shareUrl, setShareUrl] = useState(article.webUrl);
@@ -317,6 +320,8 @@ const Article = ({
 			<WebviewWithArticle
 				article={article}
 				path={path}
+				previewParam={previewParam}
+				htmlFolderInS3={htmlFolderInS3}
 				scrollEnabled={true}
 				allowsInlineMediaPlayback={true} // need this along with `mediaPlaybackRequiresUserAction = false` to ensure videos in twitter embeds play on iOS
 				mediaPlaybackRequiresUserAction={false}

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -17,7 +17,11 @@ import type {
 	Image,
 	PictureArticle,
 } from 'src/common';
-import { defaultSettings, htmlEndpoint, isPreview } from 'src/helpers/settings/defaults';
+import {
+	defaultSettings,
+	htmlEndpoint,
+	isPreview,
+} from 'src/helpers/settings/defaults';
 import { parsePing } from 'src/helpers/webview';
 import { useArticle } from 'src/hooks/use-article';
 import { selectImagePath } from 'src/hooks/use-image-paths';

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -44,7 +44,6 @@ const WebviewWithArticle = ({
 	// Online: Url to load direct from s3 (when bundle is not downloaded)
 	// When app runs in Preview Mode the url points to backend and backend needs to know
 	// which front the articles belongs to properly render an article with correct overrides from the fronts tool
-	// const previewParam = isPreviewMode ? `?frontId=${front}` : '';
 	let uri = `${htmlFolderInS3}/${article.internalPageCode}.html${previewParam}`;
 
 	// Offline/Downloaded: load from file system

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -29,18 +29,17 @@ const WebviewWithArticle = ({
 	_ref?: (ref: WebView) => void;
 	origin: IssueOrigin;
 } & WebViewProps & { onScroll?: any }) => {
-	const { localIssueId, front } = path;
+	const { localIssueId } = path;
 	const largeDeviceMemory = useLargeDeviceMemory();
 	const [isReady, setIsReady] = useState(false);
 
 	const updateSource = () => {
 		// On Android there is a potential race condition where url did get set before
 		// webview file system permission did get set and as result local html file fails to load
-		// within the webview. 
-		// Github issue: https://github.com/react-native-webview/react-native-webview/issues/656#issuecomment-551312436 
-		console.log('load started: ' + article.internalPageCode)
+		// within the webview.
+		// Github issue: https://github.com/react-native-webview/react-native-webview/issues/656#issuecomment-551312436
 		setIsReady(true);
-	 };
+	};
 
 	// Online: Url to load direct from s3 (when bundle is not downloaded)
 	// When app runs in Preview Mode the url points to backend and backend needs to know
@@ -70,9 +69,9 @@ const WebviewWithArticle = ({
 			allowFileAccess={true}
 			allowUniversalAccessFromFileURLs={true}
 			allowingReadAccessToURL={FSPaths.issuesDir}
-			onLoadStart={() => {				
+			onLoadStart={() => {
 				updateSource();
-			}}			
+			}}
 		/>
 	);
 };

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Platform, View } from 'react-native';
+import React, { useState } from 'react';
+import { Platform } from 'react-native';
 import type { WebViewProps } from 'react-native-webview';
 import { WebView } from 'react-native-webview';
 import type {
@@ -8,8 +8,6 @@ import type {
 	IssueOrigin,
 	PictureArticle,
 } from 'src/common';
-import { getSetting } from 'src/helpers/settings';
-import { htmlEndpoint, isPreview } from 'src/helpers/settings/defaults';
 import { useLargeDeviceMemory } from 'src/hooks/use-config-provider';
 import type { PathToArticle } from 'src/paths';
 import { FSPaths } from 'src/paths';
@@ -18,35 +16,37 @@ import { onShouldStartLoadWithRequest } from './helpers';
 const WebviewWithArticle = ({
 	article,
 	path,
+	previewParam,
+	htmlFolderInS3,
 	_ref,
 	origin,
 	...webViewProps
 }: {
 	article: Article | PictureArticle | GalleryArticle;
 	path: PathToArticle;
+	previewParam: string;
+	htmlFolderInS3: string;
 	_ref?: (ref: WebView) => void;
 	origin: IssueOrigin;
 } & WebViewProps & { onScroll?: any }) => {
 	const { localIssueId, front } = path;
 	const largeDeviceMemory = useLargeDeviceMemory();
 	const [isReady, setIsReady] = useState(false);
-	const [s3HtmlUrlPrefix, setS3HtmlUrlPrefix] = useState('');
-	const [isPreviewMode, setIsPreviewMode] = useState(false);
 
-	useEffect(() => {
-		getSetting('apiUrl').then(async (url) => {
-			const s3HtmlUrl = htmlEndpoint(url, path.publishedIssueId);
-			setS3HtmlUrlPrefix(s3HtmlUrl);
-			setIsPreviewMode(isPreview(url));
-			setIsReady(true);
-		});
-	}, [isReady]);
+	const updateSource = () => {
+		// On Android there is a potential race condition where url did get set before
+		// webview file system permission did get set and as result local html file fails to load
+		// within the webview. 
+		// Github issue: https://github.com/react-native-webview/react-native-webview/issues/656#issuecomment-551312436 
+		console.log('load started: ' + article.internalPageCode)
+		setIsReady(true);
+	 };
 
 	// Online: Url to load direct from s3 (when bundle is not downloaded)
 	// When app runs in Preview Mode the url points to backend and backend needs to know
 	// which front the articles belongs to properly render an article with correct overrides from the fronts tool
-	const previewParam = isPreviewMode ? `?frontId=${front}` : '';
-	let uri = `${s3HtmlUrlPrefix}/${article.internalPageCode}.html${previewParam}`;
+	// const previewParam = isPreviewMode ? `?frontId=${front}` : '';
+	let uri = `${htmlFolderInS3}/${article.internalPageCode}.html${previewParam}`;
 
 	// Offline/Downloaded: load from file system
 	if (origin === 'filesystem') {
@@ -56,16 +56,7 @@ const WebviewWithArticle = ({
 		uri = Platform.OS === 'android' ? 'file://' + htmlUri : htmlUri;
 	}
 
-	// set url only when component is ready
-	// https://github.com/react-native-webview/react-native-webview/issues/656#issuecomment-551312436
-	const finalUrl = isReady ? uri : '';
-
-	// returning an empty view instead of setting empty url to the webview that results in showing error msg for a brief period
-	if (!isReady) {
-		return <View />;
-	}
-
-	console.log(`URL (${origin}): ${finalUrl}`);
+	console.log(`URL (${origin}): ${uri}`);
 
 	return (
 		<WebView
@@ -73,12 +64,15 @@ const WebviewWithArticle = ({
 			bounces={largeDeviceMemory ? true : false}
 			originWhitelist={['*']}
 			scrollEnabled={true}
-			source={{ uri: finalUrl }}
+			source={isReady ? { uri: uri } : undefined}
 			ref={_ref}
 			onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
 			allowFileAccess={true}
-			allowFileAccessFromFileURLs={true}
+			allowUniversalAccessFromFileURLs={true}
 			allowingReadAccessToURL={FSPaths.issuesDir}
+			onLoadStart={() => {				
+				updateSource();
+			}}			
 		/>
 	);
 };

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -12766,10 +12766,10 @@ react-native-switch@^1.5.0:
   dependencies:
     prop-types "^15.6.0"
 
-react-native-webview@^11.4.2:
-  version "11.4.5"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.4.5.tgz#a264ac2f9146b23b10dcea1a12b9ce3ec0df9db8"
-  integrity sha512-hH+0QjetQ8A6TpXdXba7QLeEX1mi7fVClu+CVjj+PwKCirl1GPPhYMeq6/qR+zEifh6KnQINLFifOb651lOuhA==
+react-native-webview@^11.6.5:
+  version "11.6.5"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.6.5.tgz#34e86a342c6a2cbcf109db98f639f7bb8f055da2"
+  integrity sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## Why are you doing this?
There is a known issue on android where it often fails to load file from the local file system due to a race condition.

https://github.com/react-native-webview/react-native-webview/issues/656

This PR fixed that problem along with some optimizations.

## Changes

- Updated the webview to the latest version
- Fixed the article load failure by adding an event that triggers once webview is ready
- Moved some props to the top-level to reduce the redraw of the child component 

