### PR TITLE
fix: Offline Articles

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -27,6 +27,7 @@ import { useAppState } from '../use-app-state-provider';
 import { useApiUrl } from '../use-config-provider';
 import { useEditions } from '../use-edition-provider';
 import { useIssueSummary } from '../use-issue-summary-provider';
+import { useNetInfo } from '../use-net-info-provider';
 
 type ArticleProps = Omit<
 	PathToArticle,
@@ -124,6 +125,7 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 	// A change in the selected edition should require a fetch of the latest issue
 	const { selectedEdition } = useEditions();
 	const { isActive } = useAppState();
+	const { isConnected } = useNetInfo();
 
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [issueWithFronts, setIssueWithFronts] =
@@ -179,7 +181,7 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		}
 	}, [apiUrl, selectedEdition]);
 
-	// When the issue ID changes, we want to fetch from the file system
+	// When the issue ID changes, or connection changes we want to fetch from the file system first if available
 	useEffect(() => {
 		if (!isLoading) {
 			setIsLoading(true);
@@ -194,7 +196,7 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 				})
 				.finally(() => setIsLoading(false));
 		}
-	}, [issueId]);
+	}, [issueId, isConnected]);
 
 	// When the app state returns, we fore grab the latest issue from the API
 	// But we dont save it to our local state. This means we have a fresh copy but dont update the user experience


### PR DESCRIPTION
## Why are you doing this?

When you have a downloaded edition, and you are reading an article, if the you go offline, you cannot read the articles anymore as you are shown an error.

This PR fixes this.

However, this is not the most optimal solution. It fixes the biggest issue of offline reading, however, if you go from online to offline and you are reading an article, and its not downloaded, it will disappear, even though you had it before. I think this can be solved with more fine grained control, but was keen to fix the bigger issue first.

## Changes

- Added `isConnected` check to the issue provider so that we can force a change to the `origin`

## Screenshots

#### After the change
![2022-03-03 08 22 25](https://user-images.githubusercontent.com/935975/156526592-3f6fe16f-6c6e-4f15-847e-bc53c5193f86.gif)

