### PR TITLE
fix: Amazon Release

### DIFF
--- a/.github/workflows/amazon-release.yml
+++ b/.github/workflows/amazon-release.yml
@@ -44,7 +44,8 @@ jobs:
     - run: echo $BUILD_NUMBER
 
     - name: install
-      run: make install
+      run: |
+          yarn install-mallard
 
     - name: validate
       run: make validate-Mallard


### PR DESCRIPTION
## Why are you doing this?

A fix for the Amazon release where it looks to just install the `Mallard` project rather than the whole ecosystem

## Changes

- Install `Mallard` only