### PR TITLE
chore: Safe Area Context

### DIFF
--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -499,7 +499,7 @@ PODS:
     - React-Core
   - react-native-restart (0.0.27):
     - React-Core
-  - react-native-safe-area-context (4.9.0):
+  - react-native-safe-area-context (4.10.8):
     - React-Core
   - react-native-safe-area-insets (0.1.0):
     - React
@@ -1013,7 +1013,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 95d0418c3c74279840abec6926653d32447bafb6
   react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
+  react-native-safe-area-context: b7daa1a8df36095a032dff095a1ea8963cb48371
   react-native-safe-area-insets: 5f827f8f343c8a02347a65f1a7861c195dcb1a2c
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-webview: baaebe143b736a26939d76243769df97f60e27b2

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -86,7 +86,7 @@
 		"react-native-reanimated": "^3.6.1",
 		"react-native-render-html": "^6.3.4",
 		"react-native-restart": "^0.0.27",
-		"react-native-safe-area-context": "^4.9.0",
+		"react-native-safe-area-context": "^4.10.8",
 		"react-native-screens": "^3.29.0",
 		"react-native-splash-screen": "^3.3.0",
 		"react-native-status-bar-height": "^2.4.0",

--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -2,6 +2,7 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { logUserId } from 'src/helpers/analytics';
 import { ConfigProvider } from 'src/hooks/use-config-provider';
 import { NavPositionProvider } from 'src/hooks/use-nav-position';
@@ -76,21 +77,23 @@ const App = () => {
 		<GestureHandlerRootView style={{ flex: 1 }}>
 			<ErrorBoundary>
 				<ActionSheetProvider>
-					<WithProviders>
-						<AccessProvider
-							onIdentityStatusChange={handleIdStatus}
-							onOktaStatusChange={handleOktaStatus}
-						>
-							<StatusBar
-								barStyle="light-content"
-								backgroundColor="#041f4a"
-							/>
-							<View style={styles.appContainer}>
-								<AppNavigation />
-							</View>
-							<BugButtonHandler />
-						</AccessProvider>
-					</WithProviders>
+					<SafeAreaProvider>
+						<WithProviders>
+							<AccessProvider
+								onIdentityStatusChange={handleIdStatus}
+								onOktaStatusChange={handleOktaStatus}
+							>
+								<StatusBar
+									barStyle="light-content"
+									backgroundColor="#041f4a"
+								/>
+								<View style={styles.appContainer}>
+									<AppNavigation />
+								</View>
+								<BugButtonHandler />
+							</AccessProvider>
+						</WithProviders>
+					</SafeAreaProvider>
 				</ActionSheetProvider>
 			</ErrorBoundary>
 		</GestureHandlerRootView>

--- a/projects/Mallard/src/components/layout/ui/row.tsx
+++ b/projects/Mallard/src/components/layout/ui/row.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Highlight } from 'src/components/highlight';
 import { UiBodyCopy, UiExplainerCopy } from 'src/components/styled-text';
 import { useAppAppearance } from 'src/theme/appearance';

--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -4,14 +4,8 @@ import type { RouteProp } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useRef, useState } from 'react';
-import {
-	Animated,
-	FlatList,
-	SafeAreaView,
-	StatusBar,
-	StyleSheet,
-	View,
-} from 'react-native';
+import { Animated, FlatList, StatusBar, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArticleTheme } from 'src/components/article/article';
 import { themeColors } from 'src/components/article/helpers/css';
 import {

--- a/projects/Mallard/src/screens/onboarding-screen.tsx
+++ b/projects/Mallard/src/screens/onboarding-screen.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import React from 'react';
-import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { color } from 'src/theme/color';
 import { metrics } from 'src/theme/spacing';
 import { OnboardingConsent } from './onboarding/cards';

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -7033,18 +7033,6 @@ react-native-iap@^12.13.0:
   dependencies:
     "@expo/config-plugins" "^7.8.4"
 
-react-native-image-pan-zoom@^2.1.12:
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
-  integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
-
-react-native-image-zoom-viewer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-3.0.1.tgz#a2bd5fb3bda15e0686ce88fcde8576726495d7fb"
-  integrity sha512-la6s5DNSuq4GCRLsi5CZ29FPjgTpdCuGIRdO5T9rUrAtxrlpBPhhSnHrbmPVxsdtOUvxHacTh2Gfa9+RraMZQA==
-  dependencies:
-    react-native-image-pan-zoom "^2.1.12"
-
 react-native-in-app-utils@^6.0.2:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-native-in-app-utils/-/react-native-in-app-utils-6.1.0.tgz#e40ac25a5f8720ea7ef164eda3cc747693314c9c"
@@ -7127,10 +7115,10 @@ react-native-restart@^0.0.27:
   resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.27.tgz#43aa8210312c9dfa5ec7bd4b2f35238ad7972b19"
   integrity sha512-8KScVICrXwcTSJ1rjWkqVTHyEKQIttm5AIMGSK1QG1+RS5owYlE4z/1DykOTdWfVl9l16FIk0w9Xzk9ZO6jxlA==
 
-react-native-safe-area-context@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.9.0.tgz#21a570ca3594cb4259ba65f93befaa60d91bcbd0"
-  integrity sha512-/OJD9Pb8IURyvn+1tWTszWPJqsbZ4hyHBU9P0xhOmk7h5owSuqL0zkfagU0pg7Vh0G2NKQkaPpUKUMMCUMDh/w==
+react-native-safe-area-context@^4.10.8:
+  version "4.10.8"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.10.8.tgz#038bd6a4853a38189c186d119302943c8d13f56f"
+  integrity sha512-Jx1lovhvIdYygg0UsMCBUJN0Wvj9GlA5bbcBLzjZf93uJpNHzaiHC4hR280+sNVK1+/pMHEyEkXVHDZE5JWn0w==
 
 react-native-screens@^3.29.0:
   version "3.29.0"


### PR DESCRIPTION
## Why are you doing this?

`SafeAreaView` has some inconsistencies in older version of Android. This gives better support across both across both platforms

## Changes

- Updated `react-native-safe-area-context` 
- Added the provider
- Added the Safe Area View
