### PR TITLE
feat: Today download delay

### DIFF
--- a/projects/Mallard/src/download-edition/prepare-and-download-issue.ts
+++ b/projects/Mallard/src/download-edition/prepare-and-download-issue.ts
@@ -20,7 +20,10 @@ const prepareAndDownloadTodaysIssue = async (
 	// Check to see if the device has a decent amount of memory before doing intensive tasks
 	const largeRAM = await largeDeviceMemory();
 	if (largeRAM) {
-		return await downloadTodaysIssue(downloadBlocked);
+		return setTimeout(
+			async () => await downloadTodaysIssue(downloadBlocked),
+			5000,
+		);
 	}
 	return;
 };


### PR DESCRIPTION
## Why are you doing this?

Testing in production, we seem to kick off a download for todays edition on open. But we are also kicking off cleanup tasks, including the download folder.

The clean up tasks should happen, then the download, but despite the async code, they are happening synchronously.

As a result, I have added a 5 second delay before the download kicks off. Which I think will reduce the problem, but on slower devices, this may not solve it.

Need to look at the libraries and why they are not working async.

## Changes

- Delay added to Download today.
