### PR TITLE
chore: Location Permission Refactor

### DIFF
--- a/projects/Mallard/src/apollo.ts
+++ b/projects/Mallard/src/apollo.ts
@@ -5,7 +5,6 @@
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloClient } from 'apollo-client';
 import { NON_IMPLEMENTED_LINK } from './helpers/apollo_link';
-import { resolveLocationPermissionStatus } from './helpers/location-permission';
 import { SETTINGS_RESOLVERS } from './helpers/settings/resolvers';
 import { resolveWeather } from './helpers/weather';
 
@@ -28,7 +27,6 @@ export const createApolloClient = () => {
 		Query: {
 			...SETTINGS_RESOLVERS,
 			weather: resolveWeather,
-			locationPermissionStatus: resolveLocationPermissionStatus,
 		},
 	};
 

--- a/projects/Mallard/src/helpers/location-permission.ts
+++ b/projects/Mallard/src/helpers/location-permission.ts
@@ -10,30 +10,13 @@ const LOCATION_PERMISSION = Platform.select({
 	default: PERMISSIONS.IOS.LOCATION_WHEN_IN_USE,
 });
 
-const { resolveLocationPermissionStatus, requestLocationPermission } = (() => {
-	let promise: Promise<PermissionStatus> | undefined;
+export const resolveLocationPermissionStatus =
+	async (): Promise<PermissionStatus> => await check(LOCATION_PERMISSION);
 
-	const resolveLocationPermissionStatus = () => {
-		if (promise) return promise;
-		promise = check(LOCATION_PERMISSION);
-		return promise;
-	};
-
-	const requestLocationPermission = async (
-		apolloClient: ApolloClient<object>,
-	): Promise<PermissionStatus> => {
-		promise = request(LOCATION_PERMISSION);
-		const result = await promise;
-		apolloClient.writeData({
-			data: {
-				locationPermissionStatus: result,
-			},
-		});
-		refreshWeather(apolloClient);
-		return result;
-	};
-
-	return { resolveLocationPermissionStatus, requestLocationPermission };
-})();
-
-export { resolveLocationPermissionStatus, requestLocationPermission };
+export const requestLocationPermission = async (
+	apolloClient: ApolloClient<object>,
+): Promise<PermissionStatus> => {
+	const result = await request(LOCATION_PERMISSION);
+	refreshWeather(apolloClient);
+	return result;
+};

--- a/projects/Mallard/src/helpers/weather.ts
+++ b/projects/Mallard/src/helpers/weather.ts
@@ -15,7 +15,7 @@ Geolocation.setRNConfiguration({
 	/**
 	 * We want to control the exact moment the permission pop-up shows, so
 	 * we don't rely on the Geolocation module and instead manage permissions
-	 * ourselves (see `locationPermissionStatus` Apollo field).
+	 * ourselves
 	 */
 	skipPermissionRequests: true,
 	authorizationLevel: 'whenInUse',


### PR DESCRIPTION
## Why are you doing this?

As part of our move away from Apollo, this removes the need to store the permission result there. It also makes the function a bit simpler.

## Changes

- Refactored the permission logic to be simpler and closer to the standards of the project
- Removed the location permission resolver.