### PR TITLE
chore: Refactor isUsingProdDevTools

### DIFF
--- a/projects/Mallard/src/helpers/settings.ts
+++ b/projects/Mallard/src/helpers/settings.ts
@@ -5,7 +5,6 @@ export const SETTINGS_KEY_PREFIX = '@Setting_';
 
 export interface DevSettings {
 	apiUrl: string;
-	isUsingProdDevtools: boolean;
 	notificationServiceRegister: string;
 	cacheClearUrl: string;
 	deprecationWarningUrl: string;

--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -102,7 +102,6 @@ const storeDetails = {
 
 export const defaultSettings: Settings = {
 	apiUrl,
-	isUsingProdDevtools: false,
 	notificationServiceRegister: __DEV__
 		? notificationServiceRegister.code
 		: notificationServiceRegister.prod,

--- a/projects/Mallard/src/helpers/settings/resolvers.ts
+++ b/projects/Mallard/src/helpers/settings/resolvers.ts
@@ -12,7 +12,6 @@ const makeFragment = (names: string[]) =>
 
 const ALL_NAMES = [
 	'apiUrl', // This should be an east one to remove.
-	'isUsingProdDevtools', // This should be an easy one to remove
 ];
 
 /**

--- a/projects/Mallard/src/helpers/settings/setters.ts
+++ b/projects/Mallard/src/helpers/settings/setters.ts
@@ -25,4 +25,3 @@ const createSetter = <Name extends keyof Settings>(
 };
 
 export const setApiUrl = createSetter('apiUrl');
-export const setIsUsingProdDevtools = createSetter('isUsingProdDevtools');

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -120,6 +120,10 @@ const isWeatherShownCache = createAsyncCache<boolean>(
 	'@Setting_isWeatherShown',
 );
 
+const isUsingProdDevtoolsCache = createAsyncCache<boolean>(
+	'@Setting_isUsingProdDevtools',
+);
+
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -196,4 +200,5 @@ export {
 	gdprAllowFunctionalityCache,
 	gdprConsentVersionCache,
 	isWeatherShownCache,
+	isUsingProdDevtoolsCache,
 };

--- a/projects/Mallard/src/hooks/use-article.tsx
+++ b/projects/Mallard/src/hooks/use-article.tsx
@@ -4,7 +4,7 @@ import { getPillarColors } from 'src/helpers/transform';
 import { DevTools } from 'src/hooks/article/dev-tools';
 import type { Appearance, ArticlePillar, Collection } from '../common';
 import { ArticleType } from '../common';
-import { useIsUsingProdDevtools } from './use-settings';
+import { useIsUsingProdDevtools } from './use-config-provider';
 
 /*
   Exports
@@ -47,7 +47,7 @@ const ProvidersAndDevtools = ({ type, pillar, children }: PropTypes) => {
 };
 
 export const WithArticle = (props: PropTypes) => {
-	const isUsingProdDevtools = useIsUsingProdDevtools();
+	const { isUsingProdDevtools } = useIsUsingProdDevtools();
 
 	if (isUsingProdDevtools) return <ProvidersAndDevtools {...props} />;
 	return <Providers {...props} />;

--- a/projects/Mallard/src/hooks/use-settings.ts
+++ b/projects/Mallard/src/hooks/use-settings.ts
@@ -24,10 +24,3 @@ export const useIsProof = () => {
 	const apiUrl = useApiUrl();
 	return apiUrl?.includes('proof');
 };
-
-const PROD_DEV_QUERY = gql('{ isUsingProdDevtools @client }');
-export const useIsUsingProdDevtools = () => {
-	const query = useQuery<{ isUsingProdDevtools: boolean }>(PROD_DEV_QUERY);
-	// FIXME: upstream code should be handling the loading status
-	return !query.loading && query.data.isUsingProdDevtools;
-};

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -37,6 +37,7 @@ import {
 	CONNECTION_FAILED_ERROR,
 	Copy,
 } from 'src/helpers/words';
+import { useIsUsingProdDevtools } from 'src/hooks/use-config-provider';
 import {
 	getSpecialEditionProps,
 	useEditions,
@@ -45,7 +46,6 @@ import { useIssueResponse } from 'src/hooks/use-issue';
 import { useIssueSummary } from 'src/hooks/use-issue-summary-provider';
 import { useSetNavPosition } from 'src/hooks/use-nav-position';
 import useOverlayAnimation from 'src/hooks/use-overlay-animation';
-import { useIsUsingProdDevtools } from 'src/hooks/use-settings';
 import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
 import type { SettingsOverlayInterface } from 'src/hooks/use-settings-overlay';
 import { navigateToIssue } from 'src/navigation/helpers/base';
@@ -185,7 +185,7 @@ const IssueRowContainer = React.memo(
 
 const IssueListFooter = () => {
 	const navigation = useNavigation<CompositeNavigationStackProps>();
-	const isUsingProdDevtools = useIsUsingProdDevtools();
+	const { isUsingProdDevtools } = useIsUsingProdDevtools();
 	const { setIssueId } = useIssueSummary();
 	return (
 		<>

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
-import gql from 'graphql-tag';
 import React, { useContext, useState } from 'react';
 import type { AccessibilityRole } from 'react-native';
 import { Alert, Linking, Platform, Switch, Text } from 'react-native';
@@ -17,10 +16,11 @@ import { ScrollContainer } from 'src/components/layout/ui/container';
 import { Heading, Row, Separator } from 'src/components/layout/ui/row';
 import { DualButton } from 'src/components/lists/DualButton';
 import { FullButton } from 'src/components/lists/FullButton';
-import { setIsUsingProdDevtools } from 'src/helpers/settings/setters';
 import { Copy } from 'src/helpers/words';
-import { useQuery } from 'src/hooks/apollo';
-import { useNotificationsEnabled } from 'src/hooks/use-config-provider';
+import {
+	useIsUsingProdDevtools,
+	useNotificationsEnabled,
+} from 'src/hooks/use-config-provider';
 import { useIsWeatherShown } from 'src/hooks/use-weather-provider';
 import type { SettingsStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
@@ -103,14 +103,6 @@ const MiscSettingsList = () => {
 	);
 };
 
-type QueryData = { isUsingProdDevtools: boolean };
-
-const QUERY = gql`
-	{
-		isUsingProdDevtools @client
-	}
-`;
-
 const SignInButton = ({
 	username,
 	signOutIdentity,
@@ -148,7 +140,6 @@ const SignInButton = ({
 
 const SettingsScreen = () => {
 	const navigation = useNavigation();
-	const query = useQuery<QueryData>(QUERY);
 	const identityData = useIdentity();
 	const canAccess = useAccess();
 	const [, setVersionClickedTimes] = useState(0);
@@ -161,10 +152,8 @@ const SettingsScreen = () => {
 
 	const canDisplayBetaButton = !iapData && isLoggedInWithIdentity;
 	const buildNumber = DeviceInfo.getBuildNumber();
-
-	if (query.loading) return null;
-	const { client } = query;
-	const { isUsingProdDevtools } = query.data;
+	const { isUsingProdDevtools, setIsUsingProdDevTools } =
+		useIsUsingProdDevtools();
 
 	const versionClickHandler = identityData
 		? () => {
@@ -179,7 +168,7 @@ const SettingsScreen = () => {
 									text: 'Enable',
 									style: 'destructive',
 									onPress: () => {
-										setIsUsingProdDevtools(client, true);
+										setIsUsingProdDevTools(true);
 									},
 								},
 								{

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -21,12 +21,12 @@ import { locale } from 'src/helpers/locale';
 import { isInBeta, isInTestFlight } from 'src/helpers/release-stream';
 import { imageForScreenSize } from 'src/helpers/screen';
 import { ALL_SETTINGS_FRAGMENT } from 'src/helpers/settings/resolvers';
-import { setIsUsingProdDevtools } from 'src/helpers/settings/setters';
 import {
 	pushRegisteredTokens,
 	showAllEditionsCache,
 } from 'src/helpers/storage';
 import { useQuery } from 'src/hooks/apollo';
+import { useIsUsingProdDevtools } from 'src/hooks/use-config-provider';
 import { useEditions } from 'src/hooks/use-edition-provider';
 import { useNetInfo } from 'src/hooks/use-net-info-provider';
 import { useToast } from 'src/hooks/use-toast';
@@ -84,6 +84,7 @@ const DevZone = () => {
 
 	const { attempt, signOutCAS } = useContext(AccessContext);
 	const { showToast } = useToast();
+	const { setIsUsingProdDevTools } = useIsUsingProdDevtools();
 
 	const [files, setFiles] = useState('fetching...');
 	const [pushTrackingInfo, setPushTrackingInfo] = useState('fetching...');
@@ -132,7 +133,7 @@ const DevZone = () => {
 		gql(`{ ${ALL_SETTINGS_FRAGMENT} }`),
 	);
 	if (query.loading) return null;
-	const { data, client } = query;
+	const { data } = query;
 	const { apiUrl } = data;
 	if (typeof apiUrl !== 'string') throw new Error('expected string');
 
@@ -260,7 +261,7 @@ const DevZone = () => {
 								explainer:
 									'Tap the version 7 times to bring it back',
 								onPress: () => {
-									setIsUsingProdDevtools(client, false);
+									setIsUsingProdDevTools(false);
 								},
 							},
 							{


### PR DESCRIPTION
## Why are you doing this?

Another one on the Apollo cull list to be removed. This setting decides whether or not to show the duck menu

## Changes

- Shift across `isUsingProdDevTools` across to the context pattern.

N.B: There are some repeating patterns in the config provider now and it's causing a fair amount of duplicate code. Something that needs to be addressed in a follow up PR. Its a good thing as it suggests we are using the config provider to store configuration (i.e. simple switches) so it has that single responsibility.