### PR TITLE
fix: Issue change when going to the background

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -100,51 +100,59 @@ export const IssueSummaryProvider = ({
 
 	// Use Callback used so the function isnt recreated on each rerender
 	// @TODO: Look to move this logic outside of the provider so it can be tested
-	const getLatestIssueSummary = useCallback(() => {
-		return getIssueSummary(isConnected, isPoorConnection)
-			.then((retrievedIssueSummary) => {
-				setIssueSummary(retrievedIssueSummary);
-				// Clear the initial front key if it is a new issue id and set it
-				const latestIssueId = issueSummaryToLatestPath(
-					retrievedIssueSummary,
-				);
+	const getLatestIssueSummary = useCallback(
+		(skipSetting?: boolean) => {
+			return getIssueSummary(isConnected, isPoorConnection)
+				.then((retrievedIssueSummary) => {
+					setIssueSummary(retrievedIssueSummary);
+					if (skipSetting) {
+						return;
+					}
 
-				const previousIssue =
-					issueSummary && issueSummaryToLatestPath(issueSummary);
-				if (
-					issueId === null ||
-					!previousIssue ||
-					(previousIssue.localIssueId !==
-						latestIssueId.localIssueId &&
-						previousIssue.publishedIssueId !==
-							latestIssueId.publishedIssueId)
-				) {
-					setInitialFrontKey(null);
-					setLocalIssueId(latestIssueId);
-				}
-				setError('');
-			})
-			.catch((e) => {
-				setError(e.message);
-				// In the case of error, attempt to get the last stored issue summary
-				getIssueSummary(false)
-					.then((backupIssueSummary) => {
-						setIssueSummary(backupIssueSummary);
-						const backupIssueIds =
-							issueSummaryToLatestPath(backupIssueSummary);
-						setIssueId(backupIssueIds);
-					})
-					.catch((e) => {
-						e.message = `Unable to get backup issue summary: ${e.message}`;
-						errorService.captureException(e);
-					});
-			});
-	}, [
-		isConnected,
-		isPoorConnection,
-		selectedEdition.edition,
-		maxAvailableEditions,
-	]);
+					// Clear the initial front key if it is a new issue id and set it
+					const latestIssueId = issueSummaryToLatestPath(
+						retrievedIssueSummary,
+					);
+
+					const previousIssue =
+						issueSummary && issueSummaryToLatestPath(issueSummary);
+
+					if (
+						issueId === null ||
+						!previousIssue ||
+						(previousIssue.localIssueId !==
+							latestIssueId.localIssueId &&
+							previousIssue.publishedIssueId !==
+								latestIssueId.publishedIssueId)
+					) {
+						setInitialFrontKey(null);
+						setLocalIssueId(latestIssueId);
+					}
+					setError('');
+				})
+				.catch((e) => {
+					setError(e.message);
+					// In the case of error, attempt to get the last stored issue summary
+					getIssueSummary(false)
+						.then((backupIssueSummary) => {
+							setIssueSummary(backupIssueSummary);
+							const backupIssueIds =
+								issueSummaryToLatestPath(backupIssueSummary);
+							setIssueId(backupIssueIds);
+						})
+						.catch((e) => {
+							e.message = `Unable to get backup issue summary: ${e.message}`;
+							errorService.captureException(e);
+						});
+				});
+		},
+		[
+			isConnected,
+			isPoorConnection,
+			selectedEdition.edition,
+			maxAvailableEditions,
+		],
+	);
 
 	// On load, get the latest issue summary
 	useEffect(() => {
@@ -155,7 +163,7 @@ export const IssueSummaryProvider = ({
 	useEffect(() => {
 		if (isActive && !isLoading) {
 			setIsLoading(true);
-			getLatestIssueSummary().finally(() => setIsLoading(false));
+			getLatestIssueSummary(true).finally(() => setIsLoading(false));
 		}
 	}, [isConnected, isPoorConnection, maxAvailableEditions, isActive]);
 


### PR DESCRIPTION
## Why are you doing this?

"When reading an edition from the past (let’s say yesterday’s edition) and you follow a link outside the app , when you return to the edition you were in then you get ‘page not found’.
Retry does nothing and when you try to get back to page view using the down arrow at the top of the screen it throws you back to today’s edition. You then have to navigate your way back to where you were."

## Changes

- Coming from the background gets the latest issue summary but also sets the latest issue id and front key. This causes the refresh and the break to the users reading flow. This change allows the user to get the latest issue in that (and other edge case scenarios) without setting the issue. This makes it available from the menu without interrupting the user.

