### PR TITLE
chore: Update webview

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -505,7 +505,7 @@ PODS:
     - React
   - react-native-splash-screen (3.3.0):
     - React-Core
-  - react-native-webview (13.6.4):
+  - react-native-webview (13.8.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - React-NativeModulesApple (0.72.10):
@@ -1015,7 +1015,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
-  react-native-webview: 107961c73db53d66549c867a3b64eaa20d34c41f
+  react-native-webview: bdc091de8cf7f8397653e30182efcd9f772e03b3
   React-NativeModulesApple: c3e696ff867e4bc212266cbdf7e862e48a0166fd
   React-perflogger: 43287389ea08993c300897a46f95cfac04bb6c1a
   React-RCTActionSheet: 923afe77f9bb89da7c1f98e2730bfc9dde0eed6d

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -94,7 +94,7 @@
 		"react-native-splash-screen": "^3.3.0",
 		"react-native-status-bar-height": "^2.4.0",
 		"react-native-svg": "^14.1.0",
-		"react-native-webview": "^13.2.3",
+		"react-native-webview": "^13.8.1",
 		"react-native-zip-archive": "6.0.9",
 		"validator": "^13.7.0"
 	},

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -7047,10 +7047,10 @@ react-native-svg@^14.1.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-webview@^13.2.3:
-  version "13.6.4"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.6.4.tgz#6ef66db9dd78b2a2ae1b4fe79e1e3597aa29186e"
-  integrity sha512-AdgmaMBHPcyERTvng9eSGgHX6AleyUlSusWAxngSOSdiYGgHW81T6C5A8j/ImJAF9oZg0bQDxp43Hu56tzENZQ==
+react-native-webview@^13.8.1:
+  version "13.8.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.8.1.tgz#d0058c063e38241476049aaab2e5cc9f254d5480"
+  integrity sha512-7Jqm1WzWJrOWraBAXQfKtr/Uo5Jw/IJHzC40jYLwgV/eVGmLJ9BpGKw6QVw7wpRkjmTZ2Typ4B1aHJLJJQFslA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## Why are you doing this?

Minor updates to the Webview packahe

## Changes

- Update `react-native-webview`

## Screenshots

Continues to work:

![simulator_screenshot_C99C20E9-62AA-4AEF-9102-BAEE53FA9C4D](https://github.com/guardian/editions/assets/935975/c0f12717-4973-49d9-af42-83647a0c6497)
