### PR TITLE
chore: Remove Handlebars

### DIFF
--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -142,7 +142,6 @@
   "resolutions": {
     "@types/react": "16.9.1",
     "@types/react-native": "0.60.5",
-    "handlebars": "4.6.0",
     "jsdom": "16.2.1"
   },
   "jest": {


### PR DESCRIPTION
## Why are you doing this?

Remove handlebars from the Mallard project, which is not being used.

This resolves this critical dependabot warning: https://github.com/guardian/editions/security/dependabot/65