### PR TITLE
spike: FlashList

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -1,5 +1,6 @@
+import { FlashList } from '@shopify/flash-list';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Animated, FlatList, Platform, StyleSheet, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View } from 'react-native';
 import ViewPagerAndroid from 'react-native-pager-view';
 import { PreviewControls } from 'src/components/article/preview-controls';
 import { clamp } from 'src/helpers/math';
@@ -196,11 +197,9 @@ const ArticleSlider = React.memo(
 			<>
 				{Platform.OS === 'ios' ? (
 					<View style={styles.androidPager}>
-						<FlatList
+						<FlashList
+							estimatedItemSize={width}
 							style={{ paddingBottom: isPreview ? 150 : 0 }}
-							windowSize={3}
-							initialNumToRender={3}
-							maxToRenderPerBatch={6}
 							ref={(flatList: any) =>
 								(flatListRef.current = flatList)
 							}


### PR DESCRIPTION
## Why are you doing this?

Managed to get this to work. `FlashList` is a more performant version of `FlatList` which we are using for the iOS Article Slider. Still fairly new so worth a try for comparison.