### PR TITLE
chore: Assume Online

### DIFF
--- a/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-net-info-provider/index.tsx
@@ -10,9 +10,9 @@ import { isDisconnectedState, stateResolver } from './utils';
 
 const defaultState: NetInfoState = {
 	type: NetInfoStateType.unknown,
-	isConnected: false,
+	isConnected: true,
 	isPoorConnection: false,
-	isInternetReachable: false,
+	isInternetReachable: true,
 	downloadBlocked: DownloadBlockedStatus.NotBlocked,
 	isDevButtonShown: false,
 	setIsDevButtonShown: () => {},


### PR DESCRIPTION
## Why are you doing this?

The majority of users on a cold start are online. As a result, we change the default state to match this. This reducers the number of re-renders setting state for something we already know about.

## Changes

- Update net info default state
