### PR TITLE
feat: App State Provider

### DIFF
--- a/projects/Mallard/src/hooks/use-app-state-provider.tsx
+++ b/projects/Mallard/src/hooks/use-app-state-provider.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { AppStateStatus } from 'react-native';
+import { AppState } from 'react-native';
+
+const AppStateContext = createContext({ isActive: true });
+
+export const AppStateProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	const [isActive, setIsActive] = useState<boolean>(true);
+
+	useEffect(() => {
+		AppState.addEventListener('change', handleAppStateChange);
+
+		return () => {
+			AppState.removeEventListener('change', handleAppStateChange);
+		};
+	}, []);
+
+	const handleAppStateChange = (appState: AppStateStatus) => {
+		setIsActive(appState === 'active');
+	};
+
+	return (
+		<AppStateContext.Provider value={{ isActive }}>
+			{children}
+		</AppStateContext.Provider>
+	);
+};
+
+export const useAppState = () => useContext(AppStateContext);


### PR DESCRIPTION
## Why are you doing this?
In numerous places in the code we are adding and removing app state listeners. In each case we only care if the app has been foregrounded. A bit of experimentation suggests that this is causing more rerenders than we need. My feeling is a context value we can listen to will mean we can "hook" into this value and make changes as a result. This should make the code a bit more dry and neaten up our `useEffect`s

## Changes

- Added an App State provider and hook
- This is not added to the app yet but just used in isolation. 
