### PR TITLE
fix: Stop throwing in article

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -44,7 +44,7 @@ interface IssueState {
 	setIssueId: Dispatch<SetStateAction<PathToIssue>>;
 	issueId: PathToIssue;
 	error: string;
-	getArticle: (props: ArticleProps) => ArticleContent | void;
+	getArticle: (props: ArticleProps) => ArticleContent | null;
 	retry: () => void;
 }
 
@@ -53,7 +53,7 @@ const initialState: IssueState = {
 	setIssueId: () => {},
 	issueId: EMPTY_ISSUE_ID,
 	error: '',
-	getArticle: () => {},
+	getArticle: () => null,
 	retry: () => {},
 };
 

--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -194,9 +194,15 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		PathToArticle,
 		'localIssueId' | 'publishedIssueId' | 'collection'
 	>) => {
-		if (!issueWithFronts) throw ERR_404_REMOTE;
+		if (!issueWithFronts) {
+			setError(ERR_404_REMOTE);
+			return null;
+		}
 		const maybeFront = issueWithFronts.fronts.find((f) => f.key === front);
-		if (!maybeFront) throw ERR_404_REMOTE;
+		if (!maybeFront) {
+			setError(ERR_404_REMOTE);
+			return null;
+		}
 
 		const allArticles = flattenFlatCardsToFront(
 			flattenCollectionsToCards(maybeFront.collections),
@@ -208,7 +214,9 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		if (articleContent) {
 			return { ...articleContent, origin: issueWithFronts.origin };
 		}
-		throw ERR_404_REMOTE;
+
+		setError(ERR_404_REMOTE);
+		return null;
 	};
 
 	const retry = () => {

--- a/projects/Mallard/src/screens/article/body.tsx
+++ b/projects/Mallard/src/screens/article/body.tsx
@@ -39,7 +39,7 @@ const ArticleScreenBody = React.memo<
 		onIsAtTopChange,
 		...headerControlProps
 	}) => {
-		const { getArticle, error } = useIssue();
+		const { getArticle, error, retry } = useIssue();
 		const article = getArticle(path);
 		const { isPreview } = useApiUrl();
 		const previewNotice = isPreview
@@ -84,6 +84,7 @@ const ArticleScreenBody = React.memo<
 					<FlexErrorMessage
 						title={error}
 						style={{ backgroundColor: color.background }}
+						action={['Retry', retry]}
 					/>
 				) : (
 					<FlexErrorMessage


### PR DESCRIPTION
## Why are you doing this?
Users are seeing that the app has crashed when loading. While we are not sure of the issue causing it, it is related to the `getArticle` function as this is the only place that provides the wording that is seen in the screen shots.

Within the function we are throwing errors when we don't have certain pieces of data. But as this data is asynchronous, there will be times when we don't have it (e.g. a slow connection). 

So rather than throwing, we now set an error inside the article with the retry button. This means the whole app doesnt fall over, but just the article section. This may lead to new complaints around not being able to read articles in certain circumstances, but we need to find out what those are.

The logic in this function needs to be looked at in more detail