### PR TITLE
Update setup instructions to reflect gu-strap deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Guardian Editions app includes the UK Daily edition, Australia Weekend and o
 
 ## Setup
 
-If you're a guardian staff member and haven't already it's worth running the [strap](https://gu-strap.herokuapp.com/) script which installs a [load of useful stuff](https://github.com/guardian/homebrew-devtools/blob/master/Casks/gu-base.rb) including VSCode - the editor used by the editions team.
+If you haven't already it's worth running [strap](https://macos-strap.herokuapp.com/) & then installing [`gu-base`](https://github.com/guardian/homebrew-devtools) which adds a [load of useful stuff](https://github.com/guardian/homebrew-devtools/blob/master/Casks/gu-base.rb) including VSCode - the editor used by the editions team.
 
 The project uses [nvm](https://github.com/nvm-sh/nvm) so this will need to be installed before if it's not already. Do not install it using brew.
 


### PR DESCRIPTION
## Why are you doing this?

`gu-strap` has been deprecated and we ask folk to use plain `strap` and install the gu dev tools from Homebrew themselves.

## Changes

Updates the `README.md`

[Preview link](https://github.com/guardian/editions/blob/update-setup-instructions/README.md)