### PR TITLE
fix: Android Darkmode Render HTML text

### DIFF
--- a/projects/Mallard/src/components/RenderHTML/RenderHTML.tsx
+++ b/projects/Mallard/src/components/RenderHTML/RenderHTML.tsx
@@ -16,6 +16,7 @@ import { AppLogo } from '../icons/AppLogo';
 
 import { EditionsMenu } from '../icons/EditionsMenu';
 import { Button } from '../Button/Button';
+import { color } from 'src/theme/color';
 
 const customFonts = Object.values(families).reduce(
 	(acc: string[], value) => [...acc, ...Object.values(value)],
@@ -26,6 +27,7 @@ const sysetmFonts = [...defaultSystemFonts, ...customFonts];
 const tagsStyles = {
 	body: {
 		padding: 20,
+		color: color.text,
 	},
 	h2: {
 		fontFamily: 'GuardianTextEgyptian-Reg',


### PR DESCRIPTION
## Why are you doing this?

When viewing any of the `RenderHTML` pages in dark mode on Android, you will see white text on a white background. This fixes it.

Please note that the bug ticket specifically states the Credits screen, which has subsequently been removed.

## Changes

- Added a text colour to the body of the styles used in this component

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/guardian/editions/assets/935975/f74f9c51-b184-4e15-88ca-45782acb514d" width="300px" /> | <img src="https://github.com/guardian/editions/assets/935975/fc9d8365-bcff-4c24-b0d8-844a6d7d9720" width="300px" /> |
