### PR TITLE
Fix: Issue reloading

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -63,7 +63,6 @@ const fetchIssueWithFrontsFromAPI = async (
 	id: string,
 	apiUrl: string,
 ): Promise<IssueWithFronts> => {
-	console.log('~~~~~ FROM API ~~~~~');
 	const issue: Issue = await fetch(`${apiUrl}${APIPaths.issue(id)}`).then(
 		(res) => {
 			if (res.status !== 200) {
@@ -94,7 +93,6 @@ const fetchIssueWithFrontsFromAPI = async (
 const fetchIssueWithFrontsFromFS = async (
 	id: string,
 ): Promise<IssueWithFronts> => {
-	console.log('~~~~~ FROM FS ~~~~~');
 	const issue = await readFileAsJSON<Issue>(FSPaths.issue(id));
 	const fronts = await Promise.all(
 		issue.fronts.map((frontId) =>

--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -63,6 +63,7 @@ const fetchIssueWithFrontsFromAPI = async (
 	id: string,
 	apiUrl: string,
 ): Promise<IssueWithFronts> => {
+	console.log('~~~~~ FROM API ~~~~~');
 	const issue: Issue = await fetch(`${apiUrl}${APIPaths.issue(id)}`).then(
 		(res) => {
 			if (res.status !== 200) {
@@ -93,6 +94,7 @@ const fetchIssueWithFrontsFromAPI = async (
 const fetchIssueWithFrontsFromFS = async (
 	id: string,
 ): Promise<IssueWithFronts> => {
+	console.log('~~~~~ FROM FS ~~~~~');
 	const issue = await readFileAsJSON<Issue>(FSPaths.issue(id));
 	const fronts = await Promise.all(
 		issue.fronts.map((frontId) =>
@@ -137,9 +139,7 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		async (forceApiRefresh = false) => {
 			const { localIssueId, publishedIssueId } = issueId;
 			if (localIssueId && publishedIssueId) {
-				setIsLoading(true);
 				if (forceApiRefresh) {
-					setIsLoading(false);
 					return await fetchIssueWithFrontsFromAPI(
 						publishedIssueId,
 						apiUrl,
@@ -148,11 +148,9 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 
 				const issueOnDevice = await isIssueOnDevice(localIssueId);
 				if (issueOnDevice) {
-					setIsLoading(false);
 					return await fetchIssueWithFrontsFromFS(localIssueId);
 				}
 
-				setIsLoading(false);
 				return await fetchIssueWithFrontsFromAPI(
 					publishedIssueId,
 					apiUrl,
@@ -166,8 +164,27 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		globalIssueId && setIssueId(globalIssueId);
 	}, [globalIssueId]);
 
+	// When the edition changes we want to force a fetch from the API
 	useEffect(() => {
-		!isLoading &&
+		if (!isLoading) {
+			setIsLoading(true);
+			getIssue(true)
+				.then((issue) => {
+					issue && setIssueWithFronts(issue);
+					setError('');
+				})
+				.catch((e) => {
+					errorService.captureException(e);
+					setError('Unable to get issue, please try again later');
+				})
+				.finally(() => setIsLoading(false));
+		}
+	}, [apiUrl, selectedEdition]);
+
+	// When the issue ID changes, we want to fetch from the file system
+	useEffect(() => {
+		if (!isLoading) {
+			setIsLoading(true);
 			getIssue()
 				.then((issue) => {
 					issue && setIssueWithFronts(issue);
@@ -176,8 +193,10 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 				.catch((e) => {
 					errorService.captureException(e);
 					setError('Unable to get issue, please try again later');
-				});
-	}, [issueId, apiUrl, selectedEdition]);
+				})
+				.finally(() => setIsLoading(false));
+		}
+	}, [issueId]);
 
 	// When the app state returns, we fore grab the latest issue from the API
 	// But we dont save it to our local state. This means we have a fresh copy but dont update the user experience

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -360,7 +360,6 @@ const IssueScreenWithPath = React.memo(
 							}
 						}
 						await retry();
-						RNRestart.Restart();
 					}}
 				/>
 				<IssueScreenHeader issue={issue} headerStyles={headerStyle} />


### PR DESCRIPTION
## Why are you doing this?
Looks to fix the preview issue reloading.

The thinking behind it... When the API Url changes, or the edition changes, it would not **force** an update from the API. This will now do this. The code is a bit duplicated here, but I wanted to keep it verbose to be easier to read as the fetching is already fairly abstracted.

We will always look to the file system first when someone changes their issue within an edition as this shouldn't require a new fetch.

The restart on the reload button has been removed as this is what takes you to the latest edition. 

## Changes

- Force fetch from the API in API Url change and Edition change scenarios
- Remove full app restart from retry button
