### PR TITLE
fix: Misc code fixes

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -622,6 +622,8 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.21.0):
     - React-Core
+  - RNCClipboard (1.13.2):
+    - React-Core
   - RNCMaskedView (0.2.9):
     - React-Core
   - RNCPicker (2.6.1):
@@ -757,6 +759,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNBackgroundFetch (from `../node_modules/react-native-background-fetch`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
@@ -914,6 +917,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-background-fetch"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNCPicker:
@@ -1035,6 +1040,7 @@ SPEC CHECKSUMS:
   ReactCommon: 38824bfffaf4c51fbe03a2730b4fd874ef34d67b
   RNBackgroundFetch: 501c34ad6e880818ba17e7840b23f20a2d112923
   RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -46,6 +46,7 @@
 		"@guardian/src-foundations": "^2.5.0-rc.1",
 		"@okta/okta-react-native": "^2.8.0",
 		"@react-native-async-storage/async-storage": "^1.17.11",
+		"@react-native-clipboard/clipboard": "^1.13.2",
 		"@react-native-community/geolocation": "^3.0.5",
 		"@react-native-community/netinfo": "^11.3.0",
 		"@react-native-community/push-notification-ios": "^1.10.1",

--- a/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
+++ b/projects/Mallard/src/components/layout/ui/errors/error-message.tsx
@@ -1,5 +1,6 @@
+import Clipboard from '@react-native-clipboard/clipboard';
 import React from 'react';
-import { Clipboard, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import { Button } from 'src/components/Button/Button';
 import { UiBodyCopy, UiExplainerCopy } from 'src/components/styled-text';
 import { GENERIC_ERROR } from 'src/helpers/words';

--- a/projects/Mallard/src/helpers/diagnostics.ts
+++ b/projects/Mallard/src/helpers/diagnostics.ts
@@ -1,5 +1,6 @@
 import { getUserFromIdToken } from '@okta/okta-react-native';
-import { Clipboard, Linking, Platform } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
+import { Linking, Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import RNFS from 'react-native-fs';
 import { canViewEdition, getCASCode } from 'src/authentication/helpers';
@@ -252,4 +253,4 @@ const copyDiagnosticInfo = (
 	),
 });
 
-export { createSupportMailto, createMailtoHandler, copyDiagnosticInfo };
+export { copyDiagnosticInfo, createMailtoHandler, createSupportMailto };

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -12,7 +12,6 @@ import { FSPaths } from 'src/paths';
 import { errorService } from 'src/services/errors';
 import { getEditionIds } from '../../../Apps/common/src/helpers';
 import { londonTime } from './date';
-import { imageForScreenSize } from './screen';
 
 // matches the issue date, i.e. 2020-02-01
 const ISSUE_DATE_REGEX = /\d{4}-\d{2}-\d{2}/gm;
@@ -281,16 +280,10 @@ export const getFileList = async () => {
 		(value) => Object.keys(value).length !== 0,
 	);
 
-	const imageSize = await imageForScreenSize();
-
 	// Grab one images from each image folder to confirm successful unzip
 	const imageFolderSearch = await Promise.all(
 		imageFolders.map(async (file: RNFS.ReadDirItem) => {
-			return await RNFS.readDir(
-				file.name === 'media'
-					? `${file.path}/${imageSize}/media`
-					: `${file.path}/${imageSize}/thumb/media`,
-			)
+			return await RNFS.readDir(file.path)
 				.then((filestat) =>
 					filestat
 						.map((deepfile) => cleanFileDisplay(deepfile))

--- a/projects/Mallard/src/paths/index.ts
+++ b/projects/Mallard/src/paths/index.ts
@@ -33,7 +33,6 @@ export const APIPaths = {
 const issuesDir = `${RNFS.DocumentDirectoryPath}/issues`;
 
 const issueRoot = (localIssueId: string) => `${issuesDir}/${localIssueId}`;
-const mediaRoot = (localIssueId: string) => `${issueRoot(localIssueId)}/media`;
 const editionDir = (editionSlug: string) => {
 	return `${issuesDir}/${editionSlug}`;
 };
@@ -48,7 +47,6 @@ export const FSPaths = {
 	editionDir,
 	edtionsDirList,
 	issueRoot,
-	mediaRoot,
 	image: (localIssueId: string, image: Image, use: ImageUse) =>
 		imagePath(issueRoot(localIssueId), image, use),
 	zip: (localIssueId: string, filename: string) =>

--- a/projects/Mallard/src/screens/settings-screen.tsx
+++ b/projects/Mallard/src/screens/settings-screen.tsx
@@ -101,9 +101,9 @@ const MiscSettingsList = () => {
 
 	return (
 		<>
-			{data.map((item) => (
+			{data.map((item, index) => (
 				<>
-					<Row {...item} />
+					<Row {...item} key={index} />
 					<Separator />
 				</>
 			))}

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -1,8 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import Clipboard from '@react-native-clipboard/clipboard';
 import { useNavigation } from '@react-navigation/native';
 import type { ReactNode } from 'react';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { Alert, Clipboard, Platform, View } from 'react-native';
+import { Alert, Platform, View } from 'react-native';
 import { Switch } from 'react-native-gesture-handler';
 import { AccessContext } from 'src/authentication/AccessContext';
 import { isValid } from 'src/authentication/lib/Attempt';

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1760,6 +1760,11 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-clipboard/clipboard@^1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.13.2.tgz#28adcfc43ed2addddf79a59198ec1b25087c115e"
+  integrity sha512-uVM55oEGc6a6ZmSATDeTcMm55A/C1km5X47g0xaoF0Zagv7N/8RGvLceA5L/izPwflIy78t7XQeJUcnGSib0nA==
+
 "@react-native-community/cli-clean@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-11.3.10.tgz#70d14dd998ce8ad532266b36a0e5cafe22d300ac"


### PR DESCRIPTION
## Why are you doing this?

A few fixes around a few issues I found through the code base.

## Changes

- `Clipboard` is deprecated in React Native, so the community plugin has been added. I have tested this and it all seems ok
- Fix the error: `[Error: The folder “media” doesn’t exist.]`. This was because the folders had changed to a new structure, but the diagnostics which checks through the folders hadn't been updated. This now reflects correctly as shown in the screenshot below
- Remove `mediaRoot` as its not used
- Settings screen has a required key. Not ideal to use an `index` but the closest to a uid we have. 

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/guardian/editions/assets/935975/ff3e8b47-0001-4857-8dc2-b34328a5bf8f" width="300px" /> | <img src="https://github.com/guardian/editions/assets/935975/2aa22c28-43ee-4049-af69-c37425b4807f" width="300px" /> |
