### PR TITLE
Ensure pieces with Comment tag are of ArticleType.Comment in Journal pillar

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -88,11 +88,11 @@ const articleTypePicker = (article: Content): ArticleType => {
                 if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
                 else if (isLetter) return ArticleType.Letter
+                else if (isComment) return ArticleType.Opinion
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
                 else if (isEditorial) return ArticleType.Article
-                else if (isComment) return ArticleType.Opinion
                 else return ArticleType.Article
 
             case 'lifestyle':


### PR DESCRIPTION
## Why are you doing this?

At the moment, [some pieces](https://composer.gutools.co.uk/content/6634f2188f080b5e6ba920f8) in Journal are correctly styled as Opinion, and some [aren't](https://composer.gutools.co.uk/content/663244088f084fb5cf82ab94). The former example works because it is in the News pillar. The latter is in Opinion, and because it has a series tag, it receives an `articleType` of as `Article`, rather than `Opinion`. The logic is [here.](https://github.com/guardian/editions/blob/513fcd293627aa07c03778c8ce5a0dad3ab9cbad/projects/backend/capi/articleTypePicker.ts#L88)

At the moment Editions must recreate the piece without the series tag  to work around this problem.

This PR raises the check for the comment tag above the check for the series tag when picking article type for pieces with the Opinion/Journal pillar, which should fix this problem.

## Screenshots

Tested in CODE with a proofed edition.

| Before | After |
| --- | --- |
|![Screenshot_20240510-104357](https://github.com/guardian/editions/assets/7767575/2ecabb00-961d-4ff4-89cd-c63539f2aafc)|![Screenshot_20240510-104413](https://github.com/guardian/editions/assets/7767575/1ca2bcc7-2525-4365-9166-189105f137a6)|
