### PR TITLE
fix: Missing credit

### DIFF
--- a/projects/Mallard/src/screens/lightbox.tsx
+++ b/projects/Mallard/src/screens/lightbox.tsx
@@ -239,9 +239,9 @@ const LightboxScreen = () => {
 										: pillarColors.bright //bright since always on a dark background
 								}
 								displayCredit={
-									images[currentIndex].displayCredit
+									images[currentIndex]?.displayCredit ?? false
 								}
-								credit={images[currentIndex].credit}
+								credit={images[currentIndex]?.credit ?? ''}
 							/>
 						</Animated.View>
 					</View>


### PR DESCRIPTION
## Why are you doing this?

For some reason, `credit` and `displayCredit` have stopped be passed through with every image. As a result, i've added defaults

## Changes

- Added sensible credit defaults

## Screenshots

Wasnt quick enough before the republish to get a video. The experience isnt great but at least it doesnt crash the app
