### PR TITLE
chore: 9.10 bump

### DIFF
--- a/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
+++ b/projects/Mallard/ios/Mallard.xcodeproj/project.pbxproj
@@ -897,7 +897,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				KOTLIN_BUILD_TYPE = DEBUG;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 9.9;
+				MARKETING_VERSION = 9.10;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = "Guardian Editions";
@@ -929,7 +929,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				KOTLIN_BUILD_TYPE = RELEASE;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 9.9;
+				MARKETING_VERSION = 9.10;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.guardian.gce;
 				PRODUCT_NAME = "Guardian Editions";


### PR DESCRIPTION
## Why are you doing this?

Bump to 9.10 for iOS to get ready for the next release
