### PR TITLE
chpre: Update Java in github workflows

### DIFF
--- a/.github/workflows/amazon-release.yml
+++ b/.github/workflows/amazon-release.yml
@@ -15,10 +15,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up JDK 11
+            - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:
-                  java-version: '11'
+                  java-version: '17'
                   distribution: 'temurin'
 
             - name: Setup Ruby

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -15,10 +15,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up JDK 11
+            - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:
-                  java-version: '11'
+                  java-version: '17'
                   distribution: 'temurin'
 
             - name: Setup Ruby

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -15,10 +15,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up JDK 11
+            - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:
-                  java-version: '11'
+                  java-version: '17'
                   distribution: 'temurin'
 
             - name: Setup Ruby


### PR DESCRIPTION
## Why are you doing this?

In the latest RN Update, we moved from Java 11 to Java 17. This is now reflected in the CI

## Changes

- Changed 11 to 17
