### PR TITLE
Fix: Issue deletion status update 

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-on-device.ts
+++ b/projects/Mallard/src/hooks/use-issue-on-device.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { IssueWithFronts } from 'src/common';
 import { withCache } from 'src/helpers/fetch/cache';
 import { isIssueOnDevice } from 'src/helpers/files';
 
@@ -65,7 +64,7 @@ const useIssueOnDevice = (localId: string) => {
 	const [status, setStatus] = useState(
 		localIssueListStore.getStatus(localId),
 	);
-	const { clear } = withCache<IssueWithFronts>('issue');
+	const { clear } = withCache('issue');
 
 	useEffect(
 		() =>

--- a/projects/Mallard/src/hooks/use-issue-on-device.ts
+++ b/projects/Mallard/src/hooks/use-issue-on-device.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { IssueWithFronts } from 'src/common';
+import { withCache } from 'src/helpers/fetch/cache';
 import { isIssueOnDevice } from 'src/helpers/files';
 
 export enum ExistsStatus {
@@ -63,11 +65,15 @@ const useIssueOnDevice = (localId: string) => {
 	const [status, setStatus] = useState(
 		localIssueListStore.getStatus(localId),
 	);
+	const { clear } = withCache<IssueWithFronts>('issue');
 
 	useEffect(
 		() =>
 			localIssueListStore.subscribe(() => {
 				const newStatus = localIssueListStore.getStatus(localId);
+				if (newStatus == ExistsStatus.DoesNotExist) {
+					clear(localId);
+				}
 				setStatus(newStatus);
 			}),
 		[localId],


### PR DESCRIPTION
After deleting downloaded Issues we need to remove the cache `Issue` content so that next time the app loads articles from api instead of the file system

This fixes the bug where user sees error message when try to load article after deleting Issues.
Ticket is [here](https://theguardian.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=LIVE&modal=detail&selectedIssue=LIVE-2844&quickFilter=154)