### PR TITLE
fix: First article press navigates correctly

### DIFF
--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -67,8 +67,6 @@ const ArticleSlider = React.memo(
 		const [lastTrackedIndex, setLastTrackedIndex] = useState(-1);
 		const [position, setPosition] = useState<number>(startingPoint);
 		const [sliderPosition] = useState(new Animated.Value(0));
-		const [trackStartingPosition, setTrackStartingPosition] =
-			useState<number>(startingPoint);
 
 		const { width } = useDimensions();
 		const viewPagerRef = useRef<ViewPagerAndroid | null>();
@@ -208,11 +206,6 @@ const ArticleSlider = React.memo(
 				interaction();
 			}
 		};
-
-		// useEffect(() => {
-		// 	console.log('STARTING POINT: ', startingPoint);
-		// 	console.log('CURRENT: ', current);
-		// }, [startingPoint, current]);
 
 		return (
 			<>

--- a/projects/Mallard/src/screens/article/slider/index.tsx
+++ b/projects/Mallard/src/screens/article/slider/index.tsx
@@ -67,6 +67,8 @@ const ArticleSlider = React.memo(
 		const [lastTrackedIndex, setLastTrackedIndex] = useState(-1);
 		const [position, setPosition] = useState<number>(startingPoint);
 		const [sliderPosition] = useState(new Animated.Value(0));
+		const [trackStartingPosition, setTrackStartingPosition] =
+			useState<number>(startingPoint);
 
 		const { width } = useDimensions();
 		const viewPagerRef = useRef<ViewPagerAndroid | null>();
@@ -207,6 +209,11 @@ const ArticleSlider = React.memo(
 			}
 		};
 
+		// useEffect(() => {
+		// 	console.log('STARTING POINT: ', startingPoint);
+		// 	console.log('CURRENT: ', current);
+		// }, [startingPoint, current]);
+
 		return (
 			<>
 				{Platform.OS === 'ios' && hasLargeMemory ? (
@@ -269,6 +276,15 @@ const ArticleSlider = React.memo(
 						}}
 						scrollSensitivity={5}
 						onPageSelected={(ev: any) => {
+							// ev.position.newIndex gives 0 even if its not. This is intermittent.
+							// This is explained here: https://github.com/callstack/react-native-pager-view/issues/650
+							// This forces the very first article chosen to be set in the slider for Android only
+							if (lastTrackedIndex === -1) {
+								viewPagerRef?.current?.setPageWithoutAnimation(
+									startingPoint,
+								);
+							}
+
 							onShouldShowHeaderChange(true);
 							const newIndex = ev.nativeEvent.position;
 							// onPageSelected get called twice for the first time, to avoid duplicate tracking


### PR DESCRIPTION
## Why are you doing this?

On Android, when selecting an article, it occasionally goes to the top article. This is doe to a bug in the Android View Pager package we use.

However, there is currently no fix for it. Due to the use of a Webview inside the slider, we cannot use Flatlist due to inconsistent scrolling. There is also no other alternative.

As a result the following fix has been made.

## Changes

- Checks to see if its the first article chosen and forces the article chosen to be navigated to.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/guardian/editions/assets/935975/145bc188-591f-4b1b-9af9-0ea19319ff2e" width="300px" /> | <img src="https://github.com/guardian/editions/assets/935975/32fd7a22-34fc-44cf-ba8a-c3db355a2302" width="300px" /> |
