### PR TITLE
feat: Move Issue Summary to Async Storage

### DIFF
--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -128,6 +128,8 @@ const numberOfInteractionsCache = createAsyncCache<number>(
 const hasShownRatingCache = createAsyncCache<boolean>(
 	'@Setting_hasShownRating',
 );
+
+const issueSummaryCache = createAsyncCache<string>('issueSummary');
 /**
  * Creates a simple store (wrapped around the keychain) for tokens.
  *
@@ -206,4 +208,5 @@ export {
 	numberOfInteractionsCache,
 	hasShownRatingCache,
 	oktaDataCache,
+	issueSummaryCache,
 };

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -19,6 +19,7 @@ import { locale } from 'src/helpers/locale';
 import { isInBeta, isInTestFlight } from 'src/helpers/release-stream';
 import { imageForScreenSize } from 'src/helpers/screen';
 import {
+	issueSummaryCache,
 	pushRegisteredTokens,
 	showAllEditionsCache,
 } from 'src/helpers/storage';
@@ -127,6 +128,15 @@ const DevZone = () => {
 		identity: identityData?.userDetails.primaryEmailAddress !== undefined,
 		okta: oktaData?.userDetails.preferred_username !== undefined,
 	});
+
+	const clearIssueSummaryCache = async () => {
+		try {
+			await issueSummaryCache.reset();
+			Alert.alert('Cache cleared!');
+		} catch {
+			Alert.alert('Failed to clear');
+		}
+	};
 
 	// initialise local showAllEditions property
 	useEffect(() => {
@@ -266,6 +276,9 @@ const DevZone = () => {
 						</Button>
 						<Button onPress={rateUserFlow}>Rate the app</Button>
 						<Button onPress={clearAll}>Clear Rating Cache</Button>
+						<Button onPress={clearIssueSummaryCache}>
+							Clear Issue Summary Cache
+						</Button>
 					</ButtonList>
 					<List
 						data={[


### PR DESCRIPTION
## Why are you doing this?

Moves the Issue Summary from the file system to async storage to improve reliability.

## Changes

- Create Async Storage cache
- Replace file system approach with Async Storage
- Added a button to manually clear cache in dev menu

![Simulator Screenshot - iPhone 15 Pro - 2023-09-27 at 07 58 07](https://github.com/guardian/editions/assets/935975/f1abfee6-1aee-434a-99fd-e4bf9a12c460)
