### PR TITLE
fix: Prevent Scrolling on load

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -328,6 +328,7 @@ export type Front = WithKey & {
     webTitle?: string
     navSection?: string
     appearance: Appearance
+    id: string
 }
 
 export interface UnknownElement {

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -207,7 +207,7 @@ const IssueFronts = ({
 					frontSpecs: [],
 				},
 			),
-		[issue.localId, issue.publishedId, issue.fronts],
+		[issue.localId, issue.publishedId, issue.fronts[0].id],
 	);
 
 	useScrollToFrontBehavior(frontWithCards, initialFrontKey, ref);


### PR DESCRIPTION
## Why are you doing this?

Production are complaining that scroll position is moving around. I have noticed if we scroll during the initial load, the issue screen will scroll back to the top.

We memoise the data used for this screen, but one of the conditions whether to run this again is an array of objects. In other projects I have seen this be ignored as it doesn't seem to do a deep equal. In our case perhaps there is a change of reference here (something to check out).

For the time being I have pushed that check down to what I believe is a uuid on the first front in the edition.

## Changes

- Update memoised value based on the first fronts uuid
- Add this as a type in the common types