### PR TITLE
chore: Max Editions UX improvement

### DIFF
--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -40,6 +40,7 @@ import {
 import {
 	useApiUrl,
 	useIsUsingProdDevtools,
+	useMaxAvailableEditions,
 } from 'src/hooks/use-config-provider';
 import {
 	getSpecialEditionProps,
@@ -250,6 +251,7 @@ const IssueListView = React.memo(
 		setIssueId: Dispatch<PathToIssue>;
 	}) => {
 		const navigation = useNavigation();
+		const { maxAvailableEditions } = useMaxAvailableEditions();
 		const { localIssueId: localId, publishedIssueId: publishedId } =
 			currentIssue.id;
 		const { details } = currentIssue;
@@ -332,7 +334,7 @@ const IssueListView = React.memo(
 		return (
 			<FlatList
 				// Only render 7 because that is the default number of editions
-				initialNumToRender={7}
+				initialNumToRender={maxAvailableEditions}
 				ItemSeparatorComponent={Separator}
 				ListFooterComponentStyle={styles.issueListFooter}
 				ListFooterComponent={footer}

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -175,6 +175,8 @@ const IssueFronts = ({
 		frontSpecs: FrontSpec[];
 	}>(
 		(acc, front) => {
+			front.displayName === 'Top stories' &&
+				console.log(front.displayName);
 			const flatCollections = flattenCollectionsToCards(
 				front.collections,
 			);
@@ -325,6 +327,10 @@ const WeatherHeader = () => {
 
 	return <WeatherWidget />;
 };
+// WeatherHeader.whyDidYouRender = {
+// 	logOnDifferentValues: true,
+// 	customName: 'MenuJamesJames',
+// };
 
 const IssueScreenWithPath = ({
 	issue,

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -175,8 +175,6 @@ const IssueFronts = ({
 		frontSpecs: FrontSpec[];
 	}>(
 		(acc, front) => {
-			front.displayName === 'Top stories' &&
-				console.log(front.displayName);
 			const flatCollections = flattenCollectionsToCards(
 				front.collections,
 			);
@@ -327,10 +325,6 @@ const WeatherHeader = () => {
 
 	return <WeatherWidget />;
 };
-// WeatherHeader.whyDidYouRender = {
-// 	logOnDifferentValues: true,
-// 	customName: 'MenuJamesJames',
-// };
 
 const IssueScreenWithPath = ({
 	issue,


### PR DESCRIPTION
## Why are you doing this?

If you are an Tablet user (as most of our users are) and you are looking at the list of issues, by default it gives you 7. If you have this set to 14 or 30, you are in portrait mode, and you cold start the app, you will see 7 and then have to scroll slightly for the rest to load.

This change sets the initial number to the users setting. If they have not changed it, it already defaults to 7.

## Changes

- Add `maxAvailableEditions` to the initial number rendered in the menu FlatList.
