### PR TITLE
feat: Rating in background

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -419,6 +419,8 @@ PODS:
     - React-Core
   - RNPermissions (2.2.2):
     - React-Core
+  - RNRate (1.2.12):
+    - React-Core
   - RNReanimated (2.12.0):
     - DoubleConversion
     - FBLazyVector
@@ -536,6 +538,7 @@ DEPENDENCIES:
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
+  - RNRate (from `../node_modules/react-native-rate`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
@@ -688,6 +691,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-localize"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
+  RNRate:
+    :path: "../node_modules/react-native-rate"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -777,6 +782,7 @@ SPEC CHECKSUMS:
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
   RNLocalize: 7c7aeda16c01db7a0918981c14875c0a53be9b79
   RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
+  RNRate: ef3bcff84f39bb1d1e41c5593d3eea4aab2bd73a
   RNReanimated: c3e58924b9418883b0bde9e78c4c957302f02435
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@delightfulstudio/react-native-safe-area-insets": "^0.2.1",
+    "@expo/react-native-action-sheet": "^4.0.1",
     "@gorhom/bottom-sheet": "^2.4.1",
     "@guardian/pasteup": "^1.0.0-alpha.11",
     "@guardian/renditions": "^0.2.0",
@@ -86,6 +87,7 @@
     "react-native-pager-view": "^5.4.24",
     "react-native-permissions": "^2.0.3",
     "react-native-push-notification": "^7.0.0",
+    "react-native-rate": "^1.2.12",
     "react-native-reanimated": "^2.10.0",
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.17",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -1,3 +1,4 @@
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -44,6 +45,7 @@ const WithProviders = nestProviders(
 	Modal,
 	ToastProvider,
 	NavPositionProvider,
+	ActionSheetProvider,
 	ConfigProvider,
 	SettingsOverlayProvider,
 	AppStateProvider,

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -29,7 +29,7 @@ const JOIN_BETA_LINK = Platform.select({
 	default: 'https://testflight.apple.com/join/O2EojUEl',
 });
 
-const APPLE_ID = 452707806;
+const APPLE_ID = '452707806';
 const GOOGLE_PACKAGE_NAME = 'com.guardian.editions';
 
 export {

--- a/projects/Mallard/src/constants.ts
+++ b/projects/Mallard/src/constants.ts
@@ -29,6 +29,9 @@ const JOIN_BETA_LINK = Platform.select({
 	default: 'https://testflight.apple.com/join/O2EojUEl',
 });
 
+const APPLE_ID = 452707806;
+const GOOGLE_PACKAGE_NAME = 'com.guardian.editions';
+
 export {
 	CAS_ENDPOINT_URL,
 	ID_API_URL,
@@ -41,4 +44,6 @@ export {
 	ITUNES_CONNECT_SHARED_SECRET,
 	ANDROID_RELEASE_STREAM,
 	JOIN_BETA_LINK,
+	APPLE_ID,
+	GOOGLE_PACKAGE_NAME,
 };

--- a/projects/Mallard/src/helpers/rate.ts
+++ b/projects/Mallard/src/helpers/rate.ts
@@ -1,0 +1,13 @@
+import Rate, { AndroidMarket } from 'react-native-rate';
+
+export const rateApp = () => {
+	// options are chosen as this is an app driven action rather than user driven
+	const options = {
+		AppleAppID: '2193813192',
+		GooglePackageName: 'com.mywebsite.myapp',
+		preferredAndroidMarket: AndroidMarket.Google,
+		preferInApp: true,
+		openAppStoreIfInAppFails: false,
+	};
+	Rate.rate(options);
+};

--- a/projects/Mallard/src/helpers/rate.ts
+++ b/projects/Mallard/src/helpers/rate.ts
@@ -1,13 +1,26 @@
+import { Linking, Platform } from 'react-native';
 import Rate, { AndroidMarket } from 'react-native-rate';
+import { APPLE_ID, GOOGLE_PACKAGE_NAME } from 'src/constants';
 
 export const rateApp = () => {
 	// options are chosen as this is an app driven action rather than user driven
 	const options = {
-		AppleAppID: '2193813192',
-		GooglePackageName: 'com.mywebsite.myapp',
+		AppleAppID: APPLE_ID,
+		GooglePackageName: GOOGLE_PACKAGE_NAME,
 		preferredAndroidMarket: AndroidMarket.Google,
 		preferInApp: true,
 		openAppStoreIfInAppFails: false,
 	};
-	Rate.rate(options);
+	Rate.rate(options, (success) => {
+		if (!success) {
+			Platform.select({
+				ios: Linking.openURL(
+					`itms-apps://itunes.apple.com/app/id${APPLE_ID}`,
+				),
+				android: Linking.openURL(
+					`market://details?id=${GOOGLE_PACKAGE_NAME}`,
+				),
+			});
+		}
+	});
 };

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -120,6 +120,13 @@ const isUsingProdDevtoolsCache = createAsyncCache<boolean>(
 
 const apiUrlCache = createAsyncCache<string>('@Setting_apiUrl');
 
+const numberOfInteractionsCache = createAsyncCache<number>(
+	'@Setting_numberOfInteractions',
+);
+
+const hasShownRatingCache = createAsyncCache<boolean>(
+	'@Setting_hasShownRating',
+);
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -196,4 +203,6 @@ export {
 	isWeatherShownCache,
 	isUsingProdDevtoolsCache,
 	apiUrlCache,
+	numberOfInteractionsCache,
+	hasShownRatingCache,
 };

--- a/projects/Mallard/src/hooks/use-rating.tsx
+++ b/projects/Mallard/src/hooks/use-rating.tsx
@@ -1,0 +1,122 @@
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { captureException } from '@sentry/react-native';
+import { useEffect, useState } from 'react';
+import { rateApp } from 'src/helpers/rate';
+import {
+	hasShownRatingCache,
+	numberOfInteractionsCache,
+} from 'src/helpers/storage';
+import { remoteConfigService } from 'src/services/remote-config';
+
+const getFromStorage = async (
+	storage: any,
+	initialState: any,
+): Promise<any> => {
+	try {
+		const value = await storage.get();
+		return value ?? initialState;
+	} catch {
+		return Promise.resolve(initialState);
+	}
+};
+
+export const INTERACTIONS_THRESHOLD = 50;
+
+export const useRating = () => {
+	const [numberOfInteractions, setNumberOfInteractions] = useState<number>(0);
+	const [hasShownRating, setHasShownRating] = useState<boolean>(true);
+	const { showActionSheetWithOptions } = useActionSheet();
+
+	useEffect(() => {
+		getFromStorage(numberOfInteractionsCache, 0)
+			.then((numberOfInteractions) =>
+				setNumberOfInteractions(numberOfInteractions),
+			)
+			.catch((e) => {
+				captureException(e);
+			});
+	}, []);
+	useEffect(() => {
+		getFromStorage(hasShownRatingCache, 0)
+			.then((hasShownRating) => setHasShownRating(hasShownRating))
+			.catch((e) => {
+				captureException(e);
+			});
+	}, []);
+
+	const setInteractions = (num: number) => {
+		setNumberOfInteractions(num);
+		numberOfInteractionsCache.set(num);
+	};
+
+	const setShowRating = (show: boolean) => {
+		setHasShownRating(show);
+		hasShownRatingCache.set(show);
+	};
+
+	const callbacks = [
+		() => {
+			setHasShownRating(true);
+			hasShownRatingCache.set(true);
+			rateApp();
+		},
+		() => remindMeLater(),
+		() => dontShowAgain(),
+	];
+
+	const rateUserFlow = () => {
+		showActionSheetWithOptions(
+			{
+				options: ['Rate now', 'Remind me later', "Don't ask again"],
+				title: 'We want to know your thoughts',
+				destructiveButtonIndex: 2,
+			},
+			(index) => {
+				index !== undefined && callbacks[index]();
+			},
+		);
+	};
+
+	const interaction = () => {
+		// Remote Feature flag check to see if we can log an interaction
+		const isRatingOn = remoteConfigService.getBoolean('rating');
+
+		if (hasShownRating || !isRatingOn) {
+			return;
+		}
+
+		const bumpInteractions = numberOfInteractions + 1;
+		setInteractions(bumpInteractions);
+
+		if (bumpInteractions > INTERACTIONS_THRESHOLD) {
+			// Clear all in case someone clicks outside of the action sheet so we dont ask every interaction
+			clearAll();
+			rateUserFlow();
+		}
+	};
+
+	// Clears the number of interactions so the process starts again
+	const remindMeLater = () => {
+		setInteractions(0);
+	};
+
+	// Stops the user from adding interactions and therefore seeing the action sheet
+	const dontShowAgain = () => {
+		setShowRating(true);
+	};
+
+	// Used in dev-zone testing only
+	const clearAll = () => {
+		setInteractions(0);
+		setShowRating(false);
+	};
+
+	return {
+		interaction,
+		rateUserFlow,
+		hasShownRating,
+		// The following is exported for dev zone only
+		numberOfInteractions,
+		clearAll,
+	};
+};

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -11,6 +11,7 @@ import {
 	useLargeDeviceMemory,
 } from 'src/hooks/use-config-provider';
 import { useSetNavPosition } from 'src/hooks/use-nav-position';
+import { useRating } from 'src/hooks/use-rating';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator, ArticleSpec } from 'src/screens/article-screen';
 import { sendPageViewEvent } from 'src/services/ophan';
@@ -70,9 +71,16 @@ const ArticleSlider = React.memo(
 		const { width } = useDimensions();
 		const viewPagerRef = useRef<ViewPagerAndroid | null>();
 		const flatListRef = useRef<any | undefined>();
-
+		const { interaction, hasShownRating } = useRating();
 		const { isPreview } = useApiUrl();
 		const hasLargeMemory = useLargeDeviceMemory();
+
+		// Set an interaction on mount of the first article
+		// Have to wait for a change in hasShownRating as its async
+		// Otherwise it doesnt fire.
+		useEffect(() => {
+			!hasShownRating && interaction();
+		}, [hasShownRating]);
 
 		const currentArticle = flattenedArticles[Math.round(current)];
 
@@ -194,6 +202,8 @@ const ArticleSlider = React.memo(
 				setCurrent(newIndex);
 				slideToFrontFor(newIndex);
 				setPosition(newIndex);
+				// Adds an interaction for the rating
+				interaction();
 			}
 		};
 
@@ -273,6 +283,8 @@ const ArticleSlider = React.memo(
 							setCurrent(newIndex);
 							slideToFrontFor(newIndex);
 							setPosition(newIndex);
+							// Adds an interaction for the rating
+							interaction();
 						}}
 					>
 						{flattenedArticles.map((item, index) => (

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -28,6 +28,7 @@ import {
 } from 'src/hooks/use-config-provider';
 import { useEditions } from 'src/hooks/use-edition-provider';
 import { useNetInfo } from 'src/hooks/use-net-info-provider';
+import { INTERACTIONS_THRESHOLD, useRating } from 'src/hooks/use-rating';
 import { useToast } from 'src/hooks/use-toast';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import {
@@ -35,6 +36,7 @@ import {
 	getPushTracking,
 } from 'src/notifications/push-tracking';
 import { FSPaths } from 'src/paths';
+import { remoteConfigService } from 'src/services/remote-config';
 import { WithAppAppearance } from 'src/theme/appearance';
 import { metrics } from 'src/theme/spacing';
 
@@ -68,6 +70,13 @@ const DevZone = () => {
 		isInternetReachable,
 		isPoorConnection,
 	} = useNetInfo();
+	const {
+		interaction,
+		rateUserFlow,
+		numberOfInteractions,
+		hasShownRating,
+		clearAll,
+	} = useRating();
 
 	const [showAllEditions, setShowAllEditions] = useState(false);
 
@@ -91,6 +100,8 @@ const DevZone = () => {
 	const [imageSize, setImageSize] = useState('fetching...');
 	const [pushTokens, setPushTokens] = useState('fetching...');
 	const [downloadedIssues, setDownloadedIssues] = useState('fetching...');
+
+	const isRatingFFOn = remoteConfigService.getBoolean('rating');
 
 	// initialise local showAllEditions property
 	useEffect(() => {
@@ -218,6 +229,8 @@ const DevZone = () => {
 						>
 							In App Purchase
 						</Button>
+						<Button onPress={rateUserFlow}>Rate the app</Button>
+						<Button onPress={clearAll}>Clear Rating Cache</Button>
 					</ButtonList>
 					<List
 						data={[
@@ -262,6 +275,12 @@ const DevZone = () => {
 								key: 'Network Information',
 								title: 'Network Information',
 								explainer: `Type: ${type} \nisPoorConnection: ${isPoorConnection} \nisConnected: ${isConnected} \nisInternetReachable: ${isInternetReachable}`,
+							},
+							{
+								key: 'Rate the app',
+								title: 'Rate the app - Click for interaction',
+								explainer: `No of Interactions: ${numberOfInteractions} \nInteractions threshold: ${INTERACTIONS_THRESHOLD} \nRating native modal shown: ${hasShownRating.toString()} \nRemote feature flag on: ${isRatingFFOn}`,
+								onPress: interaction,
 							},
 							{
 								key: 'Clear CAS caches',

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -16,6 +16,7 @@ const remoteConfigDefaults = {
 	lightbox_enabled: true,
 	generate_share_url: true,
 	download_parallel_ssr_bundle: false,
+	rating: false,
 };
 
 const RemoteConfigProperties = [
@@ -24,6 +25,7 @@ const RemoteConfigProperties = [
 	'lightbox_enabled',
 	'generate_share_url',
 	'download_parallel_ssr_bundle',
+	'rating',
 ] as const;
 
 type RemoteConfigProperty = typeof RemoteConfigProperties[number];

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -814,6 +814,14 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@expo/react-native-action-sheet@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-4.0.1.tgz#fa78e55a87a741f235be2c4ce0b0ea2b6afd06cf"
+  integrity sha512-FwCFpjpB6yzrK8CIWssLlh/i6zQFytFBiJfNdz0mJ2ckU4hWk8SrjB37P0Q4kF7w0bnIdYzPgRbdPR9hnfFqPw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    hoist-non-react-statics "^3.3.0"
+
 "@gorhom/bottom-sheet@^2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-2.4.1.tgz#5de40fe7dddf6b8ba4c14b127e23e22f8239852c"
@@ -1710,6 +1718,14 @@
   version "2.0.41"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
   integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/invariant@^2.2.30", "@types/invariant@^2.2.35":
   version "2.2.35"
@@ -7161,6 +7177,11 @@ react-native-push-notification@^7.0.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-7.4.0.tgz#81192356eddfee8eeaf72a9a696c7c90bf5b0ece"
   integrity sha512-Ac3Ep71e2D8Q/Vy0OHBAO5JwhsFsNSuf9knkpXQWS0B9488nIZJLEMuTpF8610xPvGw7XxVrL/q0oZO5F1pOzw==
+
+react-native-rate@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/react-native-rate/-/react-native-rate-1.2.12.tgz#d4307b2994f9c849b987eb65599ec467db4aee04"
+  integrity sha512-A/z3s7Zth08aXcJnru6S4p71NG8acx2w5LhIfItwTJUbQruNJugk8WrN51dLBCSDv8W33kbS5YoUT4M9jOP5gA==
 
 react-native-reanimated@^2.10.0:
   version "2.12.0"


### PR DESCRIPTION
## Why are you doing this?

Based on a number of interactions (article views in our case) reaching a particular threshold (5), an action sheet will be shown giving three options:

1. Rate the app, which when clicked on shows the native modal. This will only show 3-4 times per user and if it fails, the user should be taken to the App Store/Play store
2. Remind the user later, essentially resetting the number of interactions.
3. Dont remind the user, disabling the functionality.

This is all behind a remote feature flag in Firebase.

Tooling has been added to the dev zone to aid with testing and expectations.

## Changes

- Rating and Action sheet, along with their native dependencies, added to the project. Action Sheet required a top level provider
- Remote Feature Flag added
- `useRating` hook added with additional exports to be used inside the dev zone
- Dev zone has a information / interaction button for testing. Alongside a way to clear the cache and to action the rating Action Sheet no matter what.
- `interaction` added to the Article Slider so each article viewed will register an interaction, assuming the feature flag is on.

## Screenshots

![2023-01-30 21 30 02](https://user-images.githubusercontent.com/935975/215599703-cfc4aafa-1377-4a0b-91e8-e13b27dbb679.gif)

