### PR TITLE
fix: Lightbox crash

### DIFF
--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -196,7 +196,6 @@ const LightboxScreen = () => {
 						onScrollBeginDrag={handleScrollStartEvent}
 						onScrollEndDrag={() => setScrollInProgress(false)}
 						renderItem={({ item }) => {
-							console.log(item);
 							return (
 								<View style={{ width, height: '100%' }}>
 									<ImageZoom
@@ -233,7 +232,7 @@ const LightboxScreen = () => {
 						</View>
 						<Animated.View style={{ opacity: fadeAnim }}>
 							<LightboxCaption
-								caption={images[currentIndex].caption ?? ''}
+								caption={images[currentIndex]?.caption ?? ''}
 								pillarColor={
 									pillar === 'neutral'
 										? palette.neutral[100]


### PR DESCRIPTION
## Why are you doing this?

Lightbox is crashing on a new type of article because there is no caption in it. This adds safety to that text by trying to not read an object property that doesn't exist.

## Changes

- Adds an optional chain to the images array
- Removes a console.log

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/dc861694-681d-42cc-a3bb-f4ddd454541f" width="300px" /> | <img src="https://github.com/user-attachments/assets/831adcc5-635c-4f9d-9d4a-66bb2e62e5a3" width="300px" /> |
