### PR TITLE
Update AndroidManifest.xml for Amazon Appstore

### DIFF
--- a/projects/Mallard/android/app/src/main/AndroidManifest.xml
+++ b/projects/Mallard/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Amazon Appstore thinks that "android.hardware.location.gps" is a requirement --> 
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 


### PR DESCRIPTION
Amazon Appstore will not distribute to the majority Fire HD devices, because of the 'android.hardware.location.gps' requirement implied by ACCESS_FINE_LOCATION permission and used by our weather component. 

See explanation for further details:

https://amazon.developer.forums.answerhub.com/articles/45349/why-does-my-app-require-capabilities-not-present-o.html

Explicitly adding these entries into the manifest file, should be an adequate workaround