### PR TITLE
fix: Android Cover Card Images

### DIFF
--- a/projects/Mallard/src/components/front/image-resource.tsx
+++ b/projects/Mallard/src/components/front/image-resource.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import type { StyleProp } from 'react-native';
-import { View } from 'react-native';
+import type { ImageStyle as RNImageStyle, StyleProp } from 'react-native';
+import { Platform, Image as RNImage, View } from 'react-native';
 import type { ImageStyle } from 'react-native-fast-image';
 import FastImage from 'react-native-fast-image';
 import { useAspectRatio } from 'src/hooks/use-aspect-ratio';
@@ -20,6 +20,7 @@ type ImageResourceProps = {
 	style?: StyleProp<ImageStyle>;
 	setAspectRatio?: boolean;
 	accessibilityLabel?: string;
+	isCoverCard?: boolean;
 };
 
 const ImageResource = ({
@@ -27,6 +28,7 @@ const ImageResource = ({
 	style,
 	setAspectRatio = false,
 	use,
+	isCoverCard = false,
 	...props
 }: ImageResourceProps) => {
 	const imagePath = useImagePath(image, use);
@@ -36,17 +38,30 @@ const ImageResource = ({
 		setAspectRatio && aspectRatio ? { aspectRatio } : {},
 	];
 
-	return imagePath ? (
-		<FastImage
-			key={imagePath}
-			{...props}
-			resizeMode={FastImage.resizeMode.cover}
-			style={[styles, style] as StyleProp<ImageStyle>}
-			source={{ uri: imagePath }}
-		/>
-	) : (
-		<View style={styles}></View>
-	);
+	// Cover Cards are not rendering properly for Android using FastImage, so this falls back to React Native Image in this case
+	if (imagePath && Platform.OS === 'android' && isCoverCard) {
+		return (
+			<RNImage
+				key={imagePath}
+				{...props}
+				resizeMode={FastImage.resizeMode.cover}
+				style={[styles, style] as StyleProp<RNImageStyle>}
+				source={{ uri: imagePath }}
+			/>
+		);
+	} else if (imagePath) {
+		return (
+			<FastImage
+				key={imagePath}
+				{...props}
+				resizeMode={FastImage.resizeMode.cover}
+				style={[styles, style] as StyleProp<ImageStyle>}
+				source={{ uri: imagePath }}
+			/>
+		);
+	} else {
+		return <View style={styles}></View>;
+	}
 };
 
 export { ImageResource };

--- a/projects/Mallard/src/components/front/items/items.tsx
+++ b/projects/Mallard/src/components/front/items/items.tsx
@@ -56,6 +56,7 @@ const SplashImageItem = ({ article, size, ...tappableProps }: PropTypes) => {
 					setAspectRatio
 					use="full-size"
 					accessibilityLabel={article.headline}
+					isCoverCard
 				/>
 			</View>
 			<HeadlineCardText style={[splashImageStyles.hidden]}>


### PR DESCRIPTION
## Why are you doing this?

Cover Card Images on Android are extremely zoomed in.

![image](https://github.com/guardian/editions/assets/935975/6656e146-4710-46b4-b310-8eb688c9fb78)

## Changes

- FastImage seems to be the cause here. There seems to be some need to rerender, but with the complexities of our image caching, flipping this to React Native's Image solves the problem
- However, `ImageResource` controls image on all the Cards, so we limit this to just Android Cover Cards.

## Screenshots

### Android Mobile
![screenshot-1690529640825](https://github.com/guardian/editions/assets/935975/9992a362-67a0-4020-b196-a3ec45f52b6b)


### Android Tablet
![screenshot-1690529934745](https://github.com/guardian/editions/assets/935975/0cc99fa1-1aaa-4ef5-af9a-cf1bbc1edf3a)


### iOS Mobile
![Simulator Screenshot - iPhone 14 - 2023-07-28 at 08 34 07](https://github.com/guardian/editions/assets/935975/157e4e2d-bdf0-4682-927b-3c03f4a51045)


### iOS Tablet
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-07-28 at 08 41 04](https://github.com/guardian/editions/assets/935975/d80abc58-a5a9-4c57-ba88-624a07b47cea)

