### PR TITLE
Feat: Remove cop from articles

### DIFF
--- a/projects/Mallard/src/helpers/fetch/cached-or-promise.ts
+++ b/projects/Mallard/src/helpers/fetch/cached-or-promise.ts
@@ -81,39 +81,4 @@ const isCached = <T>(
 	cachedOrPromise: CachedOrPromise<T>,
 ): cachedOrPromise is CachedResult<T> => cachedOrPromise.type === 'value';
 
-/*
-If you wanna chain a bunch of CachedOrPromises but retain the
-behavior where .value is always cached and .getValue() is not
-(this allows for refreshes of the entire chain) you can use
-this helper
-*/
-const chain = <T, X>(
-	cachedOrPromise: CachedOrPromise<T>,
-	callback: (t: T) => CachedOrPromise<X>,
-) => {
-	let defaultValue = null;
-	if (isCached(cachedOrPromise)) {
-		const cb = callback(cachedOrPromise.value);
-		if (isCached(cb)) {
-			defaultValue = cb.value;
-		}
-	}
-	return createCachedOrPromise<X>(
-		[
-			defaultValue,
-			async () => {
-				const resp = await cachedOrPromise.getValue();
-				return callback(resp).getValue();
-			},
-		],
-		{
-			savePromiseResultToValue: () => null,
-		},
-	);
-};
-chain.end = <X>(value: X) =>
-	createCachedOrPromise<X>([value, async () => value], {
-		savePromiseResultToValue: () => {},
-	});
-
-export { isCached, chain, createCachedOrPromise };
+export { isCached, createCachedOrPromise };

--- a/projects/Mallard/src/hooks/use-issue.ts
+++ b/projects/Mallard/src/hooks/use-issue.ts
@@ -1,14 +1,7 @@
 import type { Issue } from 'src/common';
 import { fetchIssue } from 'src/helpers/fetch';
 import type { CachedOrPromise } from 'src/helpers/fetch/cached-or-promise';
-import { chain } from 'src/helpers/fetch/cached-or-promise';
 import { withResponse } from 'src/helpers/response';
-import {
-	flattenCollectionsToCards,
-	flattenFlatCardsToFront,
-} from 'src/helpers/transform';
-import { ERR_404_REMOTE } from 'src/helpers/words';
-import type { PathToArticle } from 'src/paths';
 import { useCachedOrPromise } from './use-cached-or-promise';
 
 const useIssueWithResponse = <T>(
@@ -28,35 +21,3 @@ export const useIssueResponse = (
 		[issue],
 	);
 };
-
-const getArticleResponse = ({
-	article,
-	localIssueId,
-	publishedIssueId,
-	front,
-}: PathToArticle) =>
-	chain(fetchIssue(localIssueId, publishedIssueId, false), (issue) => {
-		const maybeFront = issue.fronts.find((f) => f.key === front);
-		if (!maybeFront) throw ERR_404_REMOTE;
-
-		const allArticles = flattenFlatCardsToFront(
-			flattenCollectionsToCards(maybeFront.collections),
-		);
-		const articleContent = allArticles.find(
-			({ article: { key } }) => key === article,
-		);
-
-		if (articleContent) {
-			return chain.end({ ...articleContent, origin: issue.origin });
-		}
-		throw ERR_404_REMOTE;
-	});
-
-export const useArticleResponse = (path: PathToArticle) =>
-	useIssueWithResponse(getArticleResponse(path), [
-		path.article,
-		path.collection,
-		path.front,
-		path.localIssueId,
-		path.publishedIssueId,
-	]);

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -11,7 +11,7 @@ import {
 	WithArticle,
 } from 'src/hooks/use-article';
 import { useApiUrl } from 'src/hooks/use-config-provider';
-import { useArticleResponse } from 'src/hooks/use-issue';
+import { useIssue } from 'src/hooks/use-issue-provider';
 import type { PathToArticle } from 'src/paths';
 import { color } from 'src/theme/color';
 
@@ -39,7 +39,8 @@ const ArticleScreenBody = React.memo<
 		onIsAtTopChange,
 		...headerControlProps
 	}) => {
-		const articleResponse = useArticleResponse(path);
+		const { getArticle, error } = useIssue();
+		const article = getArticle(path);
 		const { isPreview } = useApiUrl();
 		const previewNotice = isPreview
 			? `${path.collection}:${position}`
@@ -54,46 +55,42 @@ const ArticleScreenBody = React.memo<
 		useEffect(() => handleIsAtTopChange(true), []);
 		return (
 			<View style={[styles.container, { width }]}>
-				{articleResponse({
-					error: ({ message }) => (
-						<FlexErrorMessage
-							title={message}
-							style={{ backgroundColor: color.background }}
-						/>
-					),
-					pending: () => (
-						<FlexErrorMessage
-							title={'loading'}
-							style={{ backgroundColor: color.background }}
-						/>
-					),
-					success: (article) => (
-						<>
-							{previewNotice && (
-								<UiBodyCopy>{previewNotice}</UiBodyCopy>
-							)}
+				{article ? (
+					<>
+						{previewNotice && (
+							<UiBodyCopy>{previewNotice}</UiBodyCopy>
+						)}
 
-							<WithArticle
-								type={
-									article.article.articleType ??
-									ArticleType.Article
-								}
-								pillar={getCollectionPillarOverride(
-									pillar,
-									path.collection,
-								)}
-							>
-								<ArticleController
-									{...headerControlProps}
-									path={path}
-									article={article.article}
-									onIsAtTopChange={handleIsAtTopChange}
-									origin={article.origin}
-								/>
-							</WithArticle>
-						</>
-					),
-				})}
+						<WithArticle
+							type={
+								article.article.articleType ??
+								ArticleType.Article
+							}
+							pillar={getCollectionPillarOverride(
+								pillar,
+								path.collection,
+							)}
+						>
+							<ArticleController
+								{...headerControlProps}
+								path={path}
+								article={article.article}
+								onIsAtTopChange={handleIsAtTopChange}
+								origin={article.origin}
+							/>
+						</WithArticle>
+					</>
+				) : error ? (
+					<FlexErrorMessage
+						title={error}
+						style={{ backgroundColor: color.background }}
+					/>
+				) : (
+					<FlexErrorMessage
+						title={'loading'}
+						style={{ backgroundColor: color.background }}
+					/>
+				)}
 			</View>
 		);
 	},

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -400,6 +400,7 @@ const IssueListFetchContainer = () => {
 		Platform.select({ android: false, default: true }),
 	);
 	const { issueWithFronts, setIssueId, issueId, error } = useIssue();
+	// console.log(issueWithFronts);
 
 	useEffect(() => {
 		// Adding a tiny delay before doing full rendering means that the


### PR DESCRIPTION
## Why are you doing this?

Again to align our state management into one. This removes `cacheOrPromise` state management from the articles and uses the issue hook

## Changes

- Essentially this adds `getArticle` which does some fetching of data from the issue that is in state.
- Removes some of the `cacheOrPromise` helpers that are now not used.
