### PR TITLE
Remove cloudwatch event conversion logic

### DIFF
--- a/projects/archiver/src/invoke/index.ts
+++ b/projects/archiver/src/invoke/index.ts
@@ -23,11 +23,6 @@ export interface Record {
     eventTime: string
 } //partial of https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 
-export interface CloudWatchEvent {
-    detail: { requestParameters: { bucketName: string; key: string } }
-    time: string
-}
-
 const sf = new StepFunctions({
     region: 'eu-west-1',
 })
@@ -195,20 +190,12 @@ export const internalHandler = async (
     ]
 }
 
-const eventToRecord = (event: CloudWatchEvent): Record => {
-    return {
-        s3: {
-            bucket: { name: event.detail.requestParameters.bucketName },
-            object: { key: event.detail.requestParameters.key },
-        },
-        eventTime: event.time,
-    }
-}
-
 export const handler: Handler<
-    CloudWatchEvent,
+    {
+        Records: Record[]
+    },
     (string | Failure)[]
-> = async inputData => {
+> = async ({ Records }) => {
     const proofStateMachineArnEnv = 'proofStateMachineARN'
     const proofStateMachineArn = process.env[proofStateMachineArnEnv]
     const publishStateMachineArnEnv = 'publishStateMachineARN'
@@ -221,12 +208,9 @@ export const handler: Handler<
         throw new Error('No Publish State Machine ARN configured')
     }
 
-    console.log('input data', inputData)
-    const Records = [eventToRecord(inputData)]
-
     console.log(
         `Attempting to invoke Proof/Publish State Machines after receiving records:`,
-        inputData,
+        Records,
     )
 
     const runtimeDependencies: InvokerDependencies = {


### PR DESCRIPTION
## Why are you doing this?
Editions will soon be triggered by an S3 notifification rather than a cloudwatch events rule. This modifies the listener function to support this change