### PR TITLE
feat: isPoorConnection Update

### DIFF
--- a/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
@@ -124,7 +124,7 @@ describe('use-net-info', () => {
 				isForcedOffline: false,
 				setIsDevButtonShown: expect.any(Function),
 				setIsForcedOffline: expect.any(Function),
-				isPoorConnection: false,
+				isPoorConnection: true,
 			});
 		});
 

--- a/projects/Mallard/src/hooks/use-net-info.tsx
+++ b/projects/Mallard/src/hooks/use-net-info.tsx
@@ -98,10 +98,7 @@ const assembleNetInfo = (state: InternalState): NetInfo => {
 		? FORCED_OFFLINE_NETINFO
 		: state.netInfo;
 	const { type, isConnected, details, isInternetReachable } = netInfo;
-	const isPoorConnection =
-		netInfo.type === 'cellular'
-			? netInfo.details.cellularGeneration === '2g'
-			: false;
+	const isPoorConnection = netInfo.type === 'cellular';
 	const internetUnreachable = isInternetReachable === false;
 	return {
 		__typename,


### PR DESCRIPTION
PLEASE NOTE THAT THIS IS A HIGH RISK CHANGE

## Why are you doing this?
- The London Bridge problem. You have 4G but you connection is slow or non existent. The user's expectation is for the product to work seamlessly offline however, its inconsistent under these conditions

## Changes
- Change `isPoorConnection` from being a check of a 2G connection to being a check of a mobile connection in general.
- This impacts authentication and getting the issue summary which it in itself provides us the map to get data. I would recommend that thorough testing and expectations are considered before merging
- We should potentially consider some automation testing around these scenarios to ensure the integrity