### PR TITLE
feat: Issue Summary Context Provider

### DIFF
--- a/projects/Mallard/src/hooks/__tests__/use-issue-summary-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-issue-summary-provider.spec.tsx
@@ -1,0 +1,136 @@
+import * as files from '../../helpers/files';
+import {
+	getIssueSummary,
+	issueSummaryToLatestPath,
+} from '../use-issue-summary-provider';
+
+jest.mock('react-native-fs', () => ({
+	readFile: () => Promise.resolve(JSON.stringify(exampleIssueSummary)),
+}));
+
+jest.mock('../use-config-provider', () => ({
+	getMaxAvailableEditions: () => Promise.resolve(1),
+}));
+
+const exampleIssueSummary = [
+	{
+		assets: {
+			data: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/data.zip',
+			phone: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/phone.zip',
+			tablet: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tablet.zip',
+			tabletL:
+				'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tabletL.zip',
+			tabletXL:
+				'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tabletXL.zip',
+		},
+		assetsSSR: {
+			data: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/data.zip',
+			html: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/html.zip',
+			phone: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/phone.zip',
+			tablet: 'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tablet.zip',
+			tabletL:
+				'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tabletL.zip',
+			tabletXL:
+				'zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tabletXL.zip',
+		},
+		date: '2021-10-05',
+		key: 'daily-edition/2021-10-05',
+		localId: 'daily-edition/2021-10-05',
+		name: 'UK Daily',
+		publishedId: 'daily-edition/2021-10-05/2021-10-05T01:02:01.008Z',
+	},
+	{
+		assets: {
+			data: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/data.zip',
+			phone: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/phone.zip',
+			tablet: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/tablet.zip',
+			tabletL:
+				'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/tabletL.zip',
+			tabletXL:
+				'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/tabletXL.zip',
+		},
+		assetsSSR: {
+			data: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/data.zip',
+			html: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/ssr/html.zip',
+			phone: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/ssr/phone.zip',
+			tablet: 'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/ssr/tablet.zip',
+			tabletL:
+				'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/ssr/tabletL.zip',
+			tabletXL:
+				'zips/daily-edition/2021-10-04/2021-10-04T00:27:49.527Z/ssr/tabletXL.zip',
+		},
+		date: '2021-10-04',
+		key: 'daily-edition/2021-10-04',
+		localId: 'daily-edition/2021-10-04',
+		name: 'UK Daily',
+		publishedId: 'daily-edition/2021-10-04/2021-10-04T00:27:49.527Z',
+	},
+];
+
+const spyFetchAndStoreIssueSummary = jest
+	.spyOn(files, 'fetchAndStoreIssueSummary')
+	.mockResolvedValue(exampleIssueSummary);
+
+const spyReadSummary = jest
+	.spyOn(files, 'fetchAndStoreIssueSummary')
+	.mockResolvedValue(exampleIssueSummary);
+
+describe('use-issue-summary-provider', () => {
+	describe('getIssueSummary', () => {
+		it('should call fetchAndStoreIssueSummary by default', async () => {
+			await getIssueSummary();
+			expect(spyFetchAndStoreIssueSummary).toHaveBeenCalled();
+		});
+		it('should call fetchAndStoreIssueSummary if there is connection and its NOT poor', async () => {
+			await getIssueSummary(true, false);
+			expect(spyFetchAndStoreIssueSummary).toHaveBeenCalled();
+		});
+		it('should call readIssueSummary if there is no connection', async () => {
+			await getIssueSummary(false);
+			expect(spyReadSummary).toHaveBeenCalled();
+		});
+		it('should call readIssueSummary if there is a connection but its poor', async () => {
+			await getIssueSummary(true, true);
+			expect(spyReadSummary).toHaveBeenCalled();
+		});
+		it('should trim the issue summary based on the number of editions chosen', async () => {
+			const issueSummary = await getIssueSummary();
+			expect(issueSummary).toMatchInlineSnapshot(`
+			Array [
+			  Object {
+			    "assets": Object {
+			      "data": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/data.zip",
+			      "phone": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/phone.zip",
+			      "tablet": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tablet.zip",
+			      "tabletL": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tabletL.zip",
+			      "tabletXL": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/tabletXL.zip",
+			    },
+			    "assetsSSR": Object {
+			      "data": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/data.zip",
+			      "html": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/html.zip",
+			      "phone": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/phone.zip",
+			      "tablet": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tablet.zip",
+			      "tabletL": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tabletL.zip",
+			      "tabletXL": "zips/daily-edition/2021-10-05/2021-10-05T01:02:01.008Z/ssr/tabletXL.zip",
+			    },
+			    "date": "2021-10-05",
+			    "key": "daily-edition/2021-10-05",
+			    "localId": "daily-edition/2021-10-05",
+			    "name": "UK Daily",
+			    "publishedId": "daily-edition/2021-10-05/2021-10-05T01:02:01.008Z",
+			  },
+			]
+		`);
+		});
+	});
+
+	describe('issueSummaryToLatest', () => {
+		it('should return an appropriate issue id based on a valid issue summary', () => {
+			const latestId = issueSummaryToLatestPath(exampleIssueSummary);
+			expect(latestId).toEqual({
+				localIssueId: exampleIssueSummary[0].localId,
+				publishedIssueId: exampleIssueSummary[0].publishedId,
+			});
+		});
+	});
+});

--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -1,0 +1,158 @@
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react';
+import type { Dispatch } from 'react';
+import type { IssueSummary } from 'src/common';
+import { fetchAndStoreIssueSummary, readIssueSummary } from 'src/helpers/files';
+import type { PathToIssue } from 'src/paths';
+import { errorService } from 'src/services/errors';
+import { useAppState } from './use-app-state-provider';
+import {
+	getMaxAvailableEditions,
+	useMaxAvailableEditions,
+} from './use-config-provider';
+import { useEditions } from './use-edition-provider';
+import { useNetInfoProvider } from './use-net-info-provider';
+
+interface IssueSummaryState {
+	issueSummary: IssueSummary[] | null;
+	issueId: PathToIssue | null;
+	error: string;
+	initialFrontKey: string | null;
+	setIssueId: Dispatch<PathToIssue>;
+}
+
+const defaultState: IssueSummaryState = {
+	issueSummary: null,
+	issueId: null,
+	error: '',
+	initialFrontKey: null,
+	setIssueId: () => {},
+};
+
+const IssueSummaryContext = createContext(defaultState);
+
+export const getIssueSummary = async (
+	isConnected = true,
+	isPoorConnection = false,
+): Promise<IssueSummary[]> => {
+	const issueSummary =
+		isConnected && !isPoorConnection
+			? await fetchAndStoreIssueSummary()
+			: await readIssueSummary();
+	const maxAvailableEditions = await getMaxAvailableEditions();
+	try {
+		const trimmedSummary = issueSummary.slice(0, maxAvailableEditions);
+		return trimmedSummary;
+	} catch (e) {
+		e.message = `getIssueSummary error: maxAvailableEditions: ${maxAvailableEditions} & issueSummary: ${JSON.stringify(
+			issueSummary,
+		)}`;
+		errorService.captureException(e);
+		throw Error(e);
+	}
+};
+
+export const issueSummaryToLatestPath = (
+	issueSummary: IssueSummary[],
+): PathToIssue => ({
+	localIssueId: issueSummary[0].localId,
+	publishedIssueId: issueSummary[0].publishedId,
+});
+
+export const IssueSummaryProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	const [issueSummary, setIssueSummary] = useState<
+		IssueSummaryState['issueSummary']
+	>(defaultState.issueSummary);
+	const [issueId, setLocalIssueId] = useState<IssueSummaryState['issueId']>(
+		defaultState.issueId,
+	);
+	const [initialFrontKey, setInitialFrontKey] = useState<
+		IssueSummaryState['initialFrontKey']
+	>(defaultState.initialFrontKey);
+	const [error, setError] = useState<IssueSummaryState['error']>(
+		defaultState.error,
+	);
+
+	const { isConnected, isPoorConnection } = useNetInfoProvider();
+	const { selectedEdition } = useEditions();
+	const { maxAvailableEditions } = useMaxAvailableEditions();
+	const { isActive } = useAppState();
+
+	const setIssueId = (issueId: PathToIssue, frontKey?: string) => {
+		frontKey && setInitialFrontKey(frontKey);
+		setLocalIssueId(issueId);
+	};
+
+	// Use Callback used so the function isnt recreated on each rerender
+	const getLatestIssueSummary = useCallback(() => {
+		getIssueSummary(isConnected, isPoorConnection)
+			.then((retrievedIssueSummary) => {
+				setIssueSummary(retrievedIssueSummary);
+				// Clear the initial front key if it is a new issue id and set it
+				const latestIssueId = issueSummaryToLatestPath(
+					retrievedIssueSummary,
+				);
+				issueId !== latestIssueId && setInitialFrontKey(null);
+				setLocalIssueId(latestIssueId);
+				setError('');
+			})
+			.catch((e) => {
+				setError(e.message);
+				// In the case of error, attempt to get the last stored issue summary
+				getIssueSummary(false)
+					.then((backupIssueSummary) => {
+						setIssueSummary(backupIssueSummary);
+						const backupIssueIds =
+							issueSummaryToLatestPath(backupIssueSummary);
+						setIssueId(backupIssueIds);
+					})
+					.catch((e) => {
+						e.message = `Unable to get backup issue summary: ${e.message}`;
+						errorService.captureException(e);
+					});
+			});
+	}, [isConnected, isPoorConnection, selectedEdition, maxAvailableEditions]);
+
+	// On load, get the latest issue summary
+	useEffect(() => {
+		getLatestIssueSummary();
+	}, []);
+
+	// When the network status, edition , max available editions or app state changes
+	useEffect(() => {
+		if (isActive) {
+			getLatestIssueSummary();
+		}
+	}, [
+		isConnected,
+		isPoorConnection,
+		selectedEdition,
+		maxAvailableEditions,
+		isActive,
+	]);
+
+	return (
+		<IssueSummaryContext.Provider
+			value={{
+				issueSummary,
+				issueId,
+				setIssueId,
+				initialFrontKey,
+				error,
+			}}
+		>
+			{children}
+		</IssueSummaryContext.Provider>
+	);
+};
+
+export const useIssueSummary = () => useContext(IssueSummaryContext);


### PR DESCRIPTION
## Why are you doing this?
Attempting to recreate the Issue Summary Apollo implementation into React context to follow existing patterns in the code.

## Changes

- Created the provider and tested the helper functions. I think there are ways to test more of the logic with React Testing Library but we dont have that dependency yet.
- We should fetch new issue summaries when the network changes, max number of editions updates, the selected edition or the app comes back in from the background.
- Tried to simplify the use effects to avoid needless rerenders and to help avoid the cache issue where files are appended.
- To review this one I would suggest carefully looking at the previous issue summary and comparing against this one.