### PR TITLE
LIVE-2906: add new logic

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -41,7 +41,7 @@
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
         "@guardian/pasteup": "^1.0.0-alpha.11",
-        "@guardian/renditions": "^0.1.4",
+        "@guardian/renditions": "^0.2.0",
         "@guardian/src-foundations": "^2.5.0-rc.1",
         "@invertase/react-native-apple-authentication": "^1.0.0",
         "@react-native-community/async-storage": "^1.5.0",

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,6 +1,10 @@
 import { useApolloClient } from '@apollo/react-hooks';
-import type { LightboxMessage, PlatformMessage } from '@guardian/renditions';
 import { MessageKind, Platform as PlatformType } from '@guardian/renditions';
+import type {
+	LightboxMessage,
+	PlatformMessage,
+	ShareIconMessage,
+} from '@guardian/renditions';
 import { useNavigation } from '@react-navigation/native';
 import gql from 'graphql-tag';
 import React, { useEffect, useRef, useState } from 'react';
@@ -299,11 +303,6 @@ const Article = ({
 		});
 	};
 
-	interface ShareIconMessage {
-		kind: string;
-		value: string;
-	}
-
 	const handlePlatformQuery = (shareUrl: string): void => {
 		const getPlatformMessage = (): PlatformMessage => {
 			const value =
@@ -312,7 +311,7 @@ const Article = ({
 		};
 
 		const getShareMessage = (shareUrl: string): ShareIconMessage => {
-			return { kind: 'ShareIcon', value: shareUrl };
+			return { kind: MessageKind.ShareIcon, value: shareUrl };
 		};
 
 		const pingEditionsRenderingJsString = (

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -1,10 +1,6 @@
 import { useApolloClient } from '@apollo/react-hooks';
 import type { LightboxMessage, PlatformMessage } from '@guardian/renditions';
-import {
-	MessageKind,
-	pingEditionsRenderingJsString,
-	Platform as PlatformType,
-} from '@guardian/renditions';
+import { MessageKind, Platform as PlatformType } from '@guardian/renditions';
 import { useNavigation } from '@react-navigation/native';
 import gql from 'graphql-tag';
 import React, { useEffect, useRef, useState } from 'react';
@@ -177,6 +173,7 @@ const Article = ({
 } & HeaderControlProps) => {
 	const navigation = useNavigation();
 	const ref = useRef<WebView | null>(null);
+	const [script, setScript] = useState('');
 	const [imagePaths, setImagePaths] = useState(['']);
 	const [lightboxImages, setLightboxImages] = useState<CreditedImage[]>();
 
@@ -195,18 +192,13 @@ const Article = ({
 	const previewParam = isPreview(apiUrl) ? `?frontId=${front}` : '';
 
 	// if webUrl is undefined then we attempt to fetch a url to use for sharing
-	const [shareUrl, setShareUrl] = useState(article.webUrl);
+	const [shareUrl, setShareUrl] = useState(article.webUrl ?? '');
 	// we can only attempt to fetch the url if connected
 	const client = useApolloClient();
 	const data = client.readQuery<{ netInfo: { isConnected: boolean } }>({
 		query: gql('{ netInfo @client { isConnected @client } }'),
 	});
 	const isConnected = data?.netInfo?.isConnected;
-	const shareUrlFetchEnabled =
-		!article.webUrl &&
-		isConnected &&
-		// TODO: remove remote switch once we are happy this feature is stable
-		remoteConfigService.getBoolean('generate_share_url');
 
 	useEffect(() => {
 		const lbimages = getLightboxImages(article.elements);
@@ -239,18 +231,10 @@ const Article = ({
 
 		const updateShareUrl = async () => {
 			const url = await checkPathExists(article.key);
-			if (url) {
-				injectJavascript(
-					ref,
-					`document.getElementById('share-button').classList.remove('display-none');
-                     document.getElementById('byline-area').classList.remove('display-none');
-                    `,
-				);
-				setShareUrl(url);
-			}
+			setShareUrl(url ?? '');
 		};
 
-		shareUrlFetchEnabled && updateShareUrl();
+		isConnected && updateShareUrl();
 	}, [
 		apiUrl,
 		article.elements,
@@ -258,8 +242,19 @@ const Article = ({
 		article.image,
 		article.type,
 		article.key,
-		shareUrlFetchEnabled,
+		isConnected,
 	]);
+
+	// This is triggered when the script is updated via handlePlatformQuery
+	// which itself is trigger by a ping from Editions-Rendering to signify
+	// that the event listeners in ER are in place.
+	// The injected js controls the shareIcon icon and will not render if
+	// an article has no webUrl
+	useEffect(() => {
+		if (ref) {
+			injectJavascript(ref, script);
+		}
+	}, [script]);
 
 	const handleShare = (shareUrl: string) => {
 		if (Platform.OS === 'ios') {
@@ -304,11 +299,53 @@ const Article = ({
 		});
 	};
 
+	interface ShareIconMessage {
+		kind: string;
+		value: string;
+	}
+
+	const handlePlatformQuery = (shareUrl: string): void => {
+		const getPlatformMessage = (): PlatformMessage => {
+			const value =
+				Platform.OS === 'ios' ? PlatformType.IOS : PlatformType.Android;
+			return { kind: MessageKind.Platform, value };
+		};
+
+		const getShareMessage = (shareUrl: string): ShareIconMessage => {
+			return { kind: 'ShareIcon', value: shareUrl };
+		};
+
+		const pingEditionsRenderingJsString = (
+			platformMessage: PlatformMessage,
+			shareIconMessage: ShareIconMessage,
+		) => {
+			return `
+                try {
+                    window.pingEditionsRendering(${JSON.stringify(
+						shareIconMessage,
+					)})
+                    window.pingEditionsRendering(${JSON.stringify(
+						platformMessage,
+					)})
+                } catch {
+                    console.error("Editions -> Editions Rendering not initiated")
+                }
+        `;
+		};
+
+		const platform = getPlatformMessage();
+		const share = getShareMessage(shareUrl);
+		const platformScript = pingEditionsRenderingJsString(platform, share);
+
+		setScript(platformScript);
+	};
+
 	const handlePing = (event: string) => {
 		const parsed = parsePing(event);
 		if (parsed.kind === MessageKind.Share && shareUrl) {
 			handleShare(shareUrl);
 		}
+
 		if (parsed.kind === 'shouldShowHeaderChange') {
 			wasShowingHeader.current = parsed.shouldShowHeader;
 			onShouldShowHeaderChange(parsed.shouldShowHeader);
@@ -317,17 +354,15 @@ const Article = ({
 		if (parsed.kind === 'isAtTopChange') {
 			onIsAtTopChange(parsed.isAtTop);
 		}
+
 		if (lightboxEnabled && parsed.kind === MessageKind.Lightbox) {
 			handleLightbox(parsed);
 		}
-	};
 
-	const getPlatform = (): PlatformMessage => {
-		const value =
-			Platform.OS === 'ios' ? PlatformType.IOS : PlatformType.Android;
-		return { kind: MessageKind.Platform, value };
+		if (parsed.kind === MessageKind.PlatformQuery) {
+			handlePlatformQuery(shareUrl);
+		}
 	};
-	const platform = getPlatform();
 
 	return (
 		<Fader>
@@ -344,7 +379,6 @@ const Article = ({
 					ref.current = r;
 				}}
 				origin={origin}
-				injectedJavaScript={pingEditionsRenderingJsString(platform)}
 				onMessage={(event) => {
 					handlePing(event.nativeEvent.data);
 				}}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2042,10 +2042,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
   integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
 
-"@guardian/renditions@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/renditions/-/renditions-0.1.4.tgz#1e0e53e28cb0fb33a71930c8ec5c31f85669b143"
-  integrity sha512-OPg0ShKPlSBccIXEZBjHRt4W+f6qeGELLevpaE2qaqNG+5U2MoermC0e7YjLwXKDdMsCCpemuvqtm0XMJ1sCCw==
+"@guardian/renditions@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/renditions/-/renditions-0.2.0.tgz#eb3d464ee212eca66c997855fdf8c02b4fe53b8e"
+  integrity sha512-AXUD83v9uY1oAXj6GcnVwP64UscjEbJhwLkq2dwmHXuP0UZkSxft9Q6WtTZemjHG4kpijYU+eulS8zoYXbiSLQ==
   dependencies:
     typescript "^4.1.3"
 


### PR DESCRIPTION
## Why are you doing this?

Previously we were rendering shareIcons on all articles regardless of whether or not we were able to share them.

This PR adds a handler for a ping from Editions-Rendering to alert the app that event listeners are present, then returns a ping containing the `platformType` and article share url. Editions-Rendering then hides the icon if no share url is present.

This also fixes the race condition which was effecting the platform specific icon pings.

## Changes

- add `handlePlatformQuery` function 
- listen for ping from editions
- use different js injection approach

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/129018364-c9be8d24-ced0-416d-ab43-57549c676ad8.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/129018398-46f744e1-2ad1-44ef-8c70-754582bd8d41.png" width="300px" /> |
