### PR TITLE
chore: Crosswords update 2.0.1

### DIFF
--- a/projects/crosswords-bundle/package.json
+++ b/projects/crosswords-bundle/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@guardian/react-crossword": "^2.0.0",
+        "@guardian/react-crossword": "^2.0.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/projects/crosswords-bundle/scripts/watch-html.js
+++ b/projects/crosswords-bundle/scripts/watch-html.js
@@ -38,7 +38,7 @@ const watchHTML = () => {
 
     const main = async () => {
         fs.writeFileSync(
-            resolve(__dirname, 'src', 'html-bundle-info.json'),
+            resolve(__dirname, '..', 'src', 'html-bundle-info.json'),
             JSON.stringify(
                 {
                     'hey!': `this file is generated at build time. do not edit manually. Bump up the version by editing ./VERSION`,

--- a/projects/crosswords-bundle/yarn.lock
+++ b/projects/crosswords-bundle/yarn.lock
@@ -1312,10 +1312,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@guardian/react-crossword@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-2.0.0.tgz#7b293d0e267e8ddc43815442d07daa7747accdc9"
-  integrity sha512-ESJACi6Lm4ymI5Yd8wPBQQVB61NWYOfyZ6h/a5f22qdMQYeUBvCa4sc+woYf2L8stIB1kxFr6zDygRV89pAoDA==
+"@guardian/react-crossword@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/react-crossword/-/react-crossword-2.0.1.tgz#de3b1608208bab266535fda950e672414401f386"
+  integrity sha512-edR/sCVSpA5iHdg2VxCJvTotRMGihLCUaM93+FHPYohkweenUHKAuPffqZG2NYF3FpeMGHgqoWcKcjt7m7ticQ==
   dependencies:
     bean "~1.0.14"
     bonzo "~2.0.0"


### PR DESCRIPTION
## Why are you doing this?

A recent update to remove a vulnerability in crosswords, now being proliferated into Mallard

## Changes

- Update Crosswords
- Fix to `watch-html` as it was pointing to an incorrect path.

## Screenshots

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-07-25 at 16 22 41](https://github.com/user-attachments/assets/08ec1b24-3b26-43be-a161-c33c01a1de2b)
