### PR TITLE
chore: londonTime to date-fns

### DIFF
--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -4,7 +4,7 @@ import moment from 'moment-timezone';
 import { Platform } from 'react-native';
 import { languageLocale } from './locale';
 
-const londonTime = (date: Date) => zonedTimeToUtc(date, 'Europe/London');
+const londonTime = (date: Date) => utcToZonedTime(date, 'Europe/London');
 
 const londonTimeAsDate = (): Date =>
 	utcToZonedTime(new Date(), 'Europe/London');

--- a/projects/Mallard/src/helpers/date.ts
+++ b/projects/Mallard/src/helpers/date.ts
@@ -4,10 +4,7 @@ import moment from 'moment-timezone';
 import { Platform } from 'react-native';
 import { languageLocale } from './locale';
 
-const londonTime = (time?: string | number) => {
-	if (time != null) return moment.tz(time, 'Europe/London');
-	return moment.tz('Europe/London');
-};
+const londonTime = (date: Date) => zonedTimeToUtc(date, 'Europe/London');
 
 const londonTimeAsDate = (): Date =>
 	utcToZonedTime(new Date(), 'Europe/London');
@@ -28,9 +25,16 @@ const format = (date: Date, fomattedString: string) =>
 
 const isLondonTimeBefore = (date: Date) => isBefore(londonTimeAsDate(), date);
 
+const formatWeekday = (date: Date) => format(date, 'd');
+const formatDayNumber = (date: Date) => format(date, 'iiii');
+const formatMonth = (date: Date) => format(date, 'LLLL');
+
 export {
 	addDays,
 	format,
+	formatDayNumber,
+	formatMonth,
+	formatWeekday,
 	isLondonTimeBefore,
 	localDate,
 	londonTime,

--- a/projects/Mallard/src/helpers/files.ts
+++ b/projects/Mallard/src/helpers/files.ts
@@ -246,9 +246,9 @@ export const fetchAndStoreIssueSummary = async (): Promise<IssueSummary[]> => {
 	}
 };
 
-const cleanFileDisplay = (stat: RNFS.ReadDirItem | RNFS.StatResult) => ({
+const cleanFileDisplay = (stat: RNFS.ReadDirItem) => ({
 	path: stat.path.replace(FSPaths.issuesDir, ''),
-	lastModified: londonTime(Number(stat.mtime)).format(),
+	lastModified: stat.mtime ? londonTime(stat.mtime) : '',
 	type: stat.isDirectory() ? 'directory' : 'file',
 });
 

--- a/projects/Mallard/src/helpers/issues.ts
+++ b/projects/Mallard/src/helpers/issues.ts
@@ -1,32 +1,13 @@
 import { useMemo } from 'react';
 import type { Issue } from 'src/common';
 import { getSelectedEditionSlug } from 'src/hooks/use-edition-provider';
-import { londonTime, londonTimeAsDate } from './date';
-
-const months = [
-	'January',
-	'February',
-	'March',
-	'April',
-	'May',
-	'June',
-	'July',
-	'August',
-	'September',
-	'October',
-	'November',
-	'December',
-];
-
-const days = [
-	'Sunday',
-	'Monday',
-	'Tuesday',
-	'Wednesday',
-	'Thursday',
-	'Friday',
-	'Saturday',
-];
+import {
+	formatDayNumber,
+	formatMonth,
+	formatWeekday,
+	londonTime,
+	londonTimeAsDate,
+} from './date';
 
 interface IssueDate {
 	date: string;
@@ -34,10 +15,10 @@ interface IssueDate {
 }
 
 export const renderIssueDate = (dateString: Issue['date']): IssueDate => {
-	const date = londonTime(dateString);
+	const date = londonTime(new Date(dateString));
 	return {
-		date: `${date.date()} ${months[date.month()]}`,
-		weekday: days[date.day()],
+		date: `${formatDayNumber(date)} ${formatMonth(date)}`,
+		weekday: formatWeekday(date),
 	};
 };
 


### PR DESCRIPTION
## Why are you doing this?

Please note that this merges into #2408

This looks to move `londonTime` over to `moment`

## Changes

- `londonTime` uses date-fns zoned time function
- helper methods for specific date formats
- Updated the code where its used
