### PR TITLE
Feat: Remove card dimming

### DIFF
--- a/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
+++ b/projects/Mallard/src/components/front/items/helpers/item-tappable.tsx
@@ -1,22 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import {
-	Animated,
-	Easing,
-	StyleSheet,
-	TouchableHighlight,
-	View,
-} from 'react-native';
+import { StyleSheet, TouchableHighlight, View } from 'react-native';
 import type { CAPIArticle, Issue, ItemSizes } from 'src/common';
-import { ariaHidden } from 'src/helpers/a11y';
 import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator } from 'src/screens/article-screen';
-import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 import { useCardBackgroundStyle } from '../../helpers/helpers';
 
@@ -50,28 +42,6 @@ const tappableStyles = StyleSheet.create({
 	padding: tappablePadding,
 });
 
-/*
-To help smooth out the transition
-we fade the card contents out on tap
-and then back in when the view regains focus
-*/
-
-//https://stackoverflow.com/questions/51521809/typescript-definitions-for-animated-views-style-prop opacity: any can chhange at rn 0.61.8
-const fade = (opacity: any, direction: 'in' | 'out') =>
-	direction === 'in'
-		? Animated.timing(opacity, {
-				duration: 150,
-				delay: 150,
-				toValue: 1,
-				easing: Easing.linear,
-				useNativeDriver: true,
-		  }).start()
-		: Animated.timing(opacity, {
-				duration: 150,
-				toValue: 0,
-				useNativeDriver: true,
-		  }).start();
-
 const ItemTappable = ({
 	children,
 	articleNavigator,
@@ -84,18 +54,8 @@ const ItemTappable = ({
 	hasPadding?: boolean;
 } & TappablePropTypes) => {
 	const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
-	const [opacity] = useState(() => new Animated.Value(1));
-
-	React.useEffect(() => {
-		const unsubscribe = navigation.addListener('focus', () => {
-			fade(opacity, 'in');
-		});
-
-		return unsubscribe;
-	}, [navigation]);
 
 	const handlePress = () => {
-		fade(opacity, 'out');
 		article.type === 'crossword'
 			? navigation.navigate(RouteNames.Crossword, {
 					path,
@@ -109,7 +69,7 @@ const ItemTappable = ({
 	};
 
 	return (
-		<Animated.View style={[style]}>
+		<View style={[style]}>
 			<TouchableHighlight onPress={handlePress} activeOpacity={0.95}>
 				<View
 					style={[
@@ -121,21 +81,7 @@ const ItemTappable = ({
 					{children}
 				</View>
 			</TouchableHighlight>
-			<Animated.View
-				{...ariaHidden}
-				pointerEvents="none"
-				style={[
-					StyleSheet.absoluteFill,
-					{
-						backgroundColor: color.dimBackground,
-						opacity: opacity.interpolate({
-							inputRange: [0, 1],
-							outputRange: [1, 0],
-						}),
-					},
-				]}
-			></Animated.View>
-		</Animated.View>
+		</View>
 	);
 };
 


### PR DESCRIPTION
## Why are you doing this?

Prevents the card from dimming when an article is chosen. It looks quite strange at the moment so makes sense to remove it. Also if you navigate away to a different front, you dont even see the effect.

It always makes me a bit sad to remove these features but I think its wise considering there is a requirement to simplify the code. It also makes less sense as a feature without the previous animation effects.

Minor concerns here are from a usability and accessibility POV. We are losing that indicator of what was last clicked, so you lose your place a bit. Worth checking with @prisalcalde before merging.

## Changes

- Removed the hidden `View` and the animation code.
- Should improve performance as each card becomes less stateful.

## Screenshots

### Before
![2021-10-15 08 55 04](https://user-images.githubusercontent.com/935975/137452414-0efd9100-1aa4-4102-9e81-02835f02cd4d.gif)

### After
![2021-10-15 08 54 30](https://user-images.githubusercontent.com/935975/137452398-913c4bd1-2547-481e-8e9c-e600c1209ff3.gif)


