### PR TITLE
fix: Android ViewPager Sensitivity

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
     - React
   - react-native-netinfo (5.9.10):
     - React-Core
-  - react-native-pager-view (5.4.11):
+  - react-native-pager-view (5.4.24):
     - React-Core
   - react-native-restart (0.0.17):
     - React
@@ -714,7 +714,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-in-app-utils: 96cdefc90ad74a79a95d19239a183995a6face0b
   react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
-  react-native-pager-view: 7f00d63688f7df9fad86dfb0154814419cc5eb8d
+  react-native-pager-view: 95d0418c3c74279840abec6926653d32447bafb6
   react-native-restart: d19a0f8d053d065fe64cd2baebb6487111c77149
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -30,7 +30,8 @@
     "lint": "node_modules/eslint/bin/eslint.js 'src/**/*.{ts,tsx}'",
     "lint:fix": "node_modules/eslint/bin/eslint.js 'src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier . --write",
-    "prettier:check": "prettier . --check"
+    "prettier:check": "prettier . --check",
+    "postinstall": "patch-package"
   },
   "rnpm": {
     "assets": [
@@ -85,7 +86,7 @@
     "react-native-inappbrowser-reborn": "^3.3.3",
     "react-native-keychain": "6.2.0",
     "react-native-localize": "^1.4.0",
-    "react-native-pager-view": "^5.4.11",
+    "react-native-pager-view": "^5.4.24",
     "react-native-permissions": "^2.0.3",
     "react-native-progress-circle": "^2.1.0",
     "react-native-push-notification": "^7.0.0",
@@ -138,6 +139,8 @@
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.66.2",
     "mockdate": "^2.0.5",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.2.1",
     "react-native-storybook-loader": "^1.8.1",
     "react-test-renderer": "17.0.2",

--- a/projects/Mallard/patches/react-native-pager-view+5.4.24.patch
+++ b/projects/Mallard/patches/react-native-pager-view+5.4.24.patch
@@ -1,0 +1,95 @@
+diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+index 81070b2..03b2a6d 100644
+--- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
++++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/PagerViewViewManager.kt
+@@ -2,6 +2,7 @@ package com.reactnativepagerview
+ 
+ import android.view.View
+ import android.view.ViewGroup
++import androidx.recyclerview.widget.RecyclerView
+ import androidx.viewpager2.widget.ViewPager2
+ import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
+ import com.facebook.infer.annotation.Assertions
+@@ -25,6 +26,17 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
+     return REACT_CLASS
+   }
+ 
++  fun ViewPager2.reduceDragSensitivity() {
++    val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
++    recyclerViewField.isAccessible = true
++    val recyclerView = recyclerViewField.get(this) as RecyclerView
++
++    val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
++    touchSlopField.isAccessible = true
++    val touchSlop = touchSlopField.get(recyclerView) as Int
++    touchSlopField.set(recyclerView, touchSlop*8)
++  }
++
+   override fun createViewInstance(reactContext: ThemedReactContext): NestedScrollableHost {
+     val host = NestedScrollableHost(reactContext)
+     host.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+@@ -142,6 +154,11 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
+     return true
+   }
+ 
++  @ReactProp(name = "scrollSensitivity", defaultInt = 2)
++  fun setScrollSensitivity(viewPager: NestedScrollableHost, value: Int) {
++    getViewPager(viewPager).reduceDragSensitivity()
++  }
++
+   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
+   fun setScrollEnabled(host: NestedScrollableHost, value: Boolean) {
+     getViewPager(host).isUserInputEnabled = value
+diff --git a/node_modules/react-native-pager-view/lib/typescript/types.d.ts b/node_modules/react-native-pager-view/lib/typescript/types.d.ts
+index e14b01b..c29fd09 100644
+--- a/node_modules/react-native-pager-view/lib/typescript/types.d.ts
++++ b/node_modules/react-native-pager-view/lib/typescript/types.d.ts
+@@ -4,6 +4,7 @@ export declare type TransitionStyle = 'scroll' | 'curl';
+ export declare type Orientation = 'horizontal' | 'vertical';
+ export declare type OverScrollMode = 'auto' | 'always' | 'never';
+ export declare type PageScrollState = 'idle' | 'dragging' | 'settling';
++export declare type ScrollSensitivity = 2|3|4|5|6|7|8;
+ export declare type PagerViewOnPageScrollEvent = ReactNative.NativeSyntheticEvent<PagerViewOnPageScrollEventData>;
+ export interface PagerViewOnPageScrollEventData {
+     position: number;
+@@ -28,6 +29,13 @@ export interface PagerViewProps {
+      * The default value is true.
+      */
+     scrollEnabled?: boolean;
++    /**
++     * Higher the `scrollSensitivity` value, more the effort to swipe. 
++     * Adjust multiplier from 2-8 until you find the sweet spot.
++     *  
++     * Only supported on Android.
++     */
++    scrollSensitivity?: ScrollSensitivity;
+     /**
+      * Executed when transitioning between pages (ether because of animation for
+      * the requested page change or when user is swiping/dragging between pages)
+diff --git a/node_modules/react-native-pager-view/src/types.ts b/node_modules/react-native-pager-view/src/types.ts
+index 72cf02c..13e6be1 100644
+--- a/node_modules/react-native-pager-view/src/types.ts
++++ b/node_modules/react-native-pager-view/src/types.ts
+@@ -5,6 +5,7 @@ export type TransitionStyle = 'scroll' | 'curl';
+ export type Orientation = 'horizontal' | 'vertical';
+ export type OverScrollMode = 'auto' | 'always' | 'never';
+ export type PageScrollState = 'idle' | 'dragging' | 'settling';
++export type ScrollSensitivity = 2|3|4|5|6|7|8;
+ 
+ export type PagerViewOnPageScrollEvent = ReactNative.NativeSyntheticEvent<PagerViewOnPageScrollEventData>;
+ export interface PagerViewOnPageScrollEventData {
+@@ -35,6 +36,14 @@ export interface PagerViewProps {
+    */
+   scrollEnabled?: boolean;
+ 
++  /**
++   * Higher the `scrollSensitivity` value, more the effort to swipe. 
++   * Adjust multiplier from 2-8 until you find the sweet spot.
++   *  
++   * Only supported on Android.
++   */
++  scrollSensitivity?: ScrollSensitivity;
++
+   /**
+    * Executed when transitioning between pages (ether because of animation for
+    * the requested page change or when user is swiping/dragging between pages)

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -142,6 +142,7 @@ const ArticleSlider = React.memo(
 					ref={(viewPager) => {
 						viewPagerRef.current = viewPager;
 					}}
+					scrollSensitivity={5}
 					onPageSelected={(ev: any) => {
 						onShouldShowHeaderChange(true);
 						const newIndex = ev.nativeEvent.position;

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -3101,6 +3101,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -6538,6 +6543,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 findup@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
@@ -6678,6 +6690,15 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
@@ -8571,6 +8592,13 @@ kind-of@^6.0.0, kind-of@^6.0.1, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -9853,7 +9881,7 @@ open@^6.2.0, open@^6.3.0:
   dependencies:
     is-wsl "^1.1.0"
 
-open@^7.0.0:
+open@^7.0.0, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -10091,6 +10119,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -10355,6 +10402,11 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -10944,10 +10996,10 @@ react-native-modal@^11.0.2:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"
 
-react-native-pager-view@^5.4.11:
-  version "5.4.11"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.11.tgz#677540293c7b4e0e022efb45727ef9b4efa35409"
-  integrity sha512-4QlBL5W8yVjeYwrw89oCdABI7sDxIGapFQvIbukfB5mAj1Zn1IQPkBqROLblNFtQ8PbAeexXRgDT1ENWygiJ7A==
+react-native-pager-view@^5.4.24:
+  version "5.4.24"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.24.tgz#8626e757ddc55e41eca66d2f8a8a75aec54591ee"
+  integrity sha512-dRMB7i3B+mu4NCeIN6gqbR/kC/rr2wzqO0gisXDdJwJr78G24sWoTNpLEDFo3G8TFHY9nTMutVl5CUvkN2dp6g==
 
 react-native-permissions@^2.0.3:
   version "2.2.2"
@@ -11961,6 +12013,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Why are you doing this?

When scrolling through articles on Android, users tend to accidentally scroll to the next article rather than scroll down the article. This is an issue with ViewPager2 in Android.

This is a fix to help reduce the sensitivity as described in this PR: https://github.com/callstack/react-native-pager-view/issues/164#issuecomment-965032619

Tested on Simulator and device. It seems better, but could be done with being tested on an Android tablet.

## Changes

- Update the Viewpager to the latest
- Add `patch-package` and apply the appropriate patch