### PR TITLE
fix: Initial Load of View Pager on Android

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -72,10 +72,14 @@ const ArticleSlider = React.memo(
 		const currentArticle = flattenedArticles[Math.round(current)];
 
 		useEffect(() => {
-			flatListRef?.current?.scrollToIndex({
-				index: current,
-				animated: false,
-			});
+			if (Platform.OS === 'ios') {
+				flatListRef?.current?.scrollToIndex({
+					index: current,
+					animated: false,
+				});
+			} else {
+				viewPagerRef?.current?.setPage(startingPoint);
+			}
 		}, [width]); // eslint-disable-line react-hooks/exhaustive-deps
 
 		const sliderSections = articleNavigator.reduce(


### PR DESCRIPTION
## Why are you doing this?

ViewPager on Android was reverting back to position one after it had loaded. This fixes that and replicates code that was originally removed. Performance seems better for it as well.
