### PR TITLE
chore: Update React Native IAP

### DIFF
--- a/projects/Mallard/android/app/build.gradle
+++ b/projects/Mallard/android/app/build.gradle
@@ -145,6 +145,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
         versionName appVersionName()
+        // react-native-iap: we only use the Google Play flavor
+        missingDimensionStrategy 'store', 'play'
     }
     splits {
         abi {

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -422,8 +422,8 @@ PODS:
     - React
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNIap (3.5.9):
-    - React
+  - RNIap (7.5.0):
+    - React-Core
   - RNInAppBrowser (3.6.3):
     - React-Core
   - RNKeychain (6.2.0):
@@ -765,7 +765,7 @@ SPEC CHECKSUMS:
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNIap: 9e69c8d9ecfdd1f0882363366e85d2e1683ecc89
+  RNIap: f632e0685e37759e1a63651868d38fd08efe9a87
   RNInAppBrowser: 3ff3a3b8f458aaf25aaee879d057352862edf357
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
   RNLocalize: 7c7aeda16c01db7a0918981c14875c0a53be9b79

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -83,7 +83,7 @@
         "react-native-fs": "^2.16.6",
         "react-native-gesture-handler": "^1.9.0",
         "react-native-htmlview": "^0.15.0",
-        "react-native-iap": "^3.3.9",
+        "react-native-iap": "^7.5.0",
         "react-native-image-zoom-viewer": "^3.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",

--- a/projects/Mallard/src/__mocks__/react-native-iap.js
+++ b/projects/Mallard/src/__mocks__/react-native-iap.js
@@ -1,0 +1,3 @@
+import mock from 'react-native-iap/test/mocks/react-native-modules';
+
+jest.mock('react-native-iap', () => mock);

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -1,7 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
 import type { Purchase } from 'react-native-iap';
 import RNIAP from 'react-native-iap';
-import type { ReceiptValidationResponse } from 'react-native-iap/type/apple';
 import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants';
 import { isInBeta } from 'src/helpers/release-stream';
 import type { AuthResult } from '../lib/Result';
@@ -54,15 +53,15 @@ const isReceiptValid = (receipt: ReceiptIOS) => {
 	return expirationWithGracePeriod > nowInMilliseconds;
 };
 
-const hasLatestReceiptInfo = (receipt: ReceiptValidationResponse) => {
+const hasLatestReceiptInfo = (receipt: any) => {
 	return (receipt?.latest_receipt_info as ReceiptIOS[])?.length > 0;
 };
 
-const findValidReceiptFromLatestInfo = (receipt: ReceiptValidationResponse) => {
+const findValidReceiptFromLatestInfo = (receipt: any) => {
 	return (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid);
 };
 
-const findValidReceipt = (receipt: ReceiptValidationResponse) =>
+const findValidReceipt = (receipt: any) =>
 	hasLatestReceiptInfo(receipt)
 		? findValidReceiptFromLatestInfo(receipt) ?? null
 		: null;

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -5530,7 +5530,7 @@ domutils@^2.5.2, domutils@^2.6.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-dooboolab-welcome@^1.1.1:
+dooboolab-welcome@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz#4928595312f0429b4ea1b485ba8767bae6acdab7"
   integrity sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==
@@ -11091,12 +11091,12 @@ react-native-htmlview@^0.15.0:
     entities "^1.1.1"
     htmlparser2-without-node-native "^3.9.2"
 
-react-native-iap@^3.3.9:
-  version "3.5.9"
-  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-3.5.9.tgz#1a49702f5c5ed444da9d3c7b8db9b5e7c7066deb"
-  integrity sha512-LtL6NX4y8JCg9pjUDxMz2om03r0PaJHfzpT6Wd437ck5sr+cIAbC8QH5MgXUkyoBin+MxTSX0w92TbuZAeHp1Q==
+react-native-iap@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-7.5.0.tgz#86d0ccc4cc6a2eabc0470993921a45aec603392c"
+  integrity sha512-3iy+q3m7OAjh2+7LA53151Y+1Jmix76NMWcMXJdax/yw1dB7YWQ47eHkY3PLhShp+LO+XHZxv/iaPVtkkeiPwA==
   dependencies:
-    dooboolab-welcome "^1.1.1"
+    dooboolab-welcome "1.3.2"
 
 react-native-image-pan-zoom@^2.1.12:
   version "2.1.12"


### PR DESCRIPTION
## Why are you doing this?
Updating React Native IAP in an attempt to get a release build for Android working.

Please note this requires a firm test on iOS for the next release.

## Changes

- Updates `react-native-iap` across both platforms
- Adds the required installation step for Anrdoid however, its not used on Android.
