### PR TITLE
Serving static assets from s3

### DIFF
--- a/projects/backend/__tests__/application.spec.ts
+++ b/projects/backend/__tests__/application.spec.ts
@@ -27,6 +27,7 @@ const testStubControllers: EditionsBackendControllers = {
     imageController: stub,
     renderFrontController: stub,
     renderItemController: stub,
+    assetsController: stub,
     editionsController: stubEditionController,
 }
 

--- a/projects/backend/application.ts
+++ b/projects/backend/application.ts
@@ -17,6 +17,7 @@ export interface EditionsBackendControllers {
     imageController: (req: Request, res: Response) => void
     renderFrontController: (req: Request, res: Response) => void
     renderItemController: (req: Request, res: Response) => void
+    assetsController: (req: Request, res: Response) => void
     editionsController: {
         GET: (req: Request, res: Response) => void
         POST: (req: Request, res: Response) => void
@@ -66,11 +67,15 @@ export const createApp = (
         controllers.renderFrontController,
     )
 
-    // This html endpoint only meant be used in preview mode to serve single rendered html
+    // This html endpoint only meant to be used in preview mode to serve single rendered html
     app.get(
         '/' + htmlDirPath(issuePathSegments) + '/*.html',
         controllers.renderItemController,
     )
+
+    // This assets endpoint only meant to be used in preview mode to server static assets
+    // from editions-published-<stage> s3 assets folder
+    app.get('/assets/*?', controllers.assetsController)
 
     app.get(
         '/' +

--- a/projects/backend/backend.ts
+++ b/projects/backend/backend.ts
@@ -6,6 +6,7 @@ import { issueController, issuesSummaryController } from './controllers/issue'
 import { frontController } from './controllers/fronts'
 import { imageController } from './controllers/image'
 import {
+    assetsController,
     renderFrontController,
     renderItemController,
 } from './controllers/render'
@@ -23,6 +24,7 @@ const runtimeControllers: EditionsBackendControllers = {
     imageController,
     renderFrontController,
     renderItemController,
+    assetsController,
     editionsController: {
         GET: editionsControllerGet,
         POST: editionsControllerPost,

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -25,7 +25,7 @@ import { Tag } from '@guardian/content-api-models/v1/tag'
 import { TagType } from '@guardian/content-api-models/v1/tagType'
 import { oc } from 'ts-optchain'
 import { Attempt } from '../common'
-import { getEditionFilePath, getS3Stream, s3fetchObject } from '../s3'
+import { getEditionFilePath, s3fetchObject } from '../s3'
 
 const fetchRenderedArticle = async (
     internalPageCode: number,
@@ -378,17 +378,15 @@ export const assetsController = async (req: Request, res: Response) => {
     const inputPath = req.path.slice(1) // remove the '/' at the beginning
     const path = getEditionFilePath(inputPath, 'published')
     try {
-        // const s3Response = await s3fetchObject(path)
-        // if (hasFailed(s3Response)) throw s3Response
+        const s3Response = await s3fetchObject(path)
+        if (hasFailed(s3Response)) throw s3Response
 
-        // console.log('Content-type: ' + String(s3Response.ContentType))
-        // console.log('Content-Length: ' + String(s3Response.ContentLength))
+        console.log('Content-type: ' + String(s3Response.ContentType))
+        console.log('Content-Length: ' + String(s3Response.ContentLength))
 
-        // res.setHeader('Content-Length', String(s3Response.ContentLength))
-        // res.setHeader('Content-Type', String(s3Response.ContentType))
-        // res.send(s3Response.Body)
-
-        getS3Stream(path).pipe(res)
+        res.setHeader('Content-Length', String(s3Response.ContentLength))
+        res.setHeader('Content-Type', String(s3Response.ContentType))
+        res.send(s3Response.Body)
     } catch (error) {
         console.log(error)
         sendError('Failed fetch requested object', res)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -381,11 +381,11 @@ export const assetsController = async (req: Request, res: Response) => {
         const s3Response = await s3fetchObject(path)
         if (hasFailed(s3Response)) throw s3Response
 
-        console.log('Content-type: ' + String(s3Response.ContentType))
+        console.log('Content-Type: ' + String(s3Response.ContentType))
         console.log('Content-Length: ' + String(s3Response.ContentLength))
 
-        res.setHeader('Content-Length', String(s3Response.ContentLength))
-        res.setHeader('Content-Type', String(s3Response.ContentType))
+        res.setHeader('content-length', String(s3Response.ContentLength))
+        res.setHeader('content-type', String(s3Response.ContentType))
         res.send(s3Response.Body)
     } catch (error) {
         console.log(error)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -179,9 +179,8 @@ const processArticleRendering = async (
             }
         }
 
-        const appsRenderingProxyUrl = 'http://localhost:8080/editions-article'
-        // const appsRenderingProxyUrl =
-        //     process.env.APPS_RENDERING_URL || 'apps rendering url missing'
+        const appsRenderingProxyUrl =
+            process.env.APPS_RENDERING_URL || 'apps rendering url missing'
         const appsRenderingProxyHeader =
             process.env.APPS_RENDERING_PROXY_HEADER_KEY ||
             'proxy header missing'

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -165,6 +165,7 @@ const processArticleRendering = async (
     internalPageCode: number,
     furniture: PublishedFurniture,
     theme: Theme | null,
+    isPreview = false,
 ): Promise<RenderedArticle> => {
     try {
         const searchResponse = await fetchCapiContent(internalPageCode)
@@ -189,7 +190,7 @@ const processArticleRendering = async (
 
         // re-encode the response to send to AR backend
         const bufferData = await encodeContent(patchedContent)
-        const url = `${appsRenderingProxyUrl}?theme=${theme}`
+        const url = `${appsRenderingProxyUrl}?theme=${theme}&isPreview=${isPreview}`
         const renderedArticle = await fetchRenderedArticle(
             internalPageCode,
             url,
@@ -324,6 +325,7 @@ export const renderItemController = async (req: Request, res: Response) => {
     console.log(JSON.stringify(req.params))
     const internalPageCode = req.params[0] as number
     const frontId: string = req.query['frontId']
+    const isPreview = req.params.version === 'preview'
     console.log(
         `Rendering single article with internalPageCode=${internalPageCode} within a front: ${frontId}`,
     )
@@ -365,6 +367,7 @@ export const renderItemController = async (req: Request, res: Response) => {
         idFurniturePair[0].internalPageCode,
         idFurniturePair[0].furniture,
         mappedTheme,
+        isPreview,
     )
 
     res.setHeader('Content-Type', 'text/html')

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -179,8 +179,9 @@ const processArticleRendering = async (
             }
         }
 
-        const appsRenderingProxyUrl =
-            process.env.APPS_RENDERING_URL || 'apps rendering url missing'
+        const appsRenderingProxyUrl = 'http://localhost:8080/editions-article'
+        // const appsRenderingProxyUrl =
+        //     process.env.APPS_RENDERING_URL || 'apps rendering url missing'
         const appsRenderingProxyHeader =
             process.env.APPS_RENDERING_PROXY_HEADER_KEY ||
             'proxy header missing'
@@ -386,7 +387,7 @@ export const assetsController = async (req: Request, res: Response) => {
 
         res.setHeader('content-length', String(s3Response.ContentLength))
         res.setHeader('content-type', String(s3Response.ContentType))
-        res.send(s3Response.Body)
+        res.send(s3Response.Body as Buffer)
     } catch (error) {
         console.log(error)
         sendError('Failed fetch requested object', res)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -387,7 +387,11 @@ export const assetsController = async (req: Request, res: Response) => {
 
         res.setHeader('content-length', String(s3Response.ContentLength))
         res.setHeader('content-type', String(s3Response.ContentType))
-        res.send(s3Response.Body as Buffer)
+        // res.send(s3Response.Body as Buffer)
+        // res.write(s3Response.Body, 'binary')
+        const encoding =
+            inputPath.indexOf('assets/fonts/') == -1 ? 'utf8' : 'binary'
+        res.end(s3Response.Body, encoding)
     } catch (error) {
         console.log(error)
         sendError('Failed fetch requested object', res)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -385,12 +385,17 @@ export const assetsController = async (req: Request, res: Response) => {
         console.log('Content-Length: ' + String(s3Response.ContentLength))
 
         res.setHeader('content-length', String(s3Response.ContentLength))
-        res.setHeader('content-type', String(s3Response.ContentType))
+        // res.setHeader('content-type', String(s3Response.ContentType))
         // res.send(s3Response.Body as Buffer)
         // res.write(s3Response.Body, 'binary')
-        const encoding =
-            inputPath.indexOf('assets/fonts/') == -1 ? 'utf8' : 'binary'
-        res.end(s3Response.Body, encoding)
+        const isFont = inputPath.indexOf('assets/fonts/') != -1
+        const encoding = isFont ? 'binary' : 'utf8'
+
+        res.setHeader(
+            'content-type',
+            isFont ? 'font/ttf' : String(s3Response.ContentType),
+        )
+        res.write(s3Response.Body as Buffer, encoding)
     } catch (error) {
         console.log(error)
         sendError('Failed fetch requested object', res)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -381,6 +381,9 @@ export const assetsController = async (req: Request, res: Response) => {
         const s3Response = await s3fetchObject(path)
         if (hasFailed(s3Response)) throw s3Response
 
+        console.log('Content-type: ' + String(s3Response.ContentType))
+        console.log('Content-Length: ' + String(s3Response.ContentLength))
+
         res.setHeader('Content-Length', String(s3Response.ContentLength))
         res.setHeader('Content-Type', String(s3Response.ContentType))
         res.send(s3Response.Body)

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -325,7 +325,6 @@ export const renderItemController = async (req: Request, res: Response) => {
     console.log(JSON.stringify(req.params))
     const internalPageCode = req.params[0] as number
     const frontId: string = req.query['frontId']
-    const isPreview = req.params.version === 'preview'
     console.log(
         `Rendering single article with internalPageCode=${internalPageCode} within a front: ${frontId}`,
     )

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -25,7 +25,7 @@ import { Tag } from '@guardian/content-api-models/v1/tag'
 import { TagType } from '@guardian/content-api-models/v1/tagType'
 import { oc } from 'ts-optchain'
 import { Attempt } from '../common'
-import { getEditionFilePath, s3fetchObject } from '../s3'
+import { getEditionFilePath, getS3Stream, s3fetchObject } from '../s3'
 
 const fetchRenderedArticle = async (
     internalPageCode: number,
@@ -378,15 +378,17 @@ export const assetsController = async (req: Request, res: Response) => {
     const inputPath = req.path.slice(1) // remove the '/' at the beginning
     const path = getEditionFilePath(inputPath, 'published')
     try {
-        const s3Response = await s3fetchObject(path)
-        if (hasFailed(s3Response)) throw s3Response
+        // const s3Response = await s3fetchObject(path)
+        // if (hasFailed(s3Response)) throw s3Response
 
-        console.log('Content-type: ' + String(s3Response.ContentType))
-        console.log('Content-Length: ' + String(s3Response.ContentLength))
+        // console.log('Content-type: ' + String(s3Response.ContentType))
+        // console.log('Content-Length: ' + String(s3Response.ContentLength))
 
-        res.setHeader('Content-Length', String(s3Response.ContentLength))
-        res.setHeader('Content-Type', String(s3Response.ContentType))
-        res.send(s3Response.Body)
+        // res.setHeader('Content-Length', String(s3Response.ContentLength))
+        // res.setHeader('Content-Type', String(s3Response.ContentType))
+        // res.send(s3Response.Body)
+
+        getS3Stream(path).pipe(res)
     } catch (error) {
         console.log(error)
         sendError('Failed fetch requested object', res)

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -269,6 +269,15 @@ export const s3fetchObject = (
     })
 }
 
+export const getS3Stream = (path: Path) => {
+    return s3EditionClient()
+        .getObject({
+            Key: path.key,
+            Bucket: path.bucket,
+        })
+        .createReadStream()
+}
+
 export const s3Put = async (path: Path, data: string) => {
     await s3EditionClient()
         .putObject({

--- a/projects/backend/s3.ts
+++ b/projects/backend/s3.ts
@@ -269,15 +269,6 @@ export const s3fetchObject = (
     })
 }
 
-export const getS3Stream = (path: Path) => {
-    return s3EditionClient()
-        .getObject({
-            Key: path.key,
-            Bucket: path.bucket,
-        })
-        .createReadStream()
-}
-
 export const s3Put = async (path: Path, data: string) => {
     await s3EditionClient()
         .putObject({


### PR DESCRIPTION
We need a way to serve static assets from s3 so preview articles can render properly. Currently, preview articles have no way to access assets as they usually being accessed before an Issue is published. 