### PR TITLE
chore: Amazon Package name for Rate

### DIFF
--- a/projects/Mallard/src/helpers/rate.ts
+++ b/projects/Mallard/src/helpers/rate.ts
@@ -7,6 +7,7 @@ export const rateApp = () => {
 	const options = {
 		AppleAppID: APPLE_ID,
 		GooglePackageName: GOOGLE_PACKAGE_NAME,
+		AmazonPackageName: GOOGLE_PACKAGE_NAME,
 		preferredAndroidMarket: AndroidMarket.Google,
 		preferInApp: true,
 		openAppStoreIfInAppFails: false,


### PR DESCRIPTION
## Why are you doing this?

Adds the Amazon package name to the Rate options