### PR TITLE
fix: Diagnostics include

### DIFF
--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -302,13 +302,5 @@ export const getFileList = async () => {
 		}),
 	);
 
-	const issuesFile = await RNFS.stat(editionDirectory + '/issues');
-
-	const cleanIssuesFile = [
-		{
-			issues: cleanFileDisplay(issuesFile),
-		},
-	];
-
-	return [...cleanSubfolders, ...cleanIssuesFile, ...imageFolderSearch];
+	return [...cleanSubfolders, ...imageFolderSearch];
 };


### PR DESCRIPTION
## Why are you doing this?

`Include diagnostics` is not currently working.

This was a result of removing the issue summary file, which we did in this PR: https://github.com/guardian/editions/pull/2299. We are looking for a file that now doesnt exist and it causes the function to throw. That in itself is inside a `try...catch` meaning we dont call the `mailto` function.

I have tidied this diagnostic function so that we dont check for the file that wont exist

## Changes

- Removed code attempting to find the file
- Tested it works on both iOS and Android

## Screenshots

https://github.com/guardian/editions/assets/935975/791af6c3-3782-40a7-96dc-47353061b933

