### PR TITLE
fix: Reload Hack

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,3 +1,4 @@
+import { useNavigation, useRoute } from '@react-navigation/native';
 import type { MutableRefObject, ReactElement } from 'react';
 import React, { useEffect, useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
@@ -269,9 +270,16 @@ const IssueFronts = ({
 	);
 };
 
-const PreviewReloadButton = ({ onPress }: { onPress: () => void }) => {
+const PreviewReloadButton = ({ onPress }: { onPress: () => Promise<void> }) => {
 	const { isPreview } = useApiUrl();
-	return isPreview ? <ReloadButton onPress={onPress} /> : null;
+	const navigation = useNavigation();
+	const route = useRoute();
+	console.log(route);
+	const onPressReload = async () => {
+		await onPress();
+		navigation.navigate(route);
+	};
+	return isPreview ? <ReloadButton onPress={onPressReload} /> : null;
 };
 
 const IssueScreenWithPathError = ({

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -274,7 +274,7 @@ const PreviewReloadButton = ({ onPress }: { onPress: () => Promise<void> }) => {
 	const { isPreview } = useApiUrl();
 	const navigation = useNavigation();
 	const route = useRoute();
-	console.log(route);
+
 	const onPressReload = async () => {
 		await onPress();
 		navigation.navigate(route);


### PR DESCRIPTION
## Why are you doing this?

Currently when the reload button is pressed, the production user is taken to the latest issue. This hack maintains the previous point of navigation the user was on and navigates back to it.

Its a hack because we should really be managing the state and rerenders better so that the whole issue isnt realoaded.

## Changes

- Get the latest route before reloading and then navigating back to that route.
