### PR TITLE
chore: Updated Navigation Types

### DIFF
--- a/projects/Mallard/src/components/Header/Header.tsx
+++ b/projects/Mallard/src/components/Header/Header.tsx
@@ -1,7 +1,9 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
 import { isTablet } from 'react-native-device-info';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { color } from 'src/theme/color';
 import { Button } from '../Button/Button';
 import { CloseButton } from '../Button/CloseButton';
@@ -39,7 +41,8 @@ const HeaderScreenContainer = ({
 	children: React.ReactNode;
 	title: string;
 }) => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 
 	return (
 		<View style={ModalStyles.wrapper}>

--- a/projects/Mallard/src/components/Modals/MissingIAPModal.tsx
+++ b/projects/Mallard/src/components/Modals/MissingIAPModal.tsx
@@ -1,13 +1,16 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useContext } from 'react';
 import { AccessContext } from 'src/authentication/AccessContext';
 import { Copy } from 'src/helpers/words';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { CenterWrapper } from '../CenterWrapper/CenterWrapper';
 import { MissingIAPModalCard } from '../missing-iap-modal-card';
 
 const MissingIAPRestoreError = () => {
 	const { authIAP } = useContext(AccessContext);
-	const { goBack } = useNavigation();
+	const { goBack } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<CenterWrapper>
 			<MissingIAPModalCard
@@ -22,7 +25,8 @@ const MissingIAPRestoreError = () => {
 
 const MissingIAPRestoreMissing = () => {
 	const { authIAP } = useContext(AccessContext);
-	const { goBack } = useNavigation();
+	const { goBack } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<CenterWrapper>
 			<MissingIAPModalCard

--- a/projects/Mallard/src/components/Modals/SignInFailedModal.tsx
+++ b/projects/Mallard/src/components/Modals/SignInFailedModal.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import type { RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { useOkta } from 'src/hooks/use-okta-sign-in';
 import { RouteNames } from 'src/navigation/NavigationModels';
@@ -16,7 +17,8 @@ const SignInFailedModal = ({
 }: {
 	route: RouteProp<MainStackParamList, 'SignInFailedModal'>;
 }) => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { signIn, signOut } = useOkta();
 	return (
 		<CenterWrapper>

--- a/projects/Mallard/src/components/Modals/SignInModal.tsx
+++ b/projects/Mallard/src/components/Modals/SignInModal.tsx
@@ -1,12 +1,15 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { useOkta } from 'src/hooks/use-okta-sign-in';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { CenterWrapper } from '../CenterWrapper/CenterWrapper';
 import { SignInModalCard } from '../sign-in-modal-card';
 
 const SignInModal = () => {
-	const { navigate } = useNavigation<any>();
+	const { navigate } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { signIn } = useOkta();
 	return (
 		<CenterWrapper>

--- a/projects/Mallard/src/components/Modals/SubFoundModal.tsx
+++ b/projects/Mallard/src/components/Modals/SubFoundModal.tsx
@@ -1,5 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type {
+	NativeStackNavigationProp,
+	NativeStackScreenProps,
+} from '@react-navigation/native-stack';
 import React from 'react';
 import { Copy } from 'src/helpers/words';
 import type { MainStackParamList } from 'src/navigation/NavigationModels';
@@ -13,7 +16,8 @@ type SubFoundModalCardProps = NativeStackScreenProps<
 >;
 
 const SubFoundModalCard = ({ route }: SubFoundModalCardProps) => {
-	const { goBack } = useNavigation();
+	const { goBack } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<CenterWrapper>
 			<OnboardingCard

--- a/projects/Mallard/src/components/Modals/SubNotFoundModal.tsx
+++ b/projects/Mallard/src/components/Modals/SubNotFoundModal.tsx
@@ -1,12 +1,15 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { useOkta } from 'src/hooks/use-okta-sign-in';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { CenterWrapper } from '../CenterWrapper/CenterWrapper';
 import { SubNotFoundModalCard } from '../sub-not-found-modal-card';
 
 const SubNotFoundModal = () => {
-	const { navigate } = useNavigation<any>();
+	const { navigate } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { signIn } = useOkta();
 	return (
 		<CenterWrapper>

--- a/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssuePickerHeader/IssuePickerHeader.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useContext } from 'react';
 import type { SpecialEditionHeaderStyles } from 'src/common';
 import { CloseButton } from 'src/components/Button/CloseButton';
@@ -6,6 +7,7 @@ import { SettingsButton } from 'src/components/Button/SettingsButton';
 import { IssueTitle } from 'src/components/issue/issue-title';
 import { Header } from 'src/components/layout/header/header';
 import { styles } from 'src/components/styled-text';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { SettingsOverlayContext } from '../../../hooks/use-settings-overlay';
 
@@ -18,7 +20,8 @@ const IssuePickerHeader = ({
 	subTitle?: string;
 	title: string;
 }) => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const settingsOverlay = useContext(SettingsOverlayContext);
 
 	return (

--- a/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
+++ b/projects/Mallard/src/components/ScreenHeader/IssueScreenHeader/IssueScreenHeader.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback } from 'react';
 import type { IssueWithFronts, SpecialEditionHeaderStyles } from 'src/common';
 import { IssueTitle } from 'src/components/issue/issue-title';
@@ -7,6 +8,7 @@ import { styles } from 'src/components/styled-text';
 import { logEvent } from 'src/helpers/analytics';
 import { useIssueDate } from 'src/helpers/issues';
 import { useEditions } from 'src/hooks/use-edition-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { remoteConfigService } from 'src/services/remote-config';
 import { IssueMenuButton } from '../../Button/IssueMenuButton';
@@ -26,7 +28,8 @@ const IssueScreenHeader = React.memo(
 		headerStyles?: SpecialEditionHeaderStyles;
 		issue?: IssueWithFronts;
 	}) => {
-		const { navigate } = useNavigation<any>();
+		const { navigate } =
+			useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 		const { date, weekday } = useIssueDate(issue);
 		const { setNewEditionSeen, selectedEdition } = useEditions();
 

--- a/projects/Mallard/src/components/article/types/article.tsx
+++ b/projects/Mallard/src/components/article/types/article.tsx
@@ -5,6 +5,7 @@ import type {
 	ShareIconMessage,
 } from '@guardian/renditions';
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useEffect, useRef, useState } from 'react';
 import { PixelRatio, Platform, Share, StyleSheet } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
@@ -26,6 +27,7 @@ import { useApiUrl } from 'src/hooks/use-config-provider';
 import { selectImagePath } from 'src/hooks/use-image-paths';
 import { useIssueSummary } from 'src/hooks/use-issue-summary-provider';
 import { useNetInfo } from 'src/hooks/use-net-info-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToArticle } from 'src/paths';
 import { remoteConfigService } from 'src/services/remote-config';
@@ -171,7 +173,8 @@ const Article = ({
 	path: PathToArticle;
 	origin: IssueOrigin;
 } & HeaderControlProps) => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const ref = useRef<WebView | null>(null);
 	const [script, setScript] = useState('');
 	const [imagePaths, setImagePaths] = useState(['']);

--- a/projects/Mallard/src/components/layout/slide-card/header.tsx
+++ b/projects/Mallard/src/components/layout/slide-card/header.tsx
@@ -1,6 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 import { Chevron } from '../../chevron';
@@ -27,7 +29,8 @@ const styles = StyleSheet.create({
 });
 
 const Header = () => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<View style={styles.headerContainer}>
 			<TouchableWithoutFeedback

--- a/projects/Mallard/src/components/weather.tsx
+++ b/projects/Mallard/src/components/weather.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
@@ -7,6 +8,7 @@ import { logEvent } from 'src/helpers/analytics';
 import { format } from 'src/helpers/date';
 import { Weather } from 'src/helpers/words';
 import { useWeather } from 'src/hooks/use-weather-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { Breakpoints } from 'src/theme/breakpoints';
 import { color } from 'src/theme/color';
@@ -198,7 +200,8 @@ const WeatherIconView = ({
 };
 
 const SetLocationButton = () => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const onSetLocation = useCallback(() => {
 		navigation.navigate(RouteNames.WeatherGeolocationConsent);
 		logEvent({

--- a/projects/Mallard/src/hooks/use-login-overlay.tsx
+++ b/projects/Mallard/src/hooks/use-login-overlay.tsx
@@ -1,14 +1,17 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useEffect } from 'react';
 import {
 	useAccess,
 	useIdentity,
 	useOktaData,
 } from 'src/authentication/AccessContext';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 
 const useLoginOverlay = () => {
-	const { navigate } = useNavigation<any>();
+	const { navigate } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const canAccess = useAccess();
 	const oktaData = useOktaData();
 	const idData = useIdentity();

--- a/projects/Mallard/src/hooks/use-okta-sign-in.tsx
+++ b/projects/Mallard/src/hooks/use-okta-sign-in.tsx
@@ -1,16 +1,18 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useContext, useState } from 'react';
 import { Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import { AccessContext } from 'src/authentication/AccessContext';
 import { isValid } from 'src/authentication/lib/Attempt';
 import { oktaSignOut } from 'src/authentication/services/okta';
-import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 
 const useOkta = () => {
 	const { authOkta, signOutOkta } = useContext(AccessContext);
-	const navigation = useNavigation<CompositeNavigationStackProps>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [error, setError] = useState<string | null>(null);
 

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -23,7 +23,7 @@ export type OnboardingStackParamList = {
 
 export type MainStackParamList = {
 	Home: undefined;
-	Issue: IssueNavigationProps;
+	Issue: IssueNavigationProps | undefined;
 	Article: ArticleNavigationProps;
 	IssueList: undefined;
 	EditionsMenu: undefined;
@@ -36,7 +36,7 @@ export type MainStackParamList = {
 	SignInFailedModal: SignInFailedProps;
 	MissingIAPRestoreError: undefined;
 	MissingIAPRestoreMissing: undefined;
-	Settings: { screen: RouteNames };
+	Settings: { screen: RouteNames } | undefined;
 	Endpoints: undefined;
 	Edition: undefined;
 	GdprConsent: undefined;

--- a/projects/Mallard/src/screens/editions-menu-screen.tsx
+++ b/projects/Mallard/src/screens/editions-menu-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { ReactElement } from 'react';
 import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
@@ -8,6 +9,7 @@ import { EditionsMenu } from 'src/components/EditionsMenu/EditionsMenu';
 import { EditionsMenuScreenHeader } from 'src/components/ScreenHeader/EditionMenuScreenHeader';
 import { logEvent } from 'src/helpers/analytics';
 import { useEditions } from 'src/hooks/use-edition-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { WithAppAppearance } from 'src/theme/appearance';
 import { ApiState } from './settings/api-screen';
@@ -75,7 +77,8 @@ export const EditionsMenuScreen = () => {
 		selectedEdition,
 		storeSelectedEdition,
 	} = useEditions();
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<WithAppAppearance value="default">
 			<ScreenFiller>

--- a/projects/Mallard/src/screens/external-subscription.tsx
+++ b/projects/Mallard/src/screens/external-subscription.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import type { ColorSchemeName, TextStyle, ViewStyle } from 'react-native';
 import {
@@ -12,6 +13,7 @@ import {
 } from 'react-native';
 import { getDeviceId, isTablet } from 'react-native-device-info';
 import { Copy } from 'src/helpers/words';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 
 const isTabletDevice = isTablet();
 
@@ -128,7 +130,8 @@ const subscribe = () =>
 	Linking.openURL('https://support.theguardian.com/uk/subscribe/digital');
 
 export const ExternalSubscriptionScreen = () => {
-	const { goBack } = useNavigation();
+	const { goBack } =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const colorScheme = useColorScheme();
 	const style = styles(colorScheme);
 	return (

--- a/projects/Mallard/src/screens/home-screen.tsx
+++ b/projects/Mallard/src/screens/home-screen.tsx
@@ -1,4 +1,5 @@
 import { useIsFocused, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { Dispatch } from 'react';
 import React, {
 	useCallback,
@@ -47,7 +48,10 @@ import { useSetNavPosition } from 'src/hooks/use-nav-position';
 import useOverlayAnimation from 'src/hooks/use-overlay-animation';
 import { SettingsOverlayContext } from 'src/hooks/use-settings-overlay';
 import { navigateToIssue } from 'src/navigation/helpers/base';
-import type { CompositeNavigationStackProps } from 'src/navigation/NavigationModels';
+import type {
+	CompositeNavigationStackProps,
+	MainStackParamList,
+} from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import type { PathToIssue } from 'src/paths';
 import { WithAppAppearance } from 'src/theme/appearance';
@@ -262,7 +266,8 @@ const IssueListView = React.memo(
 	}) => {
 		const [refreshing, setRefreshing] = useState(false);
 		const { getLatestIssueSummary } = useIssueSummary();
-		const navigation = useNavigation();
+		const navigation =
+			useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 		const { maxAvailableEditions } = useMaxAvailableEditions();
 		const { localIssueId: localId, publishedIssueId: publishedId } =
 			currentIssue.id;

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { MutableRefObject, ReactElement } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
@@ -44,6 +45,7 @@ import { useIssue } from 'src/hooks/use-issue-provider';
 import { useIssueSummary } from 'src/hooks/use-issue-summary-provider';
 import { useNavPositionChange } from 'src/hooks/use-nav-position';
 import { useWeather } from 'src/hooks/use-weather-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { Breakpoints } from 'src/theme/breakpoints';
 import { metrics } from 'src/theme/spacing';
 import type {
@@ -288,7 +290,8 @@ const IssueFronts = ({
 
 const PreviewReloadButton = ({ onPress }: { onPress: () => Promise<void> }) => {
 	const { isPreview } = useApiUrl();
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const route = useRoute();
 
 	const onPressReload = async () => {

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -1,6 +1,7 @@
 import { palette } from '@guardian/pasteup/palette';
 import type { RouteProp } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useEffect, useState } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import ImageViewer from 'react-native-image-zoom-viewer';
@@ -76,7 +77,8 @@ const styles = StyleSheet.create({
 });
 
 const LightboxScreen = () => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const route =
 		useRoute<RouteProp<MainStackParamList, RouteNames.Lightbox>>();
 	const imagePaths = route.params?.imagePaths ?? [];

--- a/projects/Mallard/src/screens/onboarding/cards.tsx
+++ b/projects/Mallard/src/screens/onboarding/cards.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { ButtonAppearance } from 'src/components/Button/Button';
@@ -10,6 +11,7 @@ import {
 } from 'src/components/onboarding/onboarding-card';
 import { Copy } from 'src/helpers/words';
 import { useGdprSettings } from 'src/hooks/use-gdpr';
+import type { OnboardingStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 
 const Aligner = ({ children }: { children: React.ReactNode }) => (
@@ -34,7 +36,8 @@ const styles = StyleSheet.create({
 });
 
 const OnboardingConsent = () => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>();
 	const { enableAllSettings } = useGdprSettings();
 
 	return (

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useContext, useState } from 'react';
 import type { AccessibilityRole } from 'react-native';
 import { Alert, Linking, Platform, Switch, Text } from 'react-native';
@@ -24,12 +25,14 @@ import {
 } from 'src/hooks/use-config-provider';
 import { useOkta } from 'src/hooks/use-okta-sign-in';
 import { useIsWeatherShown } from 'src/hooks/use-weather-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { BetaButtonOption } from 'src/screens/settings/join-beta-button';
 import { WithAppAppearance } from 'src/theme/appearance';
 
 const MiscSettingsList = () => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { notificationsEnabled, setNotifications } =
 		useNotificationsEnabled();
 	const [settingNotificationsEnabled, setSettingNotificationsEnabled] =
@@ -148,7 +151,8 @@ const SignInButton = ({
 	);
 
 const SettingsScreen = () => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const identityData = useIdentity();
 	const oktaData = useOktaData();
 	const canAccess = useAccess();

--- a/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
+++ b/projects/Mallard/src/screens/settings/already-subscribed-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useContext } from 'react';
 import { Platform } from 'react-native';
 import { AccessContext, useAccess } from 'src/authentication/AccessContext';
@@ -10,6 +11,7 @@ import { Heading } from 'src/components/layout/ui/row';
 import { List } from 'src/components/lists/list';
 import { Copy } from 'src/helpers/words';
 import { useOkta } from 'src/hooks/use-okta-sign-in';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { WithAppAppearance } from 'src/theme/appearance';
 
@@ -17,7 +19,8 @@ const AlreadySubscribedScreen = () => {
 	const canAccess = useAccess();
 	const { authIAP } = useContext(AccessContext);
 	const rightChevronIcon = <RightChevron />;
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { signIn } = useOkta();
 
 	return (

--- a/projects/Mallard/src/screens/settings/api-screen.tsx
+++ b/projects/Mallard/src/screens/settings/api-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { TextInput } from 'react-native-gesture-handler';
@@ -10,6 +11,7 @@ import { UiBodyCopy } from 'src/components/styled-text';
 import { backends } from 'src/helpers/settings/defaults';
 import { ENDPOINTS_HEADER_TITLE } from 'src/helpers/words';
 import { API_URL_DEFAULT, useApiUrl } from 'src/hooks/use-config-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 
@@ -27,7 +29,8 @@ const ApiState = () => {
 
 const ApiScreen = () => {
 	const { apiUrl, setApiUrl } = useApiUrl();
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 
 	return (
 		<HeaderScreenContainer title={ENDPOINTS_HEADER_TITLE} actionLeft={true}>

--- a/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
+++ b/projects/Mallard/src/screens/settings/cas-sign-in-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useContext, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Image from 'react-native-fast-image';
@@ -8,6 +9,7 @@ import { LoginButton } from 'src/components/login/login-button';
 import { LoginInput } from 'src/components/login/login-input';
 import { LoginLayout } from 'src/components/login/login-layout';
 import { useFormField } from 'src/hooks/use-form-field';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { getFont } from 'src/theme/typography';
 
@@ -18,7 +20,8 @@ const styles = StyleSheet.create({
 });
 
 const CasSignInScreen = () => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { authCAS } = useContext(AccessContext);
 
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -1,6 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
 import type { ReactNode } from 'react';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Alert, Clipboard, Platform, View } from 'react-native';
@@ -65,7 +64,7 @@ const ButtonList = ({ children }: { children: ReactNode }) => {
 };
 
 const DevZone = () => {
-	const navigation = useNavigation<StackNavigationProp<any>>();
+	const navigation = useNavigation<any>();
 	const {
 		isDevButtonShown: showNetInfoButton,
 		setIsDevButtonShown: setShowNetInfoButton,

--- a/projects/Mallard/src/screens/settings/editions-screen.tsx
+++ b/projects/Mallard/src/screens/settings/editions-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { HeaderScreenContainer } from 'src/components/Header/Header';
 import { ScrollContainer } from 'src/components/layout/ui/container';
@@ -6,9 +7,11 @@ import { Heading } from 'src/components/layout/ui/row';
 import { List } from 'src/components/lists/list';
 import { EDITIONS_HEADER_TITLE } from 'src/helpers/words';
 import { useEditions } from 'src/hooks/use-edition-provider';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 
 const EditionsScreen = () => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { editionsList, storeSelectedEdition } = useEditions();
 
 	const consolidatedEditions = [

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { Alert, FlatList, Text, View } from 'react-native';
 import { Button, ButtonAppearance } from 'src/components/Button/Button';
@@ -17,6 +18,7 @@ import {
 import type { GdprSwitches } from 'src/hooks/use-gdpr';
 import { useGdprSettings } from 'src/hooks/use-gdpr';
 import { useToast } from 'src/hooks/use-toast';
+import type { OnboardingStackParamList } from 'src/navigation/NavigationModels';
 import { RouteNames } from 'src/navigation/NavigationModels';
 import { WithAppAppearance } from 'src/theme/appearance';
 
@@ -44,7 +46,8 @@ const GdprConsent = ({
 	shouldShowDismissableHeader?: boolean;
 	continueText: string;
 }) => {
-	const navigation = useNavigation<any>();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<OnboardingStackParamList>>();
 	const { showToast } = useToast();
 
 	const {

--- a/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
+++ b/projects/Mallard/src/screens/settings/privacy-policy-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { LoginHeader } from 'src/components/login/login-layout';
 import {
@@ -7,13 +8,15 @@ import {
 } from 'src/components/RenderHTML/RenderHTML';
 import { html } from 'src/constants/settings/privacy-policy';
 import { PRIVACY_POLICY_HEADER_TITLE } from 'src/helpers/words';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 
 const PrivacyPolicyScreen = () => (
 	<RenderHTMLWithHeader html={html} title={PRIVACY_POLICY_HEADER_TITLE} />
 );
 
 const PrivacyPolicyScreenForOnboarding = () => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<>
 			<LoginHeader onDismiss={() => navigation.goBack()}>

--- a/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
+++ b/projects/Mallard/src/screens/weather-geolocation-consent-screen.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { Alert, Linking, Platform, StyleSheet, View } from 'react-native';
 import { RESULTS } from 'react-native-permissions';
@@ -10,6 +11,7 @@ import { requestLocationPermission } from 'src/helpers/location-permission';
 import { Copy } from 'src/helpers/words';
 import { useIsWeatherShown, useWeather } from 'src/hooks/use-weather-provider';
 import { getGeolocation } from 'src/hooks/use-weather-provider/utils';
+import type { MainStackParamList } from 'src/navigation/NavigationModels';
 import { metrics } from 'src/theme/spacing';
 
 const styles = StyleSheet.create({
@@ -31,7 +33,8 @@ const showIsDisabledAlert = () => {
 };
 
 const WeatherGeolocationConsentScreen = () => {
-	const navigation = useNavigation();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	const { refreshWeather } = useWeather();
 	const { setIsWeatherShown } = useIsWeatherShown();
 	const onConsentPress = async () => {


### PR DESCRIPTION
## Why are you doing this?

As part of the React Navigation update, a few `any` types were added in. These look to resolve these with stricter types

## Changes

- Update previously added `any` types with stricter types
- Some routes have props and can be undefined. There is no change to the route, just how the type is consumed with the latest update

## Output

Passing type check determines the success of this PR