### PR TITLE
Live 2787 : Pass Theme to AR

### DIFF
--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -14,7 +14,7 @@ import { decodeVersionOrPreview } from '../utils/issue'
 import { lastModified, LastModifiedUpdater } from '../lastModified'
 import { IssuePublicationIdentifier, RenderedArticle } from '../common'
 import { fetchPublishedIssue } from '../fronts'
-import { PublishedFront, PublishedFurniture } from '../fronts/issue'
+import { PublishedFront, PublishedFurniture, Swatch, Theme } from '../fronts/issue'
 import { Content } from '@guardian/content-api-models/v1/content'
 import { Tag } from '@guardian/content-api-models/v1/tag'
 import { TagType } from '@guardian/content-api-models/v1/tagType'
@@ -71,9 +71,9 @@ const fetchSingleCapiContent = async (
         const data = await capiSearchDecoder(buffer)
         console.log(
             'Fetched data from CAPI: ' +
-                capi +
-                ' internalCode: ' +
-                internalPageCode,
+            capi +
+            ' internalCode: ' +
+            internalPageCode,
         )
         return data
     } catch (error) {
@@ -250,6 +250,27 @@ export const renderFrontController = async (req: Request, res: Response) => {
             res,
         )
         return
+    }
+
+    const mapSwatchToTheme = (swatch: Swatch) => {
+        switch (swatch) {
+            case 'neutral':
+            case 'news': {
+                return Theme.News
+            }
+            case 'opinion': {
+                return Theme.Opinion
+            }
+            case 'culture': {
+                return Theme.Culture
+            }
+            case 'lifestyle': {
+                return Theme.Lifestyle
+            }
+            case 'sport': {
+                return Theme.Sport
+            }
+        }
     }
 
     const idFurniturePair = front.collections

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -14,7 +14,12 @@ import { decodeVersionOrPreview } from '../utils/issue'
 import { lastModified, LastModifiedUpdater } from '../lastModified'
 import { IssuePublicationIdentifier, RenderedArticle } from '../common'
 import { fetchPublishedIssue } from '../fronts'
-import { PublishedFront, PublishedFurniture, Swatch, Theme } from '../fronts/issue'
+import {
+    PublishedFront,
+    PublishedFurniture,
+    Swatch,
+    Theme,
+} from '../fronts/issue'
 import { Content } from '@guardian/content-api-models/v1/content'
 import { Tag } from '@guardian/content-api-models/v1/tag'
 import { TagType } from '@guardian/content-api-models/v1/tagType'
@@ -71,9 +76,9 @@ const fetchSingleCapiContent = async (
         const data = await capiSearchDecoder(buffer)
         console.log(
             'Fetched data from CAPI: ' +
-            capi +
-            ' internalCode: ' +
-            internalPageCode,
+                capi +
+                ' internalCode: ' +
+                internalPageCode,
         )
         return data
     } catch (error) {

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -278,7 +278,7 @@ export const renderFrontController = async (req: Request, res: Response) => {
 
     const mappedTheme = mapSwatchToTheme(front.swatch)
 
-    const groupIdToFurnitureAndTheme = front.collections
+    const idFurniturePair = front.collections
         .map(collection =>
             collection.items.map((item): [number, PublishedFurniture] => {
                 return [item.internalPageCode, item.furniture]
@@ -290,10 +290,10 @@ export const renderFrontController = async (req: Request, res: Response) => {
         })
 
     const finalResult: RenderedArticle[] = []
-    for (const group of groupIdToFurnitureAndTheme) {
+    for (const pair of idFurniturePair) {
         const result = await processArticleRendering(
-            group.internalPageCode,
-            group.furniture,
+            pair.internalPageCode,
+            pair.furniture,
             mappedTheme,
         )
         finalResult.push(result)
@@ -330,7 +330,7 @@ export const renderItemController = async (req: Request, res: Response) => {
     const mappedTheme = mapSwatchToTheme(front.swatch)
 
     // find the corresponding furniture for the article so we can apply the fronts overrides
-    const groupIdToFurnitureAndTheme = front.collections
+    const idFurniturePair = front.collections
         .map(collection =>
             collection.items.map((item): [number, PublishedFurniture] => {
                 return [item.internalPageCode, item.furniture]
@@ -342,7 +342,7 @@ export const renderItemController = async (req: Request, res: Response) => {
         })
         .filter(item => item.internalPageCode == internalPageCode)
 
-    if (groupIdToFurnitureAndTheme.length != 1) {
+    if (idFurniturePair.length != 1) {
         // there should be only one article within a front, if not then throw error
         sendError(
             `Failed to find item with internalPageCode: ${internalPageCode} in front: ${frontId}`,
@@ -352,8 +352,8 @@ export const renderItemController = async (req: Request, res: Response) => {
     }
 
     const renderedArticle = await processArticleRendering(
-        groupIdToFurnitureAndTheme[0].internalPageCode,
-        groupIdToFurnitureAndTheme[0].furniture,
+        idFurniturePair[0].internalPageCode,
+        idFurniturePair[0].furniture,
         mappedTheme,
     )
 

--- a/projects/backend/fronts/issue.ts
+++ b/projects/backend/fronts/issue.ts
@@ -52,3 +52,13 @@ export interface PublishedCardImage {
     mobile: PublishedImage
     tablet: PublishedImage
 }
+
+export enum Theme {
+    News = 0,
+    Opinion = 1,
+    Sport = 2,
+    Culture = 3,
+    Lifestyle = 4,
+    SpecialReport = 5,
+    Labs = 6,
+}


### PR DESCRIPTION
## Why are you doing this?

We want to override article themes with that articles front theme. 

## Changes

- Add Theme enum for type safety
- Convert current `swatch` into `Theme`
- Pass theme as query param to AR

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/125668053-13c65d57-9783-4202-afae-ef39e504eb9d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/125667992-baceaa24-899c-4032-9d66-8eef599c05d0.png" width="300px" /> |
