### PR TITLE
fix: Already Subscribed Screen Bug

### DIFF
--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -307,6 +307,17 @@ const SettingsStack = () => {
 				component={AlreadySubscribedScreen}
 			/>
 			<Settings.Screen
+				name={RouteNames.AlreadySubscribedOverlay}
+				component={AlreadySubscribedScreen}
+				options={{
+					cardStyleInterpolator: forFade,
+					cardStyle: {
+						backgroundColor: 'rgba(0,0,0,0.8)',
+					},
+				}}
+			/>
+
+			<Settings.Screen
 				name={RouteNames.GdprConsent}
 				component={GdprConsentScreen}
 			/>

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -37,6 +37,7 @@ export type SettingsStackParamList = {
 	WeatherGeolocationConsent: undefined;
 	DevZone: undefined;
 	InAppPurchase: undefined;
+	AlreadySubscribedOverlay: undefined;
 };
 
 export type MainStackParamList = {
@@ -98,4 +99,5 @@ export enum RouteNames {
 	SignInFailedModal = 'SignInFailedModal',
 	MissingIAPRestoreError = 'MissingIAPRestoreError',
 	MissingIAPRestoreMissing = 'MissingIAPRestoreMissing',
+	AlreadySubscribedOverlay = 'AlreadySubscribedOverlay',
 }

--- a/projects/Mallard/src/screens/identity-login-screen.tsx
+++ b/projects/Mallard/src/screens/identity-login-screen.tsx
@@ -118,7 +118,7 @@ const AuthSwitcherScreen = () => {
 			isLoading={isLoading}
 			onDismiss={() => navigation.popToTop()}
 			onHelpPress={() =>
-				navigation.navigate(RouteNames.AlreadySubscribed)
+				navigation.navigate(RouteNames.AlreadySubscribedOverlay)
 			}
 			onGooglePress={() =>
 				handleAuthClick(


### PR DESCRIPTION
## Why are you doing this?

Spotted a visual bug on the login screen which required fixing.

## Changes

- Added a new route so we could apply a different card style. Ideally I would have liked to have done this conditionally, but my experimentation with `setOptions` wasnt working as expected.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/935975/228165799-5cb461b0-89de-46f9-9592-30dbbc9c1995.gif" width="300px" /> | <img src="https://user-images.githubusercontent.com/935975/228165927-4381086b-d044-46aa-bac2-890ace27d1f0.gif" width="300px" /> |
