### PR TITLE
fix: Alternative Reload Button Fix

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -219,8 +219,8 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		return null;
 	};
 
-	const retry = () => {
-		getIssue(true)
+	const retry = async () => {
+		return await getIssue(true)
 			.then((issue) => {
 				issue && setIssueWithFronts(issue);
 				setError('');

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -347,7 +347,8 @@ const IssueScreenWithPath = React.memo(() => {
 							RNRestart.Restart();
 						}
 					}
-					retry();
+					await retry();
+					RNRestart.Restart();
 				}}
 			/>
 			<IssueScreenHeader issue={issue} headerStyles={headerStyle} />


### PR DESCRIPTION
## Why are you doing this?

Allowing the app to restart when the reload button is pressed in preview, to aid with memoisation issues.
