### PR TITLE
feat: Firebase Analytics

### DIFF
--- a/projects/Mallard/src/App.tsx
+++ b/projects/Mallard/src/App.tsx
@@ -12,7 +12,7 @@ import { isValid } from './authentication/lib/Attempt';
 import { oktaInitialisation } from './authentication/services/okta';
 import { BugButtonHandler } from './components/Button/BugButtonHandler';
 import { ErrorBoundary } from './components/layout/ui/errors/error-boundary';
-import { logUserId } from './helpers/analytics';
+import { logUserId, toggleAnalyticsRecording } from './helpers/analytics';
 import { prepFileSystem } from './helpers/files';
 import { nestProviders } from './helpers/provider';
 import { AppStateProvider } from './hooks/use-app-state-provider';
@@ -30,6 +30,7 @@ import { WeatherProvider } from './hooks/use-weather-provider';
 import { remoteConfigService } from './services/remote-config';
 
 remoteConfigService.init();
+toggleAnalyticsRecording(true);
 
 // --- SETUP OPERATIONS ---
 prepFileSystem();

--- a/projects/Mallard/src/components/Button/BugButtonHandler.tsx
+++ b/projects/Mallard/src/components/Button/BugButtonHandler.tsx
@@ -24,16 +24,11 @@ const BugButtonHandler = () => {
 		type,
 	};
 
-	const {
-		gdprAllowEssential,
-		gdprAllowPerformance,
-		gdprAllowFunctionality,
-		gdprConsentVersion,
-	} = useGdprSettings();
+	const { gdprAllowEssential, gdprAllowPerformance, gdprConsentVersion } =
+		useGdprSettings();
 	const gdprSettings = {
 		gdprAllowEssential,
 		gdprAllowPerformance,
-		gdprAllowFunctionality,
 		gdprConsentVersion,
 	};
 	return isInBeta() ? (

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -108,9 +108,6 @@ const maxAvailableEditionsCache = createAsyncCache<number>(
 const gdprAllowPerformanceCache = createAsyncCache<boolean>(
 	'@Setting_gdprAllowPerformance',
 );
-const gdprAllowFunctionalityCache = createAsyncCache<boolean>(
-	'@Setting_gdprAllowFunctionality',
-);
 const gdprConsentVersionCache = createAsyncCache<number>(
 	'@Setting_gdprConsentVersion',
 );
@@ -204,7 +201,6 @@ export {
 	wifiOnlyDownloadsCache,
 	maxAvailableEditionsCache,
 	gdprAllowPerformanceCache,
-	gdprAllowFunctionalityCache,
 	gdprConsentVersionCache,
 	isWeatherShownCache,
 	isUsingProdDevtoolsCache,

--- a/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
+++ b/projects/Mallard/src/screens/settings/gdpr-consent-screen.tsx
@@ -36,7 +36,7 @@ type EssentialGdprSwitch = Omit<GdprSwitch, 'key' | 'modifier' | 'value'>;
 const essentials: EssentialGdprSwitch = {
 	name: 'Essential',
 	services:
-		'YouTube Player - Firebase Cloud Messaging - Firebase Remote Config',
+		'YouTube Player - Firebase Cloud Messaging - Firebase Remote Config - Firebase Analytics',
 	description:
 		'These are essential to provide you with services that you have requested. These services support the ability for you to watch videos, see service-related messages, download content automatically and receive new features without app releases.',
 };
@@ -61,9 +61,7 @@ const GdprConsent = ({
 		rejectAllSettings,
 		resetAllSettings,
 		gdprAllowPerformance,
-		gdprAllowFunctionality,
 		setGdprPerformanceBucket,
-		setGdprFunctionalityBucket,
 		hasSetGdpr,
 		isCorrectConsentVersion,
 	} = useGdprSettings();
@@ -71,19 +69,11 @@ const GdprConsent = ({
 	const switches: { [key in keyof GdprSwitches]: GdprSwitch } = {
 		gdprAllowPerformance: {
 			name: 'Performance',
-			services: 'Sentry - Crashlytics',
+			services: 'Crashlytics',
 			description:
 				'Enabling these allow us to observe and measure how you use our services. We use this information to fix bugs more quickly so that users have a better experience. For example, we would be able to see the journey you have taken and where the error was encountered. Your data will only be stored in our servers for two weeks. If you disable this, we will not be able to observe and measure your use of our services, and we will have less information about their performance and details of any issues encountered.',
 			modifier: setGdprPerformanceBucket,
 			value: gdprAllowPerformance,
-		},
-		gdprAllowFunctionality: {
-			name: 'Functionality',
-			services: 'Apple - Google',
-			description:
-				'Enabling these allow us to provide extra sign-in functionality. It enables us to offer alternative options for you to sign-in to your Guardian account using your Apple or Google credentials. If you disable this, you won’t be able to sign-in with the third-party services above.',
-			modifier: setGdprFunctionalityBucket,
-			value: gdprAllowFunctionality,
 		},
 	};
 

--- a/projects/Mallard/src/screens/settings/help-screen.tsx
+++ b/projects/Mallard/src/screens/settings/help-screen.tsx
@@ -51,16 +51,11 @@ const HelpScreen = () => {
 		downloadBlocked,
 		isInternetReachable,
 	};
-	const {
-		gdprAllowEssential,
-		gdprAllowPerformance,
-		gdprAllowFunctionality,
-		gdprConsentVersion,
-	} = useGdprSettings();
+	const { gdprAllowEssential, gdprAllowPerformance, gdprConsentVersion } =
+		useGdprSettings();
 	const gdprSettings = {
 		gdprAllowEssential,
 		gdprAllowPerformance,
-		gdprAllowFunctionality,
 		gdprConsentVersion,
 	};
 


### PR DESCRIPTION
## Why are you doing this?

Changing the GDPR settings to reflect the current state of the app and to make Firebase Analytics essential

## Changes

- Remove the "functionality" GDPR setting content block
- Remove the associated functionality settings as login is through Okta now where there is a privacy policy.
- Enable analytics recording when the user opens the app rather than from behind the performance flag
- Upped the consent version to force a consent check
- Removed Sentry as its not being used.

## Screenshots

### Privacy screenshot

![Simulator Screenshot - iPhone 15 Pro - 2024-09-04 at 20 44 12](https://github.com/user-attachments/assets/64d1a7e7-8d87-426b-b1cd-3f7db54cdc3b)

### Flow

https://github.com/user-attachments/assets/93b0136e-9f22-445e-8ba9-3db72f5c326b


