### PR TITLE
chore: Upgrade react-native-iap to minimum version

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -580,8 +580,8 @@ PODS:
     - React-Core
   - RNGestureHandler (2.8.0):
     - React-Core
-  - RNIap (3.5.9):
-    - React
+  - RNIap (9.0.4):
+    - React-Core
   - RNInAppBrowser (3.7.0):
     - React-Core
   - RNKeychain (8.1.1):
@@ -892,8 +892,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  boost: 20b6b3a53cb43939b6ffc2fd27d15ec7497167d0
+  DoubleConversion: 2d248a4174d78beaaa49735340c9bcc564091245
   FBLazyVector: 4eb7ee83e8d0ad7e20a829485295ff48823c4e4c
   FBReactNativeSpec: b24809f97ae83c786928d56b732957195b4fa390
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
@@ -907,11 +907,11 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfig: bc7f260e6596956fafbb532443c19bd3c30f5258
   FirebaseSessions: 991fb4c20b3505eef125f7cbfa20a5b5b189c2a4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5b8834f2f3f7d36c1c73e5a9837f53f03cfe84eb
   GoogleAppMeasurement: 2d800fab85e7848b1e66a6f8ce5bca06c5aad892
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: b60ebc812e0179a612d8146ac54730d533c804a2
+  hermes-engine: f4a6b6092c700a9699a855d2f0eda4919265b078
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
@@ -919,7 +919,7 @@ SPEC CHECKSUMS:
   OktaSdkBridgeReactNative: 3e1064998683414e3883b757a736cb0707000705
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   PromisesSwift: 28dca69a9c40779916ac2d6985a0192a5cb4a265
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 30d165d2e977f66793419c3314296392cb793f38
   RCTRequired: 4db5e3e18b906377a502da5b358ff159ba4783ed
   RCTTypeSafety: 6c1a8aed043050de0d537336c95cd1be7b66c272
   React: 214e77358d860a3ed707fede9088e7c00663a087
@@ -972,11 +972,11 @@ SPEC CHECKSUMS:
   RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
-  RNIap: 9e69c8d9ecfdd1f0882363366e85d2e1683ecc89
+  RNIap: 77ec4fb16e0d6fa0617daf896a8d82bd36cc55b0
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
   RNLocalize: d4b8af4e442d4bcca54e68fc687a2129b4d71a81
-  RNPermissions: 5e1908f7381d825cbae3215975703a81c598f864
+  RNPermissions: f1b49dd05fa9b83993cd05a9ee115247944d8f1a
   RNRate: ef3bcff84f39bb1d1e41c5593d3eea4aab2bd73a
   RNReanimated: f186e85d9f28c9383d05ca39e11dd194f59093ec
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -78,7 +78,7 @@
     "react-native-fast-image": "^8.6.3",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "2.8.0",
-    "react-native-iap": "^3.3.9",
+    "react-native-iap": "^9.0.4",
     "react-native-image-zoom-viewer": "^3.0.1",
     "react-native-in-app-utils": "^6.0.2",
     "react-native-inappbrowser-reborn": "^3.3.3",

--- a/projects/Mallard/src/authentication/services/iap.ts
+++ b/projects/Mallard/src/authentication/services/iap.ts
@@ -1,7 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
 import type { Purchase } from 'react-native-iap';
 import RNIAP from 'react-native-iap';
-import type { ReceiptValidationResponse } from 'react-native-iap/type/apple';
 import { ITUNES_CONNECT_SHARED_SECRET } from 'src/constants';
 import { isInBeta } from 'src/helpers/release-stream';
 import type { AuthResult } from '../lib/Result';
@@ -54,15 +53,15 @@ const isReceiptValid = (receipt: ReceiptIOS) => {
 	return expirationWithGracePeriod > nowInMilliseconds;
 };
 
-const hasLatestReceiptInfo = (receipt: ReceiptValidationResponse) => {
+const hasLatestReceiptInfo = (receipt: any) => {
 	return (receipt?.latest_receipt_info as ReceiptIOS[])?.length > 0;
 };
 
-const findValidReceiptFromLatestInfo = (receipt: ReceiptValidationResponse) => {
+const findValidReceiptFromLatestInfo = (receipt: any) => {
 	return (receipt.latest_receipt_info as ReceiptIOS[]).find(isReceiptValid);
 };
 
-const findValidReceipt = (receipt: ReceiptValidationResponse) =>
+const findValidReceipt = (receipt: any) =>
 	hasLatestReceiptInfo(receipt)
 		? findValidReceiptFromLatestInfo(receipt) ?? null
 		: null;

--- a/projects/Mallard/src/screens/in-app-purchase-screen.tsx
+++ b/projects/Mallard/src/screens/in-app-purchase-screen.tsx
@@ -24,7 +24,7 @@ export const InAppPurchaseScreen = () => {
 			(purchase: any) => {
 				const receipt = purchase.transactionReceipt;
 				if (receipt) {
-					RNIAP.finishTransactionIOS(purchase);
+					RNIAP.finishTransaction(purchase);
 					setReceipt(receipt);
 				}
 			},
@@ -48,7 +48,9 @@ export const InAppPurchaseScreen = () => {
 								<Text>{localizedPrice}</Text>
 								<Button
 									onPress={() =>
-										RNIAP.requestSubscription(productId)
+										RNIAP.requestSubscription({
+											sku: productId,
+										})
 									}
 								>
 									Subscribe

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -4243,11 +4243,6 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
 
-dooboolab-welcome@^1.1.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz#4928595312f0429b4ea1b485ba8767bae6acdab7"
-  integrity sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -7794,12 +7789,10 @@ react-native-gradle-plugin@^0.71.19:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.19.tgz#3379e28341fcd189bc1f4691cefc84c1a4d7d232"
   integrity sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==
 
-react-native-iap@^3.3.9:
-  version "3.5.9"
-  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-3.5.9.tgz#1a49702f5c5ed444da9d3c7b8db9b5e7c7066deb"
-  integrity sha512-LtL6NX4y8JCg9pjUDxMz2om03r0PaJHfzpT6Wd437ck5sr+cIAbC8QH5MgXUkyoBin+MxTSX0w92TbuZAeHp1Q==
-  dependencies:
-    dooboolab-welcome "^1.1.1"
+react-native-iap@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-9.0.4.tgz#8d2dca3f169194859056427e5d422a2a3bee1ffa"
+  integrity sha512-3ohw1uNpckD6XCsfumtKgewlQoz2p/Be+xbPvvyKN9Gb9Z8TF8V4o1SDzVkfziIBfdrblBiD5TMQ5dIGfZkcTg==
 
 react-native-image-pan-zoom@^2.1.12:
   version "2.1.12"


### PR DESCRIPTION
## Why are you doing this?

Goole Play's billing library V4 is being decommissioned and as a result, apps containing it need to remove it.

In App Purchase in this app is a legacy feature and was only available on iOS. No new subscriptions are sold in this way. Therefore the IAP functionality is iOS only.

As a result, this is difficult to test and has not been updated for a long time. However, the situation above forces our hand.

## Changes

- Update the IAP library to the minimum version (9). From https://www.npmjs.com/package/react-native-iap : `Version 9.0.0 The module migrates android sdk to play billing library v5.`

## Outputs

- Needs to be tested n Beta
