### PR TITLE
chore: Lower Powered iOS devices Article Slider

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -5,7 +5,11 @@ import { PreviewControls } from 'src/components/article/preview-controls';
 import { clamp } from 'src/helpers/math';
 import { getColor } from 'src/helpers/transform';
 import { getAppearancePillar } from 'src/hooks/use-article';
-import { useApiUrl, useDimensions } from 'src/hooks/use-config-provider';
+import {
+	useApiUrl,
+	useDimensions,
+	useLargeDeviceMemory,
+} from 'src/hooks/use-config-provider';
 import { useSetNavPosition } from 'src/hooks/use-nav-position';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator, ArticleSpec } from 'src/screens/article-screen';
@@ -68,6 +72,7 @@ const ArticleSlider = React.memo(
 		const flatListRef = useRef<any | undefined>();
 
 		const { isPreview } = useApiUrl();
+		const hasLargeMemory = useLargeDeviceMemory();
 
 		const currentArticle = flattenedArticles[Math.round(current)];
 
@@ -194,7 +199,7 @@ const ArticleSlider = React.memo(
 
 		return (
 			<>
-				{Platform.OS === 'ios' ? (
+				{Platform.OS === 'ios' && hasLargeMemory ? (
 					<View style={styles.androidPager}>
 						<FlatList
 							style={{ paddingBottom: isPreview ? 150 : 0 }}


### PR DESCRIPTION
## Why are you doing this?

Lower powered devices appear to be having a worse experience with the new slider than the old. This change will move those lower powered devices to use the old slider

If this does not achieve the desired effect, we may need to change the threshold on what is considered lower powered.