### PR TITLE
feat: Fast Image

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -60,6 +60,15 @@ PODS:
     - GoogleUtilities/Logger
   - hermes-engine (0.9.0)
   - libevent (2.1.12)
+  - libwebp (1.2.1):
+    - libwebp/demux (= 1.2.1)
+    - libwebp/mux (= 1.2.1)
+    - libwebp/webp (= 1.2.1)
+  - libwebp/demux (1.2.1):
+    - libwebp/webp
+  - libwebp/mux (1.2.1):
+    - libwebp/demux
+  - libwebp/webp (1.2.1)
   - nanopb (2.30907.0):
     - nanopb/decode (= 2.30907.0)
     - nanopb/encode (= 2.30907.0)
@@ -384,6 +393,10 @@ PODS:
     - React-Core
   - RNDeviceInfo (8.1.4):
     - React-Core
+  - RNFastImage (8.5.11):
+    - React-Core
+    - SDWebImage (~> 5.11.1)
+    - SDWebImageWebPCoder (~> 0.8.4)
   - RNFBApp (10.8.1):
     - Firebase/CoreOnly (~> 7.6.0)
     - React-Core
@@ -425,6 +438,12 @@ PODS:
   - RNZipArchive/Core (5.0.1):
     - React
     - SSZipArchive (= 2.2.2)
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
+  - SDWebImageWebPCoder (0.8.4):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.10)
   - Sentry (7.5.1):
     - Sentry/Core (= 7.5.1)
   - Sentry/Core (7.5.1)
@@ -484,6 +503,7 @@ DEPENDENCIES:
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - RNFastImage (from `../node_modules/react-native-fast-image`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBCrashlytics (from `../node_modules/@react-native-firebase/crashlytics`)"
   - "RNFBRemoteConfig (from `../node_modules/@react-native-firebase/remote-config`)"
@@ -515,8 +535,11 @@ SPEC REPOS:
     - GoogleUtilities
     - hermes-engine
     - libevent
+    - libwebp
     - nanopb
     - PromisesObjC
+    - SDWebImage
+    - SDWebImageWebPCoder
     - Sentry
     - SSZipArchive
 
@@ -617,6 +640,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNFastImage:
+    :path: "../node_modules/react-native-fast-image"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBCrashlytics:
@@ -668,6 +693,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   hermes-engine: bf7577d12ac6ccf53ab8b5af3c6ccf0dd8458c5c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   Permission-LocationWhenInUse: 871e81c06c1fc578353fce962d5d8e6efa697f1a
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
@@ -713,6 +739,7 @@ SPEC CHECKSUMS:
   RNCPicker: f7a40b21b915b7a187624d52f52b7bc2f73ea413
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
   RNDeviceInfo: 0b3e0154c1c659ea9779cb3e883e66ece92326a9
+  RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNFBApp: 02bde3edecf2e9694b908a5d3504e03449980f20
   RNFBCrashlytics: 0e6347d4e2251c6656b43ce8544662d1bac7deff
   RNFBRemoteConfig: 1adf37593b23dfec015a48016cd26982257889ba
@@ -728,6 +755,8 @@ SPEC CHECKSUMS:
   RNSentry: 97bc62fa65b7d663daee16fbf9771470852217cf
   RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
   RNZipArchive: 87111bb6130a38edd68c8d2059d46ac94d53ffe4
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageWebPCoder: f93010f3f6c031e2f8fb3081ca4ee6966c539815
   Sentry: 0718c3ad7a08e1107599610795adaf08864102f3
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23
   Yoga: d6b6a80659aa3e91aaba01d0012e7edcbedcbecd

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -75,6 +75,7 @@
     "react-native-background-fetch": "^4.0.4",
     "react-native-config": "^1.4.2",
     "react-native-device-info": "^8.0.2",
+    "react-native-fast-image": "^8.5.11",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-htmlview": "^0.15.0",

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import type { ImageProps, ImageStyle, StyleProp } from 'react-native';
-import { Image, View } from 'react-native';
+import type { ImageStyle, StyleProp } from 'react-native';
+import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio';
 import { useImagePath } from 'src/hooks/use-image-paths';
 import type { Image as IImage, ImageUse } from '../../../../Apps/common/src';
@@ -17,7 +18,8 @@ type ImageResourceProps = {
 	use: ImageUse;
 	style?: StyleProp<ImageStyle>;
 	setAspectRatio?: boolean;
-} & Omit<ImageProps, 'source'>;
+	accessibilityLabel?: string;
+};
 
 const ImageResource = ({
 	image,
@@ -34,15 +36,15 @@ const ImageResource = ({
 	];
 
 	return imagePath ? (
-		<Image
+		<FastImage
 			key={imagePath}
-			resizeMethod={'resize'}
 			{...props}
+			resizeMode={FastImage.resizeMode.cover}
 			style={[styles, style]}
 			source={{ uri: imagePath }}
 		/>
 	) : (
-		<View style={styles}></View>
+		<View style={[styles, { backgroundColor: 'pink' }]}></View>
 	);
 };
 

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -10842,6 +10842,11 @@ react-native-device-info@^8.0.2:
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.1.4.tgz#709a424b64cd01b26e91000e9b7e2c36e8b832f0"
   integrity sha512-PiYRJf3GBaVnGAUUB9YKzaGc5h6Rmn7NniD328JUXLeepKvLaDhK6EvFWU98YiZ2jePOF9/jg2cxfyN4jhZ2LA==
 
+react-native-fast-image@^8.5.11:
+  version "8.5.11"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.5.11.tgz#e3dc969d0e4e8df026646bf18194465aa55cbc2b"
+  integrity sha512-cNW4bIJg3nvKaheG8vGMfqCt5LMWX9MS5+wMudgKIHbGO51spRr4sgnlhVgwHLcZ5aeNOVJ8CPRxDIWKRq/0QA==
+
 react-native-fs@^2.16.6:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.18.0.tgz#987b99cc90518ef26663a8d60e62104694b41c21"


### PR DESCRIPTION
## Why are you doing this?

Fast Image is a library that will do some native caching of images and make virtualised lists of images load a lot... faster
https://github.com/DylanVann/react-native-fast-image

This has been attempted a few years ago, however, the library didnt cope well with locally stored images. This appears to have been resolved

## Changes

- Implemented `FastImage` into the `ImageResource` component.
