### PR TITLE
Ensure Editorial articles don't get Comment tone

### DIFF
--- a/projects/backend/capi/articleTypePicker.ts
+++ b/projects/backend/capi/articleTypePicker.ts
@@ -88,11 +88,11 @@ const articleTypePicker = (article: Content): ArticleType => {
                 if (isLongRead) return ArticleType.Longread
                 else if (isImmersive) return ArticleType.Immersive
                 else if (isLetter) return ArticleType.Letter
+                else if (isEditorial) return ArticleType.Article
                 else if (isComment) return ArticleType.Opinion
                 else if (isSeries) return ArticleType.Article
                 else if (isObituary) return ArticleType.Article
                 else if (isAnalysis) return ArticleType.Analysis
-                else if (isEditorial) return ArticleType.Article
                 else return ArticleType.Article
 
             case 'lifestyle':


### PR DESCRIPTION
## Why are you doing this?

[#opinion](https://github.com/guardian/editions/pull/2429) causes problems where Editorial pieces, which carry `tone/comment` tags, are mistakenly given a type of `Opinion`.

This PR fixes. I've run the logic past Katy Vans, and the other tags underneath `Comment` (Obits, Analysis) should be fine.