### PR TITLE
chore: Enable Dev menu for external organisation

### DIFF
--- a/projects/Mallard/src/authentication/helpers.ts
+++ b/projects/Mallard/src/authentication/helpers.ts
@@ -4,7 +4,11 @@ import {
 } from 'src/helpers/storage';
 import type { IdentityAuthData } from './authorizers/IdentityAuthorizer';
 
-const GUARDIAN_SUFFIXES = ['guardian.co.uk', 'theguardian.com'];
+const GUARDIAN_SUFFIXES = [
+	'guardian.co.uk',
+	'theguardian.com',
+	'james-miller.co.uk',
+];
 
 const isGuardianEmail = (email: string) =>
 	GUARDIAN_SUFFIXES.some((suffix) => email.endsWith(suffix));


### PR DESCRIPTION
## Why are you doing this?

Currently I am unable to access the developer menu in production as I do not have a guardian email address. This allows access as long as I have a subscription. So this can be easily revoked via a PR or via the subscription platform

## Changes

- Added my organisation suffix to those that are allowed.
