### PR TITLE
Fix: Production reload issues

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -141,19 +141,6 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 						publishedIssueId,
 						apiUrl,
 					);
-					// const james = await fetchIssueWithFrontsFromAPI(
-					// 	publishedIssueId,
-					// 	apiUrl,
-					// );
-					// return james;
-					// console.log(
-					// 	james.fronts[0].collections[0].cards[0].articles,
-					// );
-					// const testFronts = [james.fronts[0], ...james.fronts];
-					// return {
-					// 	...james,
-					// 	fronts: testFronts,
-					// };
 				}
 
 				const issueOnDevice = await isIssueOnDevice(localIssueId);

--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -24,6 +24,7 @@ interface IssueSummaryState {
 	error: string;
 	initialFrontKey: string | null;
 	setIssueId: Dispatch<PathToIssue>;
+	getLatestIssueSummary: () => Promise<void>;
 }
 
 const defaultState: IssueSummaryState = {
@@ -32,6 +33,7 @@ const defaultState: IssueSummaryState = {
 	error: '',
 	initialFrontKey: null,
 	setIssueId: () => {},
+	getLatestIssueSummary: () => Promise.resolve(),
 };
 
 const IssueSummaryContext = createContext(defaultState);
@@ -100,7 +102,7 @@ export const IssueSummaryProvider = ({
 	// @TODO: Look to move this logic outside of the provider so it can be tested
 	const getLatestIssueSummary = useCallback(() => {
 		setIsLoading(true);
-		getIssueSummary(isConnected, isPoorConnection)
+		return getIssueSummary(isConnected, isPoorConnection)
 			.then((retrievedIssueSummary) => {
 				setIssueSummary(retrievedIssueSummary);
 				// Clear the initial front key if it is a new issue id and set it
@@ -121,7 +123,6 @@ export const IssueSummaryProvider = ({
 					setInitialFrontKey(null);
 					setLocalIssueId(latestIssueId);
 				}
-
 				setError('');
 			})
 			.catch((e) => {
@@ -167,6 +168,7 @@ export const IssueSummaryProvider = ({
 				setIssueId,
 				initialFrontKey,
 				error,
+				getLatestIssueSummary,
 			}}
 		>
 			{children}


### PR DESCRIPTION
## Why are you doing this?

When pressing reload, nothing would happen. It now shows changes as a result of this change. 

## Changes

- Force the issue summary to be fetched as part of the reload process. Otherwise when you added a new issue, it wouldn't show.
- Removed the memoisation on the Issue Screen and the data manipulation for the fronts. As a result, overall performance of the app will drop. However, we have a point at which to improve on.