### PR TITLE
Create external shell script for building the Android APK using TeamCity

### DIFF
--- a/build_apk.sh
+++ b/build_apk.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# CI script for building and deploying Editions android APK
+# to either BETA (beta-android) or RELEASE (release-android)
+
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: build_apk.sh [BETA|RELEASE]"
+  exit 1
+fi
+
+case $1 in
+         "BETA")
+             TARGET="beta-android"
+             ;;
+         "RELEASE")
+             TARGET="release-android"
+             ;;
+         *)
+             echo "Invalid option '$1' must be either 'BETA' or 'RELEASE'"
+             exit 1
+             ;;
+     esac
+
+npm cache clean -f
+npm install -g n
+n 16.16
+PATH="$PATH"
+echo "NEW NODE VERSION"
+node --version
+
+npm install -g yarn npx --force
+cd projects/Mallard
+yarn prestorybook
+echo "building APK with command 'make $TARGET'"
+make "$TARGET"
+
+exit 0

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -30,7 +30,6 @@ node --version
 
 npm install -g yarn npx --force
 cd projects/Mallard
-yarn prestorybook
 echo "building APK with command 'make $TARGET'"
 make "$TARGET"
 

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -2,6 +2,8 @@
 # CI script for building and deploying Editions android APK
 # to either BETA (beta-android) or RELEASE (release-android)
 
+set -e
+
 if [ "$#" -ne 1 ]
 then
   echo "Usage: build_apk.sh [BETA|RELEASE]"
@@ -32,5 +34,3 @@ npm install -g yarn npx --force
 cd projects/Mallard
 echo "building APK with command 'make $TARGET'"
 make "$TARGET"
-
-exit 0


### PR DESCRIPTION
## Why are you doing this?

With the new WAF rules, we are unable to update the Editions Android TeamCity build pipeline. When attempting to update the Build APK step, the size of the POST request is too large. Therefore, as advised by DevX, this configuration step should be migrated to an external bash script and then called from TeamCity. This PR introduces a new build_apk.sh script which allows us to deploy the APK to either BETA or RELEASE channels dependent on the supplied argument

Original android-beta-deploy Build Step:

```
#!/usr/bin/env bash
npm cache clean -f
npm install -g n
n 16.16
PATH="$PATH"
echo "NEW NODE VERSION"
node --version

npm install -g yarn npx --force
cd projects/Mallard
make beta-android
```

The original android-release-deploy Build Step:

```
#!/usr/bin/env bash
npm cache clean -f
npm install -g n
n 16.16
PATH="$PATH"
echo "NEW NODE VERSION"
node --version

npm install -g yarn npx --force
cd projects/Mallard
make release-android
```
