### PR TITLE
fix: Menu orientation issue

### DIFF
--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -13,24 +13,6 @@ import { ApiState } from './settings/api-screen';
 
 const sidebarWidth = 360;
 
-const styles = StyleSheet.create({
-	container: {
-		display: 'flex',
-		justifyContent: 'flex-end',
-		flexDirection: 'row-reverse',
-	},
-	touchable: {
-		backgroundColor: 'transparent',
-		height: Dimensions.get('window').height,
-		width: Dimensions.get('window').width - sidebarWidth,
-	},
-	screenFiller: {
-		flex: 1,
-		backgroundColor: 'white',
-		maxWidth: DeviceInfo.isTablet() ? sidebarWidth : undefined,
-	},
-});
-
 export const ScreenFiller = ({
 	direction,
 	children,
@@ -39,6 +21,25 @@ export const ScreenFiller = ({
 	children: ReactElement;
 }) => {
 	const navigation = useNavigation();
+
+	const styles = StyleSheet.create({
+		container: {
+			display: 'flex',
+			justifyContent: 'flex-end',
+			flexDirection: 'row-reverse',
+		},
+		touchable: {
+			backgroundColor: 'transparent',
+			height: Dimensions.get('window').height,
+			width: Dimensions.get('window').width - sidebarWidth,
+		},
+		screenFiller: {
+			flex: 1,
+			backgroundColor: 'white',
+			maxWidth: DeviceInfo.isTablet() ? sidebarWidth : undefined,
+		},
+	});
+
 	return (
 		<View
 			style={[


### PR DESCRIPTION
## Why are you doing this?

When opening the sidebar and changing orientation, it would often disappear.

Essentially the width values were being calculated outside the component, so brought them inside so that they are recalculated on rerender which happens when the orientation changes. 

## Changes

- Move styles inside component so they recalculate on rerender

## Screenshots

#### Before

![2022-05-17 08 42 30](https://user-images.githubusercontent.com/935975/168757544-80291d8f-ffde-4e18-996e-0dc94041ec3e.gif)

#### After

![2022-05-17 08 41 55](https://user-images.githubusercontent.com/935975/168757593-a97e4e44-80a7-4d2e-bd97-dc3093a4a265.gif)

