### PR TITLE
chore: Remove Android debug Webview

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainApplication.java
@@ -18,7 +18,6 @@ import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.guardian.editions.newarchitecture.MainApplicationReactNativeHost;
 import java.lang.reflect.InvocationTargetException;
-import android.webkit.WebView;
 
 import java.util.Arrays;
 import java.util.List;
@@ -81,7 +80,6 @@ public class MainApplication extends Application implements ReactApplication {
         ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
         SoLoader.init(this, /* native exopackage */ false);
         initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-        WebView.setWebContentsDebuggingEnabled(true);
     }
 
   /**


### PR DESCRIPTION
## Why are you doing this?

Removes the debugger we added the other day as I feel that Crosswords should be fixed and having the debug on by default feels like an "open window"