### PR TITLE
chore: Removal of Front Animations

### DIFF
--- a/projects/Mallard/src/components/front/collection-page.tsx
+++ b/projects/Mallard/src/components/front/collection-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { Animated } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import type {
@@ -207,7 +206,7 @@ const CollectionPage = React.memo(
 		publishedIssueId,
 		front,
 		appearance,
-	}: { translate: Animated.AnimatedInterpolation } & PropTypes) => {
+	}: PropTypes) => {
 		const background = useCardBackgroundStyle();
 		const { size, card } = useIssueScreenSize();
 		if (!articlesInCard.length) {


### PR DESCRIPTION
## Why are you doing this?

Previously the card used to animate out to the article screen. This was removed to simplify the code going forward for maintenance mode.

This is some leftover calculations that are not needed.

## Changes

- Remove the animation code in the Collection wrapper
- Tidy up types