### PR TITLE
Stop request to AR for crossword front

### DIFF
--- a/projects/archiver/src/tasks/front/index.ts
+++ b/projects/archiver/src/tasks/front/index.ts
@@ -104,6 +104,14 @@ export const handler: Handler<
     const failedImages = failedImageUseUploads.length
     const success = failedImages === 0
 
+    if (front.toLowerCase() == 'crosswords') {
+        return {
+            message: `Crosswords Front data and images uploaded ${
+                success ? 'succesfully' : 'with some images missing'
+            }. Ignoring Apps Rendering process for "${front}" Front, happens locally within the app`,
+        }
+    }
+
     // *** Server Side Rendering ***
     // Fetch ER articles for this 'front' and upload them to the 'html' folder of the given Issue
     const renderedFront = await getRenderedFront(publishedId, front)


### PR DESCRIPTION
## Why are you doing this?
Crosswords do not need rendered content to render in the apps, rendering happens within the app. 

Test:
I have created a fresh Issue on CODE and crossword works nicely in the app online and offline
https://editions-published-code.s3.eu-west-1.amazonaws.com/daily-edition/2021-07-31/2021-08-13T14%3A54%3A15.125Z/issue

Deploy:
To avoid deploying on Friday we can deploy this on Monday. No problems are expected from this PR.