### PR TITLE
chore: Attempt to disable IAP for Android

### DIFF
--- a/projects/Mallard/react-native.config.js
+++ b/projects/Mallard/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    dependencies: {
+      "react-native-iap": {
+        platforms: {
+          android: null // disable Android platform, other platforms will still autolink if provided
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## Why are you doing this?

This one is a bit of a "Hail Mary". This attempts to disable the installation of the React Native IAP module for Android. This is based on the following links:

https://stackoverflow.com/questions/61939769/ignore-a-react-native-library-for-android-only-when-using-autolinking
https://github.com/react-native-community/cli/blob/master/docs/dependencies.md
