### PR TITLE
chore: nth check vulnerability

### DIFF
--- a/docs/11-yarn-modern.md
+++ b/docs/11-yarn-modern.md
@@ -1,0 +1,9 @@
+# Yarn Modern (Berry) investigation
+
+As part of the above I have been exploring moving the repo across to yarn modern so everything is on the same: https://github.com/guardian/editions/compare/spike/yarn-berry?expand=1.
+
+The idea being that we reduce the issues seen with releases. Keeping everything on one version of yarn makes sense
+
+However, I have decided that it shouldn't be done yet. This is because each project currently uses different versions of node. As dependency installation is specific to a version and without access to how installation happens on the backend projects, they could fail to install their dependencies on release without us knowing.
+
+As a result, this is something that should take place if/when there is resource for updating the three backend repositories.

--- a/projects/crosswords-bundle/package.json
+++ b/projects/crosswords-bundle/package.json
@@ -19,6 +19,9 @@
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
     },
+    "resolutions": {
+        "nth-check": "^2.0.1"
+    },
     "scripts": {
         "start": "BROWSER=none react-scripts start",
         "build": "react-scripts build",

--- a/projects/crosswords-bundle/yarn.lock
+++ b/projects/crosswords-bundle/yarn.lock
@@ -4371,7 +4371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boolbase@npm:^1.0.0, boolbase@npm:~1.0.0":
+"boolbase@npm:^1.0.0":
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 3e25c80ef626c3a3487c73dbfc70ac322ec830666c9ad915d11b701142fab25ec1e63eff2c450c74347acfd2de854ccde865cd79ef4db1683f7c7b046ea43bb0
@@ -9649,15 +9649,6 @@ __metadata:
   dependencies:
     path-key: ^3.0.0
   checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
-  languageName: node
-  linkType: hard
-
-"nth-check@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "nth-check@npm:1.0.2"
-  dependencies:
-    boolbase: ~1.0.0
-  checksum: 59e115fdd75b971d0030f42ada3aac23898d4c03aa13371fa8b3339d23461d1badf3fde5aad251fb956aaa75c0a3b9bfcd07c08a34a83b4f9dadfdce1d19337c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why are you doing this?

Looking to fix this: https://github.com/guardian/editions/security/dependabot/365.

The outdated package is in `react-scripts` which surprisingly has not seen an update in 2 years. Which is a concern considering its a core package of CRA.

This forces a resolution to a higher package. We bundle the CSS outside of this project, so I dont foresee too much of an issue.

## Changes

- package json resolution

## Screenshots

![simulator_screenshot_89ABA50F-7554-411F-AFB5-64CA76EE6D38](https://github.com/user-attachments/assets/9baf51d0-e576-4cbf-bff5-574c7d6327f8)
