### PR TITLE
fix: Android first load

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -101,7 +101,6 @@ export const IssueSummaryProvider = ({
 	// Use Callback used so the function isnt recreated on each rerender
 	// @TODO: Look to move this logic outside of the provider so it can be tested
 	const getLatestIssueSummary = useCallback(() => {
-		setIsLoading(true);
 		return getIssueSummary(isConnected, isPoorConnection)
 			.then((retrievedIssueSummary) => {
 				setIssueSummary(retrievedIssueSummary);
@@ -139,19 +138,19 @@ export const IssueSummaryProvider = ({
 						e.message = `Unable to get backup issue summary: ${e.message}`;
 						errorService.captureException(e);
 					});
-			})
-			.finally(() => setIsLoading(false));
+			});
 	}, [isConnected, isPoorConnection, selectedEdition, maxAvailableEditions]);
 
 	// On load, get the latest issue summary
 	useEffect(() => {
-		!isLoading && getLatestIssueSummary();
+		getLatestIssueSummary();
 	}, []);
 
 	// When the network status, max available editions or app state changes
 	useEffect(() => {
 		if (isActive && !isLoading) {
-			getLatestIssueSummary();
+			setIsLoading(true);
+			getLatestIssueSummary().finally(() => setIsLoading(false));
 		}
 	}, [isConnected, isPoorConnection, maxAvailableEditions, isActive]);
 


### PR DESCRIPTION
## Why are you doing this?

On Android, the connection value seems to default to false on first load. This meant we tried to fetch the issue summary when there was "no connection" and as its the first install, there was no issue summary on the device.

The `isLoading` was then subsequently blocking the attempt to get a new issue summary when the connection value became `true`. Therefore it became stuck.

## Changes

- Remove the loading from the function that gets issue summary and manages its state
- Make sure loading doesn't affect the initial render
- Apply loading only to scenarios where external changes happen. Not too worried about blocking here as we should always have a stored issue summary in this instance.
