### PR TITLE
Explicitly set the aws-s3 publicReadAcl property to false

### DIFF
--- a/riff-raff-builds-gutools.yaml
+++ b/riff-raff-builds-gutools.yaml
@@ -14,3 +14,4 @@ deployments:
             prefixStack: false
             mimeTypes:
                 json: application/json
+            publicReadAcl: false


### PR DESCRIPTION
Update the publicReadAcl to false (required by recent RiffRaff change)

From DevX on 04-01-2022:

This is part of a migration effort to changing the default of publicReadAcl to false (riff-raff PR #664).

By marking the parameter as required (aka not optional) an error will be thrown complaining about a missing parameter, meaning:

the deploy fails until the parameter is explicitly set
previous deploys are not effected, therefore the app still works
BREAKING CHANGE: publicReadAcl is now required to be set for aws-s3 type.

