### PR TITLE
Allow apks to be uploaded to the release track in the play store

### DIFF
--- a/projects/Mallard/fastlane/Fastfile
+++ b/projects/Mallard/fastlane/Fastfile
@@ -128,7 +128,6 @@ platform :android do
            project_dir: 'android/'
     )
     supply(
-      skip_upload_apk: true, # TODO: Remove when new upload key approved
       track: 'production',
       package_name: 'com.guardian.editions'
     )


### PR DESCRIPTION
## Why are you doing this?

We intend to ship a production version on Wednesday, and this change is a pre-requisite for that.
