### PR TITLE
chore: Temporary remove Australia edition

### DIFF
--- a/projects/Apps/common/src/editions-defaults.ts
+++ b/projects/Apps/common/src/editions-defaults.ts
@@ -15,18 +15,4 @@ morning by 6am (GMT)`,
         notificationUTCOffset: 3,
         locale: 'en_GB',
     },
-    {
-        title: 'Australia Weekend',
-        subTitle: `Published from Sydney every 
-Saturday by 6 am (AEST)`,
-        edition: editions.ausWeekly,
-        header: {
-            title: 'Australia',
-            subTitle: 'Weekend',
-        },
-        editionType: 'Regional',
-        topic: 'au',
-        notificationUTCOffset: -5,
-        locale: 'en_AU',
-    },
 ]

--- a/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
+++ b/projects/Mallard/src/components/EditionsMenu/__tests__/__snapshots__/EditionsMenu.spec.tsx.snap
@@ -102,20 +102,6 @@ morning by 6am (GMT)",
         "topic": "uk",
       },
       {
-        "edition": "australian-edition",
-        "editionType": "Regional",
-        "header": {
-          "subTitle": "Weekend",
-          "title": "Australia",
-        },
-        "locale": "en_AU",
-        "notificationUTCOffset": -5,
-        "subTitle": "Published from Sydney every 
-Saturday by 6 am (AEST)",
-        "title": "Australia Weekend",
-        "topic": "au",
-      },
-      {
         "buttonImageUri": "https://media.guim.co.uk/49cebb0db4a3e4d26d7d190da7be4a2e9bd7534f/0_0_103_158/103.png",
         "buttonStyle": {
           "backgroundColor": "#FEEEF7",
@@ -201,20 +187,6 @@ Monthly",
       style={null}
     >
       EditionButton
-      <View
-        style={
-          {
-            "height": 10,
-          }
-        }
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      onLayout={[Function]}
-      style={null}
-    >
-      EditionButton
     </View>
   </View>
 </RCTScrollView>
@@ -238,20 +210,6 @@ exports[`EditionsMenu should display a default EditionsMenu with correct styling
 morning by 6am (GMT)",
         "title": "UK Daily",
         "topic": "uk",
-      },
-      {
-        "edition": "australian-edition",
-        "editionType": "Regional",
-        "header": {
-          "subTitle": "Weekend",
-          "title": "Australia",
-        },
-        "locale": "en_AU",
-        "notificationUTCOffset": -5,
-        "subTitle": "Published from Sydney every 
-Saturday by 6 am (AEST)",
-        "title": "Australia Weekend",
-        "topic": "au",
       },
     ]
   }
@@ -279,20 +237,6 @@ Saturday by 6 am (AEST)",
   viewabilityConfigCallbackPairs={[]}
 >
   <View>
-    <View
-      onFocusCapture={[Function]}
-      onLayout={[Function]}
-      style={null}
-    >
-      EditionButton
-      <View
-        style={
-          {
-            "height": 10,
-          }
-        }
-      />
-    </View>
     <View
       onFocusCapture={[Function]}
       onLayout={[Function]}

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.altlocale.spec.tsx
@@ -3,7 +3,6 @@ import {
 	editionsListCache,
 	selectedEditionCache,
 } from 'src/helpers/storage';
-import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-defaults';
 import { BASE_EDITION, defaultEditionDecider } from '../use-edition-provider';
 import { DownloadBlockedStatus } from '../use-net-info-provider';
 
@@ -25,16 +24,10 @@ describe('useEditions', () => {
 		it('should set the BASE EDITION if locale is not in the list', async () => {
 			const defaultLocalState = jest.fn();
 			const selectedLocalState = jest.fn();
-			const editionsList = {
-				regionalEditions: defaultRegionalEditions,
-				specialEditions: [],
-				trainingEditions: [],
-			};
 
 			await defaultEditionDecider(
 				defaultLocalState,
 				selectedLocalState,
-				editionsList,
 				DownloadBlockedStatus.NotBlocked,
 				() => {},
 			);

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -9,14 +9,12 @@ import { defaultRegionalEditions } from '../../../../Apps/common/src/editions-de
 import {
 	BASE_EDITION,
 	DEFAULT_EDITIONS_LIST,
-	defaultEditionDecider,
 	fetchEditions,
 	getDefaultEdition,
 	getEditions,
 	getSelectedEditionSlug,
 	removeExpiredSpecialEditions,
 } from '../use-edition-provider';
-import { DownloadBlockedStatus } from '../use-net-info-provider';
 
 const IS_CONNECTED = true;
 

--- a/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
+++ b/projects/Mallard/src/hooks/__tests__/use-edition-provider.spec.tsx
@@ -137,12 +137,6 @@ describe('useEditions', () => {
 			const editionSlug = await getSelectedEditionSlug();
 			expect(editionSlug).toEqual(BASE_EDITION.edition);
 		});
-		it('should return "australian-edition" slug when the AU edition is set', async () => {
-			await selectedEditionCache.set(defaultRegionalEditions[1]);
-			await editionsListCache.set(DEFAULT_EDITIONS_LIST);
-			const editionSlug = await getSelectedEditionSlug();
-			expect(editionSlug).toEqual('australian-edition');
-		});
 	});
 
 	describe('fetchEditions', () => {
@@ -219,72 +213,15 @@ describe('useEditions', () => {
 		});
 	});
 
-	describe('defaultEditionDecider', () => {
-		beforeEach(async () => {
-			await defaultEditionCache.reset();
-			await selectedEditionCache.reset();
-		});
-		it('should set default and selected edition local state as well as selected storage if found in default storage', async () => {
-			const defaultLocalState = jest.fn();
-			const selectedLocalState = jest.fn();
-			defaultEditionCache.set(defaultRegionalEditions[1]);
-
-			await defaultEditionDecider(
-				defaultLocalState,
-				selectedLocalState,
-				DEFAULT_EDITIONS_LIST,
-				DownloadBlockedStatus.NotBlocked,
-				() => {},
-			);
-			expect(defaultLocalState).toBeCalledTimes(1);
-			expect(defaultLocalState).toBeCalledWith(
-				defaultRegionalEditions[1],
-			);
-			expect(selectedLocalState).toBeCalledTimes(1);
-			expect(selectedLocalState).toBeCalledWith(
-				defaultRegionalEditions[1],
-			);
-			const selectedEdition = await selectedEditionCache.get();
-			expect(selectedEdition).toEqual(defaultRegionalEditions[1]);
-			const defaultEdition = await defaultEditionCache.get();
-			expect(defaultEdition).toEqual(defaultRegionalEditions[1]);
-		});
-		it('should set a default based on locale if the feature flag is on and nothing in the default edition cache', async () => {
-			// defaultRegionalEditions[1] = AU and locale mock = AU
-			const defaultLocalState = jest.fn();
-			const selectedLocalState = jest.fn();
-
-			await defaultEditionDecider(
-				defaultLocalState,
-				selectedLocalState,
-				DEFAULT_EDITIONS_LIST,
-				DownloadBlockedStatus.NotBlocked,
-				() => {},
-			);
-			expect(defaultLocalState).toBeCalledTimes(1);
-			expect(defaultLocalState).toBeCalledWith(
-				defaultRegionalEditions[1],
-			);
-			expect(selectedLocalState).toBeCalledTimes(1);
-			expect(selectedLocalState).toBeCalledWith(
-				defaultRegionalEditions[1],
-			);
-			const selectedEdition = await selectedEditionCache.get();
-			expect(selectedEdition).toEqual(defaultRegionalEditions[1]);
-			const defaultEdition = await defaultEditionCache.get();
-			expect(defaultEdition).toEqual(defaultRegionalEditions[1]);
-		});
-	});
-
 	describe('getDefaultEdition', () => {
 		beforeEach(async () => {
 			await defaultEditionCache.reset();
 		});
 		it('should return the default edition from storage if its there', async () => {
-			await defaultEditionCache.set(defaultRegionalEditions[1]);
+			await defaultEditionCache.set(defaultRegionalEditions[0]);
 
 			const defaultEdition = await getDefaultEdition();
-			expect(defaultEdition).toEqual(defaultRegionalEditions[1]);
+			expect(defaultEdition).toEqual(defaultRegionalEditions[0]);
 		});
 		it('should return null if default edition is not in storage', async () => {
 			const defaultEdition = await getDefaultEdition();

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -3,12 +3,10 @@ import type { Dispatch } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import type {
 	EditionsList,
-	Locale,
 	RegionalEdition,
 	SpecialEdition,
 	SpecialEditionHeaderStyles,
 } from 'src/common';
-import { locale } from 'src/helpers/locale';
 import {
 	defaultSettings,
 	editionsEndpoint,


### PR DESCRIPTION
## Why are you doing this?

This has not been published since 1st April 2023. There may be an appetite to bring it back in future.

## Changes

- The regional editions are determined by the `/editions` endpoint. Which in turn is controlled in an S3 bucket. To change this there would change all versions of the app, and is arguably a quicker but potentially more destructive approach
- This change allows us to control via app release.
- Filter out australia edition wherever we set the editions list
- Remove the auto edition to locale feature as there is only one now.

Please note, to reinstate this edition in future would require our readers to update the app

## Screenshots

### Removed from current version

https://github.com/guardian/editions/assets/935975/ed644e49-97f5-48bd-b037-99a007dd9dc2

### Unable to access auto edition on a new install

https://github.com/guardian/editions/assets/935975/e101bc8a-56ca-43c4-b35f-1bd0775413c2

