### PR TITLE
feat: use net info devmode

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -40,6 +40,7 @@
     "dependencies": {
         "@apollo/react-hooks": "^3.1.3",
         "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
+        "@gorhom/bottom-sheet": "^2.4.0",
         "@guardian/pasteup": "^1.0.0-alpha.11",
         "@guardian/renditions": "^0.2.0",
         "@guardian/src-foundations": "^2.5.0-rc.1",
@@ -53,6 +54,7 @@
         "@react-native-firebase/app": "^10.0.0",
         "@react-native-firebase/crashlytics": "^10.0.0",
         "@react-native-firebase/remote-config": "^10.0.0",
+        "@react-native-picker/picker": "^2.1.0",
         "@react-navigation/native": "^5.9.3",
         "@react-navigation/stack": "^5.14.3",
         "@sentry/react-native": "^2.0.1",

--- a/projects/Mallard/src/components/NetInfoDevOverlay.tsx
+++ b/projects/Mallard/src/components/NetInfoDevOverlay.tsx
@@ -1,7 +1,19 @@
+import {
+	BottomSheetModal,
+	BottomSheetModalProvider,
+} from '@gorhom/bottom-sheet';
+import { Picker } from '@react-native-picker/picker';
 import gql from 'graphql-tag';
 import * as React from 'react';
-import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native';
+import {
+	StyleSheet,
+	Switch,
+	Text,
+	TouchableWithoutFeedback,
+	View,
+} from 'react-native';
 import { useQuery } from 'src/hooks/apollo';
+import { isDisconnectedState, NetInfoStateType } from 'src/hooks/use-net-info';
 import type { NetInfo } from 'src/hooks/use-net-info';
 
 const DevButton = (() => {
@@ -9,11 +21,23 @@ const DevButton = (() => {
 		bg: {
 			backgroundColor: 'black',
 			padding: 8,
-			borderRadius: 999,
+			borderRadius: 10,
 			position: 'absolute',
 			bottom: 20,
 			left: 20,
 			zIndex: 999999999,
+		},
+		contentContainer: {
+			alignItems: 'center',
+			backgroundColor: '#EEEEEE',
+			flex: 1,
+		},
+		row: {
+			flexDirection: 'row',
+			padding: 10,
+			justifyContent: 'space-between',
+			maxWidth: 400,
+			width: '100%',
 		},
 		text: {
 			color: 'white',
@@ -23,49 +47,159 @@ const DevButton = (() => {
 	type QueryValue = {
 		netInfo: Pick<
 			NetInfo,
-			| 'isForcedOffline'
 			| 'type'
-			| 'setIsForcedOffline'
+			| 'isConnected'
+			| 'isPoorConnection'
+			| 'isInternetReachable'
 			| 'isDevButtonShown'
+			| 'overrideIsConnected'
+			| 'setOverrideIsConnected'
+			| 'overrideNetworkType'
+			| 'setOverrideNetworkType'
+			| 'overrideIsInternetReachable'
+			| 'setOverrideIsInternetReachable'
 		>;
 	};
 	const QUERY = gql`
 		{
 			netInfo @client {
 				type @client
-				isForcedOffline @client
-				setIsForcedOffline @client
+				isConnected @client
+				isPoorConnection @client
+				isInternetReachable @client
 				isDevButtonShown @client
+				overrideIsConnected @client
+				setOverrideIsConnected @client
+				overrideNetworkType @client
+				setOverrideNetworkType @client
+				overrideIsInternetReachable @client
+				setOverrideIsInternetReachable @client
 			}
 		}
 	`;
 
 	return () => {
+		// ref
+		const bottomSheetModalRef = React.useRef<BottomSheetModal>(null);
+
+		// variables
+		const snapPoints = React.useMemo(() => ['50%', '50%'], []);
+
+		// callbacks
+		const handlePresentModalPress = React.useCallback(() => {
+			bottomSheetModalRef.current?.present();
+		}, []);
+		const handleSheetChanges = React.useCallback((index: number) => {
+			console.log('handleSheetChanges', index);
+		}, []);
+
 		const res = useQuery<QueryValue>(QUERY);
 		if (res.loading) return null;
 
 		const {
 			netInfo: {
 				type,
-				isForcedOffline,
-				setIsForcedOffline,
+				isConnected,
+				isPoorConnection,
+				isInternetReachable,
+				overrideIsConnected,
+				setOverrideIsConnected,
+				overrideNetworkType,
+				setOverrideNetworkType,
 				isDevButtonShown,
+				overrideIsInternetReachable,
+				setOverrideIsInternetReachable,
 			},
 		} = res.data;
 
 		if (!isDevButtonShown) return null;
 
 		return (
-			<View style={devToggleStyles.bg}>
-				<TouchableWithoutFeedback
-					onPress={() => setIsForcedOffline(!isForcedOffline)}
-				>
-					<Text style={devToggleStyles.text}>
-						Net info{': '}
-						{isForcedOffline ? 'forced offline' : type}
-					</Text>
-				</TouchableWithoutFeedback>
-			</View>
+			<BottomSheetModalProvider>
+				<>
+					<View style={devToggleStyles.bg}>
+						<TouchableWithoutFeedback
+							onPress={() => {
+								handlePresentModalPress();
+							}}
+						>
+							<Text style={devToggleStyles.text}>
+								Net info: {type} {'\n'}
+								isConnected: {String(isConnected)} {'\n'}
+								isPoorConnection: {String(
+									isPoorConnection,
+								)}{' '}
+								{'\n'}
+								isInternetReachable:{' '}
+								{String(isInternetReachable)}
+							</Text>
+						</TouchableWithoutFeedback>
+					</View>
+					<BottomSheetModal
+						ref={bottomSheetModalRef}
+						index={1}
+						snapPoints={snapPoints}
+						onChange={handleSheetChanges}
+					>
+						<View style={devToggleStyles.contentContainer}>
+							<View style={devToggleStyles.row}>
+								<Text>Type: </Text>
+								<Picker
+									style={{
+										flex: 1,
+									}}
+									selectedValue={overrideNetworkType}
+									onValueChange={(itemValue) =>
+										setOverrideNetworkType(itemValue)
+									}
+								>
+									{(Object.keys(NetInfoStateType) as Array<
+										keyof typeof NetInfoStateType
+									>).map((type) => (
+										<Picker.Item
+											key={type}
+											label={type}
+											value={type}
+										/>
+									))}
+								</Picker>
+							</View>
+							<View style={devToggleStyles.row}>
+								<Text>isConnected: </Text>
+								<Switch
+									value={
+										isDisconnectedState(overrideNetworkType)
+											? false
+											: overrideIsConnected
+									}
+									onValueChange={(val) =>
+										setOverrideIsConnected(val)
+									}
+									disabled={isDisconnectedState(
+										overrideNetworkType,
+									)}
+								/>
+							</View>
+							<View style={devToggleStyles.row}>
+								<Text>isInternetReachable: </Text>
+								<Switch
+									value={
+										isDisconnectedState(overrideNetworkType)
+											? false
+											: overrideIsInternetReachable
+									}
+									onValueChange={(val) =>
+										setOverrideIsInternetReachable(val)
+									}
+									disabled={isDisconnectedState(
+										overrideNetworkType,
+									)}
+								/>
+							</View>
+						</View>
+					</BottomSheetModal>
+				</>
+			</BottomSheetModalProvider>
 		);
 	};
 })();

--- a/projects/Mallard/src/components/NetInfoDevOverlay.tsx
+++ b/projects/Mallard/src/components/NetInfoDevOverlay.tsx
@@ -153,9 +153,11 @@ const DevButton = (() => {
 										setOverrideNetworkType(itemValue)
 									}
 								>
-									{(Object.keys(NetInfoStateType) as Array<
-										keyof typeof NetInfoStateType
-									>).map((type) => (
+									{(
+										Object.keys(NetInfoStateType) as Array<
+											keyof typeof NetInfoStateType
+										>
+									).map((type) => (
 										<Picker.Item
 											key={type}
 											label={type}

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -48,8 +48,8 @@ const getDiagnosticInfo = async (
 					netInfo @client {
 						type @client
 						isConnected @client
-						details @client
 						isPoorConnection @client
+						isInternetReachable @client
 					}
 				`,
 			}),
@@ -114,9 +114,10 @@ Image Size for Downloads: ${imageSize}
 ${Platform.OS} Version: ${Platform.Version}
 Device Type: ${deviceId}
 Device Id: ${uniqueId}
-Network availability: ${netInfo.type}
-isConnected: ${netInfo.isConnected}
-isPoorConnection: ${netInfo.isPoorConnection}
+Network: Type: ${netInfo.type}
+Network: Connected?: ${netInfo.isConnected}
+Network: Internet Reachable?: ${netInfo.isInternetReachable}
+Network: Poor Connection?: ${netInfo.isPoorConnection}
 Privacy settings: ${gdprEntries
 		.map(([key, value]) => `${key}:${value}`)
 		.join(' ')}

--- a/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-net-info.spec.tsx
@@ -26,30 +26,27 @@ const cellularState = {
 	isInternetReachable: true,
 } as NetInfoState;
 
-jest.mock(
-	'@react-native-community/netinfo',
-	(): NetInfoMock => {
-		let bound: Handler = () => {};
+jest.mock('@react-native-community/netinfo', (): NetInfoMock => {
+	let bound: Handler = () => {};
 
-		const addEventListener = jest.fn((fn: Handler) => {
-			bound = fn;
-			return () => {};
-		});
+	const addEventListener = jest.fn((fn: Handler) => {
+		bound = fn;
+		return () => {};
+	});
 
-		const ret = {
-			NetInfoStateType: {
-				unknown: 'unknown',
-				none: 'none',
-				wifi: 'wifi',
-				cellular: 'cellular',
-			},
-			addEventListener,
-			emit: (state: NetInfoState) => bound(state),
-			fetch: jest.fn(),
-		};
-		return ret;
-	},
-);
+	const ret = {
+		NetInfoStateType: {
+			unknown: 'unknown',
+			none: 'none',
+			wifi: 'wifi',
+			cellular: 'cellular',
+		},
+		addEventListener,
+		emit: (state: NetInfoState) => bound(state),
+		fetch: jest.fn(),
+	};
+	return ret;
+});
 
 describe('use-net-info', () => {
 	describe('createNetInfoResolver', () => {
@@ -63,8 +60,8 @@ describe('use-net-info', () => {
 
 		beforeEach(() => {
 			jest.resetModules();
-			createNetInfoResolver = require('../use-net-info')
-				.createNetInfoResolver;
+			createNetInfoResolver =
+				require('../use-net-info').createNetInfoResolver;
 			NetInfo = require('@react-native-community/netinfo');
 			NetInfo.addEventListener.mockClear(); // ignore side-effects form module load
 			client = new ApolloClient({

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -61,7 +61,9 @@ const DevZone = () => {
 	const {
 		isDevButtonShown: showNetInfoButton,
 		setIsDevButtonShown: setShowNetInfoButton,
+		type,
 		isConnected,
+		isInternetReachable,
 		isPoorConnection,
 	} = useNetInfo();
 	const [showAllEditions, setShowAllEditions] = useState(false);
@@ -254,7 +256,7 @@ const DevZone = () => {
 					{
 						key: 'Network Information',
 						title: 'Network Information',
-						explainer: `isPoorConnection: ${isPoorConnection} \nisConnected: ${isConnected}`,
+						explainer: `Type: ${type} \nisPoorConnection: ${isPoorConnection} \nisConnected: ${isConnected} \nisInternetReachable: ${isInternetReachable}`,
 					},
 					{
 						key: 'Clear CAS caches',

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1218,6 +1218,24 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@gorhom/bottom-sheet@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-2.4.0.tgz#d1a3ef31daa2c7f5456255d393bb88fcc6e122f8"
+  integrity sha512-zbcqDu71Z23F4B0fmXq9503Adq5B9F/6M832PVZTIgSfdFcLdS4nInLcViZ0NaItZq4TQEKg4EyLscPr+iYRrQ==
+  dependencies:
+    "@gorhom/portal" "^1.0.4"
+    invariant "^2.2.4"
+    lodash.isequal "^4.5.0"
+    nanoid "^3.1.20"
+    react-native-redash "^14.2.4"
+
+"@gorhom/portal@^1.0.4":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-1.0.9.tgz#bd66e0e27e49fa3163b89c4c23661f31471a6343"
+  integrity sha512-tQUBKf1kDLK1l+0duYBxRqNMtdIrOAIp2H36Bc7/qUZXRxP1rUvj7EMmv6tdlKN/MzEiKPGx9wY0EmOYTjXIFQ==
+  dependencies:
+    nanoid "^3.1.23"
+
 "@guardian/eslint-config-typescript@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.5.0.tgz#362b79da6440fc77d9c25b77ef9cfae18988ac5b"
@@ -1721,6 +1739,11 @@
   version "10.8.1"
   resolved "https://registry.yarnpkg.com/@react-native-firebase/remote-config/-/remote-config-10.8.1.tgz#c6587c2ee3610870372084ed51dbfd66d26ffbc3"
   integrity sha512-zONnuaNsyFziNXR5ee222QgcJv8OIvPufMwzXaY180XRzNnBUsCPWmOvhQouA3ko8oUKov1J/sXPAL9DWpb+JQ==
+
+"@react-native-picker/picker@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.1.0.tgz#1ef22d4e9b2e555d44b43453f51a46d8631f3182"
+  integrity sha512-iJ/QaDrBMBaW6cFuQyR3DXzcn2h7c5O7mGgmNLCBQHTTtLNBZR+Sxogy6YleFPeToNdysG5mTTkXqBmlWHMQqg==
 
 "@react-native/assets@1.0.0":
   version "1.0.0"
@@ -2932,6 +2955,11 @@ abort-controller@^3.0.0:
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   dependencies:
     event-target-shim "^5.0.0"
+
+abs-svg-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
+  integrity sha1-32Acjo0roQ1KdtYl4japo5wnI78=
 
 absolute-path@^0.0.0:
   version "0.0.0"
@@ -9498,6 +9526,11 @@ nanoid@^3.1.15:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
+nanoid@^3.1.20, nanoid@^3.1.23:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
+  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9727,6 +9760,13 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
+normalize-svg-path@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz#0e614eca23c39f0cffe821d6be6cd17e569a766c"
+  integrity sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==
+  dependencies:
+    svg-arc-to-cubic-bezier "^3.0.0"
 
 normalize-url@^6.0.1:
   version "6.1.0"
@@ -10226,6 +10266,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-svg-path@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/parse-svg-path/-/parse-svg-path-0.1.2.tgz#7a7ec0d1eb06fa5325c7d3e009b859a09b5d49eb"
+  integrity sha1-en7A0esG+lMlx9PgCbhZoJtdSes=
 
 parse5@5.1.1:
   version "5.1.1"
@@ -11137,6 +11182,15 @@ react-native-reanimated@^1.13.2:
   integrity sha512-i714H24dv6ncpFO7/SZ0PfAMbvjgVbF8Ow2NPtowoZAz8osS54DmTMrkgJ9Za+uEku/s0AEaxqiXG2Xgntvv2g==
   dependencies:
     fbjs "^1.0.0"
+
+react-native-redash@^14.2.4:
+  version "14.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-redash/-/react-native-redash-14.2.4.tgz#5dbb4b2f1a7441bb304fe3494b89e0dc9010c8ef"
+  integrity sha512-/1R9UxXv3ffKcrbxolqa2B247Cgd3ikyEm2q1VlBng77Es6PAD4LAOXQ83pBavvwNfOsbhF3ebkbMpJcLaVt3Q==
+  dependencies:
+    abs-svg-path "^0.1.1"
+    normalize-svg-path "^1.0.1"
+    parse-svg-path "^0.1.2"
 
 react-native-restart@^0.0.17:
   version "0.0.17"
@@ -12658,6 +12712,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+svg-arc-to-cubic-bezier@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
+  integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
 
 symbol-observable@^1.0.2:
   version "1.2.0"


### PR DESCRIPTION
## Why are you doing this?
To help us diagnose network issues easier

## Changes

- Turning on the netinfo button essentially puts the app in network dev mode so we can test use cases for different types of connections
- Update the net info button to give the current network state of the app when on.
- Bottom sheet added to allow for custom net info controls anywhere within the app
- Overrides for network type, isConnected and isInternetReachable. This should help with the "London Bridge" scenario
- Tests to cover the new overrides
- Updated "Download Blocked" logic to take into account the overrides. This function should have tests
- I think more scenarios need testing if we had more time on this PR.

## Demo
![2021-09-24 08 40 17](https://user-images.githubusercontent.com/935975/134637498-10cd3991-6605-4b56-8ee6-f277781c0635.gif)

