### PR TITLE
chore: Final Download Check

### DIFF
--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -209,7 +209,11 @@ const runDownload = async (issue: IssueSummary, imageSize: ImageSize) => {
 		);
 
 		await pushTracking('downloadAndUnzip', 'complete');
-		updateListeners(localId, { type: 'success' }); // null is unstarted or end
+		// Checks for any silent errors
+		const checkIssueDidComplete = await isIssueOnDevice(localId);
+		updateListeners(localId, {
+			type: checkIssueDidComplete ? 'success' : 'failure',
+		}); // null is unstarted or end
 	} catch (error: any) {
 		await pushTracking('downloadAndUnzipError', JSON.stringify(error));
 		errorService.captureException(error);


### PR DESCRIPTION
## Why are you doing this?

Currently the existence of issues on device is tightly coupled to a piece of internal state and listeners around downloading. To update state, we would need to check everytime the menu is open which would hamper performance.

We know at the moment that sometimes when a download completes, it appears that the data.zip doesnt appear to have been unpacked into the issue folder. 

As a result, I have added an additional check at the end of a successful download, that double checks the issue folder that everything is in there as expected.  This is essentially a silent fail check.

## Changes

- Checks the filesystem at the end of a download
- Updates the listeners which control the "tick" dependent on how successful that download is

## Output

We hope this gives a more accurate view of what has downloaded.

A further improvement may be to give some feedback to users in the case of a failed download.