### PR TITLE
feat: App Migration Message

### DIFF
--- a/projects/Mallard/src/AppNavigation.tsx
+++ b/projects/Mallard/src/AppNavigation.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useRef } from 'react';
 import { Animated } from 'react-native';
 import { isTablet } from 'react-native-device-info';
-import { IAPAppMigrationModal } from './components/Modals/IAPAppMigration';
+import { AppMigrationModal } from './components/Modals/AppMigration';
 import {
 	MissingIAPRestoreError,
 	MissingIAPRestoreMissing,
@@ -368,8 +368,8 @@ const MainStack = () => {
 					}}
 				/>
 				<Main.Screen
-					name={RouteNames.IAPAppMigrationModal}
-					component={IAPAppMigrationModal}
+					name={RouteNames.AppMigrationModal}
+					component={AppMigrationModal}
 					options={{
 						cardStyleInterpolator: forFade,
 						cardStyle: {

--- a/projects/Mallard/src/components/Modals/AppMigration.tsx
+++ b/projects/Mallard/src/components/Modals/AppMigration.tsx
@@ -2,30 +2,30 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { logEvent } from '../../helpers/analytics';
-import { hasSeenIapMigrationMessage } from '../../helpers/storage';
+import { hasSeenAppMigrationMessage } from '../../helpers/storage';
 import type { MainStackParamList } from '../../navigation/NavigationModels';
 import { RouteNames } from '../../navigation/NavigationModels';
+import { AppMigrationModalCard } from '../app-migration-modal-card';
 import { CenterWrapper } from '../CenterWrapper/CenterWrapper';
-import { IAPAppMigrationModalCard } from '../iap-app-migration-modal-card';
 
-const IAPAppMigrationModal = () => {
+const AppMigrationModal = () => {
 	const { navigate } =
 		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
 	return (
 		<CenterWrapper>
-			<IAPAppMigrationModalCard
+			<AppMigrationModalCard
 				onDismiss={() => {
 					navigate(RouteNames.Issue);
 
 					logEvent({
-						name: 'iap_app_migration_modal',
-						value: 'iap_app_migration_modal_dismissed',
+						name: 'app_migration_modal',
+						value: 'app_migration_modal_dismissed',
 					});
-					hasSeenIapMigrationMessage.set(true);
+					hasSeenAppMigrationMessage.set(true);
 				}}
 			/>
 		</CenterWrapper>
 	);
 };
 
-export { IAPAppMigrationModal };
+export { AppMigrationModal };

--- a/projects/Mallard/src/components/app-migration-modal-card.tsx
+++ b/projects/Mallard/src/components/app-migration-modal-card.tsx
@@ -11,20 +11,20 @@ const style = StyleSheet.create({
 	},
 });
 
-const IAPAppMigrationModalCard = ({ onDismiss }: { onDismiss: () => void }) => {
+const AppMigrationModalCard = ({ onDismiss }: { onDismiss: () => void }) => {
 	return (
 		<OnboardingCard
 			onDismissThisCard={onDismiss}
-			title={copy.iAPMigration.title}
+			title={copy.appMigration.title}
 			appearance={CardAppearance.Clashy}
 			size="medium"
 			bottomContent={
 				<UiBodyCopy style={style.bodyCopy}>
-					{copy.iAPMigration.body}
+					{copy.appMigration.body}
 				</UiBodyCopy>
 			}
 		/>
 	);
 };
 
-export { IAPAppMigrationModalCard };
+export { AppMigrationModalCard };

--- a/projects/Mallard/src/helpers/storage.ts
+++ b/projects/Mallard/src/helpers/storage.ts
@@ -130,8 +130,8 @@ const hasShownRatingCache = createAsyncCache<boolean>(
 	'@Setting_hasShownRating',
 );
 
-const hasSeenIapMigrationMessage = createAsyncCache<boolean>(
-	'@Setting_hasSeenIapMigrationMessage',
+const hasSeenAppMigrationMessage = createAsyncCache<boolean>(
+	'@Setting_hasSeenAppMigrationMessage',
 );
 
 const issueSummaryCache = createAsyncCache<string>('issueSummary');
@@ -213,5 +213,5 @@ export {
 	hasShownRatingCache,
 	oktaDataCache,
 	issueSummaryCache,
-	hasSeenIapMigrationMessage,
+	hasSeenAppMigrationMessage,
 };

--- a/projects/Mallard/src/helpers/words.ts
+++ b/projects/Mallard/src/helpers/words.ts
@@ -250,9 +250,9 @@ const enableAll = 'Enable all';
 const rejectAll = 'Reject all';
 const andContinue = 'and continue';
 
-const iAPMigration = {
+const appMigration = {
 	title: 'This app is changing ...',
-	body: "In December, we will be updating the Guardian Editions app to give an improved experience more like a digital version of our newspaper. Your subscription will be transferred automatically, so you shouldn't need to do anything. More details will be shared soon – thank you for your ongoing support.",
+	body: 'In December, we will be updating the Guardian Edition app to give you an experience that’s even closer to our printed newspaper. Your subscription will be transferred automatically, so you shouldn’t need to do anything. More details will be shared soon – thank you for your ongoing support.',
 };
 
 export const copy = {
@@ -264,7 +264,7 @@ export const copy = {
 	externalSubscription,
 	failedSignIn,
 	homeScreen,
-	iAPMigration,
+	appMigration,
 	issueListFooter,
 	manageDownloads,
 	newEditionWords,

--- a/projects/Mallard/src/navigation/NavigationModels.tsx
+++ b/projects/Mallard/src/navigation/NavigationModels.tsx
@@ -49,7 +49,7 @@ export type MainStackParamList = {
 	OnboardingConsent: undefined;
 	PrivacyPolicyInline: undefined;
 	OnboardingConsentInline: undefined;
-	IAPAppMigrationModal: undefined;
+	AppMigrationModal: undefined;
 };
 
 export enum RouteNames {
@@ -87,5 +87,5 @@ export enum RouteNames {
 	MissingIAPRestoreError = 'MissingIAPRestoreError',
 	MissingIAPRestoreMissing = 'MissingIAPRestoreMissing',
 	ManageEditionsFromSettings = 'ManageEditionsFromSettings',
-	IAPAppMigrationModal = 'IAPAppMigrationModal',
+	AppMigrationModal = 'AppMigrationModal',
 }

--- a/projects/Mallard/src/screens/issue-screen.tsx
+++ b/projects/Mallard/src/screens/issue-screen.tsx
@@ -3,7 +3,6 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { MutableRefObject, ReactElement } from 'react';
 import React, {
 	useCallback,
-	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -14,7 +13,6 @@ import { FlatList, StyleSheet, View } from 'react-native';
 import Image from 'react-native-fast-image';
 import RNRestart from 'react-native-restart';
 import SplashScreen from 'react-native-splash-screen';
-import { AccessContext } from '../authentication/AccessContext';
 import type {
 	IssueWithFronts,
 	SpecialEditionHeaderStyles,
@@ -38,7 +36,7 @@ import {
 } from '../components/weather';
 import { deleteIssueFiles } from '../download-edition/clear-issues-and-editions';
 import { logPageView } from '../helpers/analytics';
-import { hasSeenIapMigrationMessage } from '../helpers/storage';
+import { hasSeenAppMigrationMessage } from '../helpers/storage';
 import type { FlatCard } from '../helpers/transform';
 import {
 	flattenCollectionsToCards,
@@ -452,11 +450,10 @@ export const IssueScreen = React.memo(() => {
 	const { hasSetGdpr } = useGdprSettings();
 	const { navigate } =
 		useNavigation<NativeStackNavigationProp<MainStackParamList>>();
-	const { iapData } = useContext(AccessContext);
 	const [messageSeen, setMessageSeen] = useState<boolean>(false);
 
 	useEffect(() => {
-		hasSeenIapMigrationMessage.get().then((hasSeen) => {
+		hasSeenAppMigrationMessage.get().then((hasSeen) => {
 			setMessageSeen(!!hasSeen);
 		});
 	}, []);
@@ -484,10 +481,9 @@ export const IssueScreen = React.memo(() => {
 
 	if (
 		!messageSeen &&
-		iapData &&
-		remoteConfigService.getBoolean('is_iap_message_enabled')
+		remoteConfigService.getBoolean('is_app_migration_message_enabled')
 	) {
-		navigate(RouteNames.IAPAppMigrationModal);
+		navigate(RouteNames.AppMigrationModal);
 		setMessageSeen(true);
 	}
 

--- a/projects/Mallard/src/screens/settings/dev-zone.tsx
+++ b/projects/Mallard/src/screens/settings/dev-zone.tsx
@@ -19,7 +19,7 @@ import { locale } from '../../helpers/locale';
 import { isInBeta, isInTestFlight } from '../../helpers/release-stream';
 import { imageForScreenSize } from '../../helpers/screen';
 import {
-	hasSeenIapMigrationMessage,
+	hasSeenAppMigrationMessage,
 	issueSummaryCache,
 	pushRegisteredTokens,
 	showAllEditionsCache,
@@ -94,7 +94,7 @@ const DevZone = () => {
 		selectedEdition: { edition },
 	} = useEditions();
 
-	const { attempt, signOutCAS, identityData, oktaData, iapData } =
+	const { attempt, signOutCAS, identityData, oktaData } =
 		useContext(AccessContext);
 	const { showToast } = useToast();
 	const { setIsUsingProdDevTools } = useIsUsingProdDevtools();
@@ -106,7 +106,7 @@ const DevZone = () => {
 	const [imageSize, setImageSize] = useState('fetching...');
 	const [pushTokens, setPushTokens] = useState('fetching...');
 	const [downloadedIssues, setDownloadedIssues] = useState('fetching...');
-	const [iapMessge, setIapMessage] = useState<string | boolean | null>(
+	const [appMessage, setAppMessage] = useState<string | boolean | null>(
 		'fetching...',
 	);
 
@@ -150,7 +150,7 @@ const DevZone = () => {
 	}, []);
 
 	useEffect(() => {
-		hasSeenIapMigrationMessage.get().then((v) => setIapMessage(v));
+		hasSeenAppMigrationMessage.get().then((v) => setAppMessage(v));
 	}, []);
 
 	useEffect(() => {
@@ -253,10 +253,10 @@ const DevZone = () => {
 						)}
 						<Button
 							onPress={() =>
-								hasSeenIapMigrationMessage.set(false)
+								hasSeenAppMigrationMessage.set(false)
 							}
 						>
-							Reset IAP migration message
+							Reset app migration message
 						</Button>
 						<Button
 							onPress={() => {
@@ -365,9 +365,9 @@ const DevZone = () => {
 								onPress: interaction,
 							},
 							{
-								key: 'IAP Message',
-								title: 'IAP Message',
-								explainer: `Has seen IAP migration message: ${iapMessge}\nIs an IAP customer: ${!!iapData}\nFeature flag: ${remoteConfigService.getBoolean('is_iap_message_enabled')}`,
+								key: 'App Migration Message',
+								title: 'App Migration Message',
+								explainer: `Has seen App migration message: ${appMessage}\nFeature flag: ${remoteConfigService.getBoolean('is_app_migration_message_enabled')}`,
 							},
 							{
 								key: 'Clear CAS caches',

--- a/projects/Mallard/src/services/remote-config.ts
+++ b/projects/Mallard/src/services/remote-config.ts
@@ -18,7 +18,7 @@ const remoteConfigDefaults = {
 	download_parallel_ssr_bundle: false,
 	rating: false,
 	is_editions_menu_enabled: true,
-	is_iap_message_enabled: true,
+	is_app_migration_message_enabled: true,
 };
 
 const RemoteConfigProperties = [
@@ -28,7 +28,7 @@ const RemoteConfigProperties = [
 	'download_parallel_ssr_bundle',
 	'rating',
 	'is_editions_menu_enabled',
-	'is_iap_message_enabled',
+	'is_app_migration_message_enabled',
 ] as const;
 
 type RemoteConfigProperty = (typeof RemoteConfigProperties)[number];


### PR DESCRIPTION
## Why are you doing this?

Adding in a migration message for all users. Replaces IAP message following the same patterns

## Changes

- Removes the IAP message as this is now not needed.
- Replaces it with App Migration message
- Updated copy
- Updated logic
- Updated helpers
- Replaced IAP Message storage with App Message storage

## Screenshots

### Issue Screen Message
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-21 at 19 46 17](https://github.com/user-attachments/assets/617427dd-28d1-44e2-b69f-2977aab3705a)

### Reset button
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-21 at 19 46 29](https://github.com/user-attachments/assets/c33cd48f-7ed6-4481-a6f6-bbcfe1344e8d)

### Helpers
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-21 at 19 46 36](https://github.com/user-attachments/assets/12716ce2-50f1-4171-8b06-98f754b22853)

