### PR TITLE
LIVE-2973 : Dynamic Font Scaling

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -8,7 +8,7 @@ import type {
 import { useNavigation } from '@react-navigation/native';
 import gql from 'graphql-tag';
 import React, { useEffect, useRef, useState } from 'react';
-import { Platform, Share, StyleSheet } from 'react-native';
+import { PixelRatio, Platform, Share, StyleSheet } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import type WebView from 'react-native-webview';
 import type {
@@ -319,8 +319,18 @@ const Article = ({
 			platformMessage: PlatformMessage,
 			shareIconMessage: ShareIconMessage,
 		) => {
+			const scale = PixelRatio.getFontScale();
+			const lineHeight = 25 * scale;
+			const fontSize = 17 * scale;
+
 			return `
                 try {
+                    let bodyContent = document.querySelectorAll(".body-content > p");
+                    for(i = 0; i < bodyContent.length; i++) {
+                        bodyContent[i].style.setProperty("font-size", "${fontSize}px");
+                        bodyContent[i].style.setProperty("line-height", "${lineHeight}px");
+
+                    }
                     window.pingEditionsRendering(${JSON.stringify(
 						shareIconMessage,
 					)})


### PR DESCRIPTION
## Why are you doing this?
Users used to be able to scale the body text in articles by their font size preferences. This reintroduces this by updating font sizes of text inside p tags within the `body-content` .

## Changes
- Use `PixelRatio.getFontScale()` to access the user defined font scale. 
- inject js to calculate new `font-size` and `line-height` and update all `p` tags within the `body-content` class.

## Screenshots

| font size | article font |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/20416599/130638254-81c4fc2d-42a5-434a-b809-65cc6ef4c46f.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/130638240-fbefa310-ba9b-4a69-86c1-d3a767b1b41a.PNG" width="300px" /> | 
| <img src="https://user-images.githubusercontent.com/20416599/130638263-cd30e2a8-2a0a-4cc3-bb52-c6695a308ac4.PNG" width="300px" /> | <img src="https://user-images.githubusercontent.com/20416599/130638258-f8bc8ec9-d49b-49ae-968c-2b03a20c0bab.PNG" width="300px" /> |
