### PR TITLE
fix: Please report: Excessive number of pending callbacks: 501

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -71,7 +71,7 @@
     "react": "^18.0.0",
     "react-native": "0.69.7",
     "react-native-background-fetch": "^4.0.4",
-    "react-native-circular-progress-indicator": "^4.4.0",
+    "react-native-circular-progress-indicator": "^4.4.2",
     "react-native-config": "^1.4.6",
     "react-native-device-info": "^8.0.2",
     "react-native-fast-image": "^8.6.3",

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -178,9 +178,14 @@ const IssueButton = ({
 		}
 	};
 
+	const progressValue = useMemo(
+		() => (dlStatus ? getStatusPercentage(dlStatus) ?? 100 : 100),
+		[dlStatus],
+	);
+
 	return (
 		<CircularProgressBase
-			value={dlStatus ? getStatusPercentage(dlStatus) ?? 100 : 100}
+			value={progressValue}
 			maxValue={100}
 			radius={20}
 			circleBackgroundColor={

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -111,16 +111,18 @@ export const unzipNamedIssueArchive = async (zipFilePath: string) => {
  */
 export const isIssueOnDevice = async (
 	localIssueId: Issue['localId'],
-): Promise<boolean> =>
-	(
-		await Promise.all([
-			RNFS.exists(FSPaths.issue(localIssueId)),
-			RNFS.exists(FSPaths.mediaRoot(localIssueId)),
-			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/front`),
-			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/thumbs`),
-			RNFS.exists(`${FSPaths.issueRoot(localIssueId)}/html`),
-		])
-	).every((_) => _);
+): Promise<boolean> => {
+	try {
+		// Please note, this makes an assumption on the location of filenames which is not the case throughout the code
+		// However, at this stage in the project, this is unlikely to change and therefore the performance optimisation
+		// that this currently provides is a greater benefit than maintenance.
+		const expectedFolders = 'issue_front_thumbs_media_html';
+		const folders = await RNFS.readdir(FSPaths.issueRoot(localIssueId));
+		return folders.every((item) => expectedFolders.includes(item));
+	} catch {
+		return false;
+	}
+};
 
 const withPathPrefix = (prefix: string) => (str: string) => `${prefix}/${str}`;
 

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -7053,10 +7053,10 @@ react-native-background-fetch@^4.0.4:
   resolved "https://registry.yarnpkg.com/react-native-background-fetch/-/react-native-background-fetch-4.1.5.tgz#1ada72e5ea4e77539338a633f5eca5f8fd6a7a65"
   integrity sha512-fi1fE59lw2pMkhy8O2svpo21AkaUnkuP8/8Ru2FrzJ+oJ9Qe8uh9Lh96caN75Bax06sLmR4WkhP0cRHcUp/wpQ==
 
-react-native-circular-progress-indicator@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-circular-progress-indicator/-/react-native-circular-progress-indicator-4.4.0.tgz#048df184ed5b4d3d2305e5f8e13b6f29608f5707"
-  integrity sha512-+AEHzUeiIZ1pGNJ6jpCz/zo6NkqWm6zz4XygX7eN4bsalDL6VJctZArK6FxcuOStiEWR5edF5dGr92asjzVBSQ==
+react-native-circular-progress-indicator@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-circular-progress-indicator/-/react-native-circular-progress-indicator-4.4.2.tgz#5475d045950e6fcc622e54fb63863b274790fb8e"
+  integrity sha512-BlgshzIIIk0TP/CZY+5oyRsHl2Sb2l6cK5tzfmrVETfn6pN8dhOKrV0i3Z6i0SM8wRgncdUUSRBpCPAexh7JoQ==
   dependencies:
     react-native-redash "*"
 


### PR DESCRIPTION
## Why are you doing this?

`Please report: Excessive number of pending callbacks: 501` warning is showing when accessing the menu. This is due to each edition being checked if their associated folders exist. This shows the "download complete" indicator if correct.

The warning results in worse performance (and possibly crashes?) so this reduces the number of async calls by a factor of 5. It does make an assumption on folder structure, which is not what we have done elsewhere, however, due to the maintenance state of the project, file locations are unlikely to change and therefore the performance benefit outweighed the desire for more maintainable code.

## Changes

- Updates circular progress
- Make one async request instead of 5 per edition and use JS to determine the folder's existence
