### PR TITLE
Correct schedule filter logic

### DIFF
--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -292,7 +292,7 @@ const parseArticleResult = async (
 
 const isScheduledInNext30Days = (dateiso8601: string): boolean => {
     const date = new Date(dateiso8601)
-    const oneMonthAway = new Date(new Date().setDate(date.getDate() + 30))
+    const oneMonthAway = new Date(new Date().setDate(new Date().getDate() + 30))
     return date < oneMonthAway
 }
 


### PR DESCRIPTION
## Why are you doing this?

Correct the logic that filters scheduled content. We don't think we should be relying on the existing schedule date to determine what value '30 days in the future' should be.

## Changes

Just the one, as above.

## Screenshots

N/A
