### PR TITLE
fix: Snyk kill-port

### DIFF
--- a/projects/crosswords-bundle/package.json
+++ b/projects/crosswords-bundle/package.json
@@ -12,7 +12,6 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "chalk": "^3.0.0",
-        "kill-port": "^1.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",


### PR DESCRIPTION
## Why are you doing this?

`Snyk` job is currently failing on `main`: https://github.com/guardian/editions/actions/runs/10662023825/job/29548498279

This looks to resolve it.

## Changes

- Remove the duplicate import of `kill-port` from crosswords

## Outputs

Can confirm it works: https://github.com/guardian/editions/actions/runs/10662738956

Has no effect on showing crosswords in dev.

![simulator_screenshot_A00731E9-AFB0-4791-AB82-D0C965B5CDE5](https://github.com/user-attachments/assets/7778002e-6ba8-4ad7-a6c5-7751a3fcad3c)
