### PR TITLE
LIVE-2662: add flex-end to styling

### DIFF
--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -16,6 +16,7 @@ const sidebarWidth = 360;
 const styles = StyleSheet.create({
 	container: {
 		display: 'flex',
+		justifyContent: 'flex-end',
 		flexDirection: 'row-reverse',
 	},
 	touchable: {
@@ -42,7 +43,9 @@ export const ScreenFiller = ({
 		<View
 			style={[
 				styles.container,
-				{ flexDirection: direction === 'end' ? 'row' : 'row-reverse' },
+				{
+					flexDirection: direction === 'end' ? 'row' : 'row-reverse',
+				},
 			]}
 		>
 			{DeviceInfo.isTablet() && (


### PR DESCRIPTION
## Why are you doing this?

The sidebar was broken on ipads in landscape mode.

## Changes

- check for landscape and apply styles

https://user-images.githubusercontent.com/77005274/128362863-21335dab-31d6-4f6a-8ba8-fdf0d995da05.mov


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/128362251-ac4d444d-621d-4064-81b6-7dc3510f6439.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/128362309-78a36a56-55e4-43a4-8037-8bd24c671f9e.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/77005274/128362615-b95a2e2d-1fd7-4e7b-839a-7778e9326959.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/128362398-0be8e064-7722-4a03-9692-0b68e4378fe5.png" width="300px" /> |




