### PR TITLE
chore: Assume Large memory

### DIFF
--- a/projects/Mallard/src/hooks/use-config-provider.tsx
+++ b/projects/Mallard/src/hooks/use-config-provider.tsx
@@ -40,7 +40,7 @@ const notificationInitialState = () =>
 	Platform.OS === 'android' ? true : false;
 
 const initialState: ConfigState = {
-	largeDeviceMemeory: false,
+	largeDeviceMemeory: true,
 	dimensions: {
 		width: 0,
 		height: 0,


### PR DESCRIPTION
## Why are you doing this?

As we are not supporting iOS9 devices anymore, and that the original setting was 4 years ago, we can safely assume that the majority of devices accessing the app have over 1GB of memory. As a result i've updated the default state which will mean one less state change for the majority of users.
