### PR TITLE
fix: Issue Summary Status Check

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -226,7 +226,7 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
 	try {
 		const issueSummaryRequest = await fetch(fetchIssueSummaryUrl);
 		const issueSummary = await issueSummaryRequest.json();
-		if (!issueSummary) {
+		if (!issueSummary || issueSummaryRequest.status !== 200) {
 			throw new Error('No Issume Summary Avaialble');
 		}
 


### PR DESCRIPTION
## Why are you doing this?

There is a theory that in this piece of code, we were receiving a piece of XML back in the case of a status code that was a 200. So our original check assumed there was an issue summary, however the content was different. This adds in a bit more defensive coding.

## Changes

- Adds a status check to the function that fetches the issue summary