### PR TITLE
Revert "Updated `react-native-iap` to support minimum google play billing"

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -399,8 +399,8 @@ PODS:
     - React
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNIap (4.6.3):
-    - React-Core
+  - RNIap (3.5.9):
+    - React
   - RNInAppBrowser (3.6.3):
     - React-Core
   - RNKeychain (6.2.0):
@@ -718,7 +718,7 @@ SPEC CHECKSUMS:
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNIap: 66b83af54a855b6314a243a200081a64d7f64c2e
+  RNIap: 9e69c8d9ecfdd1f0882363366e85d2e1683ecc89
   RNInAppBrowser: 3ff3a3b8f458aaf25aaee879d057352862edf357
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
   RNLocalize: 7c7aeda16c01db7a0918981c14875c0a53be9b79

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -79,7 +79,7 @@
         "react-native-fs": "^2.16.6",
         "react-native-gesture-handler": "^1.10.3",
         "react-native-htmlview": "^0.15.0",
-        "react-native-iap": "^4.6.2",
+        "react-native-iap": "^3.3.9",
         "react-native-image-zoom-viewer": "^3.0.1",
         "react-native-in-app-utils": "^6.0.2",
         "react-native-inappbrowser-reborn": "^3.3.3",

--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -37,7 +37,6 @@ describe('iap', () => {
 				},
 				latest_receipt_info: [receipt],
 			};
-			// @ts-ignore
 			expect(findValidReceipt(receiptValidationResponse)).toEqual(
 				receipt,
 			);
@@ -54,7 +53,6 @@ describe('iap', () => {
 				},
 				latest_receipt_info: [],
 			};
-			// @ts-ignore
 			expect(findValidReceipt(receiptValidationResponse)).toEqual(null);
 		});
 		it('should return null if it cant find a valid receipt', () => {
@@ -71,7 +69,6 @@ describe('iap', () => {
 				},
 				latest_receipt_info: [receipt],
 			};
-			// @ts-ignore
 			expect(findValidReceipt(receiptValidationResponse)).toEqual(null);
 		});
 		it('should return null if last_receipt_info is missing', () => {

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -54,11 +54,11 @@ const isReceiptValid = (receipt: ReceiptIOS) => {
 	return expirationWithGracePeriod > nowInMilliseconds;
 };
 
-const hasLatestReceiptInfo = (receipt: any) => {
+const hasLatestReceiptInfo = (receipt: ReceiptValidationResponse) => {
 	return (receipt?.latest_receipt_info as ReceiptIOS[])?.length > 0;
 };
 
-const findValidReceiptFromLatestInfo = (receipt: any) => {
+const findValidReceiptFromLatestInfo = (receipt: ReceiptValidationResponse) => {
 	return (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid);
 };
 

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -5565,7 +5565,7 @@ domutils@^2.5.2, domutils@^2.6.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-dooboolab-welcome@^1.2.0:
+dooboolab-welcome@^1.1.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz#4928595312f0429b4ea1b485ba8767bae6acdab7"
   integrity sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==
@@ -10869,12 +10869,12 @@ react-native-htmlview@^0.15.0:
     entities "^1.1.1"
     htmlparser2-without-node-native "^3.9.2"
 
-react-native-iap@^4.6.2:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-4.6.3.tgz#3f1a88e1561156f695f52134ee04e1ace5c37487"
-  integrity sha512-BUCnaIuUUcegarzDUbqvAwdauYaCNYqc+2ExluP8CXpKr0VdNpZxDGilHptDbBt9CCqWf7dvautNP/dsSI0J6A==
+react-native-iap@^3.3.9:
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-3.5.9.tgz#1a49702f5c5ed444da9d3c7b8db9b5e7c7066deb"
+  integrity sha512-LtL6NX4y8JCg9pjUDxMz2om03r0PaJHfzpT6Wd437ck5sr+cIAbC8QH5MgXUkyoBin+MxTSX0w92TbuZAeHp1Q==
   dependencies:
-    dooboolab-welcome "^1.2.0"
+    dooboolab-welcome "^1.1.1"
 
 react-native-image-pan-zoom@^2.1.12:
   version "2.1.12"


### PR DESCRIPTION
Reverts guardian/editions#1966

It has been found that IAP doesnt work with this version on a users device, so reverting this PR.