### PR TITLE
Exclude Mallard to get snyk to work

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,6 @@ jobs:
       ORG: guardian-editions
       SKIP_NODE: false
       NODE_PACKAGE_JSON_FILES_MISSING_LOCK: projects/Mallard/package.json # not missing lock but seemingly needs to be installed for gradle build to work
+      EXCLUDE: Mallard
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Why are you doing this?

Snyk is currently failing with 

```
Server returned unexpected error for the monitor request. Status code: 413
```

Which means

```
The HTTP 413 Content Too Large response status code indicates that the request entity is larger than limits defined by server;
```

I'm not sure exactly what the root cause is for this, but I think it's related to `snyk monitor` picking up around 85 independent projects in this repo, many of them from the android app. It points towards snyk not understanding how to scan the android app properly, and not being able to discern what are actual independent projects and just dependencies included by the main project.

## Changes

This patch forces `snyk monitor` to not scan anything in the Mallard folder. Ideally we would just ignore android as I believe it's the source of the problem, but the `exclude` flag has a [somewhat counter intuitive behaviour](https://docs.snyk.io/snyk-cli/commands/monitor#exclude-less-than-name-greater-than-less-than-name-greater-than-...greater-than) (it excludes any path that contains the keyword that's excluded) and this was the only way I was able to get this to work.
