### PR TITLE
fix: Settings screen

### DIFF
--- a/projects/Mallard/src/components/layout/ui/row.tsx
+++ b/projects/Mallard/src/components/layout/ui/row.tsx
@@ -2,7 +2,6 @@ import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Highlight } from '../../../components/highlight';
 import { UiBodyCopy, UiExplainerCopy } from '../../../components/styled-text';
 import { useAppAppearance } from '../../../theme/appearance';
@@ -44,9 +43,7 @@ const Footer = ({
 
 const Heading = ({ children }: { children: string }) => (
 	<View style={styles.heading}>
-		<SafeAreaView>
-			<UiBodyCopy weight="bold">{children}</UiBodyCopy>
-		</SafeAreaView>
+		<UiBodyCopy weight="bold">{children}</UiBodyCopy>
 	</View>
 );
 


### PR DESCRIPTION
## Why are you doing this?

Fix the broken layout on the settings screen

## Changes

- Removed `SafeAreaView` from the `Heading` component. It seems the behaviour of this as changed, and I dont think its usage in this component longer applies. I have checked its usage across the app and everything looks fine.

`Heading` is used as a spacer, which cant be very accessible. Something for the list to change

## Screenshots


| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7684584e-8e47-462c-891f-1a86d137c11e" width="300px" /> | <img src="https://github.com/user-attachments/assets/3fe3edeb-b599-4e40-bb0f-a528bac74142" width="300px" /> |
