### PR TITLE
chore: Further Logging Cleanup

### DIFF
--- a/projects/Mallard/src/helpers/settings/defaults.ts
+++ b/projects/Mallard/src/helpers/settings/defaults.ts
@@ -11,7 +11,6 @@ interface Settings {
 	websiteUrl: string;
 	issuesPath: string;
 	senderId: string;
-	logging: string;
 }
 
 /*
@@ -123,9 +122,6 @@ export const defaultSettings: Settings = {
 	storeDetails,
 	senderId: __DEV__ ? senderId.code : senderId.prod,
 	websiteUrl: 'https://www.theguardian.com/',
-	logging: __DEV__
-		? 'https://editions-logging.code.dev-guardianapis.com/log/mallard'
-		: 'https://editions-logging.guardianapis.com/log/mallard',
 };
 
 export const editionsEndpoint = (apiUrl: ConfigState['apiUrl']): string =>

--- a/projects/Mallard/src/hooks/use-gdpr.tsx
+++ b/projects/Mallard/src/hooks/use-gdpr.tsx
@@ -18,8 +18,9 @@ import { errorService } from 'src/services/errors';
  * v6 - Add Crashlytics in PERFORMANCE, update wording in ESSENTIAL
  * v7 - Remove Braze from wording in ESSENTIAL
  * v8 - Add Firebase Analytics as PERFORMANCE
+ * v9 - Remove additional Logging
  */
-const CURRENT_CONSENT_VERSION = 8;
+const CURRENT_CONSENT_VERSION = 9;
 
 /*
 Consent switches can be 'unset' or null

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -61,7 +61,7 @@ const GdprConsent = ({
 	const switches: { [key in keyof GdprSwitches]: GdprSwitch } = {
 		gdprAllowPerformance: {
 			name: 'Performance',
-			services: 'Sentry - Logging - Crashlytics - Firebase Analytics',
+			services: 'Sentry - Crashlytics - Firebase Analytics',
 			description:
 				'Enabling these allow us to observe and measure how you use our services. We use this information to fix bugs more quickly so that users have a better experience. For example, we would be able to see the journey you have taken and where the error was encountered. Your data will only be stored in our servers for two weeks. If you disable this, we will not be able to observe and measure your use of our services, and we will have less information about their performance and details of any issues encountered.',
 			modifier: setGdprPerformanceBucket,

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -11,7 +11,7 @@ interface RemoteConfig {
 }
 
 const remoteConfigDefaults = {
-	logging_enabled: true,
+	logging_enabled: false,
 	join_beta_button_enabled: false,
 	lightbox_enabled: true,
 	generate_share_url: true,


### PR DESCRIPTION
## Why are you doing this?

Final cleaning up of Logging. Due to the mention of Logging on the GDPR screen, we need to ask for consent again when a user updates the app. This will happen automatically.