### PR TITLE
chore: Update React Native Device Info

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -628,7 +628,7 @@ PODS:
     - React-Core
   - RNCPushNotificationIOS (1.11.0):
     - React-Core
-  - RNDeviceInfo (10.12.0):
+  - RNDeviceInfo (10.13.1):
     - React-Core
   - RNFastImage (8.6.3):
     - React-Core
@@ -1038,7 +1038,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
+  RNDeviceInfo: 4f9c7cfd6b9db1b05eb919620a001cf35b536423
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFBAnalytics: 5a58b636d8533fc17b44b689212e921747373854
   RNFBApp: a4f5b074984cf612e4c97d68b42be690c59e2638

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -72,7 +72,7 @@
 		"react-native-background-fetch": "^4.2.0",
 		"react-native-circular-progress-indicator": "^4.4.2",
 		"react-native-config": "^1.5.1",
-		"react-native-device-info": "^10.12.0",
+		"react-native-device-info": "^10.13.1",
 		"react-native-fast-image": "^8.6.3",
 		"react-native-fs": "^2.20.0",
 		"react-native-gesture-handler": "2.12.0",

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -6888,10 +6888,10 @@ react-native-config@^1.5.1:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.5.1.tgz#73c94f511493e9b7ff9350cdf351d203a1b05acc"
   integrity sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==
 
-react-native-device-info@^10.12.0:
-  version "10.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.12.0.tgz#be4e71cbcc9a05e8643b1a419a4450d4cef9bbcc"
-  integrity sha512-gnBkjyZNEqRd+5BNrdzuvmlraHTCH/to2x0Gp9rtDt0O9xWWW1MTYohUVWX9A0Ad2HVYcGanDCIvjWp4ngMZFg==
+react-native-device-info@^10.13.1:
+  version "10.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.13.1.tgz#f87f44ba7b67933248be10ca302a4f2f6dbbdd4f"
+  integrity sha512-j/7Z+Yl9Cesjp8vKaVzbuJQKJSVs4ojXATt5WjwipZ0Ss0mBJjqtbc4x5dfZLmQ4y55VVa7c0v8KHca1iqY/TQ==
 
 react-native-fast-image@^8.6.3:
   version "8.6.3"


### PR DESCRIPTION
## Why are you doing this?

Update `react-native-device-info` to an updated minor version

## Changes

- Update the version
- Test it runs as expected

## Screenshots

### iOS

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-28 at 21 30 29](https://github.com/guardian/editions/assets/935975/02da5124-43a3-44ea-96c6-5d638ef42144)

### Android 

![Screenshot_20240228_213159](https://github.com/guardian/editions/assets/935975/dae40bc6-ff57-454a-943d-2535b9f90484)
