### PR TITLE
fix: Article Slider

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -227,6 +227,14 @@ const ArticleSlider = React.memo(
 									listener: onScrollListener,
 								},
 							)}
+							getItemLayout={(
+								_: ArticleSpec[] | null | undefined,
+								index: number,
+							) => ({
+								length: width,
+								offset: width * index,
+								index,
+							})}
 							horizontal={true}
 							initialScrollIndex={startingPoint}
 							pagingEnabled


### PR DESCRIPTION
## Why are you doing this?

Reinstates `getItemLayout` which was lost due to some poor branching. This fixes the crash when selecting an article at the bottom of the fronts