### PR TITLE
chore: Add missing endash

### DIFF
--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -252,7 +252,7 @@ const andContinue = 'and continue';
 
 const iAPMigration = {
 	title: 'This app is changing ...',
-	body: "In December, we will be updating the Guardian Editions app to give an improved experience more like a digital version of our newspaper. Your subscription will be transferred automatically, so you shouldn't need to do anything. More details will be shared soon - thank you for your ongoing support.",
+	body: "In December, we will be updating the Guardian Editions app to give an improved experience more like a digital version of our newspaper. Your subscription will be transferred automatically, so you shouldn't need to do anything. More details will be shared soon – thank you for your ongoing support.",
 };
 
 export const copy = {


### PR DESCRIPTION
Replaces the hyphen with an endash after "soon"

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/37e6204c-5a9e-410d-8093-1e03c4b05877" width="300px" /> | <img src="https://github.com/user-attachments/assets/a056a341-3f85-4e7b-a8fd-be4615dd3b01" width="300px" /> |

