### PR TITLE
chore: Upgrade React Natve SVG

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -453,8 +453,8 @@ PODS:
   - RNSentry (3.4.3):
     - React-Core
     - Sentry (= 7.11.0)
-  - RNSVG (9.13.6):
-    - React
+  - RNSVG (13.7.0):
+    - React-Core
   - RNZipArchive (5.0.1):
     - React
     - RNZipArchive/Core (= 5.0.1)
@@ -786,7 +786,7 @@ SPEC CHECKSUMS:
   RNReanimated: c3e58924b9418883b0bde9e78c4c957302f02435
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da
-  RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
+  RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
   RNZipArchive: 87111bb6130a38edd68c8d2059d46ac94d53ffe4
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: f93010f3f6c031e2f8fb3081ca4ee6966c539815

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -95,7 +95,7 @@
     "react-native-screens": "^2.18.1",
     "react-native-splash-screen": "^3.2.0",
     "react-native-status-bar-height": "^2.4.0",
-    "react-native-svg": "^9.12.0",
+    "react-native-svg": "^13.7.0",
     "react-native-webview": "^11.23.1",
     "react-native-zip-archive": "5.0.1",
     "validator": "^13.7.0"

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
@@ -36,8 +36,8 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
     }
   >
     <RNSVGSvgView
-      bbHeight={42}
-      bbWidth={42}
+      bbHeight="42"
+      bbWidth="42"
       fill="none"
       focusable={false}
       height={42}
@@ -46,10 +46,6 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
           Object {
             "backgroundColor": "transparent",
             "borderWidth": 0,
-          },
-          undefined,
-          Object {
-            "opacity": 1,
           },
           Object {
             "flex": 0,
@@ -62,92 +58,32 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
     >
       <RNSVGGroup
         fill={null}
-        fillOpacity={1}
-        fillRule={1}
-        font={Object {}}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       >
         <RNSVGRect
           fill={
-            Array [
-              0,
-              4278190080,
-            ]
+            Object {
+              "payload": 4278190080,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
           height="41"
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "stroke",
             ]
           }
-          rotation={0}
           rx="20.5"
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
           stroke={
-            Array [
-              0,
-              4294967295,
-            ]
+            Object {
+              "payload": 4294967295,
+              "type": 0,
+            }
           }
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
           width="41"
           x="0.5"
           y="0.5"
@@ -156,189 +92,65 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
           cx="29"
           cy="14"
           fill={
-            Array [
-              0,
-              4294949576,
-            ]
+            Object {
+              "payload": 4294949576,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "fill",
             ]
           }
           r="7"
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         />
         <RNSVGCircle
           cx="14"
           cy="14"
           fill={
-            Array [
-              0,
-              4294967295,
-            ]
+            Object {
+              "payload": 4294967295,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "fill",
             ]
           }
           r="7"
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         />
         <RNSVGCircle
           cx="29"
           cy="29"
           fill={
-            Array [
-              0,
-              4287683839,
-            ]
+            Object {
+              "payload": 4287683839,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "fill",
             ]
           }
           r="7"
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         />
         <RNSVGCircle
           cx="14"
           cy="29"
           fill={
-            Array [
-              0,
-              4294934287,
-            ]
+            Object {
+              "payload": 4294934287,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "fill",
             ]
           }
           r="7"
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         />
       </RNSVGGroup>
     </RNSVGSvgView>

--- a/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
+++ b/projects/Mallard/src/components/Lightbox/__tests__/__snapshots__/LightboxCaption.spec.tsx.snap
@@ -28,8 +28,8 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
   >
     <RNSVGSvgView
       align="xMidYMid"
-      bbHeight={9}
-      bbWidth={11}
+      bbHeight="9"
+      bbWidth="11"
       fill="none"
       focusable={false}
       height={9}
@@ -47,9 +47,6 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
             "marginTop": 4,
           },
           Object {
-            "opacity": 1,
-          },
-          Object {
             "flex": 0,
             "height": 9,
             "width": 11,
@@ -62,129 +59,34 @@ exports[`LightboxCaption should show a LightboxCaption with a pillar colour 1`] 
     >
       <RNSVGGroup
         fill={null}
-        fillOpacity={1}
-        fillRule={1}
-        font={Object {}}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
         propList={
           Array [
             "fill",
           ]
         }
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       >
         <RNSVGGroup
           fill={
-            Array [
-              0,
-              4278190080,
-            ]
-          }
-          fillOpacity={1}
-          fillRule={1}
-          font={Object {}}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
+            Object {
+              "payload": 4278190080,
+              "type": 0,
+            }
           }
           opacity={1}
-          originX={0}
-          originY={0}
-          propList={Array []}
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         >
           <RNSVGPath
             d="M5.5 0L10.5 9H0.5L5.5 0Z"
             fill={
-              Array [
-                0,
-                4278190335,
-              ]
+              Object {
+                "payload": 4278190335,
+                "type": 0,
+              }
             }
-            fillOpacity={1}
-            fillRule={1}
-            matrix={
-              Array [
-                1,
-                0,
-                0,
-                1,
-                0,
-                0,
-              ]
-            }
-            opacity={1}
-            originX={0}
-            originY={0}
             propList={
               Array [
                 "fill",
               ]
             }
-            rotation={0}
-            scaleX={1}
-            scaleY={1}
-            skewX={0}
-            skewY={0}
-            stroke={null}
-            strokeDasharray={null}
-            strokeDashoffset={null}
-            strokeLinecap={0}
-            strokeLinejoin={0}
-            strokeMiterlimit={4}
-            strokeOpacity={1}
-            strokeWidth={1}
-            vectorEffect={0}
-            x={0}
-            y={0}
           />
         </RNSVGGroup>
       </RNSVGGroup>

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
@@ -374,8 +374,8 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                                 }
                               >
                                 <RNSVGSvgView
-                                  bbHeight={42}
-                                  bbWidth={42}
+                                  bbHeight="42"
+                                  bbWidth="42"
                                   fill="none"
                                   focusable={false}
                                   height={42}
@@ -384,10 +384,6 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                                       Object {
                                         "backgroundColor": "transparent",
                                         "borderWidth": 0,
-                                      },
-                                      undefined,
-                                      Object {
-                                        "opacity": 1,
                                       },
                                       Object {
                                         "flex": 0,
@@ -400,92 +396,32 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                                 >
                                   <RNSVGGroup
                                     fill={null}
-                                    fillOpacity={1}
-                                    fillRule={1}
-                                    font={Object {}}
-                                    matrix={
-                                      Array [
-                                        1,
-                                        0,
-                                        0,
-                                        1,
-                                        0,
-                                        0,
-                                      ]
-                                    }
-                                    opacity={1}
-                                    originX={0}
-                                    originY={0}
                                     propList={
                                       Array [
                                         "fill",
                                       ]
                                     }
-                                    rotation={0}
-                                    scaleX={1}
-                                    scaleY={1}
-                                    skewX={0}
-                                    skewY={0}
-                                    stroke={null}
-                                    strokeDasharray={null}
-                                    strokeDashoffset={null}
-                                    strokeLinecap={0}
-                                    strokeLinejoin={0}
-                                    strokeMiterlimit={4}
-                                    strokeOpacity={1}
-                                    strokeWidth={1}
-                                    vectorEffect={0}
-                                    x={0}
-                                    y={0}
                                   >
                                     <RNSVGRect
                                       fill={
-                                        Array [
-                                          0,
-                                          4278190080,
-                                        ]
+                                        Object {
+                                          "payload": 4278190080,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
                                       height="41"
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "stroke",
                                         ]
                                       }
-                                      rotation={0}
                                       rx="20.5"
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
                                       stroke={
-                                        Array [
-                                          0,
-                                          4294967295,
-                                        ]
+                                        Object {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
                                       }
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
                                       width="41"
                                       x="0.5"
                                       y="0.5"
@@ -494,189 +430,65 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                                       cx="29"
                                       cy="14"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294949576,
-                                        ]
+                                        Object {
+                                          "payload": 4294949576,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="14"
                                       cy="14"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294967295,
-                                        ]
+                                        Object {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="29"
                                       cy="29"
                                       fill={
-                                        Array [
-                                          0,
-                                          4287683839,
-                                        ]
+                                        Object {
+                                          "payload": 4287683839,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="14"
                                       cy="29"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294934287,
-                                        ]
+                                        Object {
+                                          "payload": 4294934287,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                   </RNSVGGroup>
                                 </RNSVGSvgView>
@@ -1283,8 +1095,8 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                                 }
                               >
                                 <RNSVGSvgView
-                                  bbHeight={42}
-                                  bbWidth={42}
+                                  bbHeight="42"
+                                  bbWidth="42"
                                   fill="none"
                                   focusable={false}
                                   height={42}
@@ -1293,10 +1105,6 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                                       Object {
                                         "backgroundColor": "transparent",
                                         "borderWidth": 0,
-                                      },
-                                      undefined,
-                                      Object {
-                                        "opacity": 1,
                                       },
                                       Object {
                                         "flex": 0,
@@ -1309,92 +1117,32 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                                 >
                                   <RNSVGGroup
                                     fill={null}
-                                    fillOpacity={1}
-                                    fillRule={1}
-                                    font={Object {}}
-                                    matrix={
-                                      Array [
-                                        1,
-                                        0,
-                                        0,
-                                        1,
-                                        0,
-                                        0,
-                                      ]
-                                    }
-                                    opacity={1}
-                                    originX={0}
-                                    originY={0}
                                     propList={
                                       Array [
                                         "fill",
                                       ]
                                     }
-                                    rotation={0}
-                                    scaleX={1}
-                                    scaleY={1}
-                                    skewX={0}
-                                    skewY={0}
-                                    stroke={null}
-                                    strokeDasharray={null}
-                                    strokeDashoffset={null}
-                                    strokeLinecap={0}
-                                    strokeLinejoin={0}
-                                    strokeMiterlimit={4}
-                                    strokeOpacity={1}
-                                    strokeWidth={1}
-                                    vectorEffect={0}
-                                    x={0}
-                                    y={0}
                                   >
                                     <RNSVGRect
                                       fill={
-                                        Array [
-                                          0,
-                                          4278190080,
-                                        ]
+                                        Object {
+                                          "payload": 4278190080,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
                                       height="41"
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "stroke",
                                         ]
                                       }
-                                      rotation={0}
                                       rx="20.5"
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
                                       stroke={
-                                        Array [
-                                          0,
-                                          4294967295,
-                                        ]
+                                        Object {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
                                       }
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
                                       width="41"
                                       x="0.5"
                                       y="0.5"
@@ -1403,189 +1151,65 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                                       cx="29"
                                       cy="14"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294949576,
-                                        ]
+                                        Object {
+                                          "payload": 4294949576,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="14"
                                       cy="14"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294967295,
-                                        ]
+                                        Object {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="29"
                                       cy="29"
                                       fill={
-                                        Array [
-                                          0,
-                                          4287683839,
-                                        ]
+                                        Object {
+                                          "payload": 4287683839,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                     <RNSVGCircle
                                       cx="14"
                                       cy="29"
                                       fill={
-                                        Array [
-                                          0,
-                                          4294934287,
-                                        ]
+                                        Object {
+                                          "payload": 4294934287,
+                                          "type": 0,
+                                        }
                                       }
-                                      fillOpacity={1}
-                                      fillRule={1}
-                                      matrix={
-                                        Array [
-                                          1,
-                                          0,
-                                          0,
-                                          1,
-                                          0,
-                                          0,
-                                        ]
-                                      }
-                                      opacity={1}
-                                      originX={0}
-                                      originY={0}
                                       propList={
                                         Array [
                                           "fill",
                                         ]
                                       }
                                       r="7"
-                                      rotation={0}
-                                      scaleX={1}
-                                      scaleY={1}
-                                      skewX={0}
-                                      skewY={0}
-                                      stroke={null}
-                                      strokeDasharray={null}
-                                      strokeDashoffset={null}
-                                      strokeLinecap={0}
-                                      strokeLinejoin={0}
-                                      strokeMiterlimit={4}
-                                      strokeOpacity={1}
-                                      strokeWidth={1}
-                                      vectorEffect={0}
-                                      x={0}
-                                      y={0}
                                     />
                                   </RNSVGGroup>
                                 </RNSVGSvgView>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/AppLogo.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/AppLogo.spec.tsx.snap
@@ -17,10 +17,6 @@ exports[`AppLogo should display a AppLogo icon in SVG 1`] = `
         "backgroundColor": "transparent",
         "borderWidth": 0,
       },
-      undefined,
-      Object {
-        "opacity": 1,
-      },
       Object {
         "flex": 0,
         "height": 40,
@@ -34,323 +30,107 @@ exports[`AppLogo should display a AppLogo icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGRect
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
       height="150"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
       rx="15"
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="150"
-      x={0}
-      y={0}
+      x="0"
+      y="0"
     />
     <RNSVGCircle
       cx="107.5"
       cy="107.5"
       fill={
-        Array [
-          0,
-          4287683839,
-        ]
+        Object {
+          "payload": 4287683839,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="30"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="107.5"
       cy="45"
       fill={
-        Array [
-          0,
-          4294949576,
-        ]
+        Object {
+          "payload": 4294949576,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="30"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="45"
       cy="107.5"
       fill={
-        Array [
-          0,
-          4294934287,
-        ]
+        Object {
+          "payload": 4294934287,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="30"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="45"
       cy="45"
       fill={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="30"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGPath
       d="M46.0615 20.1275H46.0015C38.2015 20.1275 33.6415 30.8075 34.0015 45.1475V45.2675C33.6415 59.4875 38.2015 70.1675 46.0015 70.1675H46.0615V71.3075C34.5415 72.0875 18.8215 63.2675 19.0015 45.2675V45.1475C18.8215 27.0875 34.5415 18.2675 46.0615 19.0475V20.1275ZM50.0215 19.5275C54.8215 20.1875 60.0415 23.2475 62.0215 25.4075V35.2475H61.0015L50.0215 20.6675V19.5275ZM65.6815 47.3675L62.0215 48.9875V65.1875C60.0415 67.1675 55.0015 70.1075 50.0215 71.0075V48.5675L46.4815 47.3075V46.2875H65.6815V47.3675Z"
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/BurgerMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/BurgerMenu.spec.tsx.snap
@@ -17,10 +17,6 @@ exports[`BurgerMenu should display a BurgerMenu icon in SVG 1`] = `
         "backgroundColor": "transparent",
         "borderWidth": 0,
       },
-      undefined,
-      Object {
-        "opacity": 1,
-      },
       Object {
         "flex": 0,
         "height": 40,
@@ -34,225 +30,75 @@ exports[`BurgerMenu should display a BurgerMenu icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGCircle
       cx="41"
       cy="41"
       fill={
-        Array [
-          0,
-          4294960384,
-        ]
+        Object {
+          "payload": 4294960384,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="41"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGRect
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
       height="3.90478"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="48.8096"
       x="17.5714"
       y="25.381"
     />
     <RNSVGRect
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
       height="3.90477"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="48.8096"
       x="17.5714"
       y="39.0476"
     />
     <RNSVGRect
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
       height="3.90476"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="48.8096"
       x="17.5714"
       y="52.7143"

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/Editions.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/Editions.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Editions should display a Editions icon in SVG 1`] = `
 <RNSVGSvgView
-  bbHeight={42}
-  bbWidth={42}
+  bbHeight="42"
+  bbWidth="42"
   fill="none"
   focusable={false}
   height={42}
@@ -12,10 +12,6 @@ exports[`Editions should display a Editions icon in SVG 1`] = `
       Object {
         "backgroundColor": "transparent",
         "borderWidth": 0,
-      },
-      undefined,
-      Object {
-        "opacity": 1,
       },
       Object {
         "flex": 0,
@@ -28,92 +24,32 @@ exports[`Editions should display a Editions icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGRect
       fill={
-        Array [
-          0,
-          4278190080,
-        ]
+        Object {
+          "payload": 4278190080,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
       height="41"
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "stroke",
         ]
       }
-      rotation={0}
       rx="20.5"
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
       stroke={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
       width="41"
       x="0.5"
       y="0.5"
@@ -122,189 +58,65 @@ exports[`Editions should display a Editions icon in SVG 1`] = `
       cx="29"
       cy="14"
       fill={
-        Array [
-          0,
-          4294949576,
-        ]
+        Object {
+          "payload": 4294949576,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="7"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="14"
       cy="14"
       fill={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="7"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="29"
       cy="29"
       fill={
-        Array [
-          0,
-          4287683839,
-        ]
+        Object {
+          "payload": 4287683839,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="7"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="14"
       cy="29"
       fill={
-        Array [
-          0,
-          4294934287,
-        ]
+        Object {
+          "payload": 4294934287,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="7"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -17,10 +17,6 @@ exports[`EditionsMenu should display an EditionsMenu icon in SVG 1`] = `
         "backgroundColor": "transparent",
         "borderWidth": 0,
       },
-      undefined,
-      Object {
-        "opacity": 1,
-      },
       Object {
         "flex": 0,
         "height": 40,
@@ -34,68 +30,21 @@ exports[`EditionsMenu should display an EditionsMenu icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGCircle
       cx="21"
       cy="21"
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
@@ -103,215 +52,76 @@ exports[`EditionsMenu should display an EditionsMenu icon in SVG 1`] = `
         ]
       }
       r="20.5"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
       stroke={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="14.1751"
       cy="13.125"
       fill={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="6.825"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="14.1751"
       cy="27.825"
       fill={
-        Array [
-          0,
-          4294934287,
-        ]
+        Object {
+          "payload": 4294934287,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="6.825"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="28.875"
       cy="13.125"
       fill={
-        Array [
-          0,
-          4294949576,
-        ]
+        Object {
+          "payload": 4294949576,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="6.825"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGCircle
       cx="28.875"
       cy="27.825"
       fill={
-        Array [
-          0,
-          4287683839,
-        ]
+        Object {
+          "payload": 4287683839,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
       r="6.825"
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/Newspaper.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/Newspaper.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Newspaper should display a Newspaper icon in SVG 1`] = `
 <RNSVGSvgView
-  bbHeight={26}
-  bbWidth={18}
+  bbHeight="26"
+  bbWidth="18"
   fill="none"
   focusable={false}
   height={26}
@@ -12,10 +12,6 @@ exports[`Newspaper should display a Newspaper icon in SVG 1`] = `
       Object {
         "backgroundColor": "transparent",
         "borderWidth": 0,
-      },
-      undefined,
-      Object {
-        "opacity": 1,
       },
       Object {
         "flex": 0,
@@ -28,299 +24,76 @@ exports[`Newspaper should display a Newspaper icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGGroup
       fill={
-        Array [
-          0,
-          4280098075,
-        ]
+        Object {
+          "payload": 4280098075,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      font={Object {}}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     >
       <RNSVGPath
         d="M1.402 24.949a.377.377 0 01-.35-.35V2.312C.455 2.453 0 3.013 0 3.679V24.6C0 25.368.63 26 1.402 26h12.58c.665 0 1.19-.456 1.366-1.051H1.402z"
         fill={
-          Array [
-            0,
-            4278190080,
-          ]
+          Object {
+            "payload": 4278190080,
+            "type": 0,
+          }
         }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="M16.259 1.051c.21 0 .35.14.35.35v20.92c0 .21-.14.35-.35.35H3.679c-.21 0-.35-.14-.35-.35V1.4c0-.21.14-.35.35-.35h12.58zm0-1.051H3.679c-.77 0-1.402.63-1.402 1.402V22.32c0 .77.631 1.401 1.402 1.401h12.58c.77 0 1.401-.63 1.401-1.401V1.4C17.66.632 17.03 0 16.26 0z"
         fill={
-          Array [
-            0,
-            4278190080,
-          ]
+          Object {
+            "payload": 4278190080,
+            "type": 0,
+          }
         }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
       <RNSVGPath
         d="M13.036 14.226H5.432a.539.539 0 01-.526-.525c0-.28.246-.526.526-.526h7.604c.28 0 .525.245.525.526 0 .28-.245.525-.525.525zM14.507 11.143h-9.11a.539.539 0 01-.526-.526c0-.28.245-.525.526-.525h9.11c.28 0 .526.245.526.525 0 .316-.21.526-.526.526zM14.507 8.76h-9.11a.539.539 0 01-.526-.525v-4.31c0-.28.245-.526.526-.526h9.11c.28 0 .526.245.526.526v4.31c0 .28-.21.525-.526.525zM14.507 17.275h-9.11a.539.539 0 01-.526-.526c0-.28.245-.525.526-.525h9.11c.28 0 .526.245.526.525s-.21.526-.526.526zM11.599 20.323H5.432a.539.539 0 01-.526-.525c0-.28.246-.526.526-.526h6.202c.28 0 .526.245.526.526-.035.28-.246.525-.561.525z"
         fill={
-          Array [
-            0,
-            4278190080,
-          ]
+          Object {
+            "payload": 4278190080,
+            "type": 0,
+          }
         }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       />
     </RNSVGGroup>
     <RNSVGDefs>
       <RNSVGClipPath
         fill={
-          Array [
-            0,
-            4278190080,
-          ]
-        }
-        fillOpacity={1}
-        fillRule={1}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
+          Object {
+            "payload": 4278190080,
+            "type": 0,
+          }
         }
         name="clip0"
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
       >
         <RNSVGPath
           d="M0 0h17.66v26H0z"
           fill={
-            Array [
-              0,
-              4294967295,
-            ]
+            Object {
+              "payload": 4294967295,
+              "type": 0,
+            }
           }
-          fillOpacity={1}
-          fillRule={1}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
-          }
-          opacity={1}
-          originX={0}
-          originY={0}
           propList={
             Array [
               "fill",
             ]
           }
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         />
       </RNSVGClipPath>
     </RNSVGDefs>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/Quote.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/Quote.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Quote should display a Quote icon in SVG 1`] = `
 <RNSVGSvgView
-  bbHeight={21}
-  bbWidth={37}
+  bbHeight="21"
+  bbWidth="37"
   fill="none"
   focusable={false}
   height={21}
@@ -27,9 +27,6 @@ exports[`Quote should display a Quote icon in SVG 1`] = `
         ],
       },
       Object {
-        "opacity": 1,
-      },
-      Object {
         "flex": 0,
         "height": 21,
         "width": 37,
@@ -40,88 +37,25 @@ exports[`Quote should display a Quote icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGPath
       d="M7.96664 0.75H15.1666C14.3 7.18748 13.5333 13.5 13.2 20.5624H0C1.2 13.6875 3.69999 7.18748 7.96664 0.75ZM24.7332 0.75H31.8332C31.0665 7.18748 30.1999 13.5 29.8665 20.5624H16.6999C18.0666 13.6875 20.4666 7.18748 24.7332 0.75Z"
       fill={
-        Array [
-          0,
-          4279374354,
-        ]
+        Object {
+          "payload": 4279374354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/projects/Mallard/src/components/icons/__tests__/__snapshots__/SettingsCog.spec.tsx.snap
+++ b/projects/Mallard/src/components/icons/__tests__/__snapshots__/SettingsCog.spec.tsx.snap
@@ -3,8 +3,8 @@
 exports[`SettingsCog should display a SettingsCog icon in SVG 1`] = `
 <RNSVGSvgView
   align="xMidYMid"
-  bbHeight={40}
-  bbWidth={40}
+  bbHeight="40"
+  bbWidth="40"
   fill="none"
   focusable={false}
   height={40}
@@ -16,10 +16,6 @@ exports[`SettingsCog should display a SettingsCog icon in SVG 1`] = `
       Object {
         "backgroundColor": "transparent",
         "borderWidth": 0,
-      },
-      undefined,
-      Object {
-        "opacity": 1,
       },
       Object {
         "flex": 0,
@@ -34,139 +30,46 @@ exports[`SettingsCog should display a SettingsCog icon in SVG 1`] = `
 >
   <RNSVGGroup
     fill={null}
-    fillOpacity={1}
-    fillRule={1}
-    font={Object {}}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
     propList={
       Array [
         "fill",
       ]
     }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={null}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth={1}
-    vectorEffect={0}
-    x={0}
-    y={0}
   >
     <RNSVGPath
       d="M0.999998 38.5C0.999997 59.2107 17.7893 76 38.5 76C59.2107 76 76 59.2107 76 38.5C76 17.7893 59.2107 0.999999 38.5 0.999998C17.7893 0.999997 0.999999 17.7893 0.999998 38.5Z"
       fill={
-        Array [
-          0,
-          4278528354,
-        ]
+        Object {
+          "payload": 4278528354,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
           "stroke",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
       stroke={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
     <RNSVGPath
       d="M56.3977 43.0511L60.9489 42.0795C61.0511 40.9034 61.1023 39.7273 61.1023 38.5C61.1023 37.3239 61.0511 36.0966 60.9489 34.9205L56.3977 33.9489C56.0398 32.2614 55.2727 30.625 54.5057 29.142L56.9091 25.2557C55.4261 23.3636 53.7386 21.6761 51.8466 20.1932L47.9602 22.5966C46.375 21.8295 44.8409 21.0625 43.1534 20.7045L42.1818 16.1534C41.0057 16.0511 39.7784 16 38.6023 16C37.4261 16 36.0966 16 35.0227 16.1534L34.0511 20.7045C32.3636 21.0625 30.6761 21.8295 29.2443 22.5966L25.358 20.1932C23.4659 21.625 21.6761 23.4148 20.2955 25.2557L22.8011 29.142C21.9318 30.6761 21.267 32.2614 20.8068 33.9489L16.358 34.9205C16.1534 36.0966 16 37.2216 16 38.5C16 39.6761 16.1534 41.0057 16.358 42.0795L20.8068 43.0511C21.267 44.7386 21.9318 46.4261 22.8011 47.8068L20.2955 51.7443C21.6761 53.6364 23.4659 55.375 25.358 56.8068L29.2443 54.3011C30.6761 55.1705 32.3636 55.8352 34.0511 56.2955L35.0227 60.7443C36.0966 60.9489 37.4261 61.1023 38.6023 61.1023C39.8807 61.1023 41.0057 60.9489 42.1818 60.7443L43.1534 56.3977C44.8409 55.8352 46.375 55.1705 47.9602 54.3011L51.8466 56.8068C53.6875 55.4261 55.4773 53.6364 56.9091 51.7443L54.5057 47.858C55.2727 46.4261 56.0398 44.7386 56.3977 43.0511ZM38.6023 52.9716C30.625 52.9716 24.1307 46.4773 24.1307 38.5C24.1307 30.5227 30.625 24.0284 38.6023 24.0284C46.5795 24.0284 53.0739 30.5227 53.0739 38.5C53.0739 46.4773 46.5795 52.9716 38.6023 52.9716Z"
       fill={
-        Array [
-          0,
-          4294967295,
-        ]
+        Object {
+          "payload": 4294967295,
+          "type": 0,
+        }
       }
-      fillOpacity={1}
-      fillRule={1}
-      matrix={
-        Array [
-          1,
-          0,
-          0,
-          1,
-          0,
-          0,
-        ]
-      }
-      opacity={1}
-      originX={0}
-      originY={0}
       propList={
         Array [
           "fill",
         ]
       }
-      rotation={0}
-      scaleX={1}
-      scaleY={1}
-      skewX={0}
-      skewY={0}
-      stroke={null}
-      strokeDasharray={null}
-      strokeDashoffset={null}
-      strokeLinecap={0}
-      strokeLinejoin={0}
-      strokeMiterlimit={4}
-      strokeOpacity={1}
-      strokeWidth={1}
-      vectorEffect={0}
-      x={0}
-      y={0}
     />
   </RNSVGGroup>
 </RNSVGSvgView>

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -2538,7 +2538,7 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
@@ -3069,15 +3069,16 @@ css-color-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
 
-css-select@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
-  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^3.2.1"
-    domutils "^1.7.0"
-    nth-check "^1.0.2"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
 
 css-to-react-native@^3.0.0:
   version "3.0.0"
@@ -3088,7 +3089,7 @@ css-to-react-native@^3.0.0:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
 
-css-tree@^1.0.0-alpha.37:
+css-tree@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
@@ -3096,10 +3097,10 @@ css-tree@^1.0.0-alpha.37:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^3.2.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
-  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -3313,14 +3314,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
 dom-serializer@^1.0.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
@@ -3330,12 +3323,16 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-domelementtype@1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
-  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -3354,13 +3351,12 @@ domhandler@^4.2.0, domhandler@^4.2.2:
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
-  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
-    dom-serializer "0"
-    domelementtype "1"
+    domelementtype "^2.3.0"
 
 domutils@^2.8.0:
   version "2.8.0"
@@ -3370,6 +3366,15 @@ domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 dooboolab-welcome@^1.1.1:
   version "1.3.2"
@@ -3442,6 +3447,11 @@ entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
+entities@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 envinfo@^7.7.2:
   version "7.8.1"
@@ -6442,12 +6452,12 @@ npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
-    boolbase "~1.0.0"
+    boolbase "^1.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"
@@ -7254,13 +7264,13 @@ react-native-status-bar-height@^2.4.0:
   resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
   integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
 
-react-native-svg@^9.12.0:
-  version "9.13.6"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.13.6.tgz#5365fba2bc460054b90851e71f2a71006a5d373f"
-  integrity sha512-vjjuJhEhQCwWjqsgWyGy6/C/LIBM2REDxB40FU1PMhi8T3zQUwUHnA6M15pJKlQG8vaZyA+QnLyIVhjtujRgig==
+react-native-svg@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-13.7.0.tgz#be2ffb935e996762543dd7376bdc910722f7a43c"
+  integrity sha512-WR5CIURvee5cAfvMhmdoeOjh1SC8KdLq5u5eFsz4pbYzCtIFClGSkLnNgkMSDMVV5LV0qQa4jeIk75ieIBzaDA==
   dependencies:
-    css-select "^2.0.2"
-    css-tree "^1.0.0-alpha.37"
+    css-select "^5.1.0"
+    css-tree "^1.1.3"
 
 react-native-webview@^11.23.1:
   version "11.23.1"


### PR DESCRIPTION
## Why are you doing this?

As recommended by the Snyk report.

This was previously attempted, however, there was an issue with quote marks. I have upgraded this today and the quotes appear to be the same as in Production. Please see screenshots below.

Here was the previous revert: #2145

## Changes

- Upgraded React Native SVG
- Updated Snapshots

## Screenshots


![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-02-01 at 08 54 15](https://user-images.githubusercontent.com/935975/215996665-f5233fd9-1bbc-422c-b0cd-664220ddb12c.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-02-01 at 08 54 09](https://user-images.githubusercontent.com/935975/215996675-8774cfd9-1e7a-4331-b724-561f28edef4f.png)
