### PR TITLE
Add special crossword series

### DIFF
--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -30,7 +30,7 @@
         "test:watch": "jest --watch"
     },
     "dependencies": {
-        "@guardian/content-api-models": "25.0.0",
+        "@guardian/content-api-models": "25.1.0",
         "@guardian/content-atom-model": "4.0.1",
         "@types/aws-lambda": "^8.10.31",
         "@types/aws4": "^1.5.1",

--- a/projects/backend/yarn.lock
+++ b/projects/backend/yarn.lock
@@ -304,10 +304,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@guardian/content-api-models@25.0.0":
-  version "25.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-25.0.0.tgz#0bf63850b798c9dcaaa662ae824730d02d8b7820"
-  integrity sha512-6QlboykRlvfo2vR2N9Z9mWjkTzuplPVEsMvkkwEZqbA21iGr1XkoIrGGlGUvLM+i67KCABMQsTki3JLEVa7EGQ==
+"@guardian/content-api-models@25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-25.1.0.tgz#68c6eeda59c492835ff9c5de5bc99d9ed1ea2d9c"
+  integrity sha512-KePMcD6Dvnw2MRNBkfPHjOQ3sLnu4WpPBX66VtcV1/maR4os64Q+mTysZhYZ4X/xvDY8ZkcacVxc6pIcf5Uwbw==
   dependencies:
     "@guardian/content-atom-model" "^4.0.4"
     "@guardian/content-entity-model" "^3.0.3"

--- a/projects/common/src/types.ts
+++ b/projects/common/src/types.ts
@@ -427,6 +427,7 @@ export enum CrosswordType {
     DIAN_QUIPTIC_CROSSWORD = 'quiptic-dian',
     WEEKEND = 'weekend',
     QUICK_CRYPTIC = 'quick-cryptic',
+    SPECIAL = 'special',
 }
 
 export interface CapiDateTime {


### PR DESCRIPTION
## Why are you doing this?

Adds support for special crosswords.
This is a new series where crosswords which don't fit a regular schedule can live. (eg. the crosswords that are published in the paper's summer puzzle supplement could go here, and not disrupt the daily/weekly crossword series schedules). The puzzles themselves will be similar in format to the regular quicks or cryptics.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

- Upgrade content-api-models to latest version, which includes the Special crossword type
- Add special crossword type to the crosswords enum

## Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300px" /> | <img src="" width="300px" /> |
