### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,0 +1,1 @@
+@guardian/editions-developers


### PR DESCRIPTION
## Why are you doing this?

An aim to get the reviewers auto populated for each PR as per: https://stackoverflow.com/questions/46340474/set-a-default-reviewer

## Changes

- Add CODEOWNERS file
