### PR TITLE
fix: Missing HTML folder from DL progress

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -118,6 +118,7 @@ export const isIssueOnDevice = async (
 			RNFS.exists(FSPaths.mediaRoot(localIssueId)),
 			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/front`),
 			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/thumbs`),
+			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/html`),
 		])
 	).every((_) => _);
 


### PR DESCRIPTION
## Why are you doing this?

HTML folder was missing from download progress. This potentially will resolve issues around issues being reported as not fully downloaded when the app says they are.
