### PR TITLE
chore: Remove moment from tests

### DIFF
--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,6 +1,6 @@
-import { addDays, subDays } from 'date-fns';
 import MockDate from 'mockdate';
 import { receiptIOS } from 'src/authentication/__tests__/fixtures';
+import { addDays, subDays } from 'src/helpers/date';
 import { findValidReceipt, isReceiptValid } from '../iap';
 
 MockDate.set('2019-08-21');

--- a/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
+++ b/projects/Mallard/src/authentication/services/__tests__/iap.spec.ts
@@ -1,11 +1,15 @@
-import moment from 'moment';
+import { addDays, subDays } from 'date-fns';
+import MockDate from 'mockdate';
 import { receiptIOS } from 'src/authentication/__tests__/fixtures';
 import { findValidReceipt, isReceiptValid } from '../iap';
+
+MockDate.set('2019-08-21');
+const today = new Date();
 
 describe('iap', () => {
 	describe('isReceiptValid', () => {
 		it('returns false for expiry dates that are more thanthree days older than now', () => {
-			const fourDaysAgo = moment().subtract(4, 'days').toDate();
+			const fourDaysAgo = subDays(today, 4);
 			const isValid = isReceiptValid(
 				receiptIOS({ expires_date: fourDaysAgo }),
 			);
@@ -14,7 +18,7 @@ describe('iap', () => {
 		});
 
 		it('returns true for expiry dates that are less than three days older than now', () => {
-			const twoDaysAgo = moment().subtract(2, 'days').toDate();
+			const twoDaysAgo = subDays(today, 2);
 			const isValid = isReceiptValid(
 				receiptIOS({ expires_date: twoDaysAgo }),
 			);
@@ -24,7 +28,7 @@ describe('iap', () => {
 	});
 	describe('findValidReceipt', () => {
 		it('should return a valid iap receipt if its found', () => {
-			const twoDaysInFuture = moment().add(2, 'days').toDate();
+			const twoDaysInFuture = addDays(today, 2);
 			const receipt = receiptIOS({ expires_date: twoDaysInFuture });
 			const receiptValidationResponse = {
 				status: 0,
@@ -56,7 +60,7 @@ describe('iap', () => {
 			expect(findValidReceipt(receiptValidationResponse)).toEqual(null);
 		});
 		it('should return null if it cant find a valid receipt', () => {
-			const fourDaysAgo = moment().subtract(4, 'days').toDate();
+			const fourDaysAgo = subDays(today, 4);
 			const receipt = receiptIOS({ expires_date: fourDaysAgo });
 			const receiptValidationResponse = {
 				status: 0,

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,4 +1,4 @@
-import { format as dfnsFormat } from 'date-fns';
+import { addDays, format as dfnsFormat, subDays } from 'date-fns';
 import moment from 'moment-timezone';
 import { Platform } from 'react-native';
 import { languageLocale } from './locale';
@@ -22,4 +22,4 @@ const localDate = (date: Date): string => {
 const format = (date: Date, fomattedString: string) =>
 	dfnsFormat(date, fomattedString);
 
-export { londonTime, localDate, format };
+export { londonTime, localDate, format, addDays, subDays };

--- a/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
+++ b/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
@@ -1,5 +1,5 @@
-import { subDays } from 'date-fns';
 import MockDate from 'mockdate';
+import { subDays } from 'src/helpers/date';
 import { shouldReRegister } from '../helpers';
 import type { PushToken } from '../notification-service';
 

--- a/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
+++ b/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
@@ -1,23 +1,24 @@
-import moment from 'moment';
+import { subDays } from 'date-fns';
+import MockDate from 'mockdate';
 import { shouldReRegister } from '../helpers';
 import type { PushToken } from '../notification-service';
 
-const _today = moment();
-const today = () => _today.clone();
+MockDate.set('2019-08-21');
+const today = new Date();
 
 describe('push-notifications/helpers', () => {
 	describe('shouldReRegister', () => {
 		it('should return false if time is not exceeded, or the tokens are the same or topics match', () => {
 			const registrationCache = {
 				token: 'token',
-				registrationDate: today().toISOString(),
+				registrationDate: today.toISOString(),
 			};
 			const topics = [{ name: 'uk', type: 'editions' }] as PushToken[];
 			expect(
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today().toISOString(),
+					today.toISOString(),
 					topics,
 					topics,
 				),
@@ -26,14 +27,14 @@ describe('push-notifications/helpers', () => {
 		it('should return true if the 14 day period is exceeded but the rest remains the same', () => {
 			const registrationCache = {
 				token: 'token',
-				registrationDate: today().subtract(15, 'days').toISOString(),
+				registrationDate: subDays(today, 15).toISOString(),
 			};
 			const topics = [{ name: 'uk', type: 'editions' }] as PushToken[];
 			expect(
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today().toISOString(),
+					today.toISOString(),
 					topics,
 					topics,
 				),
@@ -42,14 +43,14 @@ describe('push-notifications/helpers', () => {
 		it('should return true if a different token is provided', () => {
 			const registrationCache = {
 				token: 'token',
-				registrationDate: today().toISOString(),
+				registrationDate: today.toISOString(),
 			};
 			const topics = [{ name: 'uk', type: 'editions' }] as PushToken[];
 			expect(
 				shouldReRegister(
 					'different-token',
 					registrationCache,
-					today().toISOString(),
+					today.toISOString(),
 					topics,
 					topics,
 				),
@@ -58,7 +59,7 @@ describe('push-notifications/helpers', () => {
 		it('should return true of the topics do not match', () => {
 			const registrationCache = {
 				token: 'token',
-				registrationDate: today().subtract(15, 'days').toISOString(),
+				registrationDate: subDays(today, 15).toISOString(),
 			};
 			const topics = [{ name: 'uk', type: 'editions' }] as PushToken[];
 			const differentTopics = [
@@ -68,7 +69,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today().toISOString(),
+					today.toISOString(),
 					topics,
 					differentTopics,
 				),
@@ -77,7 +78,7 @@ describe('push-notifications/helpers', () => {
 		it('should return false if the topics are but in different order', () => {
 			const registrationCache = {
 				token: 'token',
-				registrationDate: today().toISOString(),
+				registrationDate: today.toISOString(),
 			};
 			const topics = [{ name: 'uk', type: 'editions' }] as PushToken[];
 			const topics2 = [{ type: 'editions', name: 'uk' }] as PushToken[];
@@ -85,7 +86,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today().toISOString(),
+					today.toISOString(),
 					topics,
 					topics2,
 				),


### PR DESCRIPTION
## Why are you doing this?

Moment is deprecated and as a result, we need to move away from it. However, dates are a key part of the app. 

This PR looks to remove `moment` from the tests in Mallard

## Changes

- Replaced `moment` with `date-fns` 
- Import the `date-fns` functions from the date abstraction to make it easier to maintain in future

## Output

- Tests are passing.