### PR TITLE
chore: Issue Id Effects

### DIFF
--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -234,7 +234,8 @@ const Article = ({
 	}, [
 		apiUrl,
 		article.elements,
-		issueId,
+		issueId?.localIssueId,
+		issueId?.publishedIssueId,
 		article.image,
 		article.type,
 		article.key,

--- a/projects/Mallard/src/hooks/use-image-paths.ts
+++ b/projects/Mallard/src/hooks/use-image-paths.ts
@@ -65,13 +65,7 @@ export const useImagePath = (image?: Image, use: ImageUse = 'full-size') => {
 			).then((newPath) => localSetPath(newPath));
 		}
 		return () => void (localSetPath = () => {});
-	}, [
-		apiUrl,
-		image,
-		use,
-		issueId ? issueId.publishedIssueId : undefined, // Why isn't this just issueId?
-		issueId ? issueId.localIssueId : undefined,
-	]);
+	}, [apiUrl, image, use, issueId?.publishedIssueId, issueId?.localIssueId]);
 	if (image === undefined) return undefined;
 	return path;
 };

--- a/projects/Mallard/src/hooks/use-issue-provider/index.tsx
+++ b/projects/Mallard/src/hooks/use-issue-provider/index.tsx
@@ -154,12 +154,12 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 				);
 			}
 		},
-		[apiUrl, issueId],
+		[apiUrl, issueId.localIssueId, issueId.publishedIssueId],
 	);
 
 	useEffect(() => {
 		globalIssueId && setIssueId(globalIssueId);
-	}, [globalIssueId]);
+	}, [globalIssueId?.localIssueId, globalIssueId?.publishedIssueId]);
 
 	// When the API url changes, force a fetch from the API of a new issue
 	useEffect(() => {
@@ -191,7 +191,7 @@ export const IssueProvider = ({ children }: { children: React.ReactNode }) => {
 				})
 				.finally(() => setIsLoading(false));
 		}
-	}, [issueId, isConnected]);
+	}, [issueId.localIssueId, issueId.publishedIssueId, isConnected]);
 
 	// When the app state returns, we fore grab the latest issue from the API
 	// But we dont save it to our local state. This means we have a fresh copy but dont update the user experience

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -132,7 +132,14 @@ const IssueRowContainer = React.memo(
 					});
 				}
 			},
-			[navigation, setIssueId, localId, publishedId, issueId],
+			[
+				navigation,
+				setIssueId,
+				localId,
+				publishedId,
+				issueId?.localIssueId,
+				issueId?.publishedIssueId,
+			],
 		);
 
 		const onPress = useCallback(() => {
@@ -168,7 +175,14 @@ const IssueRowContainer = React.memo(
 				}
 				navToIssue(frontKey);
 			},
-			[setNavPosition, navToIssue, issueId, publishedId, localId],
+			[
+				setNavPosition,
+				navToIssue,
+				issueId?.localIssueId,
+				issueId?.publishedIssueId,
+				publishedId,
+				localId,
+			],
 		);
 
 		return (


### PR DESCRIPTION
## Why are you doing this?

React struggles to understand what has changed with objects in the dependency arrays in `useEffect` and `useCallback`. By defining the properties, we give React more information and it reduces the number of unnecessary re-renders.

## Changes

- Broken down `issueId` into its subsequent parts in dependency arrays.
