### PR TITLE
feat: Ophan Abstraction

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -3,9 +3,9 @@ import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import SplashScreen from 'react-native-splash-screen';
+import { logUserId } from 'src/helpers/analytics';
 import { ConfigProvider } from 'src/hooks/use-config-provider';
 import { NavPositionProvider } from 'src/hooks/use-nav-position';
-import { setUserId } from 'src/services/ophan';
 import { AppNavigation } from './AppNavigation';
 import { AccessProvider } from './authentication/AccessContext';
 import type { IdentityAuthData } from './authentication/authorizers/IdentityAuthorizer';
@@ -57,7 +57,7 @@ const WithProviders = nestProviders(
 );
 
 const handleIdStatus = (attempt: AnyAttempt<IdentityAuthData>) =>
-	setUserId(isValid(attempt) ? attempt.data.userDetails.id : null);
+	logUserId(isValid(attempt) ? attempt.data.userDetails.id : null);
 
 const App = () => {
 	useEffect(() => {

--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -21,6 +21,7 @@ import {
 	maybeListenToExistingDownload,
 	stopListeningToExistingDownload,
 } from 'src/download-edition/download-and-unzip';
+import { logEvent } from 'src/helpers/analytics';
 import type { DLStatus } from 'src/helpers/files';
 import { renderIssueDate } from 'src/helpers/issues';
 import type { Loaded } from 'src/helpers/Loaded';
@@ -38,7 +39,6 @@ import {
 	useNetInfo,
 } from 'src/hooks/use-net-info-provider';
 import { useToast } from 'src/hooks/use-toast';
-import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan';
 import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 import { getFont } from 'src/theme/typography';
@@ -160,9 +160,7 @@ const IssueButton = ({
 		}
 		if (isConnected) {
 			if (!dlStatus) {
-				sendComponentEvent({
-					componentType: ComponentType.AppButton,
-					action: Action.Click,
+				logEvent({
 					value: 'issues_list_issue_clicked',
 				});
 				const imageSize = await imageForScreenSize();

--- a/projects/Mallard/src/components/sign-in-modal-card.tsx
+++ b/projects/Mallard/src/components/sign-in-modal-card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
+import { logEvent } from 'src/helpers/analytics';
 import { Copy } from 'src/helpers/words';
-import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan';
 import { ModalButton } from './Button/ModalButton';
 import { CardAppearance, OnboardingCard } from './onboarding/onboarding-card';
 
@@ -39,9 +39,7 @@ const SignInModalCard = ({
 							onPress={() => {
 								close();
 								onLoginPress();
-								sendComponentEvent({
-									componentType: ComponentType.AppButton,
-									action: Action.Click,
+								logEvent({
 									value: 'sign_in_continue_clicked',
 								});
 							}}

--- a/projects/Mallard/src/helpers/analytics/__tests__/index.spec.ts
+++ b/projects/Mallard/src/helpers/analytics/__tests__/index.spec.ts
@@ -1,0 +1,32 @@
+import * as ophan from 'src/services/ophan';
+import { logEvent, logPageView, logUserId } from '..';
+
+describe('analytics', () => {
+	describe('logEvent', () => {
+		it('should call "sendComponentEvent" from ophan service', () => {
+			const mockComponentEvent = jest
+				.spyOn(ophan, 'sendComponentEvent')
+				.mockResolvedValue(true);
+			logEvent({ value: 'testing' });
+			expect(mockComponentEvent).toHaveBeenCalled();
+		});
+	});
+	describe('logPageView', () => {
+		it('should call "sendPageViewEvent" from ophan service', () => {
+			const mockPageViewEvent = jest
+				.spyOn(ophan, 'sendPageViewEvent')
+				.mockResolvedValue(true);
+			logPageView('test/path/to/article');
+			expect(mockPageViewEvent).toHaveBeenCalled();
+		});
+	});
+	describe('logUserId', () => {
+		it('should call "setUserId" from ophan service', () => {
+			const mockSetUserId = jest
+				.spyOn(ophan, 'setUserId')
+				.mockResolvedValue('12345');
+			logUserId('12345');
+			expect(mockSetUserId).toHaveBeenCalled();
+		});
+	});
+});

--- a/projects/Mallard/src/helpers/analytics/index.ts
+++ b/projects/Mallard/src/helpers/analytics/index.ts
@@ -1,0 +1,52 @@
+import {
+	Action,
+	ComponentType,
+	sendComponentEvent,
+	sendPageViewEvent,
+	setUserId,
+} from 'src/services/ophan';
+import type { AnalyticsEvent, AnalyticsUserId } from './types';
+
+// Currently not used in Ophan as this refers to user behaviour rather than journalism
+// const logScreenView = () => {
+// 	try {
+
+// 	} catch {
+
+// 	}
+// };
+
+const logEvent = async ({ name, value }: AnalyticsEvent): Promise<boolean> => {
+	try {
+		await sendComponentEvent({
+			componentType: ComponentType.AppButton,
+			action: Action.Click,
+			value,
+			componentId: name,
+		});
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+// This differs from a screen view as this is a "screen" that has significance to journalism e.g. Article screen view
+const logPageView = async (path: string): Promise<boolean> => {
+	try {
+		await sendPageViewEvent({ path });
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const logUserId = async (userId: AnalyticsUserId): Promise<boolean> => {
+	try {
+		await setUserId(userId);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export { logEvent, logPageView, logUserId };

--- a/projects/Mallard/src/helpers/analytics/types.ts
+++ b/projects/Mallard/src/helpers/analytics/types.ts
@@ -1,0 +1,23 @@
+type AnalyticsUserId = string | null;
+
+type AnalyticsEvent = {
+	name?: string;
+	value: string;
+};
+
+enum AnalyticsScreenTracking {
+	AlreadySubscribed = 'im_already_subscribed',
+	CasSignIn = 'activate_with_subscriber_id',
+	Credits = 'credits',
+	Help = 'help',
+	FAQ = 'faqs',
+	GDPRConsent = 'consent_management_options',
+	GdprConsentScreenForOnboarding = 'consent_management',
+	IssueList = 'issue_list',
+	PrivacyPolicy = 'privacy_policy',
+	Settings = 'settings',
+	SignIn = 'sign_in',
+	TermsAndConditions = 'terms_conditions',
+}
+
+export { AnalyticsUserId, AnalyticsEvent, AnalyticsScreenTracking };

--- a/projects/Mallard/src/navigation/helpers/base.tsx
+++ b/projects/Mallard/src/navigation/helpers/base.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement } from 'react';
+import { logEvent } from 'src/helpers/analytics';
 import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToArticle, PathToIssue } from 'src/paths';
 import type { ArticleNavigator } from 'src/screens/article-screen';
-import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan';
 import type {
 	ArticlePillar,
 	CreditedImage,
@@ -74,9 +74,7 @@ const navigateToIssue = ({
 	if (navigationProps.path) {
 		setIssueId(navigationProps.path, navigationProps.initialFrontKey);
 	}
-	sendComponentEvent({
-		componentType: ComponentType.AppButton,
-		action: Action.Click,
+	logEvent({
 		value: 'issues_list_issue_clicked',
 	});
 };

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Animated, FlatList, Platform, StyleSheet, View } from 'react-native';
 import ViewPagerAndroid from 'react-native-pager-view';
 import { PreviewControls } from 'src/components/article/preview-controls';
+import { logPageView } from 'src/helpers/analytics';
 import { clamp } from 'src/helpers/math';
 import { getColor } from 'src/helpers/transform';
 import { getAppearancePillar } from 'src/hooks/use-article';
@@ -14,7 +15,6 @@ import { useSetNavPosition } from 'src/hooks/use-nav-position';
 import { useRating } from 'src/hooks/use-rating';
 import type { PathToArticle } from 'src/paths';
 import type { ArticleNavigator, ArticleSpec } from 'src/screens/article-screen';
-import { sendPageViewEvent } from 'src/services/ophan';
 import { getArticleDataFromNavigator } from '../../article-screen';
 import type { OnIsAtTopChange } from '../body';
 import { ArticleScreenBody } from '../body';
@@ -224,9 +224,7 @@ const ArticleSlider = React.memo(
 							showsVerticalScrollIndicator={false}
 							scrollEventThrottle={1}
 							onMomentumScrollEnd={() => {
-								sendPageViewEvent({
-									path: flattenedArticles[current].article,
-								});
+								logPageView(flattenedArticles[current].article);
 							}}
 							onScroll={Animated.event(
 								[
@@ -276,9 +274,9 @@ const ArticleSlider = React.memo(
 							// onPageSelected get called twice for the first time, to avoid duplicate tracking
 							// we are manually checking the last tracked index
 							if (lastTrackedIndex != newIndex) {
-								sendPageViewEvent({
-									path: flattenedArticles[newIndex].article,
-								});
+								logPageView(
+									flattenedArticles[newIndex].article,
+								);
 								setLastTrackedIndex(newIndex);
 							}
 							setCurrent(newIndex);

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -22,6 +22,7 @@ import {
 	WeatherWidget,
 } from 'src/components/weather';
 import { deleteIssueFiles } from 'src/download-edition/clear-issues-and-editions';
+import { logPageView } from 'src/helpers/analytics';
 import type { FlatCard } from 'src/helpers/transform';
 import {
 	flattenCollectionsToCards,
@@ -49,7 +50,6 @@ import { useIssueSummary } from 'src/hooks/use-issue-summary-provider';
 import { useNavPositionChange } from 'src/hooks/use-nav-position';
 import { useWeather } from 'src/hooks/use-weather-provider';
 import { SLIDER_FRONT_HEIGHT } from 'src/screens/article/slider/SliderTitle';
-import { sendPageViewEvent } from 'src/services/ophan';
 import { Breakpoints } from 'src/theme/breakpoints';
 import { metrics } from 'src/theme/spacing';
 import type {
@@ -355,10 +355,7 @@ const IssueScreenWithPath = ({
 	const { initialFrontKey } = useIssueSummary();
 
 	useEffect(() => {
-		issue &&
-			sendPageViewEvent({
-				path: `editions/${issue.key}`,
-			});
+		issue && logPageView(`editions/${issue.key}`);
 	}, [issue?.key]);
 
 	return (

--- a/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/manage-editions-screen.tsx
@@ -10,13 +10,13 @@ import { HeaderScreenContainer } from 'src/components/Header/Header';
 import { List } from 'src/components/lists/list';
 import { UiBodyCopy } from 'src/components/styled-text';
 import { deleteIssueFiles } from 'src/download-edition/clear-issues-and-editions';
+import { logEvent } from 'src/helpers/analytics';
 import { Copy, MANAGE_EDITIONS_TITLE } from 'src/helpers/words';
 import {
 	useMaxAvailableEditions,
 	useWifiOnlyDownloads,
 } from 'src/hooks/use-config-provider';
 import { getIssueSummary } from 'src/hooks/use-issue-summary-provider';
-import { Action, ComponentType, sendComponentEvent } from 'src/services/ophan';
 import { WithAppAppearance } from 'src/theme/appearance';
 
 const buttonStyles = StyleSheet.create({
@@ -117,12 +117,8 @@ const ManageEditionsScreen = () => {
 									value={wifiOnlyDownloads}
 									onValueChange={(val) => {
 										setWifiOnlyDownloads(val);
-										sendComponentEvent({
-											componentType:
-												ComponentType.AppButton,
-											action: Action.Click,
-											componentId:
-												'manageEditionsWifiDownload',
+										logEvent({
+											name: 'manageEditionsWifiDownload',
 											value: val.toString(),
 										});
 									}}
@@ -141,12 +137,8 @@ const ManageEditionsScreen = () => {
 									onPress={async (n) => {
 										await setMaxAvailableEditions(n);
 										getIssueSummary(false);
-										sendComponentEvent({
-											componentType:
-												ComponentType.AppButton,
-											action: Action.Click,
-											componentId:
-												'manageEditionsAvailableEditions',
+										logEvent({
+											name: 'manageEditionsAvailableEditions',
 											value: n.toString(),
 										});
 									}}
@@ -178,11 +170,9 @@ const ManageEditionsScreen = () => {
 									],
 									{ cancelable: false },
 								);
-								sendComponentEvent({
-									componentType: ComponentType.AppButton,
-									action: Action.Click,
+								logEvent({
 									value: 'deleteAllDownload',
-									componentId: 'manageEditions',
+									name: 'manageEditions',
 								});
 							},
 						},

--- a/projects/Mallard/src/services/__tests__/ophan.spec.ts
+++ b/projects/Mallard/src/services/__tests__/ophan.spec.ts
@@ -1,8 +1,8 @@
 import { NativeModules } from 'react-native';
+import { AnalyticsScreenTracking } from 'src/helpers/analytics/types';
 import {
 	Action,
 	ComponentType,
-	ScreenTracking,
 	sendAppScreenEvent,
 	sendComponentEvent,
 	sendPageViewEvent,
@@ -31,7 +31,9 @@ describe('services/ophan', () => {
 
 	describe('sendAppScreenEvent', () => {
 		it('should use the correct native module function at a basic level', () => {
-			sendAppScreenEvent({ screenName: ScreenTracking.IssueList });
+			sendAppScreenEvent({
+				screenName: AnalyticsScreenTracking.IssueList,
+			});
 			expect(NativeModules.Ophan.sendAppScreenEvent).toHaveBeenCalled();
 			expect(NativeModules.Ophan.sendAppScreenEvent).toHaveBeenCalledWith(
 				'issue_list',
@@ -41,7 +43,7 @@ describe('services/ophan', () => {
 
 		it('should use the correct native module function with optional values', () => {
 			sendAppScreenEvent({
-				screenName: ScreenTracking.IssueList,
+				screenName: AnalyticsScreenTracking.IssueList,
 				value: '2019-08-30',
 			});
 			expect(NativeModules.Ophan.sendAppScreenEvent).toHaveBeenCalled();

--- a/projects/Mallard/src/services/ophan.ts
+++ b/projects/Mallard/src/services/ophan.ts
@@ -1,6 +1,10 @@
 // Based on: https://github.com/guardian/ophan/blob/master/event-model/src/main/thrift/componentevent.thrift
 
 import { NativeModules } from 'react-native';
+import type {
+	AnalyticsScreenTracking,
+	AnalyticsUserId,
+} from 'src/helpers/analytics/types';
 
 enum ComponentType {
 	AppButton = 'APP_BUTTON',
@@ -13,7 +17,7 @@ enum Action {
 }
 
 interface TrackScreen {
-	screenName: ScreenTracking;
+	screenName: AnalyticsScreenTracking;
 	value?: string;
 }
 
@@ -24,47 +28,53 @@ interface TrackComponentEvent {
 	componentId?: string;
 }
 
-type UserId = string | null;
-
-enum ScreenTracking {
-	AlreadySubscribed = 'im_already_subscribed',
-	CasSignIn = 'activate_with_subscriber_id',
-	Credits = 'credits',
-	Help = 'help',
-	FAQ = 'faqs',
-	GDPRConsent = 'consent_management_options',
-	GdprConsentScreenForOnboarding = 'consent_management',
-	IssueList = 'issue_list',
-	PrivacyPolicy = 'privacy_policy',
-	Settings = 'settings',
-	SignIn = 'sign_in',
-	TermsAndConditions = 'terms_conditions',
-}
-
-const setUserId = (userId: UserId): Promise<UserId> =>
-	NativeModules.Ophan.setUserId(userId);
+const setUserId = async (userId: AnalyticsUserId): Promise<AnalyticsUserId> => {
+	try {
+		return await NativeModules.Ophan.setUserId(userId);
+	} catch {
+		return null;
+	}
+};
 
 const sendAppScreenEvent = async ({
 	screenName,
 	value,
-}: TrackScreen): Promise<boolean> =>
-	NativeModules.Ophan.sendAppScreenEvent(screenName, value);
+}: TrackScreen): Promise<boolean> => {
+	try {
+		await NativeModules.Ophan.sendAppScreenEvent(screenName, value);
+		return true;
+	} catch {
+		return false;
+	}
+};
 
-const sendComponentEvent = ({
+const sendComponentEvent = async ({
 	componentType,
 	action,
 	value,
 	componentId,
-}: TrackComponentEvent) =>
-	NativeModules.Ophan.sendComponentEvent(
-		componentType,
-		action,
-		value,
-		componentId,
-	);
+}: TrackComponentEvent): Promise<boolean> => {
+	try {
+		await NativeModules.Ophan.sendComponentEvent(
+			componentType,
+			action,
+			value,
+			componentId,
+		);
+		return true;
+	} catch {
+		return false;
+	}
+};
 
-const sendPageViewEvent = ({ path }: { path: string }) =>
-	NativeModules.Ophan.sendPageViewEvent(path);
+const sendPageViewEvent = async ({ path }: { path: string }) => {
+	try {
+		await NativeModules.Ophan.sendPageViewEvent(path);
+		return true;
+	} catch {
+		return false;
+	}
+};
 
 export {
 	Action,
@@ -73,5 +83,4 @@ export {
 	sendComponentEvent,
 	sendPageViewEvent,
 	setUserId,
-	ScreenTracking,
 };


### PR DESCRIPTION
## Why are you doing this?

As we are bringing in Firebase Analytics, it seems prudent to abstract Ophan under Analytics so we can use the same methods for both.

This aims to define and test an API that will be compatible for both and apply it throughout the code where it has been previously.

## Changes

- New Analytics abstraction and test suite
- Convert Ophan to promise based architecture to actually match what is happening in the module.
- Apply abstraction throughout the code base
