### PR TITLE
fix: Editions list and dates

### DIFF
--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,4 +1,4 @@
-import { addDays, format as dfnsFormat, subDays } from 'date-fns';
+import { addDays, format as dfnsFormat, isBefore, subDays } from 'date-fns';
 import moment from 'moment-timezone';
 import { Platform } from 'react-native';
 import { languageLocale } from './locale';
@@ -22,4 +22,7 @@ const localDate = (date: Date): string => {
 const format = (date: Date, fomattedString: string) =>
 	dfnsFormat(date, fomattedString);
 
-export { londonTime, localDate, format, addDays, subDays };
+const isLondonTimeBefore = (date: Date) =>
+	isBefore(londonTime().toDate(), date);
+
+export { addDays, format, isLondonTimeBefore, localDate, londonTime, subDays };

--- a/projects/Mallard/src/hooks/use-edition-provider.tsx
+++ b/projects/Mallard/src/hooks/use-edition-provider.tsx
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import type { Dispatch } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import type {
@@ -7,6 +6,7 @@ import type {
 	SpecialEdition,
 	SpecialEditionHeaderStyles,
 } from 'src/common';
+import { isLondonTimeBefore } from 'src/helpers/date';
 import {
 	defaultSettings,
 	editionsEndpoint,
@@ -133,7 +133,7 @@ export const removeExpiredSpecialEditions = (
 	return {
 		...editionsList,
 		specialEditions: editionsList.specialEditions.filter((e) =>
-			moment().isBefore(e.expiry),
+			isLondonTimeBefore(new Date(e.expiry)),
 		),
 	};
 };
@@ -297,8 +297,7 @@ export const EditionProvider = ({
 			getEditions(isConnected, fullUrl)
 				.then((ed) => {
 					if (ed) {
-						const removeAus =
-							temporaryFilterEditionsList(editionsList);
+						const removeAus = temporaryFilterEditionsList(ed);
 						setEditionsList(removeAus);
 					}
 				})


### PR DESCRIPTION
## Why are you doing this?

1. Specials could not show as we were filtering the default list with no specials in it, rather that what was on the server
2. New `isBefore` abstraction that now works to a consistent "london time" rather than where you are located

## Output

Tested by fiddling with dates with the current expiry