### PR TITLE
LIVE-2879 - Lightbox

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -284,8 +284,18 @@ const Article = ({
 	};
 
 	const handleLightbox = (parsed: LightboxMessage) => {
-		const index = parsed.index;
+		let index = parsed.index;
 
+		// the following if statement is required to make sure the lightbox opens on the correct image.
+		if (
+			article.type !== 'gallery' &&
+			article.image &&
+			!parsed.isMainImage &&
+			lightboxImages &&
+			lightboxImages.length > 1
+		) {
+			index++;
+		}
 		navigation.navigate(RouteNames.Lightbox, {
 			images: lightboxImages,
 			imagePaths: imagePaths,


### PR DESCRIPTION
## Why are you doing this?

This reintroduces some logic that makes sure the lightbox opens on the correct image. Without this logic, the lightbox opens up on the image after the one that was clicked.
