### PR TITLE
Bump CAPI models libraries to version that includes new list element

### DIFF
--- a/projects/Apps/common/src/index.ts
+++ b/projects/Apps/common/src/index.ts
@@ -431,6 +431,7 @@ export enum CrosswordType {
     EVERYMAN = 'everyman',
     DIAN_QUIPTIC_CROSSWORD = 'quiptic-dian',
     WEEKEND = 'weekend',
+    QUICK_CRYPTIC = 'quick-cryptic',
 }
 
 export interface CapiDateTime {

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -30,8 +30,8 @@
         "test:watch": "jest --watch"
     },
     "dependencies": {
-        "@guardian/content-api-models": "^17.8.0",
-        "@guardian/content-atom-model": "^3.2.4",
+        "@guardian/content-api-models": "20.1.0",
+        "@guardian/content-atom-model": "4.0.1",
         "@types/aws-lambda": "^8.10.31",
         "@types/aws4": "^1.5.1",
         "@types/jest": "^29.5.5",

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -304,12 +304,12 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@guardian/content-api-models@^17.8.0":
-  version "17.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-17.8.0.tgz#ef42d8d0d6c9afe896c3a34880f02ebfe8ab2f6d"
-  integrity sha512-qfYCnrWupF3CncBioFwqxiFAgZt/hD+ax1XH0kMWm1IhkxZXBVV06ZZyk7eUcDUYYyakAgQxIjS8Z0LXy3nHYw==
+"@guardian/content-api-models@20.1.0":
+  version "20.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-20.1.0.tgz#4f0d0c0d2a74f59a6951e8b2e09a74e5edc9f005"
+  integrity sha512-Xi4Fl7I1A9/YRv0wRDzb4j3T5kTlDh+i9xmUNQG30vYqOk5CKcjBlmIgpDbLoi1hQHpOnD10wlEQUmOZUy/6FQ==
   dependencies:
-    "@guardian/content-atom-model" "^3.4.2"
+    "@guardian/content-atom-model" "^4.0.0"
     "@guardian/content-entity-model" "^2.2.1"
     "@guardian/story-packages-model" "^2.2.0"
     "@types/node-int64" "^0.4.29"
@@ -317,37 +317,16 @@
     node-int64 "^0.4.0"
     thrift "^0.15.0"
 
-"@guardian/content-atom-model@^3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@guardian/content-atom-model/-/content-atom-model-3.2.4.tgz#5ba9db208b3acb8a30f67e284696f20fa8f69393"
-  integrity sha512-XJ1jleNm5et+1tVxHwDOz94ODn1MLrchwAQKb3XXEX6jnguLLTKKcHPP5UQ4WqgJuuEoEo5ZLpgOXcCDE0HN5A==
-  dependencies:
-    "@guardian/content-entity-model" "^2.0.6"
-    "@types/node-int64" "^0.4.29"
-    "@types/thrift" "^0.10.9"
-    node-int64 "^0.4.0"
-    thrift "^0.12.0"
-
-"@guardian/content-atom-model@^3.4.2":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@guardian/content-atom-model/-/content-atom-model-3.4.4.tgz#289c9c0d2ff1c889787667c2c08cf30bbf72356d"
-  integrity sha512-OeLqmQODJPqSa9Y/RhLhJOTIYj0BK07tSZBn71QZ3OstQhcW2nZGxSCN9tbYLYHhj30Uzn6fsLwZcv4JlNTbtg==
+"@guardian/content-atom-model@4.0.1", "@guardian/content-atom-model@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/content-atom-model/-/content-atom-model-4.0.1.tgz#e4bb784cfbe3fee13f998680734d1f9b53e3e9d4"
+  integrity sha512-c2biKd9SPbXiCmN9ZOyYdaiPlwLCJNEzRGqWW0hISq3ELOzqndhTG6/vYrQMp0+7CmDEeQ+4pSzZxPfvIN10Tw==
   dependencies:
     "@guardian/content-entity-model" "^2.2.1"
     "@types/node-int64" "^0.4.29"
     "@types/thrift" "^0.10.11"
     node-int64 "^0.4.0"
     thrift "^0.15.0"
-
-"@guardian/content-entity-model@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@guardian/content-entity-model/-/content-entity-model-2.0.6.tgz#5a5a3dec91f6f4744a2c04843eb0272424e54f81"
-  integrity sha512-mcRxXqJY9jAJWjv/xANQ6wuwwN76IV8WYLDWhCB0dQB/BpQm9VZIs81el4nWGOUTTOw/7Ls5TdERWvBDzadvwQ==
-  dependencies:
-    "@types/node-int64" "^0.4.29"
-    "@types/thrift" "^0.10.9"
-    node-int64 "^0.4.0"
-    thrift "^0.12.0"
 
 "@guardian/content-entity-model@^2.2.1":
   version "2.2.1"
@@ -878,15 +857,6 @@
   version "0.10.17"
   resolved "https://registry.yarnpkg.com/@types/thrift/-/thrift-0.10.17.tgz#54e835b9a0cb032da9535fad534557991d13dff7"
   integrity sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==
-  dependencies:
-    "@types/node" "*"
-    "@types/node-int64" "*"
-    "@types/q" "*"
-
-"@types/thrift@^0.10.9":
-  version "0.10.10"
-  resolved "https://registry.yarnpkg.com/@types/thrift/-/thrift-0.10.10.tgz#f90f6c84c8b003c79f54463f909b0a12a993029d"
-  integrity sha512-sEhRbmmQgiTn+JdophEPiuTFkc9QRl7R/Kxs/le5GXZAc2K1/VCHauW734nCwpu1cFI8jL1niyrqk7E4tGL92w==
   dependencies:
     "@types/node" "*"
     "@types/node-int64" "*"
@@ -3165,15 +3135,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-thrift@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.12.0.tgz#67678beba655ca40dd30744b65455f2b9f8e9912"
-  integrity sha512-qE9PZi4XSbSQLz/sNxj6+ZiiFQYgbM4GmlO3CS/EVJBjCVfd46Zw0aiVIqOvVn74M7XUGyjOs2chAOwK4d4/hQ==
-  dependencies:
-    node-int64 "^0.4.0"
-    q "^1.5.0"
-    ws "^5.0.0"
-
 thrift@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/thrift/-/thrift-0.15.0.tgz#9c502ab3763e12b93e33c8b4e5c1e0e12ed864cf"
@@ -3431,7 +3392,7 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@^5.0.0, ws@^5.2.2, ws@^5.2.3:
+ws@^5.2.2, ws@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
   integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==


### PR DESCRIPTION
## Why are you doing this?

Editions currently cannot render the new Key Takeaways article format. AR has been updated to support this, but I believe Editions backend also needs to know about the new model so that it can correctly pass it to AR.