### PR TITLE
chore: Update Moment

### DIFF
--- a/projects/archiver/package.json
+++ b/projects/archiver/package.json
@@ -13,6 +13,8 @@
         "@types/ramda": "^0.26.15",
         "@zeit/ncc": "^0.20.4",
         "dotenv": "^16.3.1",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
     },
@@ -31,13 +33,11 @@
         "archiver": "^5.3.0",
         "aws-sdk": "2.518.0",
         "encoding": "^0.1.12",
-        "jest": "^29.7.0",
+        "moment": "^2.29.2",
         "node-fetch": "^2.6.7",
         "p-all": "^2.1.0",
         "ramda": "^0.26.1",
-        "ts-jest": "^29.1.1",
         "ts-optchain": "^0.1.8",
-        "uuidv4": "5.0.1",
-        "moment": "^2.24.0"
+        "uuidv4": "5.0.1"
     }
 }

--- a/projects/archiver/yarn.lock
+++ b/projects/archiver/yarn.lock
@@ -2385,10 +2385,10 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-moment@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+moment@^2.29.2:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@^2.1.1:
   version "2.1.2"

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -43,7 +43,7 @@
         "express": "^4.18.2",
         "express-list-endpoints": "^6.0.0",
         "jest": "^29.7.0",
-        "moment": "^2.24.0",
+        "moment": "^2.29.2",
         "node-fetch": "^2.7.0",
         "ramda": "^0.29.0",
         "striptags": "^3.2.0",

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -2693,10 +2693,10 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+moment@^2.29.2:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Why are you doing this?

Update Moment to solve this vulnerability: https://github.com/guardian/editions/security/dependabot/136

## Changes

- Update Moment in backend and archiver

## Outputs

Tests still pass