### PR TITLE
fix: Empty Cards causing crash

### DIFF
--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -225,16 +225,17 @@ const IssueFronts = ({
 	};
 
 	const renderItem = useCallback(
-		({ item }: { item: any }) => (
-			<Front
-				localIssueId={issue.localId}
-				publishedIssueId={issue.publishedId}
-				articleNavigator={frontSpecs}
-				frontData={item}
-				cards={item.cards}
-				key={item.key}
-			/>
-		),
+		({ item }: { item: any }) =>
+			item.cards.length > 0 ? (
+				<Front
+					localIssueId={issue.localId}
+					publishedIssueId={issue.publishedId}
+					articleNavigator={frontSpecs}
+					frontData={item}
+					cards={item.cards}
+					key={item.key}
+				/>
+			) : null,
 		[frontSpecs, issue.localId, issue.publishedId],
 	);
 


### PR DESCRIPTION
## Why are you doing this?

Production team reported that when a Crossword front is created without any data in, it would cause the app to crash. On further investigation @groakland saw that this was due to "empty cards".

Testing this hypothesis locally I can confirm this is the case and that the following fix solves this issue.

## Changes

- Render null Fronts if there are no cards