### PR TITLE
chore: useIsWeatherShown refactor

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -28,6 +28,7 @@ import { IssueSummaryProvider } from './hooks/use-issue-summary-provider';
 import { NetInfoProvider } from './hooks/use-net-info-provider';
 import { SettingsOverlayProvider } from './hooks/use-settings-overlay';
 import { ToastProvider } from './hooks/use-toast';
+import { WeatherProvider } from './hooks/use-weather-provider';
 import { DeprecateVersionModal } from './screens/deprecate-screen';
 import { apolloClient } from './services/apollo-singleton';
 import { remoteConfigService } from './services/remote-config';
@@ -56,6 +57,7 @@ const WithProviders = nestProviders(
 	IssueSummaryProvider,
 	GDPRProvider,
 	CoreProvider,
+	WeatherProvider,
 );
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>

--- a/projects/Mallard/src/helpers/weather-hider.ts
+++ b/projects/Mallard/src/helpers/weather-hider.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import type { IsWeatherShown } from 'src/hooks/use-config-provider';
 import { largeDeviceMemory } from 'src/hooks/use-config-provider';
 import { getDefaultEditionSlug } from 'src/hooks/use-edition-provider';
+import type { IsWeatherShown } from 'src/hooks/use-weather-provider';
 import { errorService } from 'src/services/errors';
 
 // Purpose: To hide the weather on the first load unless the user turns it on

--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Dimensions, Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {
-	isWeatherShownCache,
 	maxAvailableEditionsCache,
 	notificationsEnabledCache,
 	wifiOnlyDownloadsCache,
@@ -25,14 +24,7 @@ interface ConfigState {
 	setWifiOnlyDownloadsSetting: (setting: boolean) => Promise<void>;
 	maxAvailableEditions: number;
 	setMaxAvailableEditionsSetting: (setting: number) => Promise<void>;
-	isWeatherShown: boolean;
-	setIsWeatherShownSetting: (setting: boolean) => Promise<void>;
 }
-
-export type IsWeatherShown = {
-	isWeatherShown: ConfigState['isWeatherShown'];
-	setIsWeatherShown: (setting: boolean) => void;
-};
 
 const notificationInitialState = () =>
 	Platform.OS === 'android' ? true : false;
@@ -51,8 +43,6 @@ const initialState: ConfigState = {
 	setWifiOnlyDownloadsSetting: () => Promise.resolve(),
 	maxAvailableEditions: 7,
 	setMaxAvailableEditionsSetting: () => Promise.resolve(),
-	isWeatherShown: true,
-	setIsWeatherShownSetting: () => Promise.resolve(),
 };
 
 const ConfigContext = createContext(initialState);
@@ -93,17 +83,6 @@ export const getMaxAvailableEditions = async (): Promise<
 	}
 };
 
-export const getIsWeatherShown = async (): Promise<
-	ConfigState['isWeatherShown']
-> => {
-	try {
-		const isWeatherShown = await isWeatherShownCache.get();
-		return isWeatherShown ?? initialState.isWeatherShown;
-	} catch {
-		return Promise.resolve(initialState.isWeatherShown);
-	}
-};
-
 export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	const [largeDeviceMemeory, setLargeDeviceMemory] = useState(false);
 	const [dimensions, setDimensions] = useState(Dimensions.get('window'));
@@ -116,9 +95,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	const [maxAvailableEditions, setMaxAvailableEditions] = useState<
 		ConfigState['maxAvailableEditions']
 	>(initialState.maxAvailableEditions);
-	const [isWeatherShown, setIsWeatherShown] = useState<
-		ConfigState['isWeatherShown']
-	>(initialState.isWeatherShown);
 
 	const setNotifications = async (setting: boolean) => {
 		try {
@@ -153,17 +129,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 		}
 	};
 
-	const setIsWeatherShownSetting = async (setting: boolean) => {
-		try {
-			await isWeatherShownCache.set(setting);
-			setIsWeatherShown(setting);
-		} catch (e) {
-			console.log(e);
-			e.message = `Unable to Set Is Weather Shown: ${e.message}`;
-			errorService.captureException(e);
-		}
-	};
-
 	useEffect(() => {
 		notificationsAreEnabled().then((setting) =>
 			setNotificationsEnabled(setting),
@@ -179,12 +144,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 	useEffect(() => {
 		getMaxAvailableEditions().then((setting) =>
 			setMaxAvailableEditionsSetting(setting),
-		);
-	}, []);
-
-	useEffect(() => {
-		getIsWeatherShown().then((setting) =>
-			setIsWeatherShownSetting(setting),
 		);
 	}, []);
 
@@ -235,8 +194,6 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }) => {
 				setWifiOnlyDownloadsSetting,
 				maxAvailableEditions,
 				setMaxAvailableEditionsSetting,
-				isWeatherShown,
-				setIsWeatherShownSetting,
 			}}
 		>
 			{children}
@@ -263,9 +220,4 @@ export const useMaxAvailableEditions = () => ({
 	maxAvailableEditions: useContext(ConfigContext).maxAvailableEditions,
 	setMaxAvailableEditions:
 		useContext(ConfigContext).setMaxAvailableEditionsSetting,
-});
-
-export const useIsWeatherShown = (): IsWeatherShown => ({
-	isWeatherShown: useContext(ConfigContext).isWeatherShown,
-	setIsWeatherShown: useContext(ConfigContext).setIsWeatherShownSetting,
 });

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -28,10 +28,10 @@ import { errorService } from 'src/services/errors';
 import { defaultRegionalEditions } from '../../../Apps/common/src/editions-defaults';
 import { getEditionIds } from '../../../Apps/common/src/helpers';
 import { useAppState } from './use-app-state-provider';
-import type { IsWeatherShown } from './use-config-provider';
-import { useIsWeatherShown } from './use-config-provider';
 import type { NetInfoState } from './use-net-info-provider';
 import { useNetInfo } from './use-net-info-provider';
+import type { IsWeatherShown } from './use-weather-provider';
+import { useIsWeatherShown } from './use-weather-provider';
 
 interface EditionState {
 	editionsList: EditionsList;

--- a/projects/Mallard/src/hooks/use-weather-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-weather-provider/index.tsx
@@ -1,0 +1,81 @@
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react';
+import { isWeatherShownCache } from 'src/helpers/storage';
+import { errorService } from 'src/services/errors';
+
+interface WeatherState {
+	isWeatherShown: boolean;
+}
+
+export type IsWeatherShown = {
+	isWeatherShown: WeatherState['isWeatherShown'];
+	setIsWeatherShown: (setting: boolean) => void;
+};
+
+const initialState = {
+	isWeatherShown: true,
+	setIsWeatherShownSetting: (setting: boolean) => {
+		setting;
+		return Promise.resolve();
+	},
+};
+
+const WeatherContext = createContext(initialState);
+
+export const getIsWeatherShown = async (): Promise<
+	WeatherState['isWeatherShown']
+> => {
+	try {
+		const isWeatherShown = await isWeatherShownCache.get();
+		return isWeatherShown ?? initialState.isWeatherShown;
+	} catch {
+		return Promise.resolve(initialState.isWeatherShown);
+	}
+};
+
+export const WeatherProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	const [isWeatherShown, setIsWeatherShown] = useState<
+		WeatherState['isWeatherShown']
+	>(initialState.isWeatherShown);
+
+	const setIsWeatherShownSetting = useCallback(
+		async (setting: boolean) => {
+			try {
+				await isWeatherShownCache.set(setting);
+				setIsWeatherShown(setting);
+			} catch (e) {
+				e.message = `Unable to Set Is Weather Shown: ${e.message}`;
+				errorService.captureException(e);
+			}
+		},
+		[setIsWeatherShown],
+	);
+
+	useEffect(() => {
+		getIsWeatherShown().then((setting) =>
+			setIsWeatherShownSetting(setting),
+		);
+	}, []);
+
+	return (
+		<WeatherContext.Provider
+			value={{ isWeatherShown, setIsWeatherShownSetting }}
+		>
+			{children}
+		</WeatherContext.Provider>
+	);
+};
+
+export const useIsWeatherShown = (): IsWeatherShown => ({
+	isWeatherShown: useContext(WeatherContext).isWeatherShown,
+	setIsWeatherShown: useContext(WeatherContext).setIsWeatherShownSetting,
+});

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -39,7 +39,6 @@ import {
 import { useQuery } from 'src/hooks/apollo';
 import {
 	useDimensions,
-	useIsWeatherShown,
 	useLargeDeviceMemory,
 } from 'src/hooks/use-config-provider';
 import {
@@ -54,6 +53,7 @@ import {
 } from 'src/hooks/use-issue-summary-provider';
 import { useNavPositionChange } from 'src/hooks/use-nav-position';
 import { useIsPreview, useIsProof } from 'src/hooks/use-settings';
+import { useIsWeatherShown } from 'src/hooks/use-weather-provider';
 import type { PathToIssue } from 'src/paths';
 import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle';
 import { sendPageViewEvent } from 'src/services/ophan';

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -20,10 +20,8 @@ import { FullButton } from 'src/components/lists/FullButton';
 import { setIsUsingProdDevtools } from 'src/helpers/settings/setters';
 import { Copy } from 'src/helpers/words';
 import { useQuery } from 'src/hooks/apollo';
-import {
-	useIsWeatherShown,
-	useNotificationsEnabled,
-} from 'src/hooks/use-config-provider';
+import { useNotificationsEnabled } from 'src/hooks/use-config-provider';
+import { useIsWeatherShown } from 'src/hooks/use-weather-provider';
 import type { SettingsStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { BetaButtonOption } from 'src/screens/settings/join-beta-button';

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -9,7 +9,7 @@ import { requestLocationPermission } from 'src/helpers/location-permission';
 import { getGeolocation } from 'src/helpers/weather';
 import { html } from 'src/helpers/webview';
 import { Copy } from 'src/helpers/words';
-import { useIsWeatherShown } from 'src/hooks/use-config-provider';
+import { useIsWeatherShown } from 'src/hooks/use-weather-provider';
 import { metrics } from 'src/theme/spacing';
 import { DefaultInfoTextWebview } from './settings/default-info-text-webview';
 


### PR DESCRIPTION
## Why are you doing this?

In an attempt to remove the Weather resolver, there was a lot of logic still left over. To move it across would have meant putting it in an already bloated config provider. So it made sense to create a weather provider, move the previous setting changes across ready for the additional logic to come in.

## Changes

- Move the `isWeatherShown` settings from the config provider to a new weather provider
- Add weather provider to the App
- Update the usage throughout the app
- Added a useCallback on the setting as a minor performance improvement.

This should all work as before.
