### PR TITLE
Remove `need help signing in?` button

### DIFF
--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -50,12 +50,6 @@ const SignInModalCard = ({
 						>
 							Sign in
 						</ModalButton>
-						<Link
-							style={{ ...getFont('sans', 0.9, 'bold') }}
-							href="https://www.theguardian.com/help/identity-faq"
-						>
-							Need help signing in?
-						</Link>
 					</View>
 				</>
 			}


### PR DESCRIPTION
## Why are you doing this?
Apple has rejected our build again due to CTA to external mechanisms to subscribe. To unblock, this PR removes the offending CTA, `Need help signing in?`.


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/129533127-89806317-0a31-46f8-9b89-fc41a411f017.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/129533151-3f5c69af-ee47-4c7e-8bda-e92a8a0cb95f.png" width="300px" /> |
