### PR TITLE
Correctly match crossword type from inside the path

### DIFF
--- a/projects/backend/utils/__tests__/crossword.spec.ts
+++ b/projects/backend/utils/__tests__/crossword.spec.ts
@@ -1,5 +1,5 @@
 import { CrosswordType, CrosswordEntry } from '../../../Apps/common/src'
-import { patchCrossword } from '../crossword'
+import { getCrosswordType, patchCrossword } from '../crossword'
 
 const createCrossword = (type: CrosswordType = CrosswordType.QUICK) => ({
     name: '',
@@ -44,5 +44,13 @@ describe('getCrosswordArticleOverrides', () => {
                 expect(out.solutionAvailable).toBe(true)
             }
         }
+    })
+})
+
+describe('checking Quick cryptics', () => {
+    it('getCrosswordType', () => {
+        expect(getCrosswordType('crosswords/quick-cryptic/15')).toBe(
+            CrosswordType.QUICK_CRYPTIC,
+        )
     })
 })

--- a/projects/backend/utils/crossword.ts
+++ b/projects/backend/utils/crossword.ts
@@ -12,9 +12,9 @@ import { omit } from 'ramda'
 
 const enumKeyToKebabCase = (key: string) => key.toLowerCase().replace(/_/g, '-')
 
-const getCrosswordType = (path: string): CrosswordType => {
+export const getCrosswordType = (path: string): CrosswordType => {
     for (const [key, type] of Object.entries(CrosswordType)) {
-        if (path.includes(enumKeyToKebabCase(key))) return type
+        if (path.includes('/' + enumKeyToKebabCase(key) + '/')) return type
     }
     return CrosswordType.QUICK // default to something sensible as this is largely used for rendering
 }


### PR DESCRIPTION
QUICK is a substring of QUICK_CRYPTIC so matches. check that the type is inside a pair of /s as well to be sure we've matched the full type name

## Why are you doing this?

Get Quick cryptic headlines to display as that, instead of Quick
