### PR TITLE
fix: Reattempt Data Download

### DIFF
--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -2,6 +2,7 @@ import retry from 'async-retry';
 import type { DLStatus } from 'src/helpers/files';
 import {
 	downloadNamedIssueArchive,
+	isIssueOnDevice,
 	unzipNamedIssueArchive,
 } from 'src/helpers/files';
 import { localIssueListStore } from 'src/hooks/use-issue-on-device';
@@ -119,6 +120,40 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 				});
 
 				await pushTracking('attemptMediaDownload', 'completed');
+
+				// --- Check if Data did download, and if not then download again ---
+
+				const dataFailsafe = await isIssueOnDevice(
+					localId,
+					// This assumes these folders never change their names
+					'issue_front',
+				);
+				if (!dataFailsafe) {
+					// --- Data Download ---
+
+					await pushTracking(
+						'attemptDataDownload',
+						JSON.stringify({ localId, assets: assets.data }),
+					);
+
+					// We are not asking for progress update during Data bundle download (to avoid false visual completion)
+					// So, instead we are artificially triggering a small progress update to render some visual change
+					updateListeners(localId, {
+						type: 'download',
+						data: 0.5,
+					});
+					const dataDownloadResult = await downloadNamedIssueArchive({
+						localIssueId: localId,
+						assetPath: assets.data,
+						filename: 'data.zip',
+						withProgress: false,
+					});
+					console.log(
+						`Data download completed with status: ${dataDownloadResult.statusCode}`,
+					);
+
+					await pushTracking('attemptDataDownload', 'completed');
+				}
 
 				updateListeners(localId, {
 					type: 'unzip',

--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -156,12 +156,14 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 
 				await pushTracking('unzipImages', 'end');
 
+				await setTimeout(() => Promise.resolve(), 10000);
+
 				// --- Check if Data did download, and if not then download again ---
 
 				const dataFailsafe = await isIssueOnDevice(
 					localId,
 					// This assumes these folders never change their names
-					'issue_front',
+					['issue', 'front'],
 				);
 				if (!dataFailsafe) {
 					// --- Data Download ---

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -113,14 +113,16 @@ export const isIssueOnDevice = async (
 	// Please note, this makes an assumption on the location of filenames which is not the case throughout the code
 	// However, at this stage in the project, this is unlikely to change and therefore the performance optimisation
 	// that this currently provides is a greater benefit than maintenance.
-	expectedFolders = 'issue_front_thumbs_media_html',
+	expectedFolders = ['issue', 'front', 'thumbs', 'media', 'html'],
 ): Promise<boolean> => {
 	try {
 		const folders = await RNFS.readdir(FSPaths.issueRoot(localIssueId));
 		if (folders.length === 0) {
 			return false;
 		}
-		return folders.every((item) => expectedFolders.includes(item));
+		return expectedFolders.every((item) => {
+			return folders.includes(item);
+		});
 	} catch {
 		return false;
 	}

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -110,12 +110,12 @@ export const unzipNamedIssueArchive = async (zipFilePath: string) => {
  */
 export const isIssueOnDevice = async (
 	localIssueId: Issue['localId'],
+	// Please note, this makes an assumption on the location of filenames which is not the case throughout the code
+	// However, at this stage in the project, this is unlikely to change and therefore the performance optimisation
+	// that this currently provides is a greater benefit than maintenance.
+	expectedFolders = 'issue_front_thumbs_media_html',
 ): Promise<boolean> => {
 	try {
-		// Please note, this makes an assumption on the location of filenames which is not the case throughout the code
-		// However, at this stage in the project, this is unlikely to change and therefore the performance optimisation
-		// that this currently provides is a greater benefit than maintenance.
-		const expectedFolders = 'issue_front_thumbs_media_html';
 		const folders = await RNFS.readdir(FSPaths.issueRoot(localIssueId));
 		if (folders.length === 0) {
 			return false;


### PR DESCRIPTION
## Why are you doing this?

The current theory as to why users see a blue tick, but the downloaded issue doesnt show, is that due to the unreliability of `async...await` in the RNFS library, we are downloading the data package and then clearing it before its had a chance to unzip.

## Changes

- During the download script, check if the data package files are there. If at the end they are not then download again.
- Update the check to take a param of files.
