### PR TITLE
chore: Remove Moment from Push Helpers

### DIFF
--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,4 +1,10 @@
-import { addDays, format as dfnsFormat, isBefore, subDays } from 'date-fns';
+import {
+	addDays,
+	format as dfnsFormat,
+	differenceInDays,
+	isBefore,
+	subDays,
+} from 'date-fns';
 import moment from 'moment-timezone';
 import { Platform } from 'react-native';
 import { languageLocale } from './locale';
@@ -25,4 +31,15 @@ const format = (date: Date, fomattedString: string) =>
 const isLondonTimeBefore = (date: Date) =>
 	isBefore(londonTime().toDate(), date);
 
-export { addDays, format, isLondonTimeBefore, localDate, londonTime, subDays };
+const now = new Date();
+
+export {
+	addDays,
+	differenceInDays,
+	format,
+	isLondonTimeBefore,
+	localDate,
+	londonTime,
+	now,
+	subDays,
+};

--- a/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
+++ b/projects/Mallard/src/notifications/__tests__/helpers.spec.ts
@@ -18,7 +18,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today.toISOString(),
+					today,
 					topics,
 					topics,
 				),
@@ -34,7 +34,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today.toISOString(),
+					today,
 					topics,
 					topics,
 				),
@@ -50,7 +50,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'different-token',
 					registrationCache,
-					today.toISOString(),
+					today,
 					topics,
 					topics,
 				),
@@ -69,7 +69,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today.toISOString(),
+					today,
 					topics,
 					differentTopics,
 				),
@@ -86,7 +86,7 @@ describe('push-notifications/helpers', () => {
 				shouldReRegister(
 					'token',
 					registrationCache,
-					today.toISOString(),
+					today,
 					topics,
 					topics2,
 				),

--- a/projects/Mallard/src/notifications/helpers.ts
+++ b/projects/Mallard/src/notifications/helpers.ts
@@ -1,5 +1,4 @@
-import type { MomentInput } from 'moment';
-import moment from 'moment';
+import { now as dateNow, differenceInDays } from 'src/helpers/date';
 import {
 	pushNotificationRegistrationCache,
 	pushRegisteredTokens,
@@ -41,12 +40,12 @@ const isSameTopics = (t1: PushToken[] | null, t2: PushToken[]) => {
 const shouldReRegister = (
 	newToken: string,
 	registration: PushNotificationRegistration | null,
-	now: MomentInput,
+	now: Date,
 	currentTopics: PushToken[] | null,
 	newTopics: PushToken[],
 ): boolean => {
 	const exceedTime = registration
-		? moment(now).diff(moment(registration.registrationDate), 'days') > 14
+		? differenceInDays(now, new Date(registration.registrationDate)) > 14
 		: true;
 	const differentToken = registration
 		? newToken !== registration.token
@@ -65,7 +64,7 @@ const maybeRegister = async (
 	// mocks for testing
 	pushNotificationRegistrationCacheImpl = pushNotificationRegistrationCache,
 	registerWithNotificationServiceImpl = registerWithNotificationService,
-	now = moment().toString(),
+	now = dateNow,
 ) => {
 	let should: boolean;
 	const newTopics = await getTopicName();
@@ -92,7 +91,7 @@ const maybeRegister = async (
 		pushRegisteredTokens.set(response['topics']);
 
 		await pushNotificationRegistrationCacheImpl.set({
-			registrationDate: now,
+			registrationDate: now.toISOString(),
 			token,
 		});
 		return true;


### PR DESCRIPTION
## Why are you doing this?

Removes `moment` from the push notificaiton helpers and replaces it with the date abstraction

## Changes

- As above

## Output

Tests pass