### PR TITLE
Fix: Issue Screen perf

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -209,12 +209,14 @@ const IssueFronts = ({
 			},
 		);
 
+	const memoisedIssueToFronts = useMemo(
+		() => issueToFronts(),
+		[issue.localId, issue.publishedId, issue.fronts[0].id],
+	);
+
 	const { frontWithCards, frontSpecs } = isPreview
 		? issueToFronts()
-		: useMemo(
-				() => issueToFronts(),
-				[issue.localId, issue.publishedId, issue.fronts[0].id],
-		  );
+		: memoisedIssueToFronts;
 
 	useScrollToFrontBehavior(frontWithCards, initialFrontKey, ref);
 	const largeDeviceMemory = useLargeDeviceMemory();


### PR DESCRIPTION
## Why are you doing this?

This puts back the optimisation that was removed as it was causing the production team a lot of bother. This work around dramatically reduces re-renders for users and improves performance, whilst still giving the Production team flexibility over viewing content.

## Changes

- Bring the changes back and store a memoised value. Only use this value outside of Preview.
- In preview mode, do no memoisation
