### PR TITLE
chore: Update Xcode Version

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :beta do
 
-    xcode_select("/Applications/Xcode_14.0.1.app")
+    xcode_select("/Applications/Xcode_14.2.app")
 
     encoded_api_key = ENV["APPSTORE_CONNECT_API_KEY"]
 


### PR DESCRIPTION
## Why are you doing this?

In our last App Submission, we were told:
`ITMS-90725: SDK Version Issue - This app was built with the iOS 16.0 SDK. Starting April 2023, all iOS apps submitted to the App Store must be built with the iOS 16.1 SDK or later, included in Xcode 14.1 or later.`

## Changes

- Updates Xcode in Fastlane based on the info here: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
