### PR TITLE
Remove 'mobile account' identifier in publishing logs

### DIFF
--- a/projects/archiver/src/services/pub-status-notifier.ts
+++ b/projects/archiver/src/services/pub-status-notifier.ts
@@ -50,8 +50,6 @@ function throwBadStatus(s: never): never {
     throw new Error('Unknown status type')
 }
 
-export const mobileAccountIdentifier = '(Mobile account)'
-
 export const createPublishEvent = (
     identifier: IssuePublicationIdentifier,
     status: Status,
@@ -63,56 +61,56 @@ export const createPublishEvent = (
             return {
                 ...identifier,
                 status: 'Proofing',
-                message: `1/4: Started ${mobileAccountIdentifier}`,
+                message: `1/4: Started`,
                 timestamp,
             }
         case 'assembled':
             return {
                 ...identifier,
                 status: 'Proofing',
-                message: `2/4: Assembled ${mobileAccountIdentifier}`,
+                message: `2/4: Assembled`,
                 timestamp,
             }
         case 'bundled':
             return {
                 ...identifier,
                 status: 'Proofing',
-                message: `3/4: Bundled ${mobileAccountIdentifier}`,
+                message: `3/4: Bundled`,
                 timestamp,
             }
         case 'proofed':
             return {
                 ...identifier,
                 status: 'Proofed',
-                message: `4/4: Ready for proofing on-device ${mobileAccountIdentifier}`,
+                message: `4/4: Ready for proofing on-device`,
                 timestamp,
             }
         case 'copied':
             return {
                 ...identifier,
                 status: 'Publishing',
-                message: `1/2: Copied to publication location ${mobileAccountIdentifier}`,
+                message: `1/2: Copied to publication location`,
                 timestamp,
             }
         case 'published':
             return {
                 ...identifier,
                 status: 'Published',
-                message: `2/2: Added to issue index ${mobileAccountIdentifier}`,
+                message: `2/2: Added to issue index`,
                 timestamp,
             }
         case 'notified':
             return {
                 ...identifier,
                 status: 'PostProcessing',
-                message: `Notification scheduled ${mobileAccountIdentifier}`,
+                message: `Notification scheduled`,
                 timestamp,
             }
         case 'editionsListUpdated':
             return {
                 ...identifier,
                 status: 'PostProcessing',
-                message: `Editions List updated ${mobileAccountIdentifier}`,
+                message: `Editions List updated`,
                 timestamp,
             }
         case 'errored':

--- a/projects/archiver/src/services/task-handler.ts
+++ b/projects/archiver/src/services/task-handler.ts
@@ -5,7 +5,6 @@ import {
     sendPublishStatusToTopic,
     createPublishEvent,
     PublishEvent,
-    mobileAccountIdentifier,
 } from './pub-status-notifier'
 import { Handler } from 'aws-lambda'
 import { Attempt } from '../../../backend/utils/try'
@@ -67,7 +66,7 @@ export function handleAndNotifyInternal<I extends InputWithIdentifier, O>(
             const event: PublishEvent = {
                 ...issuePublication,
                 status: 'Failed',
-                message: `${errorToString(err)} ${mobileAccountIdentifier}`,
+                message: `${errorToString(err)}`,
                 timestamp: dependencies.getMoment().format(),
             }
             await dependencies.sendPublishStatusToTopic(event)

--- a/projects/archiver/test/services/task-handler.spec.ts
+++ b/projects/archiver/test/services/task-handler.spec.ts
@@ -2,7 +2,6 @@ import { handleAndNotifyInternal } from '../../src/services/task-handler'
 import moment = require('moment')
 import {
     createPublishEvent,
-    mobileAccountIdentifier,
     PublishEvent,
 } from '../../src/services/pub-status-notifier'
 import { IssuePublicationIdentifier } from '../../common'
@@ -91,7 +90,7 @@ describe('handleAndNotifyInternal', () => {
         const event: PublishEvent = {
             ...input.issuePublication,
             status: 'Failed',
-            message: `Error: error ${mobileAccountIdentifier}`,
+            message: `Error: error`,
             timestamp: now.format(),
         }
         expect(dependencies.sendPublishStatusToTopic).toBeCalledWith(event)


### PR DESCRIPTION
Now that there is only 1 editions stack we no longer need to identify which stack a publishing message has come from