### PR TITLE
Fix/issue screen analytics

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -329,10 +329,12 @@ const IssueScreenWithPath = React.memo(() => {
 	const specialEditionProps = getSpecialEditionProps(selectedEdition);
 	const headerStyle = specialEditionProps?.headerStyle;
 
-	issue &&
-		sendPageViewEvent({
-			path: `editions/uk/daily/${issue.key}`,
-		});
+	useEffect(() => {
+		issue &&
+			sendPageViewEvent({
+				path: `editions/uk/daily/${issue.key}`,
+			});
+	}, [issue?.key]);
 
 	return issue ? (
 		<>

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -332,7 +332,7 @@ const IssueScreenWithPath = React.memo(() => {
 	useEffect(() => {
 		issue &&
 			sendPageViewEvent({
-				path: `editions/uk/daily/${issue.key}`,
+				path: `editions/${issue.key}`,
 			});
 	}, [issue?.key]);
 


### PR DESCRIPTION
## Why are you doing this?
Issue screen page view event is being fired on each render. This is currently happening more than it should due to some inefficiencies.

This change ensures this is only fired when the `key` changes. So that will be on load and each issue changed, including when swapping.

**Please note that I have also changed the path here as it appeared to be incorrect. This will need to be double checked with the Ophan team**

Before:
`editions/uk/daily/australian-edition/2022-02-05`
`editions/uk/daily/daily-edition/2022-02-10`

After:
`editions/daily-edition/2022-02-10`
`editions/australian-edition/2022-02-05`
