### PR TITLE
fix: NSLocationAlwaysAndWhenInUseUsageDescription Message

### DIFF
--- a/projects/Mallard/ios/Mallard/Info.plist
+++ b/projects/Mallard/ios/Mallard/Info.plist
@@ -76,6 +76,8 @@
 	<string>Location-based weather</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location-based weather</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Location-based weather</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>GHGuardianHeadline-Black.ttf</string>


### PR DESCRIPTION
## Why are you doing this?

Based upon an email from AppStore Connect, a new purpose string was required.
