### PR TITLE
chore: Update react-native-svg

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -675,7 +675,7 @@ PODS:
   - RNScreens (3.29.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNSVG (14.1.0):
+  - RNSVG (15.0.0):
     - React-Core
   - RNZipArchive (6.0.9):
     - React-Core
@@ -1055,7 +1055,7 @@ SPEC CHECKSUMS:
   RNRate: ef3bcff84f39bb1d1e41c5593d3eea4aab2bd73a
   RNReanimated: ce6bef77caeee09d7f022532cee0c8d9bad09c9a
   RNScreens: 3c5b9f4a9dcde752466854b6109b79c0e205dad3
-  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
+  RNSVG: 3f65a03e0c61a8495dee92bf82545ed9041cbf3b
   RNZipArchive: 68a0c6db4b1c103f846f1559622050df254a3ade
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -93,7 +93,7 @@
 		"react-native-screens": "^3.29.0",
 		"react-native-splash-screen": "^3.3.0",
 		"react-native-status-bar-height": "^2.4.0",
-		"react-native-svg": "^14.1.0",
+		"react-native-svg": "^15.0.0",
 		"react-native-webview": "^13.8.1",
 		"react-native-zip-archive": "6.0.9",
 		"validator": "^13.7.0"

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -7039,10 +7039,10 @@ react-native-status-bar-height@^2.4.0:
   resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
   integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
 
-react-native-svg@^14.1.0:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-14.1.0.tgz#7903bddd3c71bf3a8a503918253c839e6edaa724"
-  integrity sha512-HeseElmEk+AXGwFZl3h56s0LtYD9HyGdrpg8yd9QM26X+d7kjETrRQ9vCjtxuT5dCZEIQ5uggU1dQhzasnsCWA==
+react-native-svg@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.0.0.tgz#3c700a33e97de6305e0fdc61dc036fc6b1bdaef2"
+  integrity sha512-ZUEXlzdU3cHjhOuc4BP7fbvabmz8yIuH4ocKSEr5V3P5skk2wnbEyZd3p7dzV9IoODgguCe7tcrNRGwr9pLRig==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
## Why are you doing this?

A new major version of `react-native-svg` has been released: https://github.com/software-mansion/react-native-svg/releases/tag/v15.0.0

This looks to update it

## Changes

- Update the package
- Test the SVGs in the app, as show in the header in the screenshots

## Screenshots

### iOS

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-28 at 21 13 53](https://github.com/guardian/editions/assets/935975/25aaa10f-cddf-4600-b2cb-3c66093cdddc)

### Android

![Screenshot_20240228_211554](https://github.com/guardian/editions/assets/935975/b2c105ad-714a-414d-b75e-d58c139a5e0c)
