### PR TITLE
chore: localDate moved to datefns

### DIFF
--- a/projects/Mallard/src/helpers/__tests__/date.altlocale.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/date.altlocale.spec.ts
@@ -1,0 +1,22 @@
+import { localDate } from '../date';
+
+jest.mock('src/helpers/locale', () => ({
+	languageLocale: 'en-US',
+}));
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => {
+	const Platform = jest.requireActual(
+		'react-native/Libraries/Utilities/Platform',
+	);
+	Platform.OS = 'android';
+	return Platform;
+});
+
+describe('helpers/date', () => {
+	describe('localDate', () => {
+		it('should return a date in the correct format if US', () => {
+			const date = new Date('2021-09-01T00:00:00.000Z');
+			expect(localDate(date)).toBe('09/01/2021');
+		});
+	});
+});

--- a/projects/Mallard/src/helpers/__tests__/date.spec.ts
+++ b/projects/Mallard/src/helpers/__tests__/date.spec.ts
@@ -1,0 +1,22 @@
+import { localDate } from '../date';
+
+jest.mock('src/helpers/locale', () => ({
+	languageLocale: 'en-GB',
+}));
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => {
+	const Platform = jest.requireActual(
+		'react-native/Libraries/Utilities/Platform',
+	);
+	Platform.OS = 'android';
+	return Platform;
+});
+
+describe('helpers/date', () => {
+	describe('localDate', () => {
+		it('should return a date in the correct format if not US', () => {
+			const date = new Date('2021-09-01T00:00:00.000Z');
+			expect(localDate(date)).toBe('01/09/2021');
+		});
+	});
+});

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -1,7 +1,7 @@
 import { addDays, format as dfnsFormat, isBefore, subDays } from 'date-fns';
 import moment from 'moment-timezone';
 import { Platform } from 'react-native';
-import { languageLocale } from './locale';
+import { languageLocale } from 'src/helpers/locale';
 
 const londonTime = (time?: string | number) => {
 	if (time != null) return moment.tz(time, 'Europe/London');
@@ -14,8 +14,8 @@ const localDate = (date: Date): string => {
 	} else {
 		// toLocaleDateString is not a reliable way of getting the format we need on android
 		return languageLocale === 'en-US'
-			? moment(date).format('MM/DD/YYYY')
-			: moment(date).format('DD/MM/YYYY');
+			? dfnsFormat(date, 'MM/dd/yyyy')
+			: dfnsFormat(date, 'dd/MM/yyyy');
 	}
 };
 


### PR DESCRIPTION
## Why are you doing this?

Still moving away from Moment towards a date abstraction that is supported by date-fns.

`localDate`'s job was to format the date passed in based on its locale.

## Changes

- Makes the required formatting changes via `date-fns`
- Unfortunately, couldnt mock by changing the constant and had to add tests by setting up two files.

## Outputs

- Tests pass