### PR TITLE
Fix: Async Storage Keys

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -97,10 +97,12 @@ const notificationsEnabledCache = createAsyncCache<boolean>(
 	'notificationsEnabled',
 );
 
-const wifiOnlyDownloadsCache = createAsyncCache<boolean>('wifiOnlyDownloads');
+const wifiOnlyDownloadsCache = createAsyncCache<boolean>(
+	'@Setting_wifiOnlyDownloads',
+);
 
 const maxAvailableEditionsCache = createAsyncCache<number>(
-	'maxAvailableEditions',
+	'@Setting_maxAvailableEditions',
 );
 
 /**


### PR DESCRIPTION
## Why are you doing this?

In the previous Mega PR: #1904 we moved some settings out of Apollo into Context. This involved updating where they were persisted. In this case this was from "setters" to "storage"

In doing this I failed to notice the `@Setting_` prefix. This means a new async storage value is being created rather than using the previous one in Apollo. Therefore if this is released, users would lose those settings.

## Changes

- Update the settings in the previous PR to have the correct prefix.