### PR TITLE
feat: Crossword Bundle Mallard Integration

### DIFF
--- a/projects/Apps/crosswords-bundle/package.json
+++ b/projects/Apps/crosswords-bundle/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@guardian/react-crossword": "^1.3.0",
+        "@guardian/react-crossword": "^2.0.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/projects/Apps/crosswords/scripts/bundle-html.js
+++ b/projects/Apps/crosswords/scripts/bundle-html.js
@@ -10,7 +10,6 @@ const bundleHTML = (location = 'Mallard') => {
             [
                 `cd ../../projects/${project}`,
                 buildScript,
-                'yarn html-update',
                 `rm -rf ../../../projects/${location}/html/${key}.bundle`,
                 `mv ./${buildPath} ../../../projects/${location}/html/${key}.bundle`,
             ].join(' && '),

--- a/projects/Apps/crosswords/scripts/manifest.js
+++ b/projects/Apps/crosswords/scripts/manifest.js
@@ -18,10 +18,10 @@
 module.exports = {
     crosswords: {
         key: 'crosswords',
-        project: 'Apps/crosswords',
-        watchPort: 8001,
-        watchScript: 'yarn watch',
+        project: 'Apps/crosswords-bundle',
+        watchPort: 3000,
+        watchScript: 'yarn start',
         buildScript: 'yarn build',
-        buildPath: 'dist',
+        buildPath: 'build',
     },
 }

--- a/projects/Apps/crosswords/src/html-bundle-info.json
+++ b/projects/Apps/crosswords/src/html-bundle-info.json
@@ -3,11 +3,11 @@
 	"bundles": {
 		"crosswords": {
 			"key": "crosswords",
-			"project": "Apps/crosswords",
-			"watchPort": 8001,
-			"watchScript": "yarn watch",
+			"project": "Apps/crosswords-bundle",
+			"watchPort": 3000,
+			"watchScript": "yarn start",
 			"buildScript": "yarn build",
-			"buildPath": "dist"
+			"buildPath": "build"
 		}
 	}
 }

--- a/projects/Apps/yarn.lock
+++ b/projects/Apps/yarn.lock
@@ -2202,14 +2202,14 @@
   optionalDependencies:
     fsevents "^1.1.2"
 
-"@guardian/react-crossword@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-1.3.1.tgz#1a72fc07ad1f29e70d169f6c9ae7395ea1c0cc48"
-  integrity sha512-H9NMBSp00GcS7C6KmjYQFOqdCO1kd3xWycsLgvP7mKPhamimBIreeL1NC9wKrZ6FfFLij0GHVL4wGlGmAV/Zmw==
+"@guardian/react-crossword@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-2.0.0.tgz#7b293d0e267e8ddc43815442d07daa7747accdc9"
+  integrity sha512-ESJACi6Lm4ymI5Yd8wPBQQVB61NWYOfyZ6h/a5f22qdMQYeUBvCa4sc+woYf2L8stIB1kxFr6zDygRV89pAoDA==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"
-    fastdom "1.0.11"
+    fastdom "1.0.12"
     lodash "^4.17.21"
     qwery "4.0.0"
     react "18.2.0"
@@ -7307,10 +7307,10 @@ fastdom@0.8.5:
   resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-0.8.5.tgz#4066d73a8a7ca9d9ee6cef103043aa1a0e2f19dd"
   integrity sha512-5i6dV8ZbFFg4x2QsowC4o5FofJ5gHXnQjjU0blXGi8ZXo/GGs9ytePqAgwyK50KUnj3M6NTCySCaym/aFn5oqw==
 
-fastdom@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.11.tgz#f22984f9df6b9a6081e5ce2e49cfb5525daf198a"
-  integrity sha512-jl9MwXDFxhg354W4E3s1UMsLh3HWFuVMQiRUlXpHckcHRXQvUe76yzBf1Z7b+x5Ci4TUJ1KmynI9alGUXG95IQ==
+fastdom@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.12.tgz#ae43d55af017252ae499b2e186511ab97412de39"
+  integrity sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==
   dependencies:
     strictdom "^1.0.1"
 

--- a/projects/Mallard/html/manifest.js
+++ b/projects/Mallard/html/manifest.js
@@ -18,10 +18,10 @@
 module.exports = {
     crosswords: {
         key: 'crosswords',
-        project: 'Apps/crosswords',
-        watchPort: 8001,
-        watchScript: 'yarn watch',
+        project: 'Apps/crosswords-bundle',
+        watchPort: 3000,
+        watchScript: 'yarn start',
         buildScript: 'yarn build',
-        buildPath: 'dist',
+        buildPath: 'build',
     },
 }

--- a/projects/Mallard/src/components/article/types/crossword.tsx
+++ b/projects/Mallard/src/components/article/types/crossword.tsx
@@ -27,6 +27,7 @@ const Crossword = ({
 			javaScriptEnabled={true}
 			style={styles.flex}
 			webviewDebuggingEnabled
+			bounces={false}
 		/>
 	);
 };

--- a/projects/Mallard/src/html-bundle-info.json
+++ b/projects/Mallard/src/html-bundle-info.json
@@ -4,7 +4,7 @@
 		"crosswords": {
 			"key": "crosswords",
 			"project": "Apps/editions-crossword-renderer-app",
-			"watchPort": 8001,
+			"watchPort": 3000,
 			"watchScript": "yarn watch",
 			"buildScript": "yarn build",
 			"buildPath": "dist"


### PR DESCRIPTION
## Why are you doing this?

Integrates the new crossword bundle into the app

## Changes

- Uses the newly published npm module
- Updates manifests to work with different ports and scripts
- Removes the need for `html-update` (script to be removed in a future PR)
- Removes the scroll bounce in the crosswords as it makes scrolling the clues in Landscape mode on Tablet more difficult

## Screenshots

![Simulator Screenshot - iPhone 13 Pro - 2024-06-25 at 08 22 09](https://github.com/guardian/editions/assets/935975/016e0ffa-5f19-4d93-b928-fbbff1204226)
