### PR TITLE
chore: Attempt server side fix build

### DIFF
--- a/.github/workflows/server-side-build.yml
+++ b/.github/workflows/server-side-build.yml
@@ -22,6 +22,7 @@ jobs:
           yarn build
         env:
           exclude: 'Mallard'
+          exclude: 'Apps'
 
       - name: Run yarn test
         run: |


### PR DESCRIPTION
## Why are you doing this?

The `crosswords-bundle` has a deep dependency that requires node 16. The backend services are currently stuck on 14, and awaiting upgrade. This excludes the `Apps` monorepo from the installation process.

The server side services only use the `common` package, which is a set of types. This only needs dependencies installed for its validation, which is skipped in this instance.

## Changes

- Skip `Apps` from the install and validation
