### PR TITLE
fix: Better user feedback when a download fails

### DIFF
--- a/projects/Mallard/src/components/issue/issue-row.tsx
+++ b/projects/Mallard/src/components/issue/issue-row.tsx
@@ -28,6 +28,7 @@ import type { Loaded } from 'src/helpers/Loaded';
 import { imageForScreenSize } from 'src/helpers/screen';
 import { getPillarColors } from 'src/helpers/transform';
 import {
+	DOWNLOAD_ISSUE_MESSAGE_FAILED,
 	DOWNLOAD_ISSUE_MESSAGE_OFFLINE,
 	NOT_CONNECTED,
 	WIFI_ONLY_DOWNLOAD,
@@ -160,12 +161,16 @@ const IssueButton = ({
 		if (isConnected) {
 			if (!dlStatus) {
 				const imageSize = await imageForScreenSize();
-				downloadAndUnzipIssue(
+				const isDownloaded = await downloadAndUnzipIssue(
 					issue,
 					imageSize,
 					downloadBlocked,
 					handleUpdate,
 				);
+				if (!isDownloaded) {
+					setDlStatus(null);
+					showToast(DOWNLOAD_ISSUE_MESSAGE_FAILED);
+				}
 			}
 		} else {
 			showToast(DOWNLOAD_ISSUE_MESSAGE_OFFLINE);

--- a/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
+++ b/projects/Mallard/src/download-edition/__tests__/download-and-unzip.spec.ts
@@ -1,7 +1,12 @@
 import { DownloadBlockedStatus } from 'src/hooks/use-net-info-provider';
 import { downloadAndUnzipIssue } from '../download-and-unzip';
 
+const mockIsIssueOnDevice = jest.fn();
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+jest.mock('src/helpers/files', () => ({
+	...jest.requireActual('src/helpers/files'),
+	isIssueOnDevice: () => mockIsIssueOnDevice,
+}));
 
 const createIssueSummary = (localId: string) => ({
 	key: 'de/1-1-1',
@@ -15,6 +20,7 @@ const createIssueSummary = (localId: string) => ({
 describe('download', () => {
 	describe('downloadAndUnzipIssue', () => {
 		it('should resolve the outer promise when the download runner resolves', async () => {
+			mockIsIssueOnDevice.mockResolvedValue;
 			const localId = '1';
 			const p = downloadAndUnzipIssue(
 				createIssueSummary(localId),
@@ -27,7 +33,7 @@ describe('download', () => {
 				// this is not part of the main API but passing it in tests is much easier than mocking
 				// all the downloads
 			);
-			await expect(p).resolves.toBeUndefined();
+			await expect(p).resolves.toEqual(true);
 		});
 		it('should not set any statuses without the passed promise calling an updater', async () => {
 			const updateStatus = jest.fn(() => {});

--- a/projects/Mallard/src/download-edition/download-and-unzip.ts
+++ b/projects/Mallard/src/download-edition/download-and-unzip.ts
@@ -18,7 +18,7 @@ import { deleteIssue } from './clear-issues-and-editions';
 const dlCache: Record<
 	string,
 	{
-		promise: Promise<void>;
+		promise: Promise<boolean>;
 		progressListeners: Array<(status: DLStatus) => void>;
 	}
 > = {};
@@ -250,7 +250,12 @@ export const downloadAndUnzipIssue = async (
 	const createDownloadPromise = async () => {
 		try {
 			await run(issue, imageSize);
-			localIssueListStore.add(localId);
+			const onDevice = await isIssueOnDevice(issue.localId);
+			if (onDevice) {
+				localIssueListStore.add(localId);
+				return true;
+			}
+			return false;
 		} finally {
 			await pushTracking('completeAndDeleteCache', 'completed');
 			delete dlCache[localId];

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -50,6 +50,8 @@ export const PRIVACY_POLICY_HEADER_TITLE = 'Privacy Policy';
 export const BETA_PROGRAMME_FAQ_HEADER_TITLE = 'Beta Programme FAQ';
 export const REFRESH_BUTTON_TEXT = 'Refresh';
 export const DOWNLOAD_ISSUE_MESSAGE_OFFLINE = `You're currently offline. You can download it when you go online`;
+export const DOWNLOAD_ISSUE_MESSAGE_FAILED =
+	'There was a problem downloading your issue, please try again';
 
 export const USER_EMAIL_BODY_INTRO = `\n \nThanks for taking the time to send us feedback or report an issue.\n \nIf you are reporting a bug in the app, it will be very helpful if you could describe what you were doing in the app and let us know which screen you were on when the issue occurred. Is this an issue you have seen previously? The more detail you can provide the better and screenshots of these issues are always appreciated.\n \nIf you need a hand with taking a screenshot on your device, you can use this guide: http://www.take-a-screenshot.org/ \n \nThe Guardian Editions team`;
 


### PR DESCRIPTION
## Why are you doing this?

When a download fails, it does so silently, and then gives the user feedback that is was successful. This PR checks at the end of a download that we have everything we need, and if we dont, uses the `toast` to let the user know of the failure. The "blue tick" is not shown in that instance

## Changes

- Check at the end of the download
- Download promise returns a boolean to dictate its success state
- Toast functionality added for failure, with some wording
- Test updated to reflect the promise change

## Screenshots

Both of these have a forced failed in the code to replicate a particular part of the download not unzipping as expected.

| Before | After |
| --- | --- |
| ![2023-11-03 08 57 28](https://github.com/guardian/editions/assets/935975/ba273ceb-f212-45b0-8b70-e48adb52decd) | ![2023-11-03 08 40 55](https://github.com/guardian/editions/assets/935975/f8cc8014-5eb5-465d-8081-771e870d9008)|
