### PR TITLE
Delete objects in s3 older than 1 year

### DIFF
--- a/projects/aws/editions-buckets.yaml
+++ b/projects/aws/editions-buckets.yaml
@@ -15,9 +15,18 @@ Resources:
             BucketName: !Sub editions-proofed-${Stage}
             LifecycleConfiguration:
                 Rules:
-                    - Id: DeleteContentAfter1Year
+                    - Id: DeleteContentAfter1YearUS
                       ExpirationInDays: 365
-                      Status: 'Enabled'
+                      Status: Enabled
+                      Prefix: 'american-edition'
+                    - Id: DeleteContentAfter1YearAU
+                      ExpirationInDays: 365
+                      Status: Enabled
+                      Prefix: 'australian-edition'
+                    - Id: DeleteContentAfter1YearUK
+                      ExpirationInDays: 365
+                      Status: Enabled
+                      Prefix: 'daily-edition'
 
     PublishedBucket:
         Type: AWS::S3::Bucket
@@ -25,6 +34,15 @@ Resources:
             BucketName: !Sub editions-published-${Stage}
             LifecycleConfiguration:
                 Rules:
-                    - Id: DeleteContentAfter1Year
+                    - Id: DeleteContentAfter1YearUS
                       ExpirationInDays: 365
-                      Status: 'Enabled'
+                      Status: Enabled
+                      Prefix: 'american-edition'
+                    - Id: DeleteContentAfter1YearAU
+                      ExpirationInDays: 365
+                      Status: Enabled
+                      Prefix: 'australian-edition'
+                    - Id: DeleteContentAfter1YearUK
+                      ExpirationInDays: 365
+                      Status: Enabled
+                      Prefix: 'daily-edition'

--- a/projects/aws/editions-buckets.yaml
+++ b/projects/aws/editions-buckets.yaml
@@ -13,8 +13,14 @@ Resources:
         Type: AWS::S3::Bucket
         Properties:
             BucketName: !Sub editions-proofed-${Stage}
+            LifecycleConfiguration:
+                Rules:
+                    - ExpirationInDays: 365
 
     PublishedBucket:
         Type: AWS::S3::Bucket
         Properties:
             BucketName: !Sub editions-published-${Stage}
+            LifecycleConfiguration:
+                Rules:
+                    - ExpirationInDays: 365

--- a/projects/aws/editions-buckets.yaml
+++ b/projects/aws/editions-buckets.yaml
@@ -15,7 +15,9 @@ Resources:
             BucketName: !Sub editions-proofed-${Stage}
             LifecycleConfiguration:
                 Rules:
-                    - ExpirationInDays: 365
+                    - Id: DeleteContentAfter1Year
+                      ExpirationInDays: 365
+                      Status: 'Enabled'
 
     PublishedBucket:
         Type: AWS::S3::Bucket
@@ -23,4 +25,6 @@ Resources:
             BucketName: !Sub editions-published-${Stage}
             LifecycleConfiguration:
                 Rules:
-                    - ExpirationInDays: 365
+                    - Id: DeleteContentAfter1Year
+                      ExpirationInDays: 365
+                      Status: 'Enabled'


### PR DESCRIPTION
## Why are you doing this?

Recently the 1001st issue of the Daily Edition was previewed but then broke preview.

Old editions could be updated and previewed, but new editions didn't appear in the list of available issues to preview because we can't read beyond 1000 in part of the production chain.

To mitigate this issue from happening again this change puts an expiration policy on objects in the s3 buckets.

I chose 365 days as the expiration policy but let me know whether we think that is too long/short.

Also, the cloudformation of the buckets lives outside of cdk. I wasn't sure whether it was worth moving this stack into cdk, for now I've just updated the existing cloudformation yaml.

## Changes

- Set lifecycle configuration rule for the proofed and published buckets

## Screenshots

N/A