### PR TITLE
chore: Update React Native Webview

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -426,7 +426,7 @@ PODS:
     - React
   - react-native-splash-screen (3.3.0):
     - React-Core
-  - react-native-webview (11.23.1):
+  - react-native-webview (13.2.3):
     - React-Core
   - React-perflogger (0.70.12)
   - React-RCTActionSheet (0.70.12):
@@ -902,7 +902,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
-  react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
+  react-native-webview: b85dfe0bf95bef83e82fc354d6987c80fed5e7ad
   React-perflogger: c0b9c0ab8cbaf732694cd776645b3161d128784d
   React-RCTActionSheet: c2b26d0be4e6e48ed6b4666345da16c8f7933b7b
   React-RCTAnimation: cc36ff278cd41365c98eeec3c8d1fa86e2fc2392

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -96,7 +96,7 @@
     "react-native-splash-screen": "^3.2.0",
     "react-native-status-bar-height": "^2.4.0",
     "react-native-svg": "^13.7.0",
-    "react-native-webview": "^11.23.1",
+    "react-native-webview": "^13.2.3",
     "react-native-zip-archive": "5.0.1",
     "validator": "^13.7.0"
   },

--- a/projects/Mallard/src/components/article/types/article/webview.tsx
+++ b/projects/Mallard/src/components/article/types/article/webview.tsx
@@ -78,7 +78,8 @@ const WebviewWithArticle = ({
 			bounces={largeDeviceMemory ? true : false}
 			originWhitelist={['*']}
 			scrollEnabled={true}
-			source={isReady ? { uri } : undefined}
+			// @ts-expect-error: https://github.com/react-native-webview/react-native-webview/issues/656#issuecomment-1520393422
+			source={isReady ? { uri } : { uri: undefined }}
 			ref={_ref}
 			onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
 			allowFileAccess={true}

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -7042,10 +7042,10 @@ react-native-svg@^13.7.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-webview@^11.23.1:
-  version "11.23.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.23.1.tgz#6a4bf2620e491dd4fecf4e6dc079005117fae12c"
-  integrity sha512-bmqsdg4RYOUYD37R9XTrQALm7eD62KbLNPRfgvpLGd1SjaurvAjjsLrLN4mt6yOtKOMKeZvlcAl3x6De6cCQsA==
+react-native-webview@^13.2.3:
+  version "13.2.3"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.2.3.tgz#9ede285b671f5072c1b9964ce210474ea359febd"
+  integrity sha512-f2cJ61cfpNzry0KLJg3HiwrGhhVnOLwbcHeQVMRldWTwzqSptTzk1sTO8QulYt0nVkUNw1xeboD0SLkUeaQB9Q==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## Why are you doing this?

Standard dependency update as it was a couple of major versions out of date
