### PR TITLE
chore: Remove node-fetch

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -71,7 +71,6 @@
         "jetifier": "^1.6.3",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.27",
-        "node-fetch": "^2.6.1",
         "npm-run-all": "^4.1.5",
         "query-string": "^6.8.2",
         "react": "^17.0.1",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -9365,7 +9365,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.1, node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
## Why are you doing this?

Removing node-fetch as it appears to not be used. This should also allow us to close a dependabot PR.
