### PR TITLE
chore: Issue Screen Flatlist Performance

### DIFF
--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 import type { ArticlePillar, Front as FrontType, Issue } from 'src/common';
 import { ArticleType } from 'src/common';
@@ -85,6 +85,75 @@ export const Front = React.memo(
 		const [cardIndex, setCardIndex] = useState(0);
 		const [position, setPosition] =
 			useState<Animated.AnimatedInterpolation>(new Animated.Value(0));
+
+		const renderItem = useCallback(
+			({ item }: { item: FlatCard }) => (
+				<CollectionPageInFront
+					articlesInCard={item.articles || []}
+					appearance={item.appearance}
+					collection={item.collection.key}
+					front={frontData.key}
+					width={card.width}
+					{...{
+						localIssueId,
+						publishedIssueId,
+						pillar,
+						articleNavigator,
+					}}
+				/>
+			),
+			[
+				card.width,
+				frontData.key,
+				localIssueId,
+				publishedIssueId,
+				pillar,
+				articleNavigator,
+			],
+		);
+
+		const ListFooterComponent = React.memo(() => (
+			<View
+				style={{
+					width: container.width - card.width,
+				}}
+			></View>
+		));
+
+		const getItemLayout = (_: never, index: number) => ({
+			length: card.width,
+			offset: card.width * index,
+			index,
+		});
+
+		const onScroll = Animated.event(
+			[
+				{
+					nativeEvent: {
+						contentOffset: { x: scrollX },
+					},
+				},
+			],
+			{
+				useNativeDriver: true,
+				listener: (ev: any) => {
+					const pos = ev.nativeEvent.contentOffset.x / card.width;
+
+					const slideIndex = clamp(Math.ceil(pos), 0, stops);
+					// Prevent the index being greater than the stops due to flatlist bounce
+					const index =
+						slideIndex >= stops - 1 ? stops - 1 : slideIndex;
+					setCardIndex(index);
+
+					const position = Animated.divide(
+						ev.nativeEvent.contentOffset.x,
+						new Animated.Value(card.width),
+					);
+					setPosition(position);
+				},
+			},
+		);
+
 		return (
 			<FrontWrapper
 				scrubber={
@@ -111,74 +180,17 @@ export const Front = React.memo(
 					pagingEnabled={true}
 					decelerationRate="fast"
 					snapToInterval={card.width}
-					getItemLayout={(_: never, index: number) => ({
-						length: card.width,
-						offset: card.width * index,
-						index,
-					})}
+					getItemLayout={getItemLayout}
 					keyExtractor={(item: FlatCard, index: number) =>
 						`${index}${item.collection.key}`
 					}
-					ListFooterComponent={
-						<View
-							style={{
-								width: container.width - card.width,
-							}}
-						></View>
-					}
-					onScroll={Animated.event(
-						[
-							{
-								nativeEvent: {
-									contentOffset: { x: scrollX },
-								},
-							},
-						],
-						{
-							useNativeDriver: true,
-							listener: (ev: any) => {
-								const pos =
-									ev.nativeEvent.contentOffset.x / card.width;
-
-								const slideIndex = clamp(
-									Math.ceil(pos),
-									0,
-									stops,
-								);
-								// Prevent the index being greater than the stops due to flatlist bounce
-								const index =
-									slideIndex >= stops - 1
-										? stops - 1
-										: slideIndex;
-								setCardIndex(index);
-
-								const position = Animated.divide(
-									ev.nativeEvent.contentOffset.x,
-									new Animated.Value(card.width),
-								);
-								setPosition(position);
-							},
-						},
-					)}
+					ListFooterComponent={ListFooterComponent}
+					onScroll={onScroll}
 					// this needs to be referential equal or will trigger
 					// a re-render
 					extraData={`${container.width}:${container.height}`}
 					data={cards}
-					renderItem={({ item }: { item: FlatCard }) => (
-						<CollectionPageInFront
-							articlesInCard={item.articles || []}
-							appearance={item.appearance}
-							collection={item.collection.key}
-							front={frontData.key}
-							width={card.width}
-							{...{
-								localIssueId,
-								publishedIssueId,
-								pillar,
-								articleNavigator,
-							}}
-						/>
-					)}
+					renderItem={renderItem}
 				/>
 			</FrontWrapper>
 		);

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import type { MutableRefObject, ReactElement } from 'react';
+import { MutableRefObject, ReactElement, useCallback } from 'react';
 import React, { useEffect, useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { FlatList, Image, StyleSheet, View } from 'react-native';
@@ -216,6 +216,44 @@ const IssueFronts = ({
 		maxToRenderPerBatch: 1,
 	};
 
+	const renderItem = useCallback(
+		({ item }: { item: any }) => (
+			<Front
+				localIssueId={issue.localId}
+				publishedIssueId={issue.publishedId}
+				articleNavigator={frontSpecs}
+				frontData={item}
+				cards={item.cards}
+				key={item.key}
+			/>
+		),
+		[frontSpecs, issue.localId, issue.publishedId],
+	);
+
+	const FooterComponent = React.memo(() => (
+		<>
+			<View style={[styles.illustrationPosition]}>
+				{selectedEdition &&
+					selectedEdition.edition === BASE_EDITION.edition && (
+						<Image
+							style={styles.illustrationImage}
+							resizeMode={'contain'}
+							source={require('src/assets/images/privacy.png')}
+						/>
+					)}
+			</View>
+			<View style={{ height: container.height / 3 }} />
+		</>
+	));
+
+	const getItemLayout = (_: any, index: number) => ({
+		length: card.height + SLIDER_FRONT_HEIGHT,
+		offset:
+			(card.height + SLIDER_FRONT_HEIGHT) * index +
+			(useIsWeatherActuallyShown ? WEATHER_HEIGHT : EMPTY_WEATHER_HEIGHT),
+		index,
+	});
+
 	/* setting a key will force a rerender on rotation, removing 1000s of layout bugs */
 	return (
 		<FlatList
@@ -227,45 +265,13 @@ const IssueFronts = ({
 			{...flatListOptimisationProps}
 			showsVerticalScrollIndicator={false}
 			scrollEventThrottle={1}
-			ListFooterComponent={() => (
-				<>
-					<View style={[styles.illustrationPosition]}>
-						{selectedEdition &&
-							selectedEdition.edition ===
-								BASE_EDITION.edition && (
-								<Image
-									style={styles.illustrationImage}
-									resizeMode={'contain'}
-									source={require('src/assets/images/privacy.png')}
-								/>
-							)}
-					</View>
-					<View style={{ height: container.height / 3 }} />
-				</>
-			)}
-			getItemLayout={(_: any, index: number) => ({
-				length: card.height + SLIDER_FRONT_HEIGHT,
-				offset:
-					(card.height + SLIDER_FRONT_HEIGHT) * index +
-					(useIsWeatherActuallyShown
-						? WEATHER_HEIGHT
-						: EMPTY_WEATHER_HEIGHT),
-				index,
-			})}
+			ListFooterComponent={FooterComponent}
+			getItemLayout={getItemLayout}
 			keyExtractor={(item) => item.key}
 			data={frontWithCards}
 			style={style}
 			key={width}
-			renderItem={({ item: front }) => (
-				<Front
-					localIssueId={issue.localId}
-					publishedIssueId={issue.publishedId}
-					articleNavigator={frontSpecs}
-					frontData={front}
-					cards={front.cards}
-					key={front.key}
-				/>
-			)}
+			renderItem={renderItem}
 		/>
 	);
 };

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { MutableRefObject, ReactElement, useCallback } from 'react';
-import React, { useEffect, useRef } from 'react';
+import type { MutableRefObject, ReactElement } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { FlatList, Image, StyleSheet, View } from 'react-native';
 import RNRestart from 'react-native-restart';


### PR DESCRIPTION
## Why are you doing this?

Improve the Issue Screen (Home) Performance

## Changes

Each time the Flatlists re-render, they were having to recreate the functions that they were using. These have been brought outside of the render so they should only be created once. In the cases where the function doesn't need to be recalculated each time, I have added optimisations to them.

Please note: Some of the types here are a bit funky. Would be worth looking at these as a maintenance task.
