### PR TITLE
Fix: Editions Endpoint URL

### DIFF
--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -329,7 +329,7 @@ export const EditionProvider = ({
 	useEffect(() => {
 		if (isActive) {
 			const fullUrl = editionsEndpoint(apiUrl);
-			getEditions(isConnected, editionsEndpoint(fullUrl)).then(
+			getEditions(isConnected, fullUrl).then(
 				(ed) => ed && setEditionsList(ed),
 			);
 		}


### PR DESCRIPTION
## Why are you doing this?
The editions endpoint was being requested with an additional `ediitions` due to the function resolving twice, rather than the value being used.

## Changes
- Use the value