### PR TITLE
fix: Changing Editions

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -409,7 +409,7 @@ PODS:
     - React-Core
   - RNPermissions (2.2.2):
     - React-Core
-  - RNReanimated (1.13.3):
+  - RNReanimated (1.13.4):
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
   RNLocalize: 7c7aeda16c01db7a0918981c14875c0a53be9b79
   RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
-  RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
+  RNReanimated: c1b56d030d1616239861534d9adb531f8cffab68
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSentry: 97bc62fa65b7d663daee16fbf9771470852217cf
   RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -8,7 +8,6 @@ import type {
 	SpecialEdition,
 	SpecialEditionHeaderStyles,
 } from 'src/common';
-import { eventEmitter } from 'src/helpers/event-emitter';
 import { locale } from 'src/helpers/locale';
 import {
 	defaultSettings,
@@ -327,7 +326,6 @@ export const EditionProvider = ({
 			setDefaultEdition(chosenEdition as RegionalEdition);
 			pushNotificationRegistration(downloadBlocked);
 		}
-		eventEmitter.emit('editionUpdate');
 	};
 
 	/**

--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -25,7 +25,6 @@ import { errorService } from 'src/services/errors';
 import type { IssueOrigin } from '../../../../Apps/common/src';
 import { useAppState } from '../use-app-state-provider';
 import { useApiUrl } from '../use-config-provider';
-import { useEditions } from '../use-edition-provider';
 import { useIssueSummary } from '../use-issue-summary-provider';
 import { useNetInfo } from '../use-net-info-provider';
 
@@ -122,8 +121,6 @@ export const fetchIssue = async (issueId: PathToIssue, apiUrl: string) => {
 export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 	const { apiUrl } = useApiUrl();
 	const { issueId: globalIssueId } = useIssueSummary();
-	// A change in the selected edition should require a fetch of the latest issue
-	const { selectedEdition } = useEditions();
 	const { isActive } = useAppState();
 	const { isConnected } = useNetInfo();
 
@@ -164,22 +161,20 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 		globalIssueId && setIssueId(globalIssueId);
 	}, [globalIssueId]);
 
-	// When the edition changes we want to force a fetch from the API
+	// When the API url changes, force a fetch from the API of a new issue
 	useEffect(() => {
-		if (!isLoading) {
-			setIsLoading(true);
-			getIssue(true)
-				.then((issue) => {
-					issue && setIssueWithFronts(issue);
-					setError('');
-				})
-				.catch((e) => {
-					errorService.captureException(e);
-					setError('Unable to get issue, please try again later');
-				})
-				.finally(() => setIsLoading(false));
-		}
-	}, [apiUrl, selectedEdition]);
+		setIsLoading(true);
+		getIssue(true)
+			.then((issue) => {
+				issue && setIssueWithFronts(issue);
+				setError('');
+			})
+			.catch((e) => {
+				errorService.captureException(e);
+				setError('Unable to get issue, please try again later');
+			})
+			.finally(() => setIsLoading(false));
+	}, [apiUrl]);
 
 	// When the issue ID changes, or connection changes we want to fetch from the file system first if available
 	useEffect(() => {

--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -147,18 +147,17 @@ export const IssueSummaryProvider = ({
 		!isLoading && getLatestIssueSummary();
 	}, []);
 
-	// When the network status, edition , max available editions or app state changes
+	// When the network status, max available editions or app state changes
 	useEffect(() => {
 		if (isActive && !isLoading) {
 			getLatestIssueSummary();
 		}
-	}, [
-		isConnected,
-		isPoorConnection,
-		selectedEdition,
-		maxAvailableEditions,
-		isActive,
-	]);
+	}, [isConnected, isPoorConnection, maxAvailableEditions, isActive]);
+
+	// Force getting the latest issue summary when an edition changes
+	useEffect(() => {
+		getLatestIssueSummary();
+	}, [selectedEdition]);
 
 	return (
 		<IssueSummaryContext.Provider


### PR DESCRIPTION
## Why are you doing this?

This fixes a number of issues:

1. When going from UK to Aus to UK edition, it would not load the last edition.
2. Event emitter being called but nothing listening to it
3. Conditionally fetching the issue when the API url changes.

## Changes

1. In the issue summary provider, moved the `selectedEdition` condition on its own so that it doesn't conditionally try and fetch. Essentially this was causing a race condition where the app would fetch and then block via `isLoading`. This change means that we do the logic without any blocking.
2. Event emitter removed. This was used in the old `CacheOrPromise` and is now not used.
3. In the issue, removed the need to fetch when the edition changes. This is because the id changes when we choose a new edition, which in turn causes a fetch of the issue. So it was doing double the work.
4. Removed the condition around fetching when the API url changes, because we always want to get this and block other state changes.
5. `Podfile.lock` has changed. I think this might change again, but there was no harm in adding it.
