### PR TITLE
fix: Editions menu error

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -69,24 +69,29 @@ const EditionsMenu = ({
 		);
 	};
 
+	const renderItem = ({
+		item,
+	}: {
+		item: RegionalEdition | SpecialEdition;
+	}) => {
+		if (item.editionType === 'Regional') {
+			return renderRegionalItem({ item } as { item: RegionalEdition });
+		}
+		return renderSpecialItem({ item } as { item: SpecialEdition });
+	};
+
+	const menuItems = [
+		...(regionalEditions ?? defaultRegionalEditions),
+		...(specialEditions ?? []),
+	];
+
 	return (
-		<ScrollView style={styles.container}>
-			<FlatList
-				data={regionalEditions ?? defaultRegionalEditions}
-				renderItem={renderRegionalItem}
-				ItemSeparatorComponent={() => <ItemSeperator />}
-				ListFooterComponent={() => <ItemSeperator />}
-			/>
-			{specialEditions && specialEditions.length > 0 && (
-				<>
-					<FlatList
-						data={specialEditions}
-						renderItem={renderSpecialItem}
-						ItemSeparatorComponent={() => <ItemSeperator />}
-					/>
-				</>
-			)}
-		</ScrollView>
+		<FlatList
+			style={styles.container}
+			data={menuItems}
+			renderItem={renderItem}
+			ItemSeparatorComponent={() => <ItemSeperator />}
+		/>
 	);
 };
 

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -2,6 +2,51 @@
 
 exports[`EditionsMenu should display a EditionsMenu with correct styling and alternative Regional Buttons 1`] = `
 <RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "edition": "daily-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Daily",
+          "title": "UK Daily",
+        },
+        "locale": "en_GB",
+        "notificationUTCOffset": 1,
+        "subTitle": "Published every day by 12am (GMT)",
+        "title": "UK Daily",
+        "topic": "au",
+      },
+      Object {
+        "edition": "australian-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Weekend",
+          "title": "Austraila",
+        },
+        "locale": "en_AU",
+        "notificationUTCOffset": 1,
+        "subTitle": "Published every day by 9:30am (AEST)",
+        "title": "Australia Daily",
+        "topic": "au",
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  keyExtractor={[Function]}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
   style={
     Object {
       "height": 1334,
@@ -9,96 +54,121 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling and alt
       "paddingTop": 17,
     }
   }
+  viewabilityConfigCallbackPairs={Array []}
 >
   <View>
-    <RCTScrollView
-      ItemSeparatorComponent={[Function]}
-      ListFooterComponent={[Function]}
-      data={
-        Array [
-          Object {
-            "edition": "daily-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Daily",
-              "title": "UK Daily",
-            },
-            "locale": "en_GB",
-            "notificationUTCOffset": 1,
-            "subTitle": "Published every day by 12am (GMT)",
-            "title": "UK Daily",
-            "topic": "au",
-          },
-          Object {
-            "edition": "australian-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "Austraila",
-            },
-            "locale": "en_AU",
-            "notificationUTCOffset": 1,
-            "subTitle": "Published every day by 9:30am (AEST)",
-            "title": "Australia Daily",
-            "topic": "au",
-          },
-        ]
-      }
-      getItem={[Function]}
-      getItemCount={[Function]}
-      keyExtractor={[Function]}
-      onContentSizeChange={[Function]}
+    <View
       onLayout={[Function]}
-      onMomentumScrollBegin={[Function]}
-      onMomentumScrollEnd={[Function]}
-      onScroll={[Function]}
-      onScrollBeginDrag={[Function]}
-      onScrollEndDrag={[Function]}
-      removeClippedSubviews={false}
-      renderItem={[Function]}
-      scrollEventThrottle={50}
-      stickyHeaderIndices={Array []}
-      viewabilityConfigCallbackPairs={Array []}
+      style={null}
     >
-      <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-        </View>
-        <View
-          onLayout={[Function]}
-        >
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-      </View>
-    </RCTScrollView>
+      EditionButton
+      <View
+        style={
+          Object {
+            "height": 10,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      EditionButton
+    </View>
   </View>
 </RCTScrollView>
 `;
 
 exports[`EditionsMenu should display a EditionsMenu with correct styling default Regional Buttons and a Special Edition Button 1`] = `
 <RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "edition": "daily-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Daily",
+          "title": "UK",
+        },
+        "locale": "en_GB",
+        "notificationUTCOffset": 3,
+        "subTitle": "Published from London every 
+morning by 6am (GMT)",
+        "title": "UK Daily",
+        "topic": "uk",
+      },
+      Object {
+        "edition": "australian-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Weekend",
+          "title": "Australia",
+        },
+        "locale": "en_AU",
+        "notificationUTCOffset": -5,
+        "subTitle": "Published from Sydney every 
+Saturday by 6 am (AEST)",
+        "title": "Australia Weekend",
+        "topic": "au",
+      },
+      Object {
+        "buttonImageUri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
+        "buttonStyle": Object {
+          "backgroundColor": "#FEEEF7",
+          "expiry": Object {
+            "color": "#7D0068",
+            "font": "GuardianTextSans-Regular",
+            "lineHeight": 16,
+            "size": 15,
+          },
+          "image": Object {
+            "height": 134,
+            "width": 87,
+          },
+          "subTitle": Object {
+            "color": "#7D0068",
+            "font": "GuardianTextSans-Bold",
+            "lineHeight": 20,
+            "size": 17,
+          },
+          "title": Object {
+            "color": "#121212",
+            "font": "GHGuardianHeadline-Regular",
+            "lineHeight": 34,
+            "size": 34,
+          },
+        },
+        "edition": "special-edition",
+        "editionType": "Special",
+        "expiry": "1998-02-01T00:00:00.000Z",
+        "header": Object {
+          "subTitle": "Monthly",
+          "title": "Food",
+        },
+        "notificationUTCOffset": 1,
+        "subTitle": "Store cupboard special: 20 quick and easy lockdown suppers",
+        "title": "Food
+Monthly",
+        "topic": "food",
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  keyExtractor={[Function]}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
   style={
     Object {
       "height": 1334,
@@ -106,169 +176,94 @@ exports[`EditionsMenu should display a EditionsMenu with correct styling default
       "paddingTop": 17,
     }
   }
+  viewabilityConfigCallbackPairs={Array []}
 >
   <View>
-    <RCTScrollView
-      ItemSeparatorComponent={[Function]}
-      ListFooterComponent={[Function]}
-      data={
-        Array [
-          Object {
-            "edition": "daily-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Daily",
-              "title": "UK",
-            },
-            "locale": "en_GB",
-            "notificationUTCOffset": 3,
-            "subTitle": "Published from London every 
-morning by 6am (GMT)",
-            "title": "UK Daily",
-            "topic": "uk",
-          },
-          Object {
-            "edition": "australian-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "Australia",
-            },
-            "locale": "en_AU",
-            "notificationUTCOffset": -5,
-            "subTitle": "Published from Sydney every 
-Saturday by 6 am (AEST)",
-            "title": "Australia Weekend",
-            "topic": "au",
-          },
-        ]
-      }
-      getItem={[Function]}
-      getItemCount={[Function]}
-      keyExtractor={[Function]}
-      onContentSizeChange={[Function]}
+    <View
       onLayout={[Function]}
-      onMomentumScrollBegin={[Function]}
-      onMomentumScrollEnd={[Function]}
-      onScroll={[Function]}
-      onScrollBeginDrag={[Function]}
-      onScrollEndDrag={[Function]}
-      removeClippedSubviews={false}
-      renderItem={[Function]}
-      scrollEventThrottle={50}
-      stickyHeaderIndices={Array []}
-      viewabilityConfigCallbackPairs={Array []}
+      style={null}
     >
-      <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-        </View>
-        <View
-          onLayout={[Function]}
-        >
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-      </View>
-    </RCTScrollView>
-    <RCTScrollView
-      ItemSeparatorComponent={[Function]}
-      data={
-        Array [
+      EditionButton
+      <View
+        style={
           Object {
-            "buttonImageUri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
-            "buttonStyle": Object {
-              "backgroundColor": "#FEEEF7",
-              "expiry": Object {
-                "color": "#7D0068",
-                "font": "GuardianTextSans-Regular",
-                "lineHeight": 16,
-                "size": 15,
-              },
-              "image": Object {
-                "height": 134,
-                "width": 87,
-              },
-              "subTitle": Object {
-                "color": "#7D0068",
-                "font": "GuardianTextSans-Bold",
-                "lineHeight": 20,
-                "size": 17,
-              },
-              "title": Object {
-                "color": "#121212",
-                "font": "GHGuardianHeadline-Regular",
-                "lineHeight": 34,
-                "size": 34,
-              },
-            },
-            "edition": "special-edition",
-            "editionType": "Special",
-            "expiry": "1998-02-01T00:00:00.000Z",
-            "header": Object {
-              "subTitle": "Monthly",
-              "title": "Food",
-            },
-            "notificationUTCOffset": 1,
-            "subTitle": "Store cupboard special: 20 quick and easy lockdown suppers",
-            "title": "Food
-Monthly",
-            "topic": "food",
-          },
-        ]
-      }
-      getItem={[Function]}
-      getItemCount={[Function]}
-      keyExtractor={[Function]}
-      onContentSizeChange={[Function]}
+            "height": 10,
+          }
+        }
+      />
+    </View>
+    <View
       onLayout={[Function]}
-      onMomentumScrollBegin={[Function]}
-      onMomentumScrollEnd={[Function]}
-      onScroll={[Function]}
-      onScrollBeginDrag={[Function]}
-      onScrollEndDrag={[Function]}
-      removeClippedSubviews={false}
-      renderItem={[Function]}
-      scrollEventThrottle={50}
-      stickyHeaderIndices={Array []}
-      viewabilityConfigCallbackPairs={Array []}
+      style={null}
     >
-      <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-        </View>
-      </View>
-    </RCTScrollView>
+      EditionButton
+      <View
+        style={
+          Object {
+            "height": 10,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      EditionButton
+    </View>
   </View>
 </RCTScrollView>
 `;
 
 exports[`EditionsMenu should display a default EditionsMenu with correct styling and default Regional Buttons 1`] = `
 <RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "edition": "daily-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Daily",
+          "title": "UK",
+        },
+        "locale": "en_GB",
+        "notificationUTCOffset": 3,
+        "subTitle": "Published from London every 
+morning by 6am (GMT)",
+        "title": "UK Daily",
+        "topic": "uk",
+      },
+      Object {
+        "edition": "australian-edition",
+        "editionType": "Regional",
+        "header": Object {
+          "subTitle": "Weekend",
+          "title": "Australia",
+        },
+        "locale": "en_AU",
+        "notificationUTCOffset": -5,
+        "subTitle": "Published from Sydney every 
+Saturday by 6 am (AEST)",
+        "title": "Australia Weekend",
+        "topic": "au",
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  keyExtractor={[Function]}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
   style={
     Object {
       "height": 1334,
@@ -276,92 +271,28 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
       "paddingTop": 17,
     }
   }
+  viewabilityConfigCallbackPairs={Array []}
 >
   <View>
-    <RCTScrollView
-      ItemSeparatorComponent={[Function]}
-      ListFooterComponent={[Function]}
-      data={
-        Array [
-          Object {
-            "edition": "daily-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Daily",
-              "title": "UK",
-            },
-            "locale": "en_GB",
-            "notificationUTCOffset": 3,
-            "subTitle": "Published from London every 
-morning by 6am (GMT)",
-            "title": "UK Daily",
-            "topic": "uk",
-          },
-          Object {
-            "edition": "australian-edition",
-            "editionType": "Regional",
-            "header": Object {
-              "subTitle": "Weekend",
-              "title": "Australia",
-            },
-            "locale": "en_AU",
-            "notificationUTCOffset": -5,
-            "subTitle": "Published from Sydney every 
-Saturday by 6 am (AEST)",
-            "title": "Australia Weekend",
-            "topic": "au",
-          },
-        ]
-      }
-      getItem={[Function]}
-      getItemCount={[Function]}
-      keyExtractor={[Function]}
-      onContentSizeChange={[Function]}
+    <View
       onLayout={[Function]}
-      onMomentumScrollBegin={[Function]}
-      onMomentumScrollEnd={[Function]}
-      onScroll={[Function]}
-      onScrollBeginDrag={[Function]}
-      onScrollEndDrag={[Function]}
-      removeClippedSubviews={false}
-      renderItem={[Function]}
-      scrollEventThrottle={50}
-      stickyHeaderIndices={Array []}
-      viewabilityConfigCallbackPairs={Array []}
+      style={null}
     >
-      <View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-        <View
-          onLayout={[Function]}
-          style={null}
-        >
-          EditionButton
-        </View>
-        <View
-          onLayout={[Function]}
-        >
-          <View
-            style={
-              Object {
-                "height": 10,
-              }
-            }
-          />
-        </View>
-      </View>
-    </RCTScrollView>
+      EditionButton
+      <View
+        style={
+          Object {
+            "height": 10,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      EditionButton
+    </View>
   </View>
 </RCTScrollView>
 `;


### PR DESCRIPTION
## Why are you doing this?
Since upgrading to RN66, we see the following error

![simulator_screenshot_2A7833CF-7F81-4A97-A602-E904AD5DB1E0](https://user-images.githubusercontent.com/935975/142378761-a51a7845-fefc-446c-8d55-0ba9aea71ecc.png)


## Changes

- Originally Editions Menu had nested `FlatList`, this move it all into one.

## Screenshots

### iOS
![Simulator Screen Shot - iPhone 13 - 2021-11-18 at 08 05 32](https://user-images.githubusercontent.com/935975/142379082-291fd673-b4b8-4852-9dbe-a9f36b92d092.png)

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2021-11-18 at 08 25 53](https://user-images.githubusercontent.com/935975/142379097-5f93e612-19fe-44e7-84cb-a7183c0a4ad3.png)

### Android
![Screenshot_1637224104](https://user-images.githubusercontent.com/935975/142379268-108e1225-4bbf-42df-b4d5-8b69f76bc3ed.png)
