### PR TITLE
feat: External Subscription Modal

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -120,7 +120,7 @@
     "@types/moment-timezone": "^0.5.12",
     "@types/node": "^12.7.2",
     "@types/react": "^16.9.1",
-    "@types/react-native": "^0.60.5",
+    "@types/react-native": "0.67.4",
     "@types/react-native-push-notification": "^3.0.9",
     "@types/react-test-renderer": "^16.9.0",
     "@types/validator": "^10.11.2",

--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -7,6 +7,7 @@ import {
 } from '@react-navigation/stack';
 import React from 'react';
 import { Animated } from 'react-native';
+import { isTablet } from 'react-native-device-info';
 import { LoadingScreen } from './components/LoadingScreen/LoadingScreen';
 import { useIsOnboarded } from './hooks/use-onboarding';
 import type {
@@ -18,6 +19,7 @@ import type {
 import { RouteNames } from './navigation/NavigationModels';
 import { ArticleWrapper } from './navigation/navigators/article';
 import { EditionsMenuScreen } from './screens/editions-menu-screen';
+import { ExternalSubscriptionScreen } from './screens/external-subscription';
 import { HomeScreen } from './screens/home-screen';
 import { AuthSwitcherScreen } from './screens/identity-login-screen';
 import { InAppPurchaseScreen } from './screens/in-app-purchase-screen';
@@ -49,6 +51,12 @@ import { WeatherGeolocationConsentScreen } from './screens/weather-geolocation-c
 import { color } from './theme/color';
 
 const { multiply } = Animated;
+
+const forFade = ({ current }: StackCardInterpolationProps) => ({
+	cardStyle: {
+		opacity: current.progress,
+	},
+});
 
 const cardStyleInterpolator = (props: StackCardInterpolationProps) => {
 	const translateX = multiply(
@@ -166,6 +174,25 @@ const MainStack = () => {
 				options={{
 					...TransitionPresets.ModalSlideFromBottomIOS,
 				}}
+			/>
+			<Main.Screen
+				name={RouteNames.ExternalSubscription}
+				component={ExternalSubscriptionScreen}
+				options={
+					isTablet()
+						? {
+								cardStyle: {
+									backgroundColor: 'rgba(0,0,0,0.6)',
+								},
+								cardStyleInterpolator: forFade,
+						  }
+						: {
+								cardStyleInterpolator:
+									CardStyleInterpolators.forModalPresentationIOS,
+								gestureEnabled: true,
+								gestureDirection: 'vertical',
+						  }
+				}
 			/>
 		</Main.Navigator>
 	);

--- a/projects/Mallard/src/components/Button/Button.tsx
+++ b/projects/Mallard/src/components/Button/Button.tsx
@@ -232,7 +232,7 @@ const Button = ({
 							textStyles,
 						]}
 					>
-						{innards.children}
+						{innards.children as string | string[]}
 					</UiBodyCopy>
 				)}
 				{iconPosition === 'right' && icon}

--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import type { ImageStyle, StyleProp } from 'react-native';
+import type { StyleProp } from 'react-native';
 import { View } from 'react-native';
+import type { ImageStyle } from 'react-native-fast-image';
 import FastImage from 'react-native-fast-image';
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio';
 import { useImagePath } from 'src/hooks/use-image-paths';
@@ -40,7 +41,7 @@ const ImageResource = ({
 			key={imagePath}
 			{...props}
 			resizeMode={FastImage.resizeMode.cover}
-			style={[styles, style]}
+			style={[styles, style] as StyleProp<ImageStyle>}
 			source={{ uri: imagePath }}
 		/>
 	) : (

--- a/projects/Mallard/src/components/front/index.tsx
+++ b/projects/Mallard/src/components/front/index.tsx
@@ -72,7 +72,7 @@ export const Front = React.memo(
 		const stops = cards.length;
 		const { card, container } = useIssueScreenSize();
 		const largeDeviceMemory = useLargeDeviceMemory();
-		const ref = useRef<FlatList<FlatCard[]> | null>(null);
+		const ref = useRef<FlatList | null>(null);
 		const { issueId } = useIssue();
 		const flatListOptimisationProps = largeDeviceMemory
 			? {
@@ -98,7 +98,7 @@ export const Front = React.memo(
 		}, [issueId.publishedIssueId, issueId.localIssueId]);
 
 		const renderItem = useCallback(
-			({ item }: { item: FlatCard }) => (
+			({ item }: { item: any }) => (
 				<CollectionPageInFront
 					articlesInCard={item.articles || []}
 					appearance={item.appearance}
@@ -131,7 +131,7 @@ export const Front = React.memo(
 			></View>
 		));
 
-		const getItemLayout = (_: never, index: number) => ({
+		const getItemLayout = (_: any, index: number) => ({
 			length: card.width,
 			offset: card.width * index,
 			index,
@@ -193,7 +193,7 @@ export const Front = React.memo(
 					decelerationRate="fast"
 					snapToInterval={card.width}
 					getItemLayout={getItemLayout}
-					keyExtractor={(item: FlatCard, index: number) =>
+					keyExtractor={(item, index) =>
 						`${index}${item.collection.key}`
 					}
 					ListFooterComponent={ListFooterComponent}

--- a/projects/Mallard/src/helpers/platform.ts
+++ b/projects/Mallard/src/helpers/platform.ts
@@ -1,4 +1,4 @@
 import { Platform } from 'react-native';
 
 export const iosMajorVersion =
-	Platform.OS === 'ios' ? parseInt(Platform.Version as string, 10) : 0;
+	Platform.OS === 'ios' ? parseInt(Platform.Version, 10) : 0;

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -240,6 +240,14 @@ export const WeatherConsentHtml = {
 `,
 };
 
+const ExternalSubscription = {
+	title: "You're about to leave the app and go to an external website. You will no longer be transacting with Apple.",
+	body: 'Any accounts or purchases made outside of this app will be managed by the developer "Guardian News and Media Limited" Your App Store account, stored payment method, and related features, such as subscription management and refund requests, will not be available. Apple is not responsible for the privacy or security of transactions made with this developer.',
+	learnMore: 'Learn More',
+	continue: 'Continue',
+	cancel: 'Cancel',
+};
+
 export const Copy = {
 	signIn: SignIn,
 	failedSignIn: FailedSignIn,
@@ -255,4 +263,5 @@ export const Copy = {
 	subscriptionDetails: SubscriptionDetails,
 	authSwitcherScreen: AuthSwitcherScreen,
 	weatherConsentHtml: WeatherConsentHtml,
+	externalSubscription: ExternalSubscription,
 };

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -46,6 +46,7 @@ export type MainStackParamList = {
 	EditionsMenu: undefined;
 	Lightbox: LightboxNavigationProps;
 	Crossword: ArticleNavigationProps;
+	ExternalSubscription: undefined;
 };
 
 // This is used on pages which include both main and root stacks
@@ -83,4 +84,5 @@ export enum RouteNames {
 	Crossword = 'Crossword',
 	DevZone = 'DevZone',
 	InAppPurchase = 'InAppPurchase',
+	ExternalSubscription = 'ExternalSubscription',
 }

--- a/projects/Mallard/src/screens/external-subscription.tsx
+++ b/projects/Mallard/src/screens/external-subscription.tsx
@@ -1,0 +1,160 @@
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import type { ColorSchemeName, TextStyle, ViewStyle } from 'react-native';
+import {
+	Linking,
+	ScrollView,
+	StyleSheet,
+	Text,
+	TouchableOpacity,
+	useColorScheme,
+	View,
+} from 'react-native';
+import { getDeviceId, isTablet } from 'react-native-device-info';
+import { Copy } from 'src/helpers/words';
+
+const isTabletDevice = isTablet();
+
+// Accounts for iOS devices below iOS16 at launch
+const proOrMaxPhoneIds = [
+	'iPhone12,3',
+	'iPhone12,5',
+	'iPhone13,3',
+	'iPhone13,4',
+	'iPhone14,2',
+	'iPhone14,3',
+];
+
+const standardUIKitLayoutMargins = (): number => {
+	if (isTabletDevice) {
+		return 88;
+	}
+	const deviceId = getDeviceId();
+	const isOriginalIPhoneSE = deviceId === 'iPhone8,4';
+	if (isOriginalIPhoneSE) {
+		return 16;
+	}
+	const isPhoneProOrMax = proOrMaxPhoneIds.includes(deviceId);
+	if (isPhoneProOrMax) {
+		return 44;
+	}
+	return 24;
+};
+
+const styles = (colorScheme: ColorSchemeName) => {
+	const darkMode = colorScheme === 'dark';
+	return StyleSheet.create({
+		container: {
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			flex: 1,
+		},
+		card: {
+			marginVertical: isTabletDevice ? 44 : 0,
+			backgroundColor: darkMode ? '#000000' : '#FFFFFF',
+			flex: 1,
+
+			paddingHorizontal: standardUIKitLayoutMargins(),
+			paddingTop: isTabletDevice ? 88 : 70,
+			borderRadius: 14,
+			justifyContent: 'space-between',
+		},
+		largeTitleBold: {
+			fontFamily: 'System',
+			fontWeight: 'bold',
+			fontSize: 34,
+			lineHeight: 41,
+			marginBottom: isTabletDevice ? 15 : 16,
+			color: darkMode ? '#FFFFFF' : '#000000',
+			textAlign: 'center',
+		},
+		headline: {
+			fontFamily: 'System',
+			fontWeight: 'bold',
+			fontSize: 17,
+			lineHeight: 22,
+			color: darkMode ? '#0A84FF' : '#007AFF',
+		},
+		body: {
+			fontFamily: 'System',
+			fontSize: 17,
+			lineHeight: 22,
+			textAlign: 'center',
+			marginBottom: 15,
+			color: darkMode ? '#FFFFFF' : '#000000',
+		},
+		link: {
+			fontFamily: 'System',
+			fontSize: 17,
+			lineHeight: 22,
+			color: darkMode ? '#0A84FF' : '#007AFF',
+			textAlign: 'center',
+		},
+		buttonGroup: {
+			paddingTop: 24,
+			paddingBottom: isTabletDevice ? 28 : 15,
+			paddingHorizontal: isTabletDevice ? 44 : 0,
+		},
+		iOSButton: {
+			backgroundColor: darkMode ? '#2C2C2E' : '#F2F2F7',
+			borderRadius: 14,
+			alignItems: 'center',
+			justifyContent: 'center',
+			height: 50,
+			marginBottom: 12,
+		},
+	});
+};
+
+const IOSButton = ({
+	children,
+	onPress,
+	style,
+}: {
+	children: string;
+	onPress: () => void;
+	style: { iOSButton: ViewStyle; headline: TextStyle };
+}) => (
+	<TouchableOpacity onPress={onPress} style={style.iOSButton}>
+		<Text style={style.headline}>{children}</Text>
+	</TouchableOpacity>
+);
+
+const learnMore = () =>
+	Linking.openURL('https://apps.apple.com/story/id1614232807');
+
+const subscribe = () =>
+	Linking.openURL('https://support.theguardian.com/uk/subscribe/digital');
+
+export const ExternalSubscriptionScreen = () => {
+	const { goBack } = useNavigation();
+	const colorScheme = useColorScheme();
+	const style = styles(colorScheme);
+	return (
+		<View style={style.container}>
+			<View style={style.card}>
+				<ScrollView>
+					<Text style={style.largeTitleBold}>
+						{Copy.externalSubscription.title}
+					</Text>
+					<Text style={style.body}>
+						{Copy.externalSubscription.body}
+					</Text>
+					<Text style={style.link} onPress={learnMore}>
+						{Copy.externalSubscription.learnMore}
+					</Text>
+				</ScrollView>
+
+				<View style={style.buttonGroup}>
+					<IOSButton onPress={subscribe} style={style}>
+						{Copy.externalSubscription.continue}
+					</IOSButton>
+					<IOSButton onPress={goBack} style={style}>
+						{Copy.externalSubscription.cancel}
+					</IOSButton>
+				</View>
+			</View>
+		</View>
+	);
+};

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -94,7 +94,7 @@ type FrontWithCards = Array<TFront & { cards: FlatCard[] }>;
 const useScrollToFrontBehavior = (
 	frontWithCards: FrontWithCards,
 	initialFrontKey: string | null,
-	ref: MutableRefObject<FlatList<any> | null>,
+	ref: MutableRefObject<FlatList | null>,
 ) => {
 	// Linear search to find the right index to scroll to, front count is bound.
 	const findFrontIndex = (frontKey: string | null | undefined) =>
@@ -155,7 +155,7 @@ const IssueFronts = ({
 }) => {
 	const { container, card } = useIssueScreenSize();
 	const { width } = useDimensions();
-	const ref = useRef<FlatList<any> | null>(null);
+	const ref = useRef<FlatList | null>(null);
 	const { selectedEdition } = useEditions();
 	const { isPreview } = useApiUrl();
 	const weatherResult = useWeather();

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2781,12 +2781,11 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react-native@^0.60.5":
-  version "0.60.31"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.60.31.tgz#a7af12197f884ad8dd22cda2df9862ed72973ded"
-  integrity sha512-Y0Q+nv50KHnLL+jM0UH68gQQv7Wt6v2KuNepiHKwK1DoWGVd1oYun/GJCnvUje+/V8pMQQWW6QuBvHZz1pV7tQ==
+"@types/react-native@0.67.4":
+  version "0.67.4"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.67.4.tgz#97a8d3cff2a7606f247008e93d9fe2a3879bc84e"
+  integrity sha512-L81CB6W1m0s7d+TH/loP318+VKPwwjWQBUTVYQ1+lQTWiE5jHxyihgCmd7JbwLICo708FRSDwJW7pJoiZHy6yg==
   dependencies:
-    "@types/prop-types" "*"
     "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.4":


### PR DESCRIPTION
## Why are you doing this?

To allow iOS devices under iOS 16 to see the External Subscription modal required for Reader Apps.

## Changes

- Add the modal based on the iOS specification
- Add the modal into the navigation.
- Updated the React Native types to take into account the `colourScheme` hook

## Screenshots

<img width="941" alt="Screenshot 2022-09-08 at 09 01 53" src="https://user-images.githubusercontent.com/935975/189835929-9014b1a0-0b3d-4c5a-80b9-e12b92f714fb.png">

