### PR TITLE
feat: Pull to Refresh on Issue List

### DIFF
--- a/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
+++ b/projects/Mallard/src/hooks/use-issue-summary-provider.tsx
@@ -24,7 +24,7 @@ interface IssueSummaryState {
 	error: string;
 	initialFrontKey: string | null;
 	setIssueId: Dispatch<PathToIssue>;
-	getLatestIssueSummary: () => Promise<void>;
+	getLatestIssueSummary: (skipSetting?: boolean) => Promise<void>;
 }
 
 const defaultState: IssueSummaryState = {

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -13,6 +13,7 @@ import {
 	Dimensions,
 	FlatList,
 	Platform,
+	RefreshControl,
 	StyleSheet,
 	View,
 } from 'react-native';
@@ -259,11 +260,19 @@ const IssueListView = React.memo(
 		currentIssue: { id: PathToIssue; details: Loaded<IssueWithFronts> };
 		setIssueId: Dispatch<PathToIssue>;
 	}) => {
+		const [refreshing, setRefreshing] = useState(false);
+		const { getLatestIssueSummary } = useIssueSummary();
 		const navigation = useNavigation();
 		const { maxAvailableEditions } = useMaxAvailableEditions();
 		const { localIssueId: localId, publishedIssueId: publishedId } =
 			currentIssue.id;
 		const { details } = currentIssue;
+
+		// PTR: We get the latest list of issues but do not change the current issue the user is reading
+		const onRefresh = useCallback(async () => {
+			await getLatestIssueSummary(true);
+			setRefreshing(false);
+		}, [getLatestIssueSummary, setRefreshing]);
 
 		// We want to scroll to the current issue.
 		const currentIssueIndex = issueList.findIndex(
@@ -342,6 +351,14 @@ const IssueListView = React.memo(
 
 		return (
 			<FlatList
+				refreshControl={
+					<RefreshControl
+						onRefresh={onRefresh}
+						refreshing={refreshing}
+						colors={[color.primary]}
+						tintColor={color.primary}
+					/>
+				}
 				// Only render 7 because that is the default number of editions
 				initialNumToRender={maxAvailableEditions}
 				ItemSeparatorComponent={Separator}


### PR DESCRIPTION
## Why are you doing this?

Adds pull to refresh on the issue list.

## Changes

- Add in the `RefreshControl` to the `FlatList`
- Use the primary blue to colour it
- Call the function to get the latest issue summary, but don't reset the users issue to latest as to not disturb their reading.

## Screenshots

### Android

https://github.com/guardian/editions/assets/935975/be95b4aa-9f8c-424c-98a1-1db0bd2a5480

### iOS

https://github.com/guardian/editions/assets/935975/6eadc218-b40d-4cb6-b271-b1e074e9e510




