### PR TITLE
chore: Only allow Android 11 and above

### DIFF
--- a/projects/Mallard/android/build.gradle
+++ b/projects/Mallard/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 30
         compileSdkVersion = 33
         targetSdkVersion = 33
         supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX


### PR DESCRIPTION
## Why are you doing this?

Aim to focus on modern Android devices. 

## Changes

- Restrict install to Android 11 and above
- Tested on Android 10 sim (failed to install as expected) and Android 11 sim (installed as expected)
