### PR TITLE
feat: FF to disable the editions button

### DIFF
--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/EditionsMenuButton.tsx
@@ -33,13 +33,16 @@ const styles = (selected: boolean) =>
 	});
 
 const EditionsMenuButton = ({
+	disabled = false,
 	onPress,
 	selected = false,
 }: {
+	disabled?: boolean;
 	onPress: () => void;
 	selected?: boolean;
 }) => (
 	<TouchableOpacity
+		disabled={disabled}
 		accessibilityRole="button"
 		accessibilityLabel="Regions and specials editions menu"
 		onPress={onPress}

--- a/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/EditionsMenuButton/__tests__/__snapshots__/EditionsMenuButton.spec.tsx.snap
@@ -4,6 +4,11 @@ exports[`EditionsMenuButton should display a default EditionsMenuButton with cor
 <View
   accessibilityLabel="Regions and specials editions menu"
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   collapsable={false}
   focusable={true}
@@ -175,6 +180,11 @@ exports[`EditionsMenuButton should display a selected EditionsMenuButton with co
 <View
   accessibilityLabel="Regions and specials editions menu"
   accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   collapsable={false}
   focusable={true}

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
@@ -8,6 +8,7 @@ import { logEvent } from 'src/helpers/analytics';
 import { useIssueDate } from 'src/helpers/issues';
 import { useEditions } from 'src/hooks/use-edition-provider';
 import { RouteNames } from 'src/navigation/NavigationModels';
+import { remoteConfigService } from 'src/services/remote-config';
 import { IssueMenuButton } from '../../Button/IssueMenuButton';
 import { EditionsMenuButton } from '../../EditionsMenu/EditionsMenuButton/EditionsMenuButton';
 
@@ -70,12 +71,19 @@ const IssueScreenHeader = React.memo(
 
 		const { title, subTitle, titleStyle } = getTitles();
 
+		const isEditionsMenuEnabled = remoteConfigService.getBoolean(
+			'is_editions_menu_enabled',
+		);
+
 		return (
 			<Header
 				onPress={goToIssueList}
 				action={<IssueMenuButton onPress={goToIssueList} />}
 				leftAction={
-					<EditionsMenuButton onPress={handleEditionMenuPress} />
+					<EditionsMenuButton
+						disabled={!isEditionsMenuEnabled}
+						onPress={handleEditionMenuPress}
+					/>
 				}
 				headerStyles={headerStyles}
 			>

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/__tests__/__snapshots__/IssueScreenHeader.spec.tsx.snap
@@ -342,6 +342,11 @@ exports[`IssueScreenHeader should match the altered style by the prop headerStyl
                             <View
                               accessibilityLabel="Regions and specials editions menu"
                               accessibilityRole="button"
+                              accessibilityState={
+                                Object {
+                                  "disabled": false,
+                                }
+                              }
                               accessible={true}
                               collapsable={false}
                               focusable={true}
@@ -1063,6 +1068,11 @@ exports[`IssueScreenHeader should match the default style 1`] = `
                             <View
                               accessibilityLabel="Regions and specials editions menu"
                               accessibilityRole="button"
+                              accessibilityState={
+                                Object {
+                                  "disabled": false,
+                                }
+                              }
                               accessible={true}
                               collapsable={false}
                               focusable={true}

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -18,6 +18,7 @@ const remoteConfigDefaults = {
 	generate_share_url: true,
 	download_parallel_ssr_bundle: false,
 	rating: false,
+	is_editions_menu_enabled: true,
 };
 
 const RemoteConfigProperties = [
@@ -27,6 +28,7 @@ const RemoteConfigProperties = [
 	'generate_share_url',
 	'download_parallel_ssr_bundle',
 	'rating',
+	'is_editions_menu_enabled',
 ] as const;
 
 type RemoteConfigProperty = typeof RemoteConfigProperties[number];


### PR DESCRIPTION
## Why are you doing this?

Due to Australia Edition being discontinued, we are experimenting disabling the edition button to test the appetite 

## Changes

- Add the feature flag to remote config setup
- Apply that to the Issue Screen Header
- Add disabled prop to Editions button to make it not give a clickable feedback.

## Screenshots

#### Disabled
![2023-07-24 20 15 43](https://github.com/guardian/editions/assets/935975/3d77f1e9-2afc-4ace-abe7-d5d8ef8e31de)

#### Enabled
![2023-07-24 20 15 55](https://github.com/guardian/editions/assets/935975/1b1c659d-b613-49df-8ff4-6a5614f52e06)

#### Feature Flag on Dev Menu
![Simulator Screenshot - iPhone 14 - 2023-07-24 at 20 16 25](https://github.com/guardian/editions/assets/935975/2bb8043b-a6c7-42cd-bdd4-b519b9259264)
