### PR TITLE
Ship first android beta from GHA

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -28,6 +28,12 @@ jobs:
         ruby-version: 2.7.3
         bundler-cache: true
 
+    - name: update fastlane
+      run: |
+        gem install fastlane
+        fastlane -v
+        exit 1
+
     - name: inject credentials
       run: |
         echo -e "\n\n${{ secrets.ANDROID_GRADLE_PROPERTIES }}" >> projects/Mallard/android/gradle.properties

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -75,6 +75,7 @@ jobs:
         FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
         SUPPLY_JSON_KEY_DATA: ${{ secrets.SUPPLY_JSON_KEY_DATA }}
         BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
+        SUPPLY_UPLOAD_MAX_RETRIES: 5
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -32,7 +32,6 @@ jobs:
       run: |
         gem install fastlane
         fastlane -v
-        exit 1
 
     - name: inject credentials
       run: |

--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -113,7 +113,6 @@ platform :android do
            project_dir: 'android/'
     )
     supply(
-      skip_upload_apk: true, # TODO: Remove when new upload key approved
       track: 'internal',
       package_name: 'com.guardian.editions'
     )


### PR DESCRIPTION
## Why are you doing this?

This PR disables the skip_upload_apk option in fastlane to start uploading beta builds to the play console.

We had to introduce a workaround to make it work though. We started getting this error [in the logs](https://github.com/guardian/editions/actions/runs/6220846084/job/16881668455)
```
[10:06:57]: Google Api Error: Unauthorized - Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.
```
And it turns out this is actually a problem with the google API, as reported here:
https://github.com/fastlane/fastlane/issues/21507
Fastlane just shipped update 2.215.1 [with a workaround]( https://github.com/fastlane/fastlane/pull/21518) that consists in adding retry functionality to the supply command, which we can control via the environment variable `SUPPLY_UPLOAD_MAX_RETRIES`. In this PR we set it to the recommended 5.

co-authored by @JuliaBrigitte and @michaelclapham 