### PR TITLE
fix: iOS Push Notifications

### DIFF
--- a/projects/Mallard/ios/Mallard/AppDelegate.h
+++ b/projects/Mallard/ios/Mallard/AppDelegate.h
@@ -1,7 +1,8 @@
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UNUserNotificationCenter.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate, UNUserNotificationCenterDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 

--- a/projects/Mallard/ios/Mallard/AppDelegate.m
+++ b/projects/Mallard/ios/Mallard/AppDelegate.m
@@ -5,6 +5,7 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
+#import <UserNotifications/UserNotifications.h>
 #import <RNCPushNotificationIOS.h>
 #import "RNSplashScreen.h"
 #import <AVFoundation/AVFoundation.h>
@@ -56,8 +57,17 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
   [self.window makeKeyAndVisible];
   [RNSplashScreen show];
   [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  // Define UNUserNotificationCenter
+  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+  center.delegate = self;
 
   return YES;
+}
+
+//Called when a notification is delivered to a foreground app.
+-(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
+{
+  completionHandler(UNNotificationPresentationOptionSound | UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge);
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
@@ -85,7 +95,7 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
 // Required for the register event.
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-  [RNCPushNotificationIOS didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+ [RNCPushNotificationIOS didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 // Required for the notification event. You must call the completion handler after handling the remote notification.
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
@@ -96,12 +106,14 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 // Required for the registrationError event.
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-  [RNCPushNotificationIOS didFailToRegisterForRemoteNotificationsWithError:error];
+ [RNCPushNotificationIOS didFailToRegisterForRemoteNotificationsWithError:error];
 }
-// Required for the localNotification event.
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+// Required for localNotification event
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler
 {
-  [RNCPushNotificationIOS didReceiveLocalNotification:notification];
+  [RNCPushNotificationIOS didReceiveNotificationResponse:response];
 }
 
 @end

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -49,7 +49,7 @@
         "@react-native-community/geolocation": "^2.0.2",
         "@react-native-community/masked-view": "^0.1.1",
         "@react-native-community/netinfo": "^5.6.2",
-        "@react-native-community/push-notification-ios": "^1.2.2",
+        "@react-native-community/push-notification-ios": "^1.10.1",
         "@react-native-community/viewpager": "^4.2.1",
         "@react-native-firebase/app": "^10.0.0",
         "@react-native-firebase/crashlytics": "^10.0.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1963,10 +1963,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.10.tgz#97d3a9fa62a3a4838ec7a6ec91cfec5a26e365b6"
   integrity sha512-1NPlBA2Hu/KWc3EnQcDRPRX0x8Dg9tuQlQQVWVQjlg+u+PjCq7ANEtbikOFKp5yQqfF8tqzU5+84/IfDO8zpiA==
 
-"@react-native-community/push-notification-ios@^1.2.2":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.8.0.tgz#7d43cb37b9e644ff3069aafa91befe71688a2dc4"
-  integrity sha512-vxvkeampafjmtDoQBN8Q4azP21l6cMX93+OQZemyIWZmG++OjCVDQVitobf/kWLm5zyGwdylejbpMGo75qo7rA==
+"@react-native-community/push-notification-ios@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.10.1.tgz#d52a6d69ac1112df0f79e1d17978077629b76784"
+  integrity sha512-k6bZWUKLif4GjenyTD3aQLwA2VT3bNmt22INO/34lexnpmqkPDZF7nreqbckTHG0Zso9wDTe4N/AZJUC/d8iRg==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
## Why are you doing this?

We are currently investigating a drop in push notification registration. The drop seems to have occured in the following time period: https://github.com/guardian/editions/compare/5846cbb1..0971f5ff

One thing that stuck out was a version bump on `react-native-push-notifications`: https://github.com/guardian/editions/commit/7250ebe39347e79ac5ab5108bc4060a8ec91986d

This in itself, looking at the docs says you need to preinstall `@react-native-community/push-notification-ios`: https://github.com/zo0r/react-native-push-notification#ios-manual-installation.

Looking at the installation steps (https://github.com/react-native-push-notification/ios) there were some steps missing in our native iOS code.

## Changes

- Bumped the underlying push notification library for iOS
- Added in the missing code