### PR TITLE
Fix: Download Tick showing when no folders present

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -118,6 +118,9 @@ export const isIssueOnDevice = async (
 		// that this currently provides is a greater benefit than maintenance.
 		const expectedFolders = 'issue_front_thumbs_media_html';
 		const folders = await RNFS.readdir(FSPaths.issueRoot(localIssueId));
+		if (folders.length === 0) {
+			return false;
+		}
 		return folders.every((item) => expectedFolders.includes(item));
 	} catch {
 		return false;


### PR DESCRIPTION
## Why are you doing this?

`every` is returning `true` when no folders exist. Therefore during the error that I experienced yesterday, I was not able to attempt to download again, or default back to the API.

This change fixes it

## Changes

- Adds an empty check
