### PR TITLE
fix: Update phonenumber to fix iOS build

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -99,7 +99,7 @@ platform :ios do
             contact_email: "Editions.coreteam@guardian.co.uk",
             contact_first_name: "Editions",
             contact_last_name: "Team",
-            contact_phone: "+3303336767"
+            contact_phone: "+443303336767"
     },
     )
   end

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -99,7 +99,7 @@ platform :ios do
             contact_email: "Editions.coreteam@guardian.co.uk",
             contact_first_name: "Editions",
             contact_last_name: "Team",
-            contact_phone: "03303336767"
+            contact_phone: "+3303336767"
     },
     )
   end


### PR DESCRIPTION
## Why are you doing this?

iOS build has been failing due to 

`fastlane An attribute value has invalid phone number. - The format of the phone number is invalid - contactPhone`

The suggestion is that the format is invalid

## Changes

- Change the phone number to international format
