### PR TITLE
fix: Show Image Menu Change (Temporary)

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,5 +1,4 @@
 import { useIsFocused, useNavigation } from '@react-navigation/native';
-import type { Dispatch } from 'react';
 import React, {
 	useCallback,
 	useContext,
@@ -386,7 +385,7 @@ const IssueListFetchContainer = () => {
 		// if this is enabled. See below description of this mechanism.
 		Platform.select({ android: false, default: true }),
 	);
-	const { issueWithFronts, setIssueId, issueId, error } = useIssue();
+	const { issueWithFronts, issueId, error } = useIssue();
 	// console.log(issueWithFronts);
 
 	useEffect(() => {
@@ -412,21 +411,18 @@ const IssueListFetchContainer = () => {
 
 	return issueWithFronts !== null ? (
 		<IssueListViewWithDelay
-			setIssueId={setIssueId}
 			issueList={issueSummary}
 			currentId={issueId}
 			currentIssue={{ value: issueWithFronts }}
 		/>
 	) : error ? (
 		<IssueListViewWithDelay
-			setIssueId={setIssueId}
 			issueList={issueSummary}
 			currentId={issueId}
 			currentIssue={{ error }}
 		/>
 	) : (
 		<IssueListViewWithDelay
-			setIssueId={setIssueId}
 			issueList={issueSummary}
 			currentId={issueId}
 			currentIssue={{ isLoading: true }}

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -92,11 +92,9 @@ const styles = StyleSheet.create({
 
 const IssueRowContainer = React.memo(
 	({
-		setIssueId: setLocalIssueId,
 		issue,
 		issueDetails,
 	}: {
-		setIssueId: Dispatch<PathToIssue>;
 		issue: IssueSummary;
 		issueDetails: Loaded<IssueWithFronts> | null;
 	}) => {
@@ -137,7 +135,7 @@ const IssueRowContainer = React.memo(
 				navToIssue(null);
 				return;
 			}
-			setLocalIssueId({
+			setIssueId({
 				localIssueId: localId,
 				publishedIssueId: publishedId,
 			});
@@ -145,7 +143,7 @@ const IssueRowContainer = React.memo(
 			setNavPosition,
 			navToIssue,
 			issueDetails,
-			setLocalIssueId,
+			setIssueId,
 			localId,
 			publishedId,
 		]);
@@ -240,11 +238,9 @@ const IssueListView = React.memo(
 	({
 		issueList,
 		currentIssue,
-		setIssueId,
 	}: {
 		issueList: IssueSummary[];
 		currentIssue: { id: PathToIssue; details: Loaded<IssueWithFronts> };
-		setIssueId: Dispatch<PathToIssue>;
 	}) => {
 		const navigation = useNavigation();
 		const { localIssueId: localId, publishedIssueId: publishedId } =
@@ -279,12 +275,11 @@ const IssueListView = React.memo(
 		const renderItem = useCallback(
 			({ item, index }) => (
 				<IssueRowContainer
-					setIssueId={setIssueId}
 					issue={item}
 					issueDetails={index === currentIssueIndex ? details : null}
 				/>
 			),
-			[currentIssueIndex, details, navigation, setIssueId],
+			[currentIssueIndex, details, navigation],
 		);
 
 		// Height of the fronts so we can provide this to `getItemLayout`.
@@ -354,12 +349,10 @@ const IssueListViewWithDelay = ({
 	issueList,
 	currentId,
 	currentIssue,
-	setIssueId,
 }: {
 	issueList: IssueSummary[];
 	currentId: PathToIssue;
 	currentIssue: Loaded<IssueWithFronts>;
-	setIssueId: Dispatch<PathToIssue>;
 }) => {
 	const [shownIssue, setShownIssue] = useState({
 		id: currentId,
@@ -381,13 +374,7 @@ const IssueListViewWithDelay = ({
 		}
 	}, [currentId, currentIssue, details]);
 
-	return (
-		<IssueListView
-			setIssueId={setIssueId}
-			issueList={issueList}
-			currentIssue={shownIssue}
-		/>
-	);
+	return <IssueListView issueList={issueList} currentIssue={shownIssue} />;
 };
 
 const NO_ISSUES: IssueSummary[] = [];


### PR DESCRIPTION
## Why are you doing this?
Noticed on iPad that the issue changes in the background when you choose a new one. Before the `cacheOrPromise` removal, this wouldnt change until you chose the front.

We will move back to this way but this requires some further investigation around multiple issueIds and also keeping a local one. I also think we can manage how fronts are shown on the menu better.

In the meantime, the current experience is quite slow and looks broken. This change maintains that slowness but makes it look less broken. 

Ideally we dont release until we solve the performance issue, however, this PR at least makes the app releasable. 

## Changes

- Update the global state when an issue is chosen so that the images load in the background
