### PR TITLE
Reverting a change that breaks the side menu expansion

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -132,7 +132,7 @@ const IssueRowContainer = React.memo(
 		);
 
 		const onPress = useCallback(() => {
-			if (issueDetails !== undefined) {
+			if (issueDetails !== null) {
 				setNavPosition(null);
 				navToIssue(null);
 				return;


### PR DESCRIPTION
This [PR](https://github.com/guardian/editions/pull/1692/files) refactored few things and one of them was replacing `null` with `undefined` that breaks the `if` statement and as a result edition side menu does not expand when clicking on the Issue title.

This PR reverts that back to `null`.

The ticket is [here](https://theguardian.atlassian.net/browse/LIVE-2726)

@joecowton1 not sure what was the original intention of this change, please have a look if you still wants to keep `undefined` for any reason then we need to refactor the code further.