### PR TITLE
feat: useNetInfoProvider

### DIFF
--- a/projects/Mallard/src/__mocks__/@react-native-community/netinfo.js
+++ b/projects/Mallard/src/__mocks__/@react-native-community/netinfo.js
@@ -3,6 +3,9 @@ module.exports = {
 	addListener: jest.fn(),
 	removeListeners: jest.fn(),
 	NetInfoStateType: {
+		none: 'none',
+		cellular: 'cellular',
+		wifi: 'wifi',
 		unknown: 'unknown',
 	},
 	fetch: jest.fn(() => Promise.resolve(true)),

--- a/projects/Mallard/src/hooks/use-net-info-provider/__tests__/utils.spec.ts
+++ b/projects/Mallard/src/hooks/use-net-info-provider/__tests__/utils.spec.ts
@@ -1,0 +1,154 @@
+import {
+	getDownloadBlockedStatus,
+	isPoorConnection,
+	isTruelyConnected,
+	stateResolver,
+} from '../utils';
+import { DownloadBlockedStatus } from '../types';
+import { NetInfoStateType } from '../index';
+import { isDisconnectedState } from 'src/hooks/use-net-info';
+
+describe('use-net-info-provider', () => {
+	describe('getDownloadBlockedStatus', () => {
+		it('should return "Offline" if the user is not connected', () => {
+			const downloadBlockedStatus = getDownloadBlockedStatus(
+				{ type: NetInfoStateType.none, isConnected: false },
+				false,
+			);
+			expect(downloadBlockedStatus).toEqual(
+				DownloadBlockedStatus.Offline,
+			);
+		});
+		it('should return "WifiOnly" if the user is connected, wifi only downloads are selected and the net info type is NOT wifi', () => {
+			const downloadBlockedStatus = getDownloadBlockedStatus(
+				{ type: NetInfoStateType.cellular, isConnected: true },
+				true,
+			);
+			expect(downloadBlockedStatus).toEqual(
+				DownloadBlockedStatus.WifiOnly,
+			);
+		});
+
+		it('should return "NotBlocked" if the user is connected, wifi only downloads are selected and the net info type is wifi', () => {
+			const downloadBlockedStatus = getDownloadBlockedStatus(
+				{ type: NetInfoStateType.wifi, isConnected: true },
+				true,
+			);
+			expect(downloadBlockedStatus).toEqual(
+				DownloadBlockedStatus.NotBlocked,
+			);
+		});
+		it('should return "NotBlocked" if the user is connected and they have NOT selected wifi only downloads', () => {
+			const downloadBlockedStatus = getDownloadBlockedStatus(
+				{ type: NetInfoStateType.cellular, isConnected: true },
+				false,
+			);
+			expect(downloadBlockedStatus).toEqual(
+				DownloadBlockedStatus.NotBlocked,
+			);
+		});
+	});
+
+	describe('isDisconnectedState', () => {
+		it('should return true if the network type is unknown', () => {
+			const disconnected = isDisconnectedState(NetInfoStateType.unknown);
+			expect(disconnected).toEqual(true);
+		});
+		it('should return true if the network type is none', () => {
+			const disconnected = isDisconnectedState(NetInfoStateType.none);
+			expect(disconnected).toEqual(true);
+		});
+		it('should return fase if the network type is anything else', () => {
+			const disconnected = isDisconnectedState(NetInfoStateType.wifi);
+			expect(disconnected).toEqual(false);
+		});
+	});
+
+	describe('isTruelyConnected', () => {
+		it('should return true if you are connected and your interenet is reachable', () => {
+			const connected = isTruelyConnected({
+				isConnected: true,
+				isInternetReachable: true,
+			});
+			expect(connected).toEqual(true);
+		});
+		it('should return false if you are connected but your internet is NOT reachable', () => {
+			const connected = isTruelyConnected({
+				isConnected: true,
+				isInternetReachable: false,
+			});
+			expect(connected).toEqual(false);
+		});
+		it('should return false if you are NOT connected and your internet is NOT reachable', () => {
+			const connected = isTruelyConnected({
+				isConnected: false,
+				isInternetReachable: false,
+			});
+			expect(connected).toEqual(false);
+		});
+	});
+
+	describe('isPoorConnection', () => {
+		it('should return true when the network type is cellular', () => {
+			const checkPoorConnection = isPoorConnection(
+				NetInfoStateType.cellular,
+			);
+			expect(checkPoorConnection).toEqual(true);
+		});
+		it('should return false when the network type is anything else', () => {
+			const checkPoorConnection = isPoorConnection(NetInfoStateType.none);
+			expect(checkPoorConnection).toEqual(false);
+		});
+	});
+
+	describe('stateResolver', () => {
+		it('should provide an expected state when no overrides are being enforced', () => {
+			const netInfo = {
+				type: NetInfoStateType.wifi,
+				isConnected: true,
+				isInternetReachable: true,
+				isDevButtonShown: false,
+				overrideIsConnected: false,
+				overrideNetworkType: NetInfoStateType.unknown,
+				overrideIsInternetReachable: false,
+			};
+
+			const resolvedState = stateResolver(netInfo);
+			expect(resolvedState).toEqual({
+				downloadBlocked: DownloadBlockedStatus.NotBlocked,
+				isConnected: true,
+				isDevButtonShown: false,
+				isInternetReachable: true,
+				isPoorConnection: false,
+				overrideIsConnected: false,
+				overrideIsInternetReachable: false,
+				overrideNetworkType: NetInfoStateType.unknown,
+				type: NetInfoStateType.wifi,
+			});
+		});
+		it('should enforce overrides when they are enabled', () => {
+			const netInfo = {
+				type: NetInfoStateType.wifi,
+				isConnected: true,
+				isInternetReachable: true,
+				isDevButtonShown: true,
+				overrideIsConnected: false,
+				overrideNetworkType: NetInfoStateType.cellular,
+				overrideIsInternetReachable: false,
+			};
+
+			const resolvedState = stateResolver(netInfo);
+			expect(resolvedState).toEqual({
+				downloadBlocked: DownloadBlockedStatus.Offline,
+				isConnected: false,
+				isDevButtonShown: true,
+				isInternetReachable: false,
+				isPoorConnection: true,
+				overrideIsConnected: false,
+				overrideIsInternetReachable: false,
+				overrideNetworkType: NetInfoStateType.cellular,
+				type: NetInfoStateType.cellular,
+			});
+		});
+	});
+});

--- a/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
@@ -1,6 +1,5 @@
 import { NetInfoStateType, useNetInfo } from '@react-native-community/netinfo';
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { NetInfoDevOverlay } from 'src/components/NetInfoDevOverlay';
 import type { NetInfoState } from './types';
 import { DownloadBlockedStatus } from './types';
 import { isDisconnectedState, stateResolver } from './utils';
@@ -110,7 +109,6 @@ export const NetInfoProvider = ({
 			}}
 		>
 			{children}
-			<NetInfoDevOverlay />
 		</NetInfoContext.Provider>
 	);
 };

--- a/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
@@ -1,0 +1,119 @@
+import { NetInfoStateType, useNetInfo } from '@react-native-community/netinfo';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { NetInfoDevOverlay } from 'src/components/NetInfoDevOverlay';
+import type { NetInfoState } from './types';
+import { DownloadBlockedStatus } from './types';
+import { isDisconnectedState, stateResolver } from './utils';
+
+const defaultState: NetInfoState = {
+	type: NetInfoStateType.unknown,
+	isConnected: false,
+	isPoorConnection: false,
+	isInternetReachable: false,
+	downloadBlocked: DownloadBlockedStatus.NotBlocked,
+	isDevButtonShown: false,
+	setIsDevButtonShown: () => {},
+	overrideIsConnected: false,
+	setOverrideIsConnected: () => {},
+	overrideNetworkType: NetInfoStateType.unknown,
+	setOverrideNetworkType: () => {},
+	overrideIsInternetReachable: false,
+	setOverrideIsInternetReachable: () => {},
+};
+
+const NetInfoContext = createContext(defaultState);
+
+export const NetInfoProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	/* Variables to track against the actual Net Info state */
+	const [localType, setLocalType] = useState<NetInfoState['type']>(
+		defaultState.type,
+	);
+	const [localIsConnected, setLocalIsConnected] = useState<
+		NetInfoState['isConnected']
+	>(defaultState.isConnected);
+	const [localIsInternetReachable, setLocalIsInternetReachable] = useState<
+		NetInfoState['isInternetReachable']
+	>(defaultState.isInternetReachable);
+
+	/* Calculated values */
+	const [localIsPoorConnection, setLocalIsPoorConnection] = useState<
+		NetInfoState['isPoorConnection']
+	>(defaultState.isPoorConnection);
+	const [localDownloadBlocked, setLocalDownloadBlocked] = useState<
+		NetInfoState['downloadBlocked']
+	>(defaultState.downloadBlocked);
+
+	/* Values associated with overrides */
+	const [isDevButtonShown, setIsDevButtonShown] = useState<
+		NetInfoState['isDevButtonShown']
+	>(defaultState.isDevButtonShown);
+	const [overrideIsConnected, setOverrideIsConnected] = useState<
+		NetInfoState['overrideIsConnected']
+	>(defaultState.overrideIsConnected);
+	const [overrideNetworkType, setOverrideNetworkType] = useState<
+		NetInfoState['overrideNetworkType']
+	>(defaultState.overrideNetworkType);
+	const [overrideIsInternetReachable, setOverrideIsInternetReachable] =
+		useState<NetInfoState['overrideIsInternetReachable']>(
+			defaultState.overrideIsInternetReachable,
+		);
+
+	const { type, isConnected, isInternetReachable } = useNetInfo();
+
+	// Update the state whenever core netinfo values change or overrides are in play
+	useEffect(() => {
+		const resolvedState = stateResolver({
+			type,
+			isConnected,
+			isInternetReachable,
+			isDevButtonShown,
+			overrideIsConnected,
+			overrideNetworkType,
+			overrideIsInternetReachable,
+		});
+
+		setLocalType(resolvedState.type);
+		setLocalIsConnected(resolvedState.isConnected);
+		setLocalIsInternetReachable(resolvedState.isInternetReachable);
+		setLocalIsPoorConnection(resolvedState.isPoorConnection);
+		setLocalDownloadBlocked(resolvedState.downloadBlocked);
+	}, [
+		type,
+		isConnected,
+		isInternetReachable,
+		isDevButtonShown,
+		overrideIsConnected,
+		overrideNetworkType,
+		overrideIsInternetReachable,
+	]);
+
+	return (
+		<NetInfoContext.Provider
+			value={{
+				type: localType,
+				isConnected: localIsConnected,
+				isInternetReachable: localIsInternetReachable,
+				isPoorConnection: localIsPoorConnection,
+				downloadBlocked: localDownloadBlocked,
+				isDevButtonShown,
+				setIsDevButtonShown,
+				overrideIsConnected,
+				setOverrideIsConnected,
+				overrideNetworkType,
+				setOverrideNetworkType,
+				overrideIsInternetReachable,
+				setOverrideIsInternetReachable,
+			}}
+		>
+			{children}
+			<NetInfoDevOverlay />
+		</NetInfoContext.Provider>
+	);
+};
+
+export const useNetInfoProvider = () => useContext(NetInfoContext);
+export { NetInfoStateType, isDisconnectedState };

--- a/projects/Mallard/src/hooks/use-net-info-provider/types.ts
+++ b/projects/Mallard/src/hooks/use-net-info-provider/types.ts
@@ -1,0 +1,40 @@
+import type { NetInfoStateType } from '@react-native-community/netinfo';
+import type { Dispatch } from 'react';
+
+export enum DownloadBlockedStatus {
+	WifiOnly,
+	Offline,
+	NotBlocked,
+}
+
+export type NetInfoCore = {
+	type: NetInfoStateType;
+	isConnected: boolean;
+	isInternetReachable: boolean | null | undefined;
+};
+
+type NetInfoCalculated = {
+	isPoorConnection: boolean;
+	downloadBlocked: DownloadBlockedStatus;
+};
+
+type NetInfoOverrides = {
+	isDevButtonShown: boolean;
+	overrideIsConnected: boolean;
+	overrideNetworkType: NetInfoStateType;
+	overrideIsInternetReachable: boolean;
+};
+
+type NetInfoOverrideSetters = {
+	setIsDevButtonShown: Dispatch<boolean>;
+	setOverrideIsConnected: Dispatch<boolean>;
+	setOverrideNetworkType: Dispatch<NetInfoStateType>;
+	setOverrideIsInternetReachable: Dispatch<boolean>;
+};
+
+export type NetInfoState = NetInfoCore &
+	NetInfoCalculated &
+	NetInfoOverrides &
+	NetInfoOverrideSetters;
+export type NetInfoInputs = NetInfoCore & NetInfoOverrides;
+export type NetInfoValues = NetInfoCore & NetInfoCalculated & NetInfoOverrides;

--- a/projects/Mallard/src/hooks/use-net-info-provider/utils.ts
+++ b/projects/Mallard/src/hooks/use-net-info-provider/utils.ts
@@ -1,0 +1,90 @@
+import { NetInfoStateType } from '@react-native-community/netinfo';
+import { DownloadBlockedStatus } from './types';
+import type { NetInfoCore, NetInfoInputs, NetInfoValues } from './types';
+
+export const getDownloadBlockedStatus = (
+	netInfo: {
+		type: NetInfoCore['type'];
+		isConnected: NetInfoCore['isConnected'];
+	},
+	wifiOnlyDownloads: boolean,
+): DownloadBlockedStatus => {
+	return !netInfo.isConnected
+		? DownloadBlockedStatus.Offline
+		: wifiOnlyDownloads && netInfo.type !== 'wifi'
+		? DownloadBlockedStatus.WifiOnly
+		: DownloadBlockedStatus.NotBlocked;
+};
+
+export const isDisconnectedState = (type: NetInfoStateType) =>
+	type === NetInfoStateType.none || type === NetInfoStateType.unknown;
+
+export const isTruelyConnected = ({
+	isConnected,
+	isInternetReachable,
+}: {
+	isConnected: NetInfoCore['isConnected'];
+	isInternetReachable: NetInfoCore['isInternetReachable'];
+}) => {
+	const internetUnreachable = isInternetReachable === false;
+	return isConnected && !internetUnreachable;
+};
+
+export const isPoorConnection = (type: NetInfoStateType) =>
+	type === NetInfoStateType.cellular;
+
+export const stateResolver = (netInfo: NetInfoInputs): NetInfoValues => {
+	const {
+		type,
+		isConnected,
+		isInternetReachable,
+		isDevButtonShown,
+		overrideIsConnected,
+		overrideNetworkType,
+		overrideIsInternetReachable,
+	} = netInfo;
+
+	const checkPoorConnection = isPoorConnection(
+		isDevButtonShown ? overrideNetworkType : type,
+	);
+	const isFullyConnected = isTruelyConnected({
+		isConnected: isDevButtonShown ? overrideIsConnected : isConnected,
+		isInternetReachable: isDevButtonShown
+			? overrideIsInternetReachable
+			: isInternetReachable,
+	});
+
+	if (isDevButtonShown) {
+		return {
+			...netInfo,
+			type: overrideNetworkType,
+			isConnected: isDisconnectedState(overrideNetworkType)
+				? false
+				: isFullyConnected,
+			isInternetReachable: isDisconnectedState(overrideNetworkType)
+				? false
+				: overrideIsInternetReachable,
+			isPoorConnection: checkPoorConnection,
+			downloadBlocked: getDownloadBlockedStatus(
+				{
+					type: overrideNetworkType,
+					isConnected: isFullyConnected,
+				},
+				true,
+			),
+		};
+	}
+
+	return {
+		...netInfo,
+		isConnected: isFullyConnected,
+		isPoorConnection: checkPoorConnection,
+		downloadBlocked: getDownloadBlockedStatus(
+			{
+				type,
+				isConnected: isFullyConnected,
+			},
+			true,
+		),
+	};
+};


### PR DESCRIPTION
## Why are you doing this?
To move `useNetInfo` from using Apollo to Context to help simplify the code base.

This just produces the Provider and logic which should match the original useNetinfo. 

This is the first PR in a series and this focusses on just the Provider and it's not hooked up to any components yet.

## Changes

- Refactored the existing netinfo logic to work as a Context hook
- Separated out the functions that perform the logic and fully tested them
- The provider itself as a result is a shell state
- Types are relatively complex and are separated as a result.