### PR TITLE
LIVE-2938 : Gallery Lightbox Behaviour

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -282,17 +282,19 @@ const Article = ({
 		return;
 	};
 
+	const isGalleryHeaderImage = (parsed: LightboxMessage) =>
+		article.type === 'gallery' && parsed.isMainImage;
+
+	const isGalleryBodyImage = (index: number) =>
+		article.type === 'gallery' && index !== 0;
+
 	const handleLightbox = (parsed: LightboxMessage) => {
+		// Gallery header images should not open the lightbox.
+		if (isGalleryHeaderImage(parsed)) return;
+
 		let index = parsed.index;
-		// // the following if statement is required to make sure the lightbox opens on the correct image.
-		if (
-			article.type === 'gallery' &&
-			index !== 0 &&
-			article.image &&
-			!parsed.isMainImage
-		) {
-			index--;
-		}
+		// Gallery body images have the the wrong index because the main media is duplicated and assumed index 0. To fix this, body images need to have their index reduced by 1.
+		if (isGalleryBodyImage(index)) index--;
 
 		navigation.navigate(RouteNames.Lightbox, {
 			images: lightboxImages,


### PR DESCRIPTION
## Why are you doing this?

For parity with the existing production app, the Gallery main image should not open the Lightbox. This is because the Lightbox already contains the main image. As a consequence of this, the gallery image array is out of sync with the article as the article has the header image at index 0. To make sure we open the body images on the correct image, we decrement the body indexes by 1.  