### PR TITLE
chore: Upgrade the Ophan version

### DIFF
--- a/projects/Apps/ophan/build.gradle
+++ b/projects/Apps/ophan/build.gradle
@@ -30,7 +30,7 @@ kotlin {
 
     def coroutinesVersion = "1.3.0"
     def ktorVersion = "1.2.3"
-    def multiplatformOphanVersion = "0.1.12"
+    def multiplatformOphanVersion = "0.2.0"
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
## Why are you doing this?

To fix the build locally and in CI. Essentially I believe the last release had dependencies that have now deprecated to such a degree that it caused the build to fail.

## Changes

- Update multiplatform Ophan version to 0.2.0
