### PR TITLE
chore: Remove subscription details headings

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -182,8 +182,6 @@ export const IssueListFooter = {
 
 export const SubscriptionDetails = {
 	title: 'Subscription Details',
-	heading: 'Paper + digital subscription',
-	iapHeading: 'Guardian Editions / App Store',
 	loggedOutHeading: 'Not logged in',
 	emailAddress: 'Email Address',
 	userId: 'User ID',

--- a/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
+++ b/projects/Mallard/src/screens/settings/subscription-details-screen.tsx
@@ -26,7 +26,6 @@ const IdentityDetails = ({
 	identityData: IdentityAuthData;
 }) => (
 	<>
-		<Heading>{Copy.subscriptionDetails.heading}</Heading>
 		<List
 			data={[
 				keyValueItem(
@@ -51,7 +50,6 @@ const getCASType = (casData: CASExpiry) =>
 
 const CASDetails = ({ casData }: { casData: CASExpiry }) => (
 	<>
-		<Heading>{Copy.subscriptionDetails.heading}</Heading>
 		<List
 			data={[
 				keyValueItem(
@@ -83,7 +81,6 @@ const getIAPType = (iapData: ReceiptIOS) =>
 
 const IAPDetails = ({ iapData }: { iapData: ReceiptIOS }) => (
 	<>
-		<Heading>{Copy.subscriptionDetails.iapHeading}</Heading>
 		<List
 			data={[
 				keyValueItem('Subscription type', getIAPType(iapData)),
@@ -101,6 +98,8 @@ const LoggedOutDetails = () => (
 const SubscriptionDetailsScreen = () => {
 	const { identityData, iapData, casData, attempt } =
 		useContext(AccessContext);
+
+	console.log(JSON.stringify(identityData));
 
 	return (
 		<HeaderScreenContainer


### PR DESCRIPTION
## Why are you doing this?

Removing the heading on the subscription details pages as requested

