### PR TITLE
Cartoon element

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -178,6 +178,7 @@ export interface Content extends WithKey {
     webUrl?: string
     displayHint?: string
     internalPageCode: number
+    cartoonImages?: Image[]
 }
 export interface Article extends Content {
     type: 'article'

--- a/projects/archiver/src/tasks/front/helpers/media.ts
+++ b/projects/archiver/src/tasks/front/helpers/media.ts
@@ -45,7 +45,6 @@ export const getImagesFromArticle = (
     console.log('Images are: ' + JSON.stringify(images))
 
     const cartoonImages = article.cartoonImages || []
-    console.log('Cartoon images are: ' + JSON.stringify(cartoonImages))
 
     const requiredImages = [
         ...images,

--- a/projects/archiver/src/tasks/front/helpers/media.ts
+++ b/projects/archiver/src/tasks/front/helpers/media.ts
@@ -44,12 +44,16 @@ export const getImagesFromArticle = (
     const images = elements.map(getImageFromElement)
     console.log('Images are: ' + JSON.stringify(images))
 
+    const cartoonImages = article.cartoonImages || []
+    console.log('Cartoon images are: ' + JSON.stringify(cartoonImages))
+
     const requiredImages = [
         ...images,
         ...cardImages,
         ...bylineImages,
         image,
         trailImage,
+        ...cartoonImages,
     ].filter(notNull)
     console.log('Required images are: ' + JSON.stringify(requiredImages))
 

--- a/projects/backend/capi/articleImgPicker.ts
+++ b/projects/backend/capi/articleImgPicker.ts
@@ -12,6 +12,7 @@ import { getCreditedImage, getImage } from './assets'
 import { ContentType } from '@guardian/content-api-models/v1/contentType'
 import { ElementType } from '@guardian/content-api-models/v1/elementType'
 import { CartoonVariant } from '@guardian/content-api-models/v1/cartoonVariant'
+import { getImageFromURL } from '../image'
 
 /**
  * This function exploits the 'role'field that is passed to the backend when generating image urls
@@ -102,21 +103,7 @@ const getCartoonImages = (result: Content): Image[] | undefined => {
             )
         if (variants) {
             return variants.images
-                .map((image) => {
-                    try {
-                        const parsed = new URL(image.file)
-                        const path = parsed.pathname.slice(1) //remove leading slash
-                        return {
-                            source: image.file,
-                            path,
-                        }
-                    } catch (e) {
-                        console.error(
-                            `Encountered error parsing cartoon ${image.file}`,
-                        )
-                        console.error(JSON.stringify(e))
-                    }
-                })
+                .map((image) => getImageFromURL(image.file))
                 .filter((item): item is Image => !!item)
         }
     }

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -13,7 +13,7 @@ import {
     MediaAtomElement,
     TrailImage,
 } from '../common'
-import { elementParser } from './elements'
+import { elementParser, parseCartoonImagesToImageElements } from './elements'
 import fetch from 'node-fetch'
 import { fromPairs } from 'ramda'
 import { kickerPicker } from './kickerPicker'
@@ -125,6 +125,13 @@ const parseArticleResult = async (
     if (body == null) throw new Error(`Body was undefined in ${path}!`)
 
     const elements = await attempt(Promise.all(body.map(parser)))
+
+    const cartoonImages = getCartoonImages(result) ?? []
+
+    // required for lightbox to work in the app
+    const cartoonImageElements =
+        parseCartoonImagesToImageElements(cartoonImages)
+
     if (hasFailed(elements)) {
         console.error(elements)
         throw new Error(`Element parsing failed in ${path}!`) //This should not fire, the parser should log if anything async fails and then return the remainder.
@@ -198,11 +205,11 @@ const parseArticleResult = async (
                     articleType,
                     headerType,
                     ...images,
-                    cartoonImages: getCartoonImages(result),
+                    cartoonImages,
                     byline: byline || '',
                     bylineHtml: bylineHtml || '',
                     standfirst: trail || '',
-                    elements,
+                    elements: [...elements, ...cartoonImageElements],
                     isFromPrint,
                     webUrl,
                     internalPageCode,

--- a/projects/backend/capi/articles.ts
+++ b/projects/backend/capi/articles.ts
@@ -20,7 +20,7 @@ import { kickerPicker } from './kickerPicker'
 import { getBylineImages } from './byline'
 import { rationaliseAtoms } from './atoms'
 import { articleTypePicker, headerTypePicker } from './articleTypePicker'
-import { getImages } from './articleImgPicker'
+import { getCartoonImages, getImages } from './articleImgPicker'
 import { capiSearchDecoder } from './decoders'
 import {
     CAPIEndpoint,
@@ -198,6 +198,7 @@ const parseArticleResult = async (
                     articleType,
                     headerType,
                     ...images,
+                    cartoonImages: getCartoonImages(result),
                     byline: byline || '',
                     bylineHtml: bylineHtml || '',
                     standfirst: trail || '',

--- a/projects/backend/capi/elements.ts
+++ b/projects/backend/capi/elements.ts
@@ -1,7 +1,7 @@
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement'
 import { ElementType } from '@guardian/content-api-models/v1/elementType'
 import { Atom } from '@guardian/content-atom-model/atom'
-import { BlockElement as EditionsBlockElement } from '../common'
+import { BlockElement as EditionsBlockElement, Image } from '../common'
 import { getImage } from './assets'
 import { renderAtomElement } from './atoms'
 
@@ -21,6 +21,17 @@ const parseImageElement = (
             role: element.imageTypeData.role,
         }
     }
+}
+
+const parseCartoonImagesToImageElements = (
+    images: Image[],
+): EditionsBlockElement[] => {
+    return images.map((image) => {
+        return {
+            id: 'image',
+            src: image,
+        }
+    })
 }
 
 const elementParser =
@@ -80,4 +91,4 @@ const elementParser =
         return { id: 'unknown' }
     }
 
-export { parseImageElement, elementParser }
+export { parseImageElement, parseCartoonImagesToImageElements, elementParser }

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -30,7 +30,7 @@
         "test:watch": "jest --watch"
     },
     "dependencies": {
-        "@guardian/content-api-models": "^15.9.16",
+        "@guardian/content-api-models": "^17.8.0",
         "@guardian/content-atom-model": "^3.2.4",
         "@types/aws-lambda": "^8.10.31",
         "@types/aws4": "^1.5.1",

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -304,18 +304,18 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@guardian/content-api-models@^15.9.16":
-  version "15.9.16"
-  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-15.9.16.tgz#76bd2a3c05c1c0dddd1c8695fd2a94ff76412ee8"
-  integrity sha512-vlC4IGfv+W62OklszZZRFKc87jbgvOuczrefloKRuU9C4UqlylwTB2FIPI4G39DlyOkeLUdNRrRjdzySCo3Kgw==
+"@guardian/content-api-models@^17.8.0":
+  version "17.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-17.8.0.tgz#ef42d8d0d6c9afe896c3a34880f02ebfe8ab2f6d"
+  integrity sha512-qfYCnrWupF3CncBioFwqxiFAgZt/hD+ax1XH0kMWm1IhkxZXBVV06ZZyk7eUcDUYYyakAgQxIjS8Z0LXy3nHYw==
   dependencies:
-    "@guardian/content-atom-model" "^3.2.4"
-    "@guardian/content-entity-model" "^2.0.6"
-    "@guardian/story-packages-model" "^2.0.4"
+    "@guardian/content-atom-model" "^3.4.2"
+    "@guardian/content-entity-model" "^2.2.1"
+    "@guardian/story-packages-model" "^2.2.0"
     "@types/node-int64" "^0.4.29"
-    "@types/thrift" "^0.10.9"
+    "@types/thrift" "^0.10.11"
     node-int64 "^0.4.0"
-    thrift "^0.12.0"
+    thrift "^0.15.0"
 
 "@guardian/content-atom-model@^3.2.4":
   version "3.2.4"
@@ -328,6 +328,17 @@
     node-int64 "^0.4.0"
     thrift "^0.12.0"
 
+"@guardian/content-atom-model@^3.4.2":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@guardian/content-atom-model/-/content-atom-model-3.4.4.tgz#289c9c0d2ff1c889787667c2c08cf30bbf72356d"
+  integrity sha512-OeLqmQODJPqSa9Y/RhLhJOTIYj0BK07tSZBn71QZ3OstQhcW2nZGxSCN9tbYLYHhj30Uzn6fsLwZcv4JlNTbtg==
+  dependencies:
+    "@guardian/content-entity-model" "^2.2.1"
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.11"
+    node-int64 "^0.4.0"
+    thrift "^0.15.0"
+
 "@guardian/content-entity-model@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@guardian/content-entity-model/-/content-entity-model-2.0.6.tgz#5a5a3dec91f6f4744a2c04843eb0272424e54f81"
@@ -338,15 +349,25 @@
     node-int64 "^0.4.0"
     thrift "^0.12.0"
 
-"@guardian/story-packages-model@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/story-packages-model/-/story-packages-model-2.0.4.tgz#f05f73c5c0e1eb6d6658f5d3c29cf30260e63328"
-  integrity sha512-i16vtZqYkNYGIr3VUdnpcIDphMRqfWhHzEKaB//idEPUlFJuSqhDoJIo2CkBQYWQYN9XmEJInkcUZSNhJz7CcA==
+"@guardian/content-entity-model@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/content-entity-model/-/content-entity-model-2.2.1.tgz#580dfb42e3c76cf41446655a51bb1714981dc504"
+  integrity sha512-ywFYEmwvM8LcLxKbP321KqRGzd4lD40MNUCxS7V38eLbo6emgIJDmPl4rpNMgznR79BL5S1Q0FOhhRqChSVv/g==
   dependencies:
     "@types/node-int64" "^0.4.29"
-    "@types/thrift" "^0.10.9"
+    "@types/thrift" "^0.10.11"
     node-int64 "^0.4.0"
-    thrift "^0.12.0"
+    thrift "^0.15.0"
+
+"@guardian/story-packages-model@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/story-packages-model/-/story-packages-model-2.2.0.tgz#9624cb88dc1b72fd44591c155d66e4cc1523ec93"
+  integrity sha512-tZWBvoBTfR9K7AGlhsiPYAefIjfA5NsU/65OhcZjBEiFN6J+ay37D1dH6uIghYZbd+fB0mQ0I9kT/ac4Lgx0yQ==
+  dependencies:
+    "@types/node-int64" "^0.4.29"
+    "@types/thrift" "^0.10.11"
+    node-int64 "^0.4.0"
+    thrift "^0.15.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -852,6 +873,15 @@
   dependencies:
     "@types/cookiejar" "*"
     "@types/node" "*"
+
+"@types/thrift@^0.10.11":
+  version "0.10.17"
+  resolved "https://registry.yarnpkg.com/@types/thrift/-/thrift-0.10.17.tgz#54e835b9a0cb032da9535fad534557991d13dff7"
+  integrity sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/node-int64" "*"
+    "@types/q" "*"
 
 "@types/thrift@^0.10.9":
   version "0.10.10"
@@ -3156,6 +3186,17 @@ thrift@^0.12.0:
     q "^1.5.0"
     ws "^5.0.0"
 
+thrift@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.15.0.tgz#9c502ab3763e12b93e33c8b4e5c1e0e12ed864cf"
+  integrity sha512-RvuFCwHD8bAHIh0Evlr+8QJui/zzistIj9k668jX6jGvDF1OyOmI5TvY+YnqI/VQxpiE2OCGucYJs/nz/CfldA==
+  dependencies:
+    browser-or-node "^1.2.1"
+    isomorphic-ws "^4.0.1"
+    node-int64 "^0.4.0"
+    q "^1.5.0"
+    ws "^5.2.2"
+
 thrift@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.19.0.tgz#340545555ea74cd129457963aa300967afcb038c"
@@ -3402,7 +3443,7 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@^5.0.0, ws@^5.2.3:
+ws@^5.0.0, ws@^5.2.2, ws@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
   integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==


### PR DESCRIPTION
## Why are you doing this?

This adds support in the cartoon element, a multi-image element which displays different sets of images (which roughly correspond to cartoon panels) at different breakpoints.

Cartoon elements are only permitted in the Picture content type and come through in the main media, so support for this element has been limited to that scenario only.

The majority of the rendering logic resides in DCR which can be seen in the companion pr here: https://github.com/guardian/dotcom-rendering/pull/9416

## Changes

- Bumping CAPI libs to include Cartoon element definition
- Add `cartoonImages` to the fronts - this allows us to use the lightbox feature

## Screenshots

https://github.com/guardian/editions/assets/33927854/5727405b-a769-4e6d-b3f4-2ddd51baed5e