### PR TITLE
fix: Crossword Sign In Crash

### DIFF
--- a/projects/Mallard/src/components/Modals/SignInModal.tsx
+++ b/projects/Mallard/src/components/Modals/SignInModal.tsx
@@ -13,7 +13,7 @@ const SignInModal = () => {
 			<SignInModalCard
 				onDismiss={() => navigate(RouteNames.Issue)}
 				onLoginPress={signIn}
-				close={() => navigate(RouteNames.Article)}
+				close={() => navigate(RouteNames.Issue)}
 			/>
 		</CenterWrapper>
 	);


### PR DESCRIPTION
## Why are you doing this?

Fix the break when a user tries to sign in via the crosswords

## Changes

- Instead of taking the user back to the Article when they choose to sign in, we take them back to the issue screen. Does mean once they log in, they will need to find the article they want to read again, but the front should be in the same place.

## Screenshots

![2023-09-05 09 56 04](https://github.com/guardian/editions/assets/935975/ca806f38-d4b7-4513-868e-9e2d2ae0af7b)
