### PR TITLE
Fix/android beta

### DIFF
--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -27,9 +27,10 @@ jobs:
                   ruby-version: 2.7.3
                   bundler-cache: true
 
-            - name: update fastlane
+            - name: install gems
               run: |
-                  gem install fastlane
+                  cd projects/Mallard
+                  bundle install
 
             - name: inject credentials
               run: |

--- a/.github/workflows/android-beta.yml
+++ b/.github/workflows/android-beta.yml
@@ -30,7 +30,6 @@ jobs:
             - name: update fastlane
               run: |
                   gem install fastlane
-                  fastlane -v
 
             - name: inject credentials
               run: |


### PR DESCRIPTION
## Why are you doing this?

Fastlane install had stopped working. Ideally we should install it via our Gems, so this replaces it

## Changes

- Install gems instead of stand alone fastlane
