### PR TITLE
Decrement if its a gallery body image

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -284,17 +284,16 @@ const Article = ({
 
 	const handleLightbox = (parsed: LightboxMessage) => {
 		let index = parsed.index;
-
-		// the following if statement is required to make sure the lightbox opens on the correct image.
+		// // the following if statement is required to make sure the lightbox opens on the correct image.
 		if (
-			article.type !== 'gallery' &&
+			article.type === 'gallery' &&
+			index !== 0 &&
 			article.image &&
-			!parsed.isMainImage &&
-			lightboxImages &&
-			lightboxImages.length > 1
+			!parsed.isMainImage
 		) {
-			index++;
+			index--;
 		}
+
 		navigation.navigate(RouteNames.Lightbox, {
 			images: lightboxImages,
 			imagePaths: imagePaths,


### PR DESCRIPTION
## Why are you doing this?

Lightbox logic was crashing the app by incrementing an index where it didn't need to be incremented. In fixing this it flagged another issue where the gallery body images were opening on the index one head of where they should be. As a temporary fix, we are decrementing the index for gallery body images here and keeping all other image indexes as they are when received from AR.