### PR TITLE
fix: Help Menu Error

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions, FlatList, ScrollView, StyleSheet } from 'react-native';
+import { Dimensions, FlatList, StyleSheet } from 'react-native';
 import type { EditionId, RegionalEdition, SpecialEdition } from 'src/common';
 import { metrics } from 'src/theme/spacing';
 import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults';

--- a/projects/Mallard/src/screens/settings/help-screen.tsx
+++ b/projects/Mallard/src/screens/settings/help-screen.tsx
@@ -4,8 +4,7 @@ import { AccessContext } from 'src/authentication/AccessContext';
 import { HeaderScreenContainer } from 'src/components/Header/Header';
 import { RightChevron } from 'src/components/icons/RightChevron';
 import { ScrollContainer } from 'src/components/layout/ui/container';
-import { Heading } from 'src/components/layout/ui/row';
-import { List } from 'src/components/lists/list';
+import { Heading, Row, Separator } from 'src/components/layout/ui/row';
 import {
 	copyDiagnosticInfo,
 	createSupportMailto,
@@ -67,64 +66,69 @@ const HelpScreen = () => {
 		<HeaderScreenContainer title={HELP_HEADER_TITLE} actionLeft={true}>
 			<WithAppAppearance value={'settings'}>
 				<ScrollContainer>
-					<List
-						data={[
-							{
-								key: 'Frequently Asked Questions',
-								title: 'Frequently Asked Questions',
-								onPress: () => {
-									navigation.navigate(RouteNames.FAQ);
-								},
-								proxy: <RightChevron />,
-							},
-						]}
+					<Row
+						title="Frequently Asked Questions"
+						onPress={() => navigation.navigate(RouteNames.FAQ)}
+						proxy={<RightChevron />}
 					/>
+					<Separator />
+
 					<Heading>Contact us</Heading>
-					<List
-						data={[
-							createSupportMailto(
-								'Report an issue',
-								ISSUE_EMAIL,
-								attempt,
-								netInfo,
-								gdprSettings,
-								DIAGNOSTICS_TITLE,
-							),
-							createSupportMailto(
-								'Subscription, payment and billing issues',
-								SUBSCRIPTION_EMAIL,
-								attempt,
-								netInfo,
-								gdprSettings,
-							),
-							createSupportMailto(
-								'Comment or query about an article',
-								READERS_EMAIL,
-								attempt,
-								netInfo,
-								gdprSettings,
-							),
-							createSupportMailto(
-								'Send feedback',
-								APPS_FEEDBACK_EMAIL,
-								attempt,
-								netInfo,
-								gdprSettings,
-							),
-						]}
+					<Separator />
+					<Row
+						{...createSupportMailto(
+							'Report an issue',
+							ISSUE_EMAIL,
+							attempt,
+							netInfo,
+							gdprSettings,
+							DIAGNOSTICS_TITLE,
+						)}
 					/>
+					<Separator />
+					<Row
+						{...createSupportMailto(
+							'Subscription, payment and billing issues',
+							SUBSCRIPTION_EMAIL,
+							attempt,
+							netInfo,
+							gdprSettings,
+						)}
+					/>
+					<Separator />
+					<Row
+						{...createSupportMailto(
+							'Comment or query about an article',
+							READERS_EMAIL,
+							attempt,
+							netInfo,
+							gdprSettings,
+						)}
+					/>
+					<Separator />
+					<Row
+						{...createSupportMailto(
+							'Send feedback',
+							APPS_FEEDBACK_EMAIL,
+							attempt,
+							netInfo,
+							gdprSettings,
+						)}
+					/>
+					<Separator />
+
 					<Heading>Diagnostics</Heading>
-					<List
-						data={[
-							copyDiagnosticInfo(
-								'Copy diagnostic information',
-								attempt,
-								netInfo,
-								gdprSettings,
-								showToastCallback,
-							),
-						]}
+					<Separator />
+					<Row
+						{...copyDiagnosticInfo(
+							'Copy diagnostic information',
+							attempt,
+							netInfo,
+							gdprSettings,
+							showToastCallback,
+						)}
 					/>
+					<Separator />
 				</ScrollContainer>
 			</WithAppAppearance>
 		</HeaderScreenContainer>


### PR DESCRIPTION
## Why are you doing this?

Due to the upgrade of RN66, we had some issues around nested flatlists. The help menu has this problem.

## Changes

- Removed the use of `List` for `Row` and `Separator`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/935975/142995447-c6391863-c2ed-4a4a-8188-ac7bcc087fa6.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/935975/142995498-7102d8e3-da7e-4ec6-896c-aceab233a51e.png" width="300px" /> |


