### PR TITLE
LIVE-2942: add trail to standfirst

### DIFF
--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -129,7 +129,7 @@ const getTags = (kicker: string, tags: Tag[]): Tag[] => {
     return [seriesTag, ...tags]
 }
 
-const standfirstContainsList = (standfirst?: string): boolean => {
+const standfirstContainsListItem = (standfirst?: string): boolean => {
     return standfirst ? !['UL', 'LI', 'A'].includes(standfirst) : false
 }
 
@@ -138,7 +138,7 @@ const mapFurnitureToContent = (
     content: Content,
 ): Content => {
     const contentStandfirst = oc(content).fields.standfirst()
-    const originalStandfirst = standfirstContainsList(contentStandfirst)
+    const filteredStandfirst = standfirstContainsListItem(contentStandfirst)
         ? contentStandfirst
         : undefined
 
@@ -149,7 +149,7 @@ const mapFurnitureToContent = (
         : ''
     const standfirst =
         oc(furniture).trailTextOverride() ||
-        originalStandfirst ||
+        filteredStandfirst ||
         oc(content).fields.trailText()
 
     return {

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -134,12 +134,8 @@ const listTags = ['<ul>', '<li>', '<a>']
 const containsListTags = (str: string): boolean =>
     listTags.some(tag => str.includes(tag))
 
-const filterStandfirst = (standfirst?: string): string | undefined => {
-    if (standfirst) {
-        return !containsListTags(standfirst) ? standfirst : undefined
-    }
-    return undefined
-}
+const filterStandfirst = (standfirst?: string): string =>
+    standfirst && !containsListTags(standfirst) ? standfirst : ''
 
 const mapFurnitureToContent = (
     furniture: PublishedFurniture,
@@ -147,7 +143,6 @@ const mapFurnitureToContent = (
 ): Content => {
     const contentStandfirst = oc(content).fields.standfirst()
     const filteredStandfirst = filterStandfirst(contentStandfirst)
-    console.log(filteredStandfirst)
     const headline =
         oc(furniture).headlineOverride() || oc(content).fields.headline()
     const byline = furniture.showByline

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -129,17 +129,29 @@ const getTags = (kicker: string, tags: Tag[]): Tag[] => {
     return [seriesTag, ...tags]
 }
 
+const standfirstContainsList = (standfirst?: string): boolean => {
+    return standfirst ? !['UL', 'LI', 'A'].includes(standfirst) : false
+}
+
 const mapFurnitureToContent = (
     furniture: PublishedFurniture,
     content: Content,
 ): Content => {
+    const contentStandfirst = oc(content).fields.standfirst()
+    const originalStandfirst = standfirstContainsList(contentStandfirst)
+        ? contentStandfirst
+        : undefined
+
     const headline =
         oc(furniture).headlineOverride() || oc(content).fields.headline()
     const byline = furniture.showByline
         ? oc(furniture).bylineOverride() || oc(content).fields.byline()
         : ''
     const standfirst =
-        oc(furniture).trailTextOverride() || oc(content).fields.standfirst()
+        oc(furniture).trailTextOverride() ||
+        originalStandfirst ||
+        oc(content).fields.trailText()
+
     return {
         ...content,
         tags: furniture.kicker

--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -129,8 +129,16 @@ const getTags = (kicker: string, tags: Tag[]): Tag[] => {
     return [seriesTag, ...tags]
 }
 
-const standfirstContainsListItem = (standfirst?: string): boolean => {
-    return standfirst ? !['UL', 'LI', 'A'].includes(standfirst) : false
+const listTags = ['<ul>', '<li>', '<a>']
+
+const containsListTags = (str: string): boolean =>
+    listTags.some(tag => str.includes(tag))
+
+const filterStandfirst = (standfirst?: string): string | undefined => {
+    if (standfirst) {
+        return !containsListTags(standfirst) ? standfirst : undefined
+    }
+    return undefined
 }
 
 const mapFurnitureToContent = (
@@ -138,10 +146,8 @@ const mapFurnitureToContent = (
     content: Content,
 ): Content => {
     const contentStandfirst = oc(content).fields.standfirst()
-    const filteredStandfirst = standfirstContainsListItem(contentStandfirst)
-        ? contentStandfirst
-        : undefined
-
+    const filteredStandfirst = filterStandfirst(contentStandfirst)
+    console.log(filteredStandfirst)
     const headline =
         oc(furniture).headlineOverride() || oc(content).fields.headline()
     const byline = furniture.showByline


### PR DESCRIPTION
## Why are you doing this?

Sometimes we receive article content from CAPI with an empty `standfirst` field. Editions Production have been used to the `trailtext` field filling this gap, this PR adds `trailtext` as a last resort to the `standfirst` field we pass to AR, behind the `trailTextOverride` (from Fronts tool) and `standfirst` from CAPI.

We're also adding a filter for `standfirst` fields which contain list tags: if a `standfirst` contains a list we want to pass the `trailText` to AR instead.

## Changes

- add `trailText` to `standfirst` logic.


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/130051696-d9e9c308-5ccd-49cc-8a9f-2a5bc0c4ce55.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/130051726-dba61eee-0d2e-472b-9f91-813071f9a578.jpg" width="300px" /> |
