### PR TITLE
Revert "chore: Don't auto download in preview"

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-downloads.tsx
+++ b/projects/Mallard/src/hooks/use-issue-downloads.tsx
@@ -5,30 +5,27 @@ import { prepareAndDownloadTodaysIssue } from 'src/download-edition/prepare-and-
 import { pushDownloadFailsafe } from 'src/helpers/push-download-failsafe';
 import { pushNotificationRegistration } from 'src/notifications/push-notifications';
 import { useAppState } from './use-app-state-provider';
-import { useApiUrl, useLargeDeviceMemory } from './use-config-provider';
+import { useLargeDeviceMemory } from './use-config-provider';
 import { useNetInfo } from './use-net-info-provider';
 
 export const useIssueDownloads = () => {
-	const { isPreview } = useApiUrl();
 	const { downloadBlocked } = useNetInfo();
 	const { isActive } = useAppState();
 	const largeRAM = useLargeDeviceMemory();
 
 	useEffect(() => {
-		if (!isPreview) {
-			prepareAndDownloadTodaysIssue(downloadBlocked);
-			// On mount, if there is plenty of memory then setup the failsafe for push downloads
-			if (largeRAM) {
-				pushDownloadFailsafe(downloadBlocked);
-			}
-			// Initial app registration for Push Notifications
-			pushNotificationRegistration(downloadBlocked);
+		prepareAndDownloadTodaysIssue(downloadBlocked);
+		// On mount, if there is plenty of memory then setup the failsafe for push downloads
+		if (largeRAM) {
+			pushDownloadFailsafe(downloadBlocked);
 		}
+		// Initial app registration for Push Notifications
+		pushNotificationRegistration(downloadBlocked);
 	}, []);
 
 	useEffect(() => {
 		// we check the value so that we dont run the function if it changes from true to false.
-		if (isActive && !isPreview) {
+		if (isActive) {
 			prepareAndDownloadTodaysIssue(downloadBlocked);
 		}
 	}, [isActive]);


### PR DESCRIPTION
Reverts guardian/editions#2076

When swapping between issues and choosing a front, we are getting an error in Preview. This only happens in the latest version. Attempting to revert this PR to see if it fixes the issue.