### PR TITLE
chore: Article Scroll stop faster

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -219,6 +219,7 @@ const ArticleSlider = React.memo(
 							ref={(flatList: any) =>
 								(flatListRef.current = flatList)
 							}
+							decelerationRate="fast"
 							showsHorizontalScrollIndicator={false}
 							showsVerticalScrollIndicator={false}
 							scrollEventThrottle={1}


### PR DESCRIPTION
## Why are you doing this?

Makes the time to stop scrolling faster on an article after a user complained about "settle time"

## Changes

- Adds a fast deceleration rate.