### PR TITLE
chore: Remove Apollo from Weather

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -66,11 +66,6 @@ const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
 const App = () => {
 	useEffect(() => {
 		SplashScreen.hide();
-		{
-			eventEmitter.on('editionCachesSet', () => {
-				weatherHider(apolloClient);
-			});
-		}
 	}, []);
 
 	return (

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -6,8 +6,6 @@ import { ApolloProvider } from '@apollo/react-hooks';
 import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import SplashScreen from 'react-native-splash-screen';
-import { eventEmitter } from 'src/helpers/event-emitter';
-import { weatherHider } from 'src/helpers/weather-hider';
 import { ConfigProvider } from 'src/hooks/use-config-provider';
 import { NavPositionProvider } from 'src/hooks/use-nav-position';
 import { setUserId } from 'src/services/ophan';

--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -20,11 +20,7 @@ export interface DevSettings {
 	logging: string;
 }
 
-interface UserSettings {
-	isWeatherShown: boolean;
-}
-
-export interface Settings extends UserSettings, DevSettings {}
+export type Settings = DevSettings;
 
 /*
 we can only store strings to memory

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -112,7 +112,6 @@ export const defaultSettings: Settings = {
 	issuesPath: `/issues`,
 	storeDetails,
 	senderId: __DEV__ ? senderId.code : senderId.prod,
-	isWeatherShown: true,
 	websiteUrl: 'https://www.theguardian.com/',
 	logging: __DEV__
 		? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'

--- a/projects/Mallard/src/helpers/settings/resolvers.ts
+++ b/projects/Mallard/src/helpers/settings/resolvers.ts
@@ -12,7 +12,6 @@ const makeFragment = (names: string[]) =>
 
 const ALL_NAMES = [
 	'apiUrl', // This should be an east one to remove.
-	'isWeatherShown',
 	'isUsingProdDevtools', // This should be an easy one to remove
 ];
 

--- a/projects/Mallard/src/helpers/settings/setters.ts
+++ b/projects/Mallard/src/helpers/settings/setters.ts
@@ -24,6 +24,5 @@ const createSetter = <Name extends keyof Settings>(
 	return setSetting.bind(undefined, name);
 };
 
-export const setIsWeatherShown = createSetter('isWeatherShown');
 export const setApiUrl = createSetter('apiUrl');
 export const setIsUsingProdDevtools = createSetter('isUsingProdDevtools');

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -116,6 +116,10 @@ const gdprConsentVersionCache = createAsyncCache<number>(
 	'@Setting_gdprConsentVersion',
 );
 
+const isWeatherShownCache = createAsyncCache<boolean>(
+	'@Setting_isWeatherShown',
+);
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -191,4 +195,5 @@ export {
 	gdprAllowPerformanceCache,
 	gdprAllowFunctionalityCache,
 	gdprConsentVersionCache,
+	isWeatherShownCache,
 };

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -1,8 +1,6 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import {
-	largeDeviceMemory,
-	useIsWeatherShown,
-} from 'src/hooks/use-config-provider';
+import type { IsWeatherShown } from 'src/hooks/use-config-provider';
+import { largeDeviceMemory } from 'src/hooks/use-config-provider';
 import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider';
 import { errorService } from 'src/services/errors';
 
@@ -12,10 +10,9 @@ import { errorService } from 'src/services/errors';
 const KEY = '@weatherLowRAMCheck';
 const EDITIONCHECKKEY = '@weatherEditionCheck';
 
-const weatherHider = async () => {
-	console.log('CALLED');
-	const { setIsWeatherShown } = useIsWeatherShown();
-
+const weatherHider = async (
+	setIsWeatherShown: IsWeatherShown['setIsWeatherShown'],
+) => {
 	try {
 		const weatherLowRamCheck = await AsyncStorage.getItem(KEY);
 		const editionWeatherCheck = await AsyncStorage.getItem(EDITIONCHECKKEY);
@@ -30,6 +27,7 @@ const weatherHider = async () => {
 			defaultEdition &&
 			defaultEdition !== 'daily-edition'
 		) {
+			console.log('IS THIS HERE?');
 			await AsyncStorage.setItem(EDITIONCHECKKEY, 'true');
 			setIsWeatherShown(false);
 		}

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -27,7 +27,6 @@ const weatherHider = async (
 			defaultEdition &&
 			defaultEdition !== 'daily-edition'
 		) {
-			console.log('IS THIS HERE?');
 			await AsyncStorage.setItem(EDITIONCHECKKEY, 'true');
 			setIsWeatherShown(false);
 		}

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -1,17 +1,21 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import type ApolloClient from 'apollo-client';
-import { largeDeviceMemory } from 'src/hooks/use-config-provider';
+import {
+	largeDeviceMemory,
+	useIsWeatherShown,
+} from 'src/hooks/use-config-provider';
 import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider';
 import { errorService } from 'src/services/errors';
-import { setIsWeatherShown } from './settings/setters';
 
-// Purpose: To hide the weahter on the first load unless the user turns it on
+// Purpose: To hide the weather on the first load unless the user turns it on
 // Intended for use on lower powered devices and for users who do not use the UK Daily edition as their default edition
 
 const KEY = '@weatherLowRAMCheck';
 const EDITIONCHECKKEY = '@weatherEditionCheck';
 
-const weatherHider = async (client: ApolloClient<object>) => {
+const weatherHider = async () => {
+	console.log('CALLED');
+	const { setIsWeatherShown } = useIsWeatherShown();
+
 	try {
 		const weatherLowRamCheck = await AsyncStorage.getItem(KEY);
 		const editionWeatherCheck = await AsyncStorage.getItem(EDITIONCHECKKEY);
@@ -19,7 +23,7 @@ const weatherHider = async (client: ApolloClient<object>) => {
 		if (!weatherLowRamCheck) {
 			const largeRAM = await largeDeviceMemory();
 			await AsyncStorage.setItem(KEY, 'true');
-			!largeRAM && setIsWeatherShown(client, false);
+			!largeRAM && setIsWeatherShown(false);
 		}
 		if (
 			!editionWeatherCheck &&
@@ -27,7 +31,7 @@ const weatherHider = async (client: ApolloClient<object>) => {
 			defaultEdition !== 'daily-edition'
 		) {
 			await AsyncStorage.setItem(EDITIONCHECKKEY, 'true');
-			setIsWeatherShown(client, false);
+			setIsWeatherShown(false);
 		}
 	} catch (e) {
 		errorService.captureException(e);

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
@@ -36,6 +36,7 @@ describe('useEditions', () => {
 				selectedLocalState,
 				editionsList,
 				DownloadBlockedStatus.NotBlocked,
+				() => {},
 			);
 			expect(defaultLocalState).toBeCalledTimes(1);
 			expect(defaultLocalState).toBeCalledWith(BASE_EDITION);

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -238,6 +238,7 @@ describe('useEditions', () => {
 				selectedLocalState,
 				DEFAULT_EDITIONS_LIST,
 				DownloadBlockedStatus.NotBlocked,
+				() => {},
 			);
 			expect(defaultLocalState).toBeCalledTimes(1);
 			expect(defaultLocalState).toBeCalledWith(
@@ -262,6 +263,7 @@ describe('useEditions', () => {
 				selectedLocalState,
 				DEFAULT_EDITIONS_LIST,
 				DownloadBlockedStatus.NotBlocked,
+				() => {},
 			);
 			expect(defaultLocalState).toBeCalledTimes(1);
 			expect(defaultLocalState).toBeCalledWith(

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -29,6 +29,11 @@ interface ConfigState {
 	setIsWeatherShownSetting: (setting: boolean) => Promise<void>;
 }
 
+export type IsWeatherShown = {
+	isWeatherShown: ConfigState['isWeatherShown'];
+	setIsWeatherShown: (setting: boolean) => void;
+};
+
 const notificationInitialState = () =>
 	Platform.OS === 'android' ? true : false;
 
@@ -260,7 +265,7 @@ export const useMaxAvailableEditions = () => ({
 		useContext(ConfigContext).setMaxAvailableEditionsSetting,
 });
 
-export const useIsWeatherShown = () => ({
+export const useIsWeatherShown = (): IsWeatherShown => ({
 	isWeatherShown: useContext(ConfigContext).isWeatherShown,
 	setIsWeatherShown: useContext(ConfigContext).setIsWeatherShownSetting,
 });

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Dimensions, Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {
+	isWeatherShownCache,
 	maxAvailableEditionsCache,
 	notificationsEnabledCache,
 	wifiOnlyDownloadsCache,
@@ -24,6 +25,8 @@ interface ConfigState {
 	setWifiOnlyDownloadsSetting: (setting: boolean) => Promise<void>;
 	maxAvailableEditions: number;
 	setMaxAvailableEditionsSetting: (setting: number) => Promise<void>;
+	isWeatherShown: boolean;
+	setIsWeatherShownSetting: (setting: boolean) => Promise<void>;
 }
 
 const notificationInitialState = () =>
@@ -43,6 +46,8 @@ const initialState: ConfigState = {
 	setWifiOnlyDownloadsSetting: () => Promise.resolve(),
 	maxAvailableEditions: 7,
 	setMaxAvailableEditionsSetting: () => Promise.resolve(),
+	isWeatherShown: true,
+	setIsWeatherShownSetting: () => Promise.resolve(),
 };
 
 const ConfigContext = createContext(initialState);
@@ -83,6 +88,17 @@ export const getMaxAvailableEditions = async (): Promise<
 	}
 };
 
+export const getIsWeatherShown = async (): Promise<
+	ConfigState['isWeatherShown']
+> => {
+	try {
+		const isWeatherShown = await isWeatherShownCache.get();
+		return isWeatherShown ?? initialState.isWeatherShown;
+	} catch {
+		return Promise.resolve(initialState.isWeatherShown);
+	}
+};
+
 export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	const [largeDeviceMemeory, setLargeDeviceMemory] = useState(false);
 	const [dimensions, setDimensions] = useState(Dimensions.get('window'));
@@ -95,6 +111,9 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	const [maxAvailableEditions, setMaxAvailableEditions] = useState<
 		ConfigState['maxAvailableEditions']
 	>(initialState.maxAvailableEditions);
+	const [isWeatherShown, setIsWeatherShown] = useState<
+		ConfigState['isWeatherShown']
+	>(initialState.isWeatherShown);
 
 	const setNotifications = async (setting: boolean) => {
 		try {
@@ -129,6 +148,17 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 		}
 	};
 
+	const setIsWeatherShownSetting = async (setting: boolean) => {
+		try {
+			await isWeatherShownCache.set(setting);
+			setIsWeatherShown(setting);
+		} catch (e) {
+			console.log(e);
+			e.message = `Unable to Set Is Weather Shown: ${e.message}`;
+			errorService.captureException(e);
+		}
+	};
+
 	useEffect(() => {
 		notificationsAreEnabled().then((setting) =>
 			setNotificationsEnabled(setting),
@@ -144,6 +174,12 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	useEffect(() => {
 		getMaxAvailableEditions().then((setting) =>
 			setMaxAvailableEditionsSetting(setting),
+		);
+	}, []);
+
+	useEffect(() => {
+		getIsWeatherShown().then((setting) =>
+			setIsWeatherShownSetting(setting),
 		);
 	}, []);
 
@@ -194,6 +230,8 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 				setWifiOnlyDownloadsSetting,
 				maxAvailableEditions,
 				setMaxAvailableEditionsSetting,
+				isWeatherShown,
+				setIsWeatherShownSetting,
 			}}
 		>
 			{children}
@@ -220,4 +258,9 @@ export const useMaxAvailableEditions = () => ({
 	maxAvailableEditions: useContext(ConfigContext).maxAvailableEditions,
 	setMaxAvailableEditions:
 		useContext(ConfigContext).setMaxAvailableEditionsSetting,
+});
+
+export const useIsWeatherShown = () => ({
+	isWeatherShown: useContext(ConfigContext).isWeatherShown,
+	setIsWeatherShown: useContext(ConfigContext).setIsWeatherShownSetting,
 });

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -1,4 +1,3 @@
-import { captureException } from '@sentry/minimal';
 import moment from 'moment';
 import type { Dispatch } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
@@ -29,6 +28,8 @@ import { errorService } from 'src/services/errors';
 import { defaultRegionalEditions } from '../../../Apps/common/src/editions-defaults';
 import { getEditionIds } from '../../../Apps/common/src/helpers';
 import { useAppState } from './use-app-state-provider';
+import type { IsWeatherShown } from './use-config-provider';
+import { useIsWeatherShown } from './use-config-provider';
 import type { NetInfoState } from './use-net-info-provider';
 import { useNetInfo } from './use-net-info-provider';
 
@@ -195,12 +196,13 @@ const setEdition = async (
 	setDefaultEdition: Dispatch<RegionalEdition>,
 	setSelectedEdition: Dispatch<RegionalEdition | SpecialEdition>,
 	downloadBlocked: NetInfoState['downloadBlocked'],
+	setIsWeatherShown: IsWeatherShown['setIsWeatherShown'],
 ) => {
 	setDefaultEdition(edition);
 	setSelectedEdition(edition);
 	await selectedEditionCache.set(edition);
 	await defaultEditionCache.set(edition);
-	await weatherHider();
+	await weatherHider(setIsWeatherShown);
 	pushNotificationRegistration(downloadBlocked);
 };
 
@@ -209,6 +211,7 @@ export const defaultEditionDecider = async (
 	setSelectedEdition: Dispatch<RegionalEdition | SpecialEdition>,
 	editionsList: EditionsList,
 	downloadBlocked: NetInfoState['downloadBlocked'],
+	setIsWeatherShown: IsWeatherShown['setIsWeatherShown'],
 ): Promise<void> => {
 	const selectedEdition = await getSelectedEdition();
 	// When user already has default edition set then that edition
@@ -232,6 +235,7 @@ export const defaultEditionDecider = async (
 				setDefaultEdition,
 				setSelectedEdition,
 				downloadBlocked,
+				setIsWeatherShown,
 			);
 		} else {
 			// auto detected edition was not possible, set default edition
@@ -240,6 +244,7 @@ export const defaultEditionDecider = async (
 				setDefaultEdition,
 				setSelectedEdition,
 				downloadBlocked,
+				setIsWeatherShown,
 			);
 		}
 	}
@@ -263,6 +268,7 @@ export const EditionProvider = ({
 
 	const { isConnected, downloadBlocked } = useNetInfo();
 	const { isActive } = useAppState();
+	const { setIsWeatherShown } = useIsWeatherShown();
 
 	/**
 	 * Default Edition and Selected
@@ -277,6 +283,7 @@ export const EditionProvider = ({
 			setSelectedEdition,
 			editionsList,
 			downloadBlocked,
+			setIsWeatherShown,
 		);
 	}, [editionsList, downloadBlocked]);
 

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/minimal';
 import moment from 'moment';
 import type { Dispatch } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
@@ -22,6 +23,7 @@ import {
 	selectedEditionCache,
 	showAllEditionsCache,
 } from 'src/helpers/storage';
+import { weatherHider } from 'src/helpers/weather-hider';
 import { pushNotificationRegistration } from 'src/notifications/push-notifications';
 import { errorService } from 'src/services/errors';
 import { defaultRegionalEditions } from '../../../Apps/common/src/editions-defaults';
@@ -198,7 +200,7 @@ const setEdition = async (
 	setSelectedEdition(edition);
 	await selectedEditionCache.set(edition);
 	await defaultEditionCache.set(edition);
-	eventEmitter.emit('editionCachesSet');
+	await weatherHider();
 	pushNotificationRegistration(downloadBlocked);
 };
 

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -6,10 +6,10 @@ import { RESULTS } from 'react-native-permissions';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
 import { HeaderScreenContainer } from 'src/components/Header/Header';
 import { requestLocationPermission } from 'src/helpers/location-permission';
-import { setIsWeatherShown } from 'src/helpers/settings/setters';
 import { getGeolocation } from 'src/helpers/weather';
 import { html } from 'src/helpers/webview';
 import { Copy } from 'src/helpers/words';
+import { useIsWeatherShown } from 'src/hooks/use-config-provider';
 import { metrics } from 'src/theme/spacing';
 import { DefaultInfoTextWebview } from './settings/default-info-text-webview';
 
@@ -34,6 +34,7 @@ const showIsDisabledAlert = () => {
 const WeatherGeolocationConsentScreen = () => {
 	const navigation = useNavigation();
 	const apolloClient = useApolloClient();
+	const { setIsWeatherShown } = useIsWeatherShown();
 	const onConsentPress = async () => {
 		const result = await requestLocationPermission(apolloClient);
 		if (result === RESULTS.BLOCKED) {
@@ -66,7 +67,7 @@ const WeatherGeolocationConsentScreen = () => {
 		}
 	};
 	const onHidePress = () => {
-		setIsWeatherShown(apolloClient, false);
+		setIsWeatherShown(false);
 		navigation.goBack();
 	};
 


### PR DESCRIPTION
## Why are you doing this?

As part of our ongoing purge from Apollo, this removes the Weather from that particular area of the code.

## Changes

- Kept the functionality as it was.
- Removed the Weather Apollo implementation and moved the state management to the config provider
- Moved persistence from being set in "settings" and moved to "storage" while maintaining the keys
- Removed the need to emit an event on the home screen to check for Weather
