### PR TITLE
chore: Remove YellowBox

### DIFF
--- a/projects/Mallard/index.js
+++ b/projects/Mallard/index.js
@@ -1,12 +1,9 @@
-import { AppRegistry, Text, YellowBox } from 'react-native';
+import { AppRegistry, Text } from 'react-native';
 import { name as appName } from './app.json';
 import App from './src/App';
 
 // In lieu of a wrapper component (i.e. <UnscaledText />), this quickly opts us out of scaled text globally.
 Text.defaultProps = Text.defaultProps || {};
 Text.defaultProps.allowFontScaling = false;
-
-// Supress Could Not Find Image warnings as a result of our approach to find the image locally
-YellowBox.ignoreWarnings([]);
 
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
## Why are you doing this?

Originally we were suppressing warnings for missing images in the time before Apps Rendering. Since this was brought it, those warnings no longer need suppressing and as a result we can remove this code.
