### PR TITLE
chore: Netinfo update

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -491,7 +491,7 @@ PODS:
     - React-Core
   - react-native-in-app-utils (6.1.0):
     - React
-  - react-native-netinfo (9.5.0):
+  - react-native-netinfo (11.3.0):
     - React-Core
   - react-native-pager-view (5.4.25):
     - React-Core
@@ -1013,7 +1013,7 @@ SPEC CHECKSUMS:
   react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-geolocation: ef66fb798d96284c6043f0b16c15d9d1d4955db4
   react-native-in-app-utils: 96cdefc90ad74a79a95d19239a183995a6face0b
-  react-native-netinfo: 48c5f79a84fbc3ba1d28a8b0d04adeda72885fa8
+  react-native-netinfo: 299dad906cdbf3b67bcc6f693c807f98bdd127cc
   react-native-pager-view: da490aa1f902c9a5aeecf0909cc975ad0e92e53e
   react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -48,7 +48,7 @@
 		"@okta/okta-react-native": "^2.8.0",
 		"@react-native-async-storage/async-storage": "^1.17.11",
 		"@react-native-community/geolocation": "^3.0.5",
-		"@react-native-community/netinfo": "^9.3.8",
+		"@react-native-community/netinfo": "^11.3.0",
 		"@react-native-community/push-notification-ios": "^1.10.1",
 		"@react-native-firebase/analytics": "^18.3.0",
 		"@react-native-firebase/app": "^18.3.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1934,10 +1934,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/geolocation/-/geolocation-3.1.0.tgz#573881e9536d55cc2af74762183fa7ba575b2553"
   integrity sha512-Aj76wMeCLz9kczpe7W2IXxSRNj+hRR7sqyfXq9ZaJIWNH23jeJfzMpovclg+e1uM8Vr8jCYEcZyD4rKub6Vc/Q==
 
-"@react-native-community/netinfo@^9.3.8":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.5.0.tgz#93663bbb105feb8f729b8f0271ee06ffc009f024"
-  integrity sha512-sppTBobjvIlPYXyDAyb5WJoBaQq1hprnHj1PWICsA10mVnlmwX5ZVkgO2vGjsfFtb+fmWK9XtZF+aQ6ijqQcwg==
+"@react-native-community/netinfo@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-11.3.0.tgz#9d99ba00138b38350a794eab5eca436f6e209114"
+  integrity sha512-mR9iqUi0GzuC8ut+goI/lLkgG+a2OViI1mjSdXHKZnkfdJVjHblyWX3xoA8GE4GH8X4r0X/PNM3Vvyf2FH9mVg==
 
 "@react-native-community/push-notification-ios@^1.10.1":
   version "1.11.0"


### PR DESCRIPTION
## Why are you doing this?

Netinfo is currently 2 major versions out of date. V10 and V11 breaking changes do no affect our current setup, so seemed prudent to keep this up to date.

## Changes

- Update to the latest version

## Screenshots

![simulator_screenshot_5A1EE0BF-264A-4965-938B-CE73A0B62B95](https://github.com/guardian/editions/assets/935975/6cb2f559-aa74-473d-be56-8af64c43a8c2)