### PR TITLE
chore: Error wording

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -41,7 +41,7 @@ export const EDITIONS_HEADER_TITLE = 'Editions';
 export const TERMS_HEADER_TITLE = 'Terms & Conditions';
 
 export const ERR_404_MISSING_PROPS = `Couldn't find a path to this item`;
-export const ERR_404_REMOTE = `Couldn't find item`;
+export const ERR_404_REMOTE = 'Unable to find the article';
 
 export const PREFS_SAVED_MSG = 'Your preferences are saved.';
 


### PR DESCRIPTION
## Why are you doing this?

Changes the error wording when an Article cannot be retrieved

