### PR TITLE
fix: Attempted fix for Android crashes

### DIFF
--- a/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainActivity.kt
+++ b/projects/Mallard/android/app/src/main/java/com/guardian/editions/MainActivity.kt
@@ -53,4 +53,9 @@ class MainActivity : ReactActivity() {
         }
         super.applyOverrideConfiguration(overrideConfiguration)
     }
+
+    //react-native-screens override
+    override fun onCreate(savedInstanceState: Bundle?) {
+      super.onCreate(null);
+    }
 }


### PR DESCRIPTION
## Why are you doing this?

We are getting reports of crashes on Android due to React Native screens. One of the suggestions was to check the installation steps. During the last upgrade, the override was missed. So trying this.

## Changes

- Add the override as per: https://github.com/software-mansion/react-native-screens#android

## Screenshots

I wasn't able to make it crash previously, but can confirm that this continues to run.

![Screenshot_20240904_081147](https://github.com/user-attachments/assets/b0e70be8-b28a-4c62-b710-f6e064f4bee7)
