### PR TITLE
Reorder standfirst override

### DIFF
--- a/projects/backend/controllers/render.ts
+++ b/projects/backend/controllers/render.ts
@@ -150,8 +150,8 @@ const mapFurnitureToContent = (
         : ''
     const standfirst =
         oc(furniture).trailTextOverride() ||
-        filteredStandfirst ||
-        oc(content).fields.trailText()
+        oc(content).fields.trailText() ||
+        filteredStandfirst
 
     return {
         ...content,


### PR DESCRIPTION
## Why are you doing this?

One of the pain points of the edition workflow has been knowing what standfirst will appear on both a front and an article. The editions team identified a specific problem:
- Composer piece has both a standfirst and a trail
- Editions fronts tool allows the production team to override the trail text
- Trail override appears on the front, original standfirst appears on the article

The editions team would like more consistency in this approach:
- Composer piece has both a standfirst and a trail
- Editions fronts tool allows the production team to override the trail text
- Trail override appears on the front and on the article
- If no override is made to the trail text in the editions fronts tool then both the front and the article should display the trail text (not the standfirst defined in the composer piece).

## Changes

- Reorder standfirst override, prioritising trail override and trail above the standfirst

## Screenshots

N/A
