### PR TITLE
Bump github actions versions

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -14,8 +14,8 @@ jobs:
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: '14.18'
 


### PR DESCRIPTION
## Why are you doing this?

We're using versions of these actions that are deprecated, and I think may have contributed to some occasional failures we've been getting, like this one https://github.com/guardian/editions/actions/runs/6186617779