### PR TITLE
LIVE-2880 : Remove external links to subs

### DIFF
--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Linking, Platform, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Copy } from 'src/helpers/words';
 import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan';
 import { getFont } from 'src/theme/typography';
-import { ButtonAppearance } from './Button/Button';
 import { ModalButton } from './Button/ModalButton';
 import { Link } from './link';
 import { CardAppearance, OnboardingCard } from './onboarding/onboarding-card';
@@ -58,29 +57,6 @@ const SignInModalCard = ({
 							Need help signing in?
 						</Link>
 					</View>
-				</>
-			}
-			explainerTitle={
-				Platform.OS === 'android' && Copy.signIn.explainerTitle
-			}
-			explainerSubtitle={
-				Platform.OS === 'android' && Copy.signIn.explainerSubtitle
-			}
-			bottomExplainerContent={
-				<>
-					{/* Added only for Android - https://trello.com/c/FsoQQx3m/707-already-a-subscriber-hide-the-learn-more-button */}
-					{Platform.OS === 'android' && (
-						<ModalButton
-							onPress={() => {
-								Linking.openURL(
-									'https://support.theguardian.com/uk/subscribe/digital',
-								);
-							}}
-							buttonAppearance={ButtonAppearance.Dark}
-						>
-							{Copy.signIn.freeTrial}
-						</ModalButton>
-					)}
 				</>
 			}
 		/>


### PR DESCRIPTION
## Why are you doing this?

Following on from [1845](https://github.com/guardian/editions/pull/1845/files), we are now removing links / callouts to the external subscription page for Android as well as it now violates Google Play policy.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/129198214-87fa6287-d5cc-496c-9dc5-ac64731d10f9.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/129198203-b68cbf8b-f7bd-4fad-aeb3-b95fd4a8520d.png" width="300px" /> |
