### PR TITLE
LIVE-2937 : Stop filtering out series tags

### DIFF
--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -114,12 +114,8 @@ const sendError = (message: string, res: Response) => {
     res.status(400).send(message)
 }
 
-const removeSeriesTags = (tags: Tag[]) =>
-    tags.filter((tag: Tag) => tag.type !== TagType.SERIES)
-
+// If we have a kicker override, add a new series tag with the override kicker at the front of the tag array.
 const getTags = (kicker: string, tags: Tag[]): Tag[] => {
-    const filteredTags = removeSeriesTags(tags)
-
     const seriesTag = {
         id: '',
         type: TagType.SERIES,
@@ -130,7 +126,7 @@ const getTags = (kicker: string, tags: Tag[]): Tag[] => {
         internalName: '',
     }
 
-    return [...filteredTags, seriesTag]
+    return [seriesTag, ...tags]
 }
 
 const mapFurnitureToContent = (


### PR DESCRIPTION
## Why are you doing this?

Design.Correction is derived from a series tag. Previously, Editions BE stripped out the series tag if there was a kicker override. This PR alters the logic to add a new series tag with the overide kicker to the front of the tag array, preserving the original series tag instead of filtering it out.

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
