### PR TITLE
chore: Remove Logging Cache

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -69,8 +69,6 @@ const pushNotificationRegistrationCache =
 
 const validAttemptCache = createAsyncCache<number>('validAttempt-cache');
 
-const loggingQueueCache = createAsyncCache<string>('loggingQueue');
-
 const selectedEditionCache = createAsyncCache<RegionalEdition | SpecialEdition>(
 	'selectedEdition',
 );
@@ -187,7 +185,6 @@ export {
 	legacyCASPasswordCache,
 	iapReceiptCache,
 	validAttemptCache,
-	loggingQueueCache,
 	selectedEditionCache,
 	defaultEditionCache,
 	editionsListCache,


### PR DESCRIPTION
## Why are you doing this?

Logging was removed a while ago, but the cache remained. This removes it.