### PR TITLE
fix: Snky Security

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,7 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-editions
       SKIP_NODE: false
-      # NODE_PACKAGE_JSON_FILES_MISSING_LOCK: projects/Mallard/package.json # not missing lock but seemingly needs to be installed for gradle build to work
       EXCLUDE: Mallard
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,7 +13,7 @@ jobs:
       DEBUG: true
       ORG: guardian-editions
       SKIP_NODE: false
-      NODE_PACKAGE_JSON_FILES_MISSING_LOCK: projects/Mallard/package.json # not missing lock but seemingly needs to be installed for gradle build to work
+      # NODE_PACKAGE_JSON_FILES_MISSING_LOCK: projects/Mallard/package.json # not missing lock but seemingly needs to be installed for gradle build to work
       EXCLUDE: Mallard
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/projects/Mallard/ios/Podfile.lock
+++ b/projects/Mallard/ios/Podfile.lock
@@ -622,7 +622,7 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.23.1):
     - React-Core
-  - RNCClipboard (1.14.1):
+  - RNCClipboard (1.13.2):
     - React-Core
   - RNCMaskedView (0.3.0):
     - React-Core
@@ -1036,7 +1036,7 @@ SPEC CHECKSUMS:
   ReactCommon: 76843a9bb140596351ac2786257ac9fe60cafabb
   RNBackgroundFetch: 501c34ad6e880818ba17e7840b23f20a2d112923
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNCClipboard: 0a720adef5ec193aa0e3de24c3977222c7e52a37
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
   RNCMaskedView: f7c74478c83c4fdfc5cf4df51f80c0dd5cf125c6
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -47,7 +47,7 @@
 		"@likashefqet/react-native-image-zoom": "^3.0.0",
 		"@okta/okta-react-native": "^2.8.0",
 		"@react-native-async-storage/async-storage": "^1.22.0",
-		"@react-native-clipboard/clipboard": "^1.14.0",
+		"@react-native-clipboard/clipboard": "1.13.2",
 		"@react-native-community/geolocation": "^3.0.5",
 		"@react-native-community/netinfo": "^11.3.0",
 		"@react-native-community/push-notification-ios": "^1.10.1",

--- a/projects/Mallard/package.json
+++ b/projects/Mallard/package.json
@@ -127,7 +127,7 @@
 		"postinstall-postinstall": "^2.1.0",
 		"prettier": "^2.4.1",
 		"react-test-renderer": "18.2.0",
-		"typescript": "4.8.4"
+		"typescript": "5.1.3"
 	},
 	"reactNativePermissionsIOS": [
 		"LocationWhenInUse"

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -1843,10 +1843,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-clipboard/clipboard@^1.14.0":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz#835f82fc86881a0808a8405f2576617bb5383554"
-  integrity sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw==
+"@react-native-clipboard/clipboard@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.13.2.tgz#28adcfc43ed2addddf79a59198ec1b25087c115e"
+  integrity sha512-uVM55oEGc6a6ZmSATDeTcMm55A/C1km5X47g0xaoF0Zagv7N/8RGvLceA5L/izPwflIy78t7XQeJUcnGSib0nA==
 
 "@react-native-community/cli-clean@11.4.1":
   version "11.4.1"
@@ -7032,18 +7032,6 @@ react-native-iap@^12.13.0:
   integrity sha512-M9pyjTipgAl459S1xjLH2s+0AwiqAHgg3KRA8QSqR7dN3qyzV2dr4W6TH7HGUsdGIA6lEEbeco0gRk8BqoThow==
   dependencies:
     "@expo/config-plugins" "^7.8.4"
-
-react-native-image-pan-zoom@^2.1.12:
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
-  integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
-
-react-native-image-zoom-viewer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-zoom-viewer/-/react-native-image-zoom-viewer-3.0.1.tgz#a2bd5fb3bda15e0686ce88fcde8576726495d7fb"
-  integrity sha512-la6s5DNSuq4GCRLsi5CZ29FPjgTpdCuGIRdO5T9rUrAtxrlpBPhhSnHrbmPVxsdtOUvxHacTh2Gfa9+RraMZQA==
-  dependencies:
-    react-native-image-pan-zoom "^2.1.12"
 
 react-native-in-app-utils@^6.0.2:
   version "6.1.0"

--- a/projects/Mallard/yarn.lock
+++ b/projects/Mallard/yarn.lock
@@ -8163,10 +8163,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 typescript@^4.1.3:
   version "4.9.5"


### PR DESCRIPTION
## Why are you doing this?

To fix the Snyk security job

## Changes

- Downgrades the Clipboard as its incompatible with RN. We upgraded it on the failed RN upgrade but didnt downgrade the Clipboard again. This was throwing a warning causing the Snyk action to fail
- Removed the missing lock file. The comment suggested it was needed to "run gradle". It seems like a fix has been put in place as removing this now passes the job.

## Output

All actions should now pass.